### PR TITLE
Fix the mobile About navigation

### DIFF
--- a/components/about/About.tsx
+++ b/components/about/About.tsx
@@ -50,21 +50,8 @@ export default function About({ section }: { readonly section: AboutSection }) {
     >
       <Row>
         <Col>
-          <AboutContentsDropdown
-            className={
-              section === AboutSection.SUBSCRIPTIONS
-                ? "max-sm:!tw-top-2 max-sm:-tw-mt-14 max-sm:tw-mb-0 max-sm:tw-py-1"
-                : undefined
-            }
-            currentSection={section}
-          />
-          <div
-            className={
-              section === AboutSection.SUBSCRIPTIONS
-                ? "tw-w-full max-sm:tw-pt-8"
-                : "tw-w-full"
-            }
-          >
+          <AboutContentsDropdown currentSection={section} />
+          <div className="tw-w-full">
             <AboutSectionContent section={section} />
           </div>
         </Col>


### PR DESCRIPTION
## Issue

On the mobile Subscription Minting page, the About contents control was shifted 56px upward and given an 8px sticky offset. This placed it beneath the 64px app header, which intercepted taps and caused the staging About smoke test to fail consistently.

## Fix

- Restore the shared About contents navigation positioning used by the other About pages.
- Remove the compensating content padding that only existed for the overlapping layout.
- Preserve Subscription Minting's full-width content layout.

## Validation

- Focused Playwright regression on desktop and mobile Chromium: 2 passed.
- Narrow browser review at 390 × 844: control is visible, menu opens, and no horizontal overflow is present.
- Tight changed-file lint: passed.
- Changed-file typecheck: passed.
- React Doctor: 100/100, no issues.
- DCO-signed commit.

## Risk

Low. One page-specific mobile positioning override is removed; the shared navigation component and all other About pages are unchanged.

## Review notes

Please verify the Subscription Minting About navigation remains below the app header on narrow mobile screens and opens by touch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the About page layout for a more consistent presentation of content dropdowns.
  * Removed special spacing and styling variations from the subscriptions section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->