### PR TITLE
Make wave information panels consistent across desktop and mobile

### DIFF
--- a/__tests__/components/brain/mobile/BrainMobileAbout.test.tsx
+++ b/__tests__/components/brain/mobile/BrainMobileAbout.test.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import BrainMobileAbout from '@/components/brain/mobile/BrainMobileAbout';
-import { useQuery } from '@tanstack/react-query';
-import { useLayout } from '@/components/brain/my-stream/layout/LayoutContext';
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import BrainMobileAbout from "@/components/brain/mobile/BrainMobileAbout";
+import { useQuery } from "@tanstack/react-query";
+import { useLayout } from "@/components/brain/my-stream/layout/LayoutContext";
 import {
   Mode,
   SidebarTab,
-} from '@/components/brain/right-sidebar/BrainRightSidebarTypes';
+} from "@/components/brain/right-sidebar/BrainRightSidebarTypes";
 
-jest.mock('@/components/brain/right-sidebar/WaveContent', () => ({
+jest.mock("@/components/brain/right-sidebar/WaveContent", () => ({
   __esModule: true,
   WaveContent: (props: any) => (
     <div
@@ -31,13 +31,13 @@ jest.mock('@/components/brain/right-sidebar/WaveContent', () => ({
   ),
 }));
 
-jest.mock('@tanstack/react-query');
-jest.mock('@/components/brain/my-stream/layout/LayoutContext');
+jest.mock("@tanstack/react-query");
+jest.mock("@/components/brain/my-stream/layout/LayoutContext");
 
 const mockUseQuery = useQuery as jest.Mock;
 const mockUseLayout = useLayout as jest.Mock;
 
-const wave = { id: '1' } as any;
+const wave = { id: "1" } as any;
 const setActiveTab = jest.fn();
 
 beforeEach(() => {
@@ -45,23 +45,24 @@ beforeEach(() => {
   mockUseLayout.mockReturnValue({ mobileAboutViewStyle: {} });
 });
 
-test('renders the shared right-panel content without a nested tab row', () => {
+test("renders the shared right-panel content without a nested tab row", () => {
   mockUseQuery.mockReturnValue({ data: wave });
-  render(
+  const { container } = render(
     <BrainMobileAbout
       activeWaveId="1"
       activeTab={SidebarTab.ABOUT}
       setActiveTab={setActiveTab}
     />
   );
-  expect(screen.getByTestId('wave-content')).toBeInTheDocument();
-  expect(screen.getByTestId('wave-content')).toHaveAttribute(
-    'data-show-tabs',
-    'false'
+  expect(screen.getByTestId("wave-content")).toBeInTheDocument();
+  expect(screen.getByTestId("wave-content")).toHaveAttribute(
+    "data-show-tabs",
+    "false"
   );
+  expect(container.firstElementChild).toHaveClass("tw-bg-iron-950");
 });
 
-test('toggles to followers view and back', async () => {
+test("toggles to followers view and back", async () => {
   mockUseQuery.mockReturnValue({ data: wave });
   const user = userEvent.setup();
   render(
@@ -71,14 +72,14 @@ test('toggles to followers view and back', async () => {
       setActiveTab={setActiveTab}
     />
   );
-  const content = screen.getByTestId('wave-content');
-  await user.click(screen.getByTestId('toggle-followers'));
-  expect(content).toHaveAttribute('data-mode', Mode.FOLLOWERS);
-  await user.click(screen.getByTestId('toggle-followers'));
-  expect(content).toHaveAttribute('data-mode', Mode.CONTENT);
+  const content = screen.getByTestId("wave-content");
+  await user.click(screen.getByTestId("toggle-followers"));
+  expect(content).toHaveAttribute("data-mode", Mode.FOLLOWERS);
+  await user.click(screen.getByTestId("toggle-followers"));
+  expect(content).toHaveAttribute("data-mode", Mode.CONTENT);
 });
 
-test('renders nothing when no wave data', () => {
+test("renders nothing when no wave data", () => {
   mockUseQuery.mockReturnValue({ data: undefined });
   const { container } = render(
     <BrainMobileAbout

--- a/__tests__/components/brain/right-sidebar/WaveContent.test.tsx
+++ b/__tests__/components/brain/right-sidebar/WaveContent.test.tsx
@@ -14,8 +14,8 @@ jest.mock("@/components/waves/header/WaveHeader", () => ({
 
 jest.mock("@/components/common/TabToggleWithOverflow", () => ({
   __esModule: true,
-  TabToggleWithOverflow: ({ options, activeKey }: any) => (
-    <div data-testid="tabs">
+  TabToggleWithOverflow: ({ options, activeKey, maxVisibleTabs }: any) => (
+    <div data-testid="tabs" data-max-visible-tabs={maxVisibleTabs}>
       {activeKey}-{options.map((option: any) => option.label).join(",")}
     </div>
   ),
@@ -74,6 +74,7 @@ describe("WaveContent", () => {
       "ABOUT-About,Rules,REP,Settings"
     );
     expect(screen.getByText("content")).toBeInTheDocument();
+    expect(container.firstElementChild).toHaveClass("tw-bg-iron-950");
     expect(container.querySelector(".tw-divide-y")).toHaveClass(
       "tw-divide-white/5"
     );
@@ -178,6 +179,10 @@ describe("WaveContent", () => {
     );
     expect(screen.getByTestId("tabs")).toHaveTextContent(
       "ABOUT-About,Rules,REP,Settings,Voters,Activity"
+    );
+    expect(screen.getByTestId("tabs")).toHaveAttribute(
+      "data-max-visible-tabs",
+      "4"
     );
     expect(screen.getByTestId("tabs")).not.toHaveTextContent("Leaderboard");
     expect(screen.getByTestId("tabs")).not.toHaveTextContent("Winners");

--- a/__tests__/components/waves/header/WaveHeader.test.tsx
+++ b/__tests__/components/waves/header/WaveHeader.test.tsx
@@ -201,7 +201,7 @@ describe("WaveHeader", () => {
     );
     expect(
       screen.getByTestId("wave-header-options").parentElement?.className
-    ).toContain("tw-mt-[22px]");
+    ).toContain("tw-mt-3.5");
     expect(screen.queryByTestId("wave-header-pin")).toBeNull();
   });
 

--- a/components/brain/BrainMobile.tsx
+++ b/components/brain/BrainMobile.tsx
@@ -140,9 +140,9 @@ const BrainMobileContent: React.FC<Props> = ({ children }) => {
     !waveId ||
     Boolean(
       wave &&
-        !fetchingProfile &&
-        !(isCompetitionWave && isWaveMetadataPending) &&
-        !isWavePollsPending
+      !fetchingProfile &&
+      !(isCompetitionWave && isWaveMetadataPending) &&
+      !isWavePollsPending
     );
   const { activeView, onViewChange } = useBrainMobileActiveView({
     firstDecisionDone,

--- a/components/brain/BrainMobile.tsx
+++ b/components/brain/BrainMobile.tsx
@@ -53,6 +53,7 @@ import { useWaveListSwipeBack } from "./mobile/useWaveListSwipeBack";
 import { SidebarTab } from "./right-sidebar/BrainRightSidebarTypes";
 import { WaveContentTabs } from "./right-sidebar/WaveContent";
 import { waveRightPanelText } from "@/helpers/waves/wave-right-panel.helpers";
+import { useLayout } from "./my-stream/layout/LayoutContext";
 
 interface Props {
   readonly children: ReactNode;
@@ -69,6 +70,7 @@ const BrainMobileContent: React.FC<Props> = ({ children }) => {
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const { isApp } = useDeviceInfo();
+  const { registerRef } = useLayout();
   const { connectedProfile, fetchingProfile } = useAuth();
   const hasAuthenticatedProfile = Boolean(connectedProfile?.handle);
   const quickVote = useMemesQuickVoteRuntimeLauncher();
@@ -176,6 +178,12 @@ const BrainMobileContent: React.FC<Props> = ({ children }) => {
       setAboutTabState({ waveId: currentWaveId, activeTab: tab });
     },
     [currentWaveId]
+  );
+  const setInformationTabsRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      registerRef?.("pinned", element);
+    },
+    [registerRef]
   );
 
   const onDropClick = (selectedDrop: ExtendedDrop) => {
@@ -298,16 +306,18 @@ const BrainMobileContent: React.FC<Props> = ({ children }) => {
       {isApp &&
         wave &&
         (activeView === BrainView.ABOUT ? (
-          <WaveContentTabs
-            wave={wave}
-            activeTab={activeAboutTab}
-            setActiveTab={onAboutTabChange}
-            maxVisibleTabs={3}
-            variant="compactPills"
-            aboutTabLabel={waveRightPanelText(
-              "waves.sidebar.rightPanel.tabs.overview"
-            )}
-          />
+          <div ref={setInformationTabsRef}>
+            <WaveContentTabs
+              wave={wave}
+              activeTab={activeAboutTab}
+              setActiveTab={onAboutTabChange}
+              maxVisibleTabs={3}
+              variant="compactPills"
+              aboutTabLabel={waveRightPanelText(
+                "waves.sidebar.rightPanel.tabs.overview"
+              )}
+            />
+          </div>
         ) : (
           <MobileWaveSubwavesBar wave={wave} />
         ))}

--- a/components/brain/mobile/BrainMobileAbout.tsx
+++ b/components/brain/mobile/BrainMobileAbout.tsx
@@ -36,7 +36,10 @@ const BrainMobileAbout: React.FC<BrainMobileAboutProps> = ({
   const { mobileAboutViewStyle } = useLayout();
 
   return (
-    <div className="tw-min-h-0 tw-overflow-hidden" style={mobileAboutViewStyle}>
+    <div
+      className="tw-min-h-0 tw-overflow-hidden tw-bg-iron-950"
+      style={mobileAboutViewStyle}
+    >
       {wave && (
         <WaveContent
           wave={wave}

--- a/components/brain/right-sidebar/WaveContent.tsx
+++ b/components/brain/right-sidebar/WaveContent.tsx
@@ -126,6 +126,7 @@ export const WaveContent: React.FC<WaveContentProps> = ({
   const isRankWave = wave.wave.type === ApiWaveType.Rank;
   const isApproveWave = wave.wave.type === ApiWaveType.Approve;
   const isCompetitionWave = isRankWave || isApproveWave;
+  const visibleTabLimit = maxVisibleTabs ?? (isCompetitionWave ? 4 : undefined);
 
   const sidebarTabComponents: Partial<Record<SidebarTab, JSX.Element>> = {
     [SidebarTab.ABOUT]: (
@@ -174,13 +175,13 @@ export const WaveContent: React.FC<WaveContentProps> = ({
   const activeSidebarComponent = sidebarTabComponents[activeSidebarTab];
 
   return (
-    <div className="tw-flex tw-h-full tw-min-h-0 tw-min-w-0 tw-flex-col tw-overflow-hidden">
+    <div className="tw-flex tw-h-full tw-min-h-0 tw-min-w-0 tw-flex-col tw-overflow-hidden tw-bg-iron-950">
       {showTabs && (
         <WaveContentTabs
           wave={wave}
           activeTab={activeSidebarTab}
           setActiveTab={setActiveTab}
-          maxVisibleTabs={maxVisibleTabs}
+          maxVisibleTabs={visibleTabLimit}
           variant={tabVariant}
           aboutTabLabel={aboutTabLabel}
         />

--- a/components/brain/right-sidebar/WaveRepDetails.tsx
+++ b/components/brain/right-sidebar/WaveRepDetails.tsx
@@ -284,12 +284,12 @@ export default function WaveRepDetails({ wave }: WaveRepDetailsProps) {
   const isShowingPreviousContributors = contributorsQuery.isPlaceholderData;
 
   return (
-    <div className="tw-flex tw-h-full tw-flex-col tw-gap-4 tw-p-4 tw-@container/rep">
+    <div className="tw-flex tw-min-h-full tw-flex-col tw-gap-4 tw-p-4 tw-@container/rep">
       <section aria-label={detailText("waves.rep.details.summary.title")}>
         <div className="tw-overflow-hidden tw-border-x-0 tw-border-y tw-border-solid tw-border-white/5">
           <div className="tw-flex tw-items-end tw-justify-between tw-gap-4 tw-px-2 tw-py-2.5">
             <div className="tw-min-w-0">
-              <p className="tw-mb-1 tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-tracking-[0.1em] tw-text-iron-500">
+              <p className="tw-mb-1 tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-iron-500 sm:tw-tracking-[0.1em]">
                 {detailText("waves.rep.details.summary.total")}
               </p>
               <p
@@ -300,7 +300,7 @@ export default function WaveRepDetails({ wave }: WaveRepDetailsProps) {
                 {formatSignedRep(summary.totalRep)}
               </p>
             </div>
-            <span className="tw-max-w-32 tw-text-right tw-text-[0.6875rem] tw-font-medium tw-leading-4 tw-text-iron-500">
+            <span className="tw-max-w-32 tw-text-right tw-text-xs tw-font-medium tw-leading-4 tw-text-iron-500">
               {getContributorCountLabel(summary.contributorCount)}
             </span>
           </div>
@@ -334,7 +334,7 @@ export default function WaveRepDetails({ wave }: WaveRepDetailsProps) {
         <div className="tw-mb-2 tw-flex tw-items-center tw-justify-between tw-gap-3">
           <h2
             id="wave-rep-categories-heading"
-            className="tw-mb-0 !tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.1em] !tw-text-iron-400"
+            className="tw-mb-0 !tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.06em] !tw-text-iron-400 sm:tw-tracking-[0.1em]"
           >
             {detailText("waves.rep.details.categories.title")}
           </h2>
@@ -432,7 +432,7 @@ export default function WaveRepDetails({ wave }: WaveRepDetailsProps) {
         )}
       </section>
 
-      <div className="tw-sticky tw-top-0 tw-z-20 tw--mx-4 tw-flex tw-flex-col tw-bg-iron-950/95 tw-px-4 tw-py-2 tw-backdrop-blur">
+      <div className="tw-sticky tw-top-0 tw-z-20 tw-flex tw-flex-col tw-bg-iron-950/95 tw-py-2 tw-backdrop-blur">
         <fieldset className="tw-m-0 tw-grid tw-min-w-0 tw-grid-cols-2 tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-white/5 tw-p-0">
           <legend className="tw-sr-only">
             {detailText("waves.rep.details.view.ariaLabel")}
@@ -470,7 +470,7 @@ export default function WaveRepDetails({ wave }: WaveRepDetailsProps) {
             <div className="tw-min-w-0">
               <h2
                 id="wave-rep-contributors-heading"
-                className="tw-mb-0 !tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.08em] !tw-text-iron-400"
+                className="tw-mb-0 !tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.06em] !tw-text-iron-400 sm:tw-tracking-[0.1em]"
               >
                 {contributorHeading}
               </h2>
@@ -573,7 +573,7 @@ export default function WaveRepDetails({ wave }: WaveRepDetailsProps) {
             <div>
               <h2
                 id="wave-rep-activity-heading"
-                className="tw-mb-0 !tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.08em] !tw-text-iron-400"
+                className="tw-mb-0 !tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.06em] !tw-text-iron-400 sm:tw-tracking-[0.1em]"
               >
                 {detailText("waves.rep.details.activity.title")}
               </h2>

--- a/components/brain/right-sidebar/WaveRepDetailsComponents.tsx
+++ b/components/brain/right-sidebar/WaveRepDetailsComponents.tsx
@@ -114,12 +114,12 @@ export function SummaryStat({
 }) {
   return (
     <div className="tw-min-w-0 tw-bg-iron-950 tw-px-2 tw-py-2">
-      <p className="tw-mb-0.5 tw-text-[0.5625rem] tw-font-semibold tw-uppercase tw-tracking-[0.1em] tw-text-iron-500">
+      <p className="tw-mb-0.5 tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-iron-500 sm:tw-tracking-[0.1em]">
         {label}
       </p>
       <p
         title={value}
-        className={`tw-mb-0 tw-whitespace-nowrap tw-text-[0.8125rem] tw-font-semibold tw-tabular-nums ${toneClassName}`}
+        className={`tw-mb-0 tw-whitespace-nowrap tw-text-sm tw-font-semibold tw-tabular-nums ${toneClassName}`}
       >
         {value}
       </p>

--- a/components/common/TabToggleWithOverflow.tsx
+++ b/components/common/TabToggleWithOverflow.tsx
@@ -39,8 +39,8 @@ const getTabStateClassName = ({
 }): string => {
   if (isCompactPills) {
     return isActive
-      ? "tw-border-violet-400/40 tw-bg-violet-500/15 tw-font-semibold tw-text-violet-200"
-      : "tw-border-white/[0.08] tw-bg-white/[0.035] tw-font-medium tw-text-iron-300 active:tw-bg-white/[0.08] desktop-hover:hover:tw-border-white/[0.12] desktop-hover:hover:tw-bg-white/[0.07] desktop-hover:hover:tw-text-iron-100";
+      ? "tw-border-iron-600 tw-bg-iron-800 tw-font-semibold tw-text-iron-50"
+      : "tw-border-transparent tw-bg-transparent tw-font-medium tw-text-iron-400 active:tw-bg-iron-800/60 desktop-hover:hover:tw-bg-iron-900 desktop-hover:hover:tw-text-iron-200";
   }
 
   return isActive
@@ -191,7 +191,7 @@ export const TabToggleWithOverflow: React.FC<TabToggleWithOverflowProps> = ({
             className={clsx(
               "tw-whitespace-nowrap tw-border-solid tw-transition-colors tw-duration-150 focus-visible:tw-outline-none focus-visible:tw-ring-inset motion-reduce:tw-transition-none",
               isCompactPills
-                ? "tw-inline-flex tw-h-7 tw-flex-none tw-items-center tw-rounded-full tw-border tw-px-2 tw-text-xs focus-visible:tw-ring-1 focus-visible:tw-ring-violet-300/70"
+                ? "tw-inline-flex tw-h-7 tw-flex-none tw-items-center tw-rounded-full tw-border tw-px-2 tw-text-xs focus-visible:tw-ring-1 focus-visible:tw-ring-iron-400/70"
                 : "-tw-mb-px tw-flex-1 tw-border-x-0 tw-border-b-2 tw-border-t-0 tw-bg-transparent tw-py-3 tw-text-sm focus-visible:tw-ring-2 focus-visible:tw-ring-primary-300",
               fullWidth && "tw-flex tw-justify-center tw-text-center",
               getTabStateClassName({
@@ -214,7 +214,7 @@ export const TabToggleWithOverflow: React.FC<TabToggleWithOverflowProps> = ({
           triggerClassName={clsx(
             "tw-whitespace-nowrap tw-border-solid tw-transition-colors tw-duration-150 focus-visible:tw-outline-none focus-visible:tw-ring-inset motion-reduce:tw-transition-none",
             isCompactPills
-              ? "tw-inline-flex tw-h-7 tw-flex-none tw-items-center tw-rounded-full tw-border tw-px-2 tw-text-xs focus-visible:tw-ring-1 focus-visible:tw-ring-violet-300/70"
+              ? "tw-inline-flex tw-h-7 tw-flex-none tw-items-center tw-rounded-full tw-border tw-px-2 tw-text-xs focus-visible:tw-ring-1 focus-visible:tw-ring-iron-400/70"
               : "-tw-mb-px tw-flex-1 tw-border-x-0 tw-border-b-2 tw-border-t-0 tw-bg-transparent tw-py-3 tw-text-sm focus-visible:tw-ring-2 focus-visible:tw-ring-primary-300",
             getTabStateClassName({
               isActive: isActiveInOverflow,
@@ -239,12 +239,14 @@ export const TabToggleWithOverflow: React.FC<TabToggleWithOverflowProps> = ({
           itemClassName="tw-block tw-w-full tw-border-0 tw-bg-transparent tw-px-4 tw-py-2 tw-text-left tw-text-sm tw-font-medium tw-transition-colors"
           inactiveItemClassName="tw-text-iron-300 hover:tw-bg-iron-800 hover:tw-text-iron-200"
           activeItemClassName={
-            isCompactPills ? "tw-text-violet-200" : "tw-text-primary-300"
+            isCompactPills ? "tw-text-iron-50" : "tw-text-primary-300"
           }
           focusItemClassName="tw-bg-iron-800 tw-text-iron-100"
           menuWidthClassName="tw-w-36"
-          menuClassName="tw-z-50 tw-mt-2 tw-rounded-md tw-bg-iron-900 tw-py-1 tw-shadow-lg tw-ring-1 tw-ring-primary-400/20 focus:tw-outline-none"
-          itemsWrapperClassName="tw-py-1"
+          menuClassName={clsx(
+            "tw-z-50 tw-mt-2 tw-rounded-md tw-bg-iron-900 tw-py-1 tw-shadow-lg tw-ring-1 focus:tw-outline-none",
+            isCompactPills ? "tw-ring-white/10" : "tw-ring-primary-400/20"
+          )}
           anchor="bottom end"
           activeItemId={isActiveInOverflow ? activeKey : undefined}
           closeOnSelect

--- a/components/waves/groups/WaveSettingsSections.tsx
+++ b/components/waves/groups/WaveSettingsSections.tsx
@@ -33,7 +33,7 @@ const SettingsSection = ({
 }) => (
   <section className="tw-px-4 tw-py-4">
     <div className="tw-flex tw-items-start tw-justify-between tw-gap-x-6">
-      <h2 className="tw-mb-0 !tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.1em] !tw-text-iron-400">
+      <h2 className="tw-mb-0 !tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.06em] !tw-text-iron-400 sm:tw-tracking-[0.1em]">
         {title}
       </h2>
     </div>

--- a/components/waves/header/WaveHeader.tsx
+++ b/components/waves/header/WaveHeader.tsx
@@ -81,7 +81,7 @@ export default function WaveHeader({
   const showOptions = showOwnerOptions;
   const showPinAction = !isSubwave;
   const showTrustStats = !isDirectMessage;
-  const titleActionAlignmentClass = isSubwave ? "tw-mt-[22px]" : "";
+  const titleActionAlignmentClass = isSubwave ? "tw-mt-3.5" : "";
   const createdDate = formatDate(
     WAVE_HEADER_LOCALE,
     Time.millis(wave.created_at).toDate()

--- a/components/waves/header/WaveHeaderTrustStats.tsx
+++ b/components/waves/header/WaveHeaderTrustStats.tsx
@@ -167,10 +167,10 @@ export default function WaveHeaderTrustStats({
               <Icon className="tw-size-3.5" aria-hidden="true" />
             </span>
             <div className="tw-flex tw-min-w-0 tw-flex-col tw-gap-0.5">
-              <dt className="tw-truncate tw-text-[0.5625rem] tw-font-semibold tw-uppercase tw-leading-3 tw-tracking-[0.1em] tw-text-iron-500">
+              <dt className="tw-truncate tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-leading-3 tw-tracking-[0.06em] tw-text-iron-500 sm:tw-tracking-[0.1em]">
                 {stat.label}
               </dt>
-              <dd className="tw-m-0 tw-truncate tw-text-sm tw-font-medium tw-tabular-nums tw-leading-5 tw-text-iron-100">
+              <dd className="tw-m-0 tw-truncate tw-text-sm tw-font-semibold tw-tabular-nums tw-leading-5 tw-text-iron-100">
                 {stat.value}
               </dd>
             </div>

--- a/components/waves/header/name/WaveHeaderName.tsx
+++ b/components/waves/header/name/WaveHeaderName.tsx
@@ -18,11 +18,11 @@ export default function WaveHeaderName({ wave }: { readonly wave: ApiWave }) {
     canEditWave({ connectedProfile, activeProfileProxy, wave });
 
   return (
-    <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-gap-y-1">
+    <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col">
       {parentWave && parentWaveName && (
         <nav
           aria-label="Wave hierarchy"
-          className="tw-flex tw-min-w-0 tw-items-center tw-gap-x-1.5 tw-text-xs tw-leading-5"
+          className="tw-flex tw-min-w-0 tw-items-center tw-gap-x-1.5 tw-text-xs tw-leading-4"
         >
           <span className="tw-shrink-0 tw-font-medium tw-text-iron-400">
             Subwave of

--- a/components/waves/specs/WaveRulesPanel.tsx
+++ b/components/waves/specs/WaveRulesPanel.tsx
@@ -27,7 +27,7 @@ function WaveRulesCustomSection({
   if (!hasCustomRules(custom)) {
     return (
       <section className="tw-px-4 tw-py-4">
-        <Heading className="tw-mb-0 !tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.08em] !tw-text-iron-400">
+        <Heading className="tw-mb-0 !tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.06em] !tw-text-iron-400 sm:tw-tracking-[0.1em]">
           {waveRightPanelText("waves.sidebar.rightPanel.rules.creatorTitle")}
         </Heading>
         <p className="tw-mb-0 tw-mt-3 tw-text-sm tw-font-light tw-italic tw-leading-5 tw-text-iron-500">
@@ -39,13 +39,13 @@ function WaveRulesCustomSection({
 
   return (
     <section className="tw-px-4 tw-py-4">
-      <Heading className="tw-mb-0 !tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.08em] !tw-text-iron-400">
+      <Heading className="tw-mb-0 !tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.06em] !tw-text-iron-400 sm:tw-tracking-[0.1em]">
         {waveRightPanelText("waves.sidebar.rightPanel.rules.creatorTitle")}
       </Heading>
       <div className="tw-mt-3 tw-flex tw-flex-col tw-gap-3">
         {custom.display && (
           <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/5 tw-pt-3">
-            <p className="tw-mb-2 tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-tracking-[0.08em] tw-text-iron-500">
+            <p className="tw-mb-2 tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-iron-500 sm:tw-tracking-[0.08em]">
               {waveRightPanelText("waves.sidebar.rightPanel.rules.displayOnly")}
             </p>
             <p className="tw-mb-0 tw-whitespace-pre-wrap tw-break-words tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-100">
@@ -55,7 +55,7 @@ function WaveRulesCustomSection({
         )}
         {custom.binding && (
           <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-primary-400/15 tw-pt-3">
-            <p className="tw-mb-2 tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-tracking-[0.08em] tw-text-primary-300">
+            <p className="tw-mb-2 tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-primary-300 sm:tw-tracking-[0.08em]">
               {waveRightPanelText(
                 "waves.sidebar.rightPanel.rules.requiresAcceptance"
               )}
@@ -98,7 +98,7 @@ export default function WaveRulesPanel({
     >
       {showTitle && (
         <div className="tw-px-4 tw-pt-6">
-          <h2 className="tw-mb-0 !tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.1em] !tw-text-iron-400">
+          <h2 className="tw-mb-0 !tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.06em] !tw-text-iron-400 sm:tw-tracking-[0.1em]">
             {resolvedTitle}
           </h2>
         </div>
@@ -107,7 +107,7 @@ export default function WaveRulesPanel({
       <div className="tw-divide-x-0 tw-divide-y tw-divide-solid tw-divide-iron-800">
         {rules.automatic.map((section) => (
           <section key={section.id} className="tw-px-4 tw-py-4">
-            <SectionHeading className="tw-mb-2.5 !tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.08em] !tw-text-iron-300">
+            <SectionHeading className="tw-mb-2.5 !tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.06em] !tw-text-iron-400 sm:tw-tracking-[0.1em]">
               {section.title}
             </SectionHeading>
             <dl className="tw-mb-0 tw-divide-x-0 tw-divide-y tw-divide-solid tw-divide-white/5">

--- a/components/waves/specs/WaveSpecs.tsx
+++ b/components/waves/specs/WaveSpecs.tsx
@@ -42,8 +42,8 @@ export default function WaveSpecs({ wave, useRing = true }: WaveSpecsProps) {
       className={`tw-relative tw-min-w-0 tw-overflow-hidden tw-bg-iron-950 ${ringClasses}`}
     >
       <div className="tw-pb-4">
-        <div className="tw-flex tw-items-center tw-justify-between tw-px-4 tw-pt-6">
-          <h2 className="tw-mb-0 !tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.1em] !tw-text-iron-400">
+        <div className="tw-flex tw-items-center tw-justify-between tw-px-4 tw-pt-4">
+          <h2 className="tw-mb-0 !tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.06em] !tw-text-iron-400 sm:tw-tracking-[0.1em]">
             {waveRightPanelText("waves.sidebar.rightPanel.specs.overview")}
           </h2>
         </div>

--- a/ops/docs/waves/sidebars/feature-right-sidebar-tabs.md
+++ b/ops/docs/waves/sidebars/feature-right-sidebar-tabs.md
@@ -43,10 +43,13 @@ linked section pages.
 
 ## Overflow and Keyboard Behavior
 
-- Desktop keeps every available section as a direct tab and scrolls the strip
-  horizontally when needed.
+- Desktop keeps the four base sections visible and moves competition-only
+  `Voters` and `Activity` into `More`, so the fixed-width panel never clips a
+  section label.
 - Native keeps three compact pills visible and moves remaining sections into
-  `More`, avoiding a compressed desktop tab row on narrow phones.
+  `More`, avoiding a compressed desktop-style tab row on narrow phones.
+- The contextual row and every section share the same panel canvas, including
+  the native app where the surrounding wave view uses a different background.
 - The native information and subwave bars use the same height, background,
   responsive insets, pill height, and label size, so switching the contextual
   row does not shift the content below it. Active information pills use a
@@ -63,8 +66,8 @@ linked section pages.
 
 1. Open a wave thread on `/waves/{waveId}` or `/messages/{waveId}`.
 2. Open the right sidebar.
-3. Select a desktop tab or native information pill. Use `More` for secondary
-   native sections.
+3. Select a desktop tab or native information pill. Use `More` for the
+   remaining sections.
 4. Sidebar content switches in place without route navigation. On native,
    selecting another main tab swaps the contextual row back to subwave pills.
 

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -1872,7 +1872,7 @@
       ],
       "facts": [
         "Desktop wave information sections live in the right sidebar and begin with About, followed by Rules, REP, and Settings.",
-        "For Rank and Approve waves, the desktop right sidebar also includes Voters and Activity.",
+        "For Rank and Approve waves, the desktop right sidebar exposes Voters and Activity from More after the four base sections.",
         "In the native app, the main About view opens compact Overview, Rules, and REP pills; More exposes the remaining sections.",
         "While native About is active, its information pills replace the subwave pills in the same contextual row; selecting another main tab restores the subwave pills.",
         "In the native app, More contains Settings and, for Rank and Approve waves, Voters and Activity.",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -1872,7 +1872,7 @@
       ],
       "facts": [
         "Desktop wave information sections live in the right sidebar and begin with About, followed by Rules, REP, and Settings.",
-        "For Rank and Approve waves, the desktop right sidebar also includes Voters and Activity.",
+        "For Rank and Approve waves, the desktop right sidebar exposes Voters and Activity from More after the four base sections.",
         "In the native app, the main About view opens compact Overview, Rules, and REP pills; More exposes the remaining sections.",
         "While native About is active, its information pills replace the subwave pills in the same contextual row; selecting another main tab restores the subwave pills.",
         "In the native app, More contains Settings and, for Rank and Approve waves, Voters and Activity.",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -7,7 +7,7 @@ Site data such as TDH, REP, and Wave activity changes continuously. Fetch the fi
 ## Machine-readable files
 
 - [llms.txt](https://6529.io/llms.txt): this file — the stable entry point.
-- [help-index.json](https://6529.io/help-index.json): 193 curated records covering routes, workflows, UI affordances, business rules, and glossary terms. Each record has an id, title, aliases, facts, and a canonical_path that is validated against the app's real routes at build time. This is the primary reference for answering questions about 6529.io.
+- [help-index.json](https://6529.io/help-index.json): 194 curated records covering routes, workflows, UI affordances, business rules, and glossary terms. Each record has an id, title, aliases, facts, and a canonical_path that is validated against the app's real routes at build time. This is the primary reference for answering questions about 6529.io.
 - [glossary.json](https://6529.io/glossary.json): 27 term definitions (TDH, xTDH, REP, NIC, Waves, Drops, Groups, Subscriptions, and more) projected from the same help corpus. Each term carries its help-index record id, definition facts, and canonical page path.
 - [sitemap.xml](https://6529.io/sitemap.xml): the crawlable page list, regenerated on every deploy.
 - [robots.txt](https://6529.io/robots.txt): standard crawler directives; it also references the files above.


### PR DESCRIPTION
## Issue

The wave information panel was visually inconsistent across desktop and the native mobile app. About, Rules, REP, Settings, Voters, and Activity used uneven canvases, typography, spacing, and overflow behavior; on mobile, the added section navigation could also leave scrollable content hidden behind the bottom bar.

This is limited to the wave information panel. Primary wave tabs such as Leaderboard and Chat are unchanged.

## Fix

- Give the shared information-panel content and native About host the same dark canvas.
- Keep About, Rules, REP, and Settings directly visible in desktop competition panels, with Voters and Activity in the accessible More menu.
- Preserve the compact native Overview, Rules, REP, and More navigation while removing excess menu whitespace.
- Measure the mobile section-navigation row and include its real height in the content inset so every subview scrolls fully above the bottom bar.
- Keep long REP, contributors, and activity content inside the correct scroll container and clear of the scrollbar.
- Unify heading, label, metric, and value typography across Overview, Rules, REP, and related views.
- Tighten the subwave/title hierarchy and use restrained neutral colors for the compact section pills without changing their height or padding.
- Update focused tests, sidebar documentation, and the Help Bot index.

## Validation

- Focused Jest suites: 2 passed, 12 tests passed
- Changed-file ESLint: passed on the latest merged tree
- Changed-file typecheck: passed for 12 changed TypeScript files on the latest merged tree
- Full TypeScript typecheck: passed
- Diff lint: passed
- React Doctor: 100/100 for the original panel change set
- Help index sync: passed
- Whitespace validation: passed
- Desktop and narrow-browser visual QA covered the information sections and More menu
- Native development build installed and launched successfully on a physical iPhone; the compact navigation, dropdown, scrolling, safe-area clearance, typography, and hierarchy were reviewed there

The aggregate changed-file check completed formatting, typecheck, and lint, then stopped at existing repository-wide Knip findings in unrelated scripts and exports.

## Risk

Low. The work is scoped to panel styling and mobile layout measurement. The dynamic inset uses the existing pinned-navigation boundary and updates from the rendered row height, so device and label-size differences do not rely on a fixed offset.

## Review notes

Please focus on mobile safe-area/bottom-bar clearance, the compact section navigation and More menu, and typography consistency between Overview, Rules, and REP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pinned the overview tabs area on mobile.
  * Enhanced Rank/Approve wave right sidebars by showing the first four sections directly and moving **Voters** and **Activity** into **More**.
* **UI Updates**
  * Improved dark/iron styling for wave sidebars and compact pill tabs/overflow, with refined typography/spacing across wave header/details/specs.
* **Documentation**
  * Updated right-sidebar tabs guidance and help text to reflect **More** placement.
* **Tests**
  * Expanded wave content/tab behavior and followers-vs-content toggle coverage, including tab visibility limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->