### PR TITLE
Fix Join 6529 checklist progress

### DIFF
--- a/__tests__/app/join/journeyFacts.test.ts
+++ b/__tests__/app/join/journeyFacts.test.ts
@@ -1,0 +1,43 @@
+import {
+  hasCollectedSupportedNft,
+  hasPublicWavePost,
+} from "@/app/join/journeyFacts";
+import type { ApiCollectedStats } from "@/generated/models/ApiCollectedStats";
+
+const EMPTY_COLLECTED_STATS: ApiCollectedStats = {
+  boost: 0,
+  gradients_balance: 0,
+  memes_balance: 0,
+  nextgen_balance: 0,
+  seasons: [],
+  unique_memes: 0,
+};
+
+describe("Join 6529 journey facts", () => {
+  it.each(["memes_balance", "nextgen_balance", "gradients_balance"] as const)(
+    "treats a positive %s as collected",
+    (balanceKey) => {
+      expect(
+        hasCollectedSupportedNft({
+          ...EMPTY_COLLECTED_STATS,
+          [balanceKey]: 1,
+        })
+      ).toBe(true);
+    }
+  );
+
+  it("does not treat zero supported balances as collected", () => {
+    expect(hasCollectedSupportedNft(EMPTY_COLLECTED_STATS)).toBe(false);
+    expect(hasCollectedSupportedNft(undefined)).toBe(false);
+  });
+
+  it("treats any positive daily public drop count as participation", () => {
+    expect(hasPublicWavePost({ date_samples: [0, 0, 1, 0] })).toBe(true);
+  });
+
+  it("does not treat empty or zero activity as participation", () => {
+    expect(hasPublicWavePost({ date_samples: [0, 0, 0] })).toBe(false);
+    expect(hasPublicWavePost({ date_samples: [] })).toBe(false);
+    expect(hasPublicWavePost(undefined)).toBe(false);
+  });
+});

--- a/__tests__/app/join/journeyProgress.test.ts
+++ b/__tests__/app/join/journeyProgress.test.ts
@@ -1,13 +1,18 @@
 import { buildJoinJourneyProgress } from "@/app/join/journeyProgress";
 import { TIMELINE_ITEM_SPECS, TIMELINE_ORDER } from "@/app/join/page.content";
 
+const NO_OPTIONAL_FACTS = {
+  hasCollected: false,
+  hasParticipated: false,
+} as const;
+
 describe("Join 6529 journey progress", () => {
   it("keeps the timeline order derived from the rendered item specs", () => {
     expect(TIMELINE_ORDER).toEqual(TIMELINE_ITEM_SPECS.map((item) => item.id));
   });
 
   it("keeps progress hidden and neutral before a wallet is connected", () => {
-    const progress = buildJoinJourneyProgress("loggedOut");
+    const progress = buildJoinJourneyProgress("loggedOut", NO_OPTIONAL_FACTS);
 
     expect(progress.visible).toBe(false);
     expect(progress.completed).toBe(0);
@@ -18,7 +23,7 @@ describe("Join 6529 journey progress", () => {
   });
 
   it("marks profile as current after wallet connection", () => {
-    const progress = buildJoinJourneyProgress("inProgress");
+    const progress = buildJoinJourneyProgress("inProgress", NO_OPTIONAL_FACTS);
 
     expect(progress.visible).toBe(true);
     expect(progress.completed).toBe(1);
@@ -29,7 +34,7 @@ describe("Join 6529 journey progress", () => {
   });
 
   it("marks the starter path complete for logged-in members", () => {
-    const progress = buildJoinJourneyProgress("loggedIn");
+    const progress = buildJoinJourneyProgress("loggedIn", NO_OPTIONAL_FACTS);
 
     expect(progress.visible).toBe(true);
     expect(progress.completed).toBe(3);
@@ -40,5 +45,41 @@ describe("Join 6529 journey progress", () => {
     expect(progress.statuses.waves).toBe("complete");
     expect(progress.statuses.message).toBe("pending");
     expect(progress.statuses.collect).toBe("pending");
+  });
+
+  it("marks participation complete when public drop activity exists", () => {
+    const progress = buildJoinJourneyProgress("loggedIn", {
+      hasCollected: false,
+      hasParticipated: true,
+    });
+
+    expect(progress.completed).toBe(4);
+    expect(progress.percent).toBe(80);
+    expect(progress.statuses.message).toBe("complete");
+    expect(progress.statuses.collect).toBe("pending");
+  });
+
+  it("marks collection complete when a supported NFT balance exists", () => {
+    const progress = buildJoinJourneyProgress("loggedIn", {
+      hasCollected: true,
+      hasParticipated: false,
+    });
+
+    expect(progress.completed).toBe(4);
+    expect(progress.percent).toBe(80);
+    expect(progress.statuses.message).toBe("pending");
+    expect(progress.statuses.collect).toBe("complete");
+  });
+
+  it("marks all five steps complete when both optional facts exist", () => {
+    const progress = buildJoinJourneyProgress("loggedIn", {
+      hasCollected: true,
+      hasParticipated: true,
+    });
+
+    expect(progress.completed).toBe(5);
+    expect(progress.percent).toBe(100);
+    expect(progress.statuses.message).toBe("complete");
+    expect(progress.statuses.collect).toBe("complete");
   });
 });

--- a/__tests__/app/join/useJoin6529Facts.test.tsx
+++ b/__tests__/app/join/useJoin6529Facts.test.tsx
@@ -1,0 +1,85 @@
+import { useJoin6529Facts } from "@/app/join/useJoin6529Facts";
+import type { ApiCollectedStats } from "@/generated/models/ApiCollectedStats";
+import { useIdentityActivity } from "@/hooks/useIdentityActivity";
+import { commonApiFetch } from "@/services/api/common-api";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+jest.mock("@/hooks/useIdentityActivity", () => ({
+  useIdentityActivity: jest.fn(),
+}));
+
+jest.mock("@/services/api/common-api", () => ({
+  commonApiFetch: jest.fn(),
+}));
+
+const activityMock = useIdentityActivity as jest.Mock;
+const apiMock = commonApiFetch as jest.Mock;
+
+const COLLECTED_STATS: ApiCollectedStats = {
+  boost: 0,
+  gradients_balance: 0,
+  memes_balance: 1,
+  nextgen_balance: 0,
+  seasons: [],
+  unique_memes: 1,
+};
+
+const renderFacts = ({
+  enabled,
+  identity,
+}: {
+  readonly enabled: boolean;
+  readonly identity: string | null;
+}) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { readonly children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return renderHook(() => useJoin6529Facts({ enabled, identity }), { wrapper });
+};
+
+describe("useJoin6529Facts", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    activityMock.mockReturnValue({ data: undefined });
+  });
+
+  it("loads both facts for the normalized profile identity", async () => {
+    activityMock.mockReturnValue({
+      data: { date_samples: [0, 1], last_date: "14.07.2026" },
+    });
+    apiMock.mockResolvedValue(COLLECTED_STATS);
+
+    const { result } = renderFacts({ enabled: true, identity: " Punk6529 " });
+
+    expect(result.current.hasParticipated).toBe(true);
+    await waitFor(() => expect(result.current.hasCollected).toBe(true));
+    expect(activityMock).toHaveBeenCalledWith({
+      enabled: true,
+      identity: "punk6529",
+    });
+    expect(apiMock).toHaveBeenCalledWith({
+      endpoint: "collected-stats/punk6529",
+      signal: expect.anything(),
+    });
+  });
+
+  it("does not load facts until a logged-in profile identity is available", () => {
+    const { result } = renderFacts({ enabled: false, identity: null });
+
+    expect(result.current).toEqual({
+      hasCollected: false,
+      hasParticipated: false,
+    });
+    expect(activityMock).toHaveBeenCalledWith({
+      enabled: false,
+      identity: "",
+    });
+    expect(apiMock).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/app/join/useJoin6529Facts.test.tsx
+++ b/__tests__/app/join/useJoin6529Facts.test.tsx
@@ -1,4 +1,5 @@
 import { useJoin6529Facts } from "@/app/join/useJoin6529Facts";
+import { STATS_QUERY_KEY } from "@/components/user/collected/stats/constants";
 import type { ApiCollectedStats } from "@/generated/models/ApiCollectedStats";
 import { useIdentityActivity } from "@/hooks/useIdentityActivity";
 import { commonApiFetch } from "@/services/api/common-api";
@@ -40,7 +41,10 @@ const renderFacts = ({
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
 
-  return renderHook(() => useJoin6529Facts({ enabled, identity }), { wrapper });
+  return {
+    ...renderHook(() => useJoin6529Facts({ enabled, identity }), { wrapper }),
+    queryClient,
+  };
 };
 
 describe("useJoin6529Facts", () => {
@@ -81,5 +85,48 @@ describe("useJoin6529Facts", () => {
       identity: "",
     });
     expect(apiMock).not.toHaveBeenCalled();
+  });
+
+  it("does not enable either query for an empty identity", () => {
+    const { result } = renderFacts({ enabled: true, identity: "   " });
+
+    expect(result.current).toEqual({
+      hasCollected: false,
+      hasParticipated: false,
+    });
+    expect(activityMock).toHaveBeenCalledWith({
+      enabled: false,
+      identity: "",
+    });
+    expect(apiMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps collection pending while collected stats are loading", async () => {
+    apiMock.mockReturnValue(new Promise<ApiCollectedStats>(() => undefined));
+
+    const { result } = renderFacts({ enabled: true, identity: "punk6529" });
+
+    await waitFor(() => expect(apiMock).toHaveBeenCalledTimes(1));
+    expect(result.current.hasCollected).toBe(false);
+  });
+
+  it("keeps collection pending when collected stats are unavailable", async () => {
+    apiMock.mockRejectedValue(new Error("Collected stats unavailable"));
+
+    const { queryClient, result } = renderFacts({
+      enabled: true,
+      identity: "punk6529",
+    });
+
+    await waitFor(() =>
+      expect(
+        queryClient.getQueryState([
+          STATS_QUERY_KEY,
+          "collected-stats",
+          "punk6529",
+        ])?.status
+      ).toBe("error")
+    );
+    expect(result.current.hasCollected).toBe(false);
   });
 });

--- a/app/join/journeyFacts.ts
+++ b/app/join/journeyFacts.ts
@@ -1,0 +1,26 @@
+import type { ApiCollectedStats } from "@/generated/models/ApiCollectedStats";
+
+export interface Join6529Facts {
+  readonly hasCollected: boolean;
+  readonly hasParticipated: boolean;
+}
+
+export const hasCollectedSupportedNft = (
+  stats:
+    | Pick<
+        ApiCollectedStats,
+        "gradients_balance" | "memes_balance" | "nextgen_balance"
+      >
+    | null
+    | undefined
+): boolean =>
+  Boolean(
+    stats &&
+    (stats.memes_balance > 0 ||
+      stats.nextgen_balance > 0 ||
+      stats.gradients_balance > 0)
+  );
+
+export const hasPublicWavePost = (
+  activity: { readonly date_samples: readonly number[] } | null | undefined
+): boolean => activity?.date_samples.some((count) => count > 0) ?? false;

--- a/app/join/journeyProgress.ts
+++ b/app/join/journeyProgress.ts
@@ -1,7 +1,8 @@
 import { TIMELINE_ORDER, type TimelineStepId } from "./page.content";
 import type { JoinPageState, StepStatus, TimelineProgress } from "./page.types";
+import type { Join6529Facts } from "./journeyFacts";
 
-const COMPLETED_STEPS: Readonly<
+const BASE_COMPLETED_STEPS: Readonly<
   Record<JoinPageState, readonly TimelineStepId[]>
 > = {
   loggedOut: [],
@@ -16,9 +17,18 @@ const CURRENT_STEP: Readonly<Record<JoinPageState, TimelineStepId | null>> = {
 };
 
 export const buildJoinJourneyProgress = (
-  pageState: JoinPageState
+  pageState: JoinPageState,
+  facts: Join6529Facts
 ): TimelineProgress => {
-  const completedSteps = new Set(COMPLETED_STEPS[pageState]);
+  const completedSteps = new Set(BASE_COMPLETED_STEPS[pageState]);
+  if (pageState === "loggedIn") {
+    if (facts.hasParticipated) {
+      completedSteps.add("message");
+    }
+    if (facts.hasCollected) {
+      completedSteps.add("collect");
+    }
+  }
   const currentStepId = CURRENT_STEP[pageState];
   const total = TIMELINE_ORDER.length;
   const completed = completedSteps.size;

--- a/app/join/useJoin6529Facts.ts
+++ b/app/join/useJoin6529Facts.ts
@@ -18,9 +18,10 @@ export function useJoin6529Facts({
   readonly identity: string | null;
 }): Join6529Facts {
   const canonicalIdentity = identity?.trim().toLowerCase() ?? "";
+  const canLoadFacts = enabled && canonicalIdentity.length > 0;
   const activityQuery = useIdentityActivity({
     identity: canonicalIdentity,
-    enabled,
+    enabled: canLoadFacts,
   });
   const collectedStatsQuery = useQuery<ApiCollectedStats, Error>({
     queryKey: [STATS_QUERY_KEY, "collected-stats", canonicalIdentity],
@@ -34,7 +35,7 @@ export function useJoin6529Facts({
         signal,
       });
     },
-    enabled: enabled && canonicalIdentity.length > 0,
+    enabled: canLoadFacts,
     retry: false,
   });
 

--- a/app/join/useJoin6529Facts.ts
+++ b/app/join/useJoin6529Facts.ts
@@ -1,0 +1,45 @@
+import { STATS_QUERY_KEY } from "@/components/user/collected/stats/constants";
+import type { ApiCollectedStats } from "@/generated/models/ApiCollectedStats";
+import { useIdentityActivity } from "@/hooks/useIdentityActivity";
+import { commonApiFetch } from "@/services/api/common-api";
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  hasCollectedSupportedNft,
+  hasPublicWavePost,
+  type Join6529Facts,
+} from "./journeyFacts";
+
+export function useJoin6529Facts({
+  enabled,
+  identity,
+}: {
+  readonly enabled: boolean;
+  readonly identity: string | null;
+}): Join6529Facts {
+  const canonicalIdentity = identity?.trim().toLowerCase() ?? "";
+  const activityQuery = useIdentityActivity({
+    identity: canonicalIdentity,
+    enabled,
+  });
+  const collectedStatsQuery = useQuery<ApiCollectedStats, Error>({
+    queryKey: [STATS_QUERY_KEY, "collected-stats", canonicalIdentity],
+    queryFn: async ({ signal }) => {
+      if (!canonicalIdentity) {
+        throw new Error("Identity is required to fetch collected stats");
+      }
+
+      return await commonApiFetch<ApiCollectedStats>({
+        endpoint: `collected-stats/${encodeURIComponent(canonicalIdentity)}`,
+        signal,
+      });
+    },
+    enabled: enabled && canonicalIdentity.length > 0,
+    retry: false,
+  });
+
+  return {
+    hasCollected: hasCollectedSupportedNft(collectedStatsQuery.data),
+    hasParticipated: hasPublicWavePost(activityQuery.data),
+  };
+}

--- a/app/join/useJoin6529Journey.ts
+++ b/app/join/useJoin6529Journey.ts
@@ -8,6 +8,7 @@ import { getProfileHref, getProfileRouteIdentity } from "./journeyIdentity";
 import { SUBSCRIPTIONS_INFO_HREF, WAVES_HREF } from "./page.content";
 import type { CurrentPanelAction, JoinPageState } from "./page.types";
 import { m } from "./page.utils";
+import { useJoin6529Facts } from "./useJoin6529Facts";
 import { useJoin6529Progress } from "./useJoin6529Progress";
 
 export function useJoin6529Journey(locale: SupportedLocale) {
@@ -22,6 +23,7 @@ export function useJoin6529Journey(locale: SupportedLocale) {
   const [authActionPending, setAuthActionPending] = useState(false);
 
   const profileHref = getProfileHref(connectedProfile, address);
+  const profileIdentity = getProfileRouteIdentity(connectedProfile, address);
   const subscriptionProfileIdentity = getProfileRouteIdentity(
     connectedProfile,
     undefined
@@ -34,7 +36,11 @@ export function useJoin6529Journey(locale: SupportedLocale) {
     hasActiveWalletAddress,
     hasProfile: Boolean(connectedProfile),
   });
-  const timelineProgress = useJoin6529Progress({ pageState });
+  const facts = useJoin6529Facts({
+    enabled: pageState === "loggedIn",
+    identity: profileIdentity,
+  });
+  const timelineProgress = useJoin6529Progress({ facts, pageState });
 
   const handleConnectWallet = useCallback(() => {
     setWalletActionPending(true);

--- a/app/join/useJoin6529Progress.ts
+++ b/app/join/useJoin6529Progress.ts
@@ -1,12 +1,18 @@
 import { useMemo } from "react";
 
 import { buildJoinJourneyProgress } from "./journeyProgress";
+import type { Join6529Facts } from "./journeyFacts";
 import type { JoinPageState, TimelineProgress } from "./page.types";
 
 export function useJoin6529Progress({
+  facts,
   pageState,
 }: {
+  readonly facts: Join6529Facts;
   readonly pageState: JoinPageState;
 }): TimelineProgress {
-  return useMemo(() => buildJoinJourneyProgress(pageState), [pageState]);
+  return useMemo(
+    () => buildJoinJourneyProgress(pageState, facts),
+    [facts.hasCollected, facts.hasParticipated, pageState]
+  );
 }

--- a/ops/docs/navigation/feature-join-6529-journey.md
+++ b/ops/docs/navigation/feature-join-6529-journey.md
@@ -19,9 +19,16 @@ to choose a lightweight onboarding state.
   back to public Waves at `/waves` so the complete state keeps the journey
   focused on exploration.
 
-The Join page does not add a separate progress API endpoint. It intentionally
-keeps progress lightweight and avoids collection, drop, or subscription data
-fetches for this onboarding surface.
+The Join page does not add a separate progress API endpoint. For logged-in
+profiles, it reuses identity activity and collected stats to complete two
+optional steps:
+
+- Participate is complete when the identity has at least one public Wave drop
+  in the 365-day activity window.
+- Collect is complete when the identity has a positive Memes, NextGen, or
+  Gradients balance.
+
+If either fact is unavailable, that optional step remains pending.
 
 ## Progress
 

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -116,6 +116,7 @@
         "/join redirects to /join-6529 for compatibility.",
         "It is a state-aware onboarding hub that adapts to wallet connection, wallet auth, and profile setup.",
         "The journey covers connecting a wallet, setting up a profile, joining a Wave, participating, and collecting.",
+        "For logged-in profiles, Participate completes after at least one public Wave drop in the 365-day activity window, and Collect completes when Memes, NextGen, or Gradients holdings are positive.",
         "The focus area links to The Memes Main Stage Wave, Waves, the current user's subscriptions route when available, delegation, and @help6529."
       ],
       "canonical_path": "/join-6529",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -116,6 +116,7 @@
         "/join redirects to /join-6529 for compatibility.",
         "It is a state-aware onboarding hub that adapts to wallet connection, wallet auth, and profile setup.",
         "The journey covers connecting a wallet, setting up a profile, joining a Wave, participating, and collecting.",
+        "For logged-in profiles, Participate completes after at least one public Wave drop in the 365-day activity window, and Collect completes when Memes, NextGen, or Gradients holdings are positive.",
         "The focus area links to The Memes Main Stage Wave, Waves, the current user's subscriptions route when available, delegation, and @help6529."
       ],
       "canonical_path": "/join-6529",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -7,7 +7,7 @@ Site data such as TDH, REP, and Wave activity changes continuously. Fetch the fi
 ## Machine-readable files
 
 - [llms.txt](https://6529.io/llms.txt): this file — the stable entry point.
-- [help-index.json](https://6529.io/help-index.json): 193 curated records covering routes, workflows, UI affordances, business rules, and glossary terms. Each record has an id, title, aliases, facts, and a canonical_path that is validated against the app's real routes at build time. This is the primary reference for answering questions about 6529.io.
+- [help-index.json](https://6529.io/help-index.json): 194 curated records covering routes, workflows, UI affordances, business rules, and glossary terms. Each record has an id, title, aliases, facts, and a canonical_path that is validated against the app's real routes at build time. This is the primary reference for answering questions about 6529.io.
 - [glossary.json](https://6529.io/glossary.json): 27 term definitions (TDH, xTDH, REP, NIC, Waves, Drops, Groups, Subscriptions, and more) projected from the same help corpus. Each term carries its help-index record id, definition facts, and canonical page path.
 - [sitemap.xml](https://6529.io/sitemap.xml): the crawlable page list, regenerated on every deploy.
 - [robots.txt](https://6529.io/robots.txt): standard crawler directives; it also references the files above.


### PR DESCRIPTION
## Issue

The Join 6529 checklist always showed 3/5 for logged-in users because participation and collection were never added to the completed-step model.

Product item: `0d3947ed-6aa1-46af-9ef2-8202bc722749`
Signal: `a28a7d3a-86dc-4895-91c0-9a373ad27c78`

## Fix

Load the logged-in profile's existing identity activity and consolidated collection stats, derive the two missing facts, and feed them into the checklist progress calculation.

## Changes

- Mark **Participate** complete when the identity activity API reports at least one public Wave post in its 365-day window.
- Mark **Collect** complete when Memes, NextGen, or Gradients balance is positive.
- Reuse existing React Query keys/API helpers so cached collection and activity data can be shared.
- Keep unavailable, loading, or failed facts pending.
- Gate both fact queries on a non-empty logged-in profile identity.
- Add focused helper, hook, progress, loading, and failure-path tests.
- Update the Join journey docs and generated Help Bot artifacts.

## Validation

- `./bin/6529 run test --testPathPatterns=__tests__/app/join` — 3 suites, 18 tests passed.
- `./bin/6529 run lint:changed` — passed.
- `./bin/6529 run typecheck:changed` — passed.
- `./bin/6529 run help-index:sync` — passed.
- `./bin/6529 run agent-files:sync` — passed.
- `git diff --check` — passed.
- `./bin/6529 run check:changed` — its focused formatting, lint, and typecheck stages passed; its local Knip stage compared against a stale local `main` ref and reported files outside this PR.
- GitHub **Installed app checks** — passed in a clean checkout, including Knip, agent-file sync, changed-source lint/typecheck, related Jest tests, full Next.js build, small Playwright smoke, and critical route-shell Playwright.
- GitHub CodeQL, DCO, debt ratchet, secret scan, SonarCloud, and Snyk — passed.
- `./bin/6529 run react-doctor:diff` — exited successfully, but the wrapper selected this new branch as its comparison base and scanned no changed files.

## Risk

- **Level:** Low to medium.
- Two public read queries now run for logged-in users visiting Join 6529.
- Participation is limited by the existing activity API's 365-day contract; an identity whose only posts are older still remains pending.
- API errors fail closed and leave the optional step pending.
- **Rollback:** Revert this PR to restore the static 3/5 logged-in progress model.

## Review Notes

The OpenAPI contract describes `GET /identities/{id}/activity` as daily public-Wave drop activity. The collection query intentionally uses the exact normalized cache-key shape already used by the collected-stats screen.

The current-head 6529bot general review is **Good to merge**; follow-up, security, i18n, and WCAG reviews report no new findings. CodeRabbit was temporarily rate-limited and did not provide a substantive review.