### PR TITLE
Fix live updates in active muted Waves

### DIFF
--- a/__tests__/useWaveRealtimeUpdater.test.ts
+++ b/__tests__/useWaveRealtimeUpdater.test.ts
@@ -929,7 +929,7 @@ describe("useWaveRealtimeUpdater", () => {
     expect(commonApiPostWithoutBodyAndResponse).not.toHaveBeenCalled();
   });
 
-  it("skips processing when wave is muted", async () => {
+  it("skips processing when an inactive wave is muted", async () => {
     const store = {
       wave1: { drops: [], latestFetchedSerialNo: 10 },
     };
@@ -950,5 +950,38 @@ describe("useWaveRealtimeUpdater", () => {
     expect(props.updateData).not.toHaveBeenCalled();
     expect(props.registerWave).not.toHaveBeenCalled();
     expect(props.syncNewestMessages).not.toHaveBeenCalled();
+  });
+
+  it("processes realtime drops when the active wave is muted", async () => {
+    const store = {
+      wave1: { drops: [], latestFetchedSerialNo: 10 },
+    };
+    const props = baseProps(store);
+    props.activeWaveId = "wave1";
+    props.isWaveMuted = jest.fn().mockReturnValue(true);
+    const { result } = renderHook(() => useWaveRealtimeUpdater(props));
+    const drop: any = { id: "d12", wave: { id: "wave1" }, author: {} };
+
+    await act(async () =>
+      result.current.processIncomingDrop(
+        drop,
+        ProcessIncomingDropType.DROP_INSERT
+      )
+    );
+    await flushPromises();
+
+    expect(props.isWaveMuted).toHaveBeenCalledWith("wave1");
+    expect(props.updateData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "wave1",
+        drops: [expect.objectContaining({ id: "d12" })],
+      })
+    );
+    expect(props.registerWave).not.toHaveBeenCalled();
+    expect(props.syncNewestMessages).toHaveBeenCalledWith(
+      "wave1",
+      10,
+      expect.any(AbortSignal)
+    );
   });
 });

--- a/__tests__/useWaveRealtimeUpdater.test.ts
+++ b/__tests__/useWaveRealtimeUpdater.test.ts
@@ -9,9 +9,16 @@ const mockSetQueriesData = jest.fn();
 const mockSetQueryData = jest.fn();
 const mockCancelQueries = jest.fn().mockResolvedValue(undefined);
 const mockFindAll = jest.fn(() => []);
+const mockRefreshEligibility = jest.fn().mockResolvedValue(undefined);
 
 jest.mock("@/services/websocket/useWebSocketMessage", () => ({
   useWebSocketMessage: () => ({ isConnected: true }),
+}));
+
+jest.mock("@/contexts/wave/WaveEligibilityContext", () => ({
+  useWaveEligibility: () => ({
+    refreshEligibility: mockRefreshEligibility,
+  }),
 }));
 
 jest.mock("@/components/auth/Auth", () => ({
@@ -100,6 +107,7 @@ describe("useWaveRealtimeUpdater", () => {
       expectedReaction: null,
       serverReaction: null,
     });
+    mockRefreshEligibility.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -983,5 +991,67 @@ describe("useWaveRealtimeUpdater", () => {
       10,
       expect.any(AbortSignal)
     );
+    expect(props.removeWaveDeliveredNotifications).toHaveBeenCalledWith(
+      "wave1"
+    );
+    expect(commonApiPostWithoutBodyAndResponse).toHaveBeenCalledWith({
+      endpoint: "notifications/wave/wave1/read",
+      headers: { Authorization: "Bearer test-jwt" },
+    });
+  });
+
+  it("stops muted drop processing when the wave becomes inactive during eligibility refresh", async () => {
+    const store = {
+      wave1: { drops: [], latestFetchedSerialNo: 10 },
+    };
+    const props = baseProps(store);
+    props.activeWaveId = "wave1";
+    props.isWaveMuted = jest.fn().mockReturnValue(true);
+
+    let resolveRefresh: (() => void) | undefined;
+    mockRefreshEligibility.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRefresh = resolve;
+        })
+    );
+
+    const { result, rerender } = renderHook(() =>
+      useWaveRealtimeUpdater(props)
+    );
+    act(() => {
+      setDocumentVisibilityState("hidden");
+      document.dispatchEvent(new Event("visibilitychange"));
+      setDocumentVisibilityState("visible");
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    let processingPromise!: Promise<void>;
+    await act(async () => {
+      processingPromise = result.current.processIncomingDrop(
+        { id: "d13", wave: { id: "wave1" }, author: {} } as any,
+        ProcessIncomingDropType.DROP_INSERT
+      );
+      await flushPromises();
+    });
+
+    expect(mockRefreshEligibility).toHaveBeenCalledWith("wave1");
+
+    act(() => {
+      props.activeWaveId = "wave2";
+      rerender();
+    });
+
+    if (!resolveRefresh) {
+      throw new Error("Expected eligibility refresh to remain pending");
+    }
+    resolveRefresh();
+    await act(async () => processingPromise);
+
+    expect(props.updateData).not.toHaveBeenCalled();
+    expect(props.registerWave).not.toHaveBeenCalled();
+    expect(props.syncNewestMessages).not.toHaveBeenCalled();
+    expect(props.removeWaveDeliveredNotifications).not.toHaveBeenCalled();
+    expect(commonApiPostWithoutBodyAndResponse).not.toHaveBeenCalled();
   });
 });

--- a/contexts/wave/hooks/useWaveRealtimeUpdater.ts
+++ b/contexts/wave/hooks/useWaveRealtimeUpdater.ts
@@ -14,7 +14,13 @@ import { DropSize } from "@/helpers/waves/drop.helpers";
 import { useMarkWaveNotificationsRead } from "@/hooks/useMarkWaveNotificationsRead";
 import { fetchDropByIdBatched } from "@/services/api/drop-api";
 import { useWebSocketMessage } from "@/services/websocket/useWebSocketMessage";
-import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  type RefObject,
+} from "react";
 import { useWaveEligibility } from "../WaveEligibilityContext";
 import type { WaveDataStoreUpdater, WaveMessages } from "./types";
 import { WebSocketStatus } from "@/services/websocket/WebSocketTypes";
@@ -446,19 +452,26 @@ const useNewestMessagesSync = ({
   return initiateFetchNewestCycle;
 };
 
-const useActiveWaveReadMarker = ({
-  activeWaveId,
-  removeWaveDeliveredNotifications,
-}: Pick<
-  UseWaveRealtimeUpdaterProps,
-  "activeWaveId" | "removeWaveDeliveredNotifications"
->): ((waveId: string) => void) => {
+const useLatestActiveWaveIdRef = (
+  activeWaveId: string | null
+): RefObject<string | null> => {
   const activeWaveIdRef = useRef(activeWaveId);
-  const pendingDeliveredNotificationsRef = useRef<Promise<void> | null>(null);
-  const pendingReadNotificationsRef = useRef<Promise<void> | null>(null);
+
   useLayoutEffect(() => {
     activeWaveIdRef.current = activeWaveId;
   }, [activeWaveId]);
+
+  return activeWaveIdRef;
+};
+
+const useActiveWaveReadMarker = ({
+  activeWaveIdRef,
+  removeWaveDeliveredNotifications,
+}: Pick<UseWaveRealtimeUpdaterProps, "removeWaveDeliveredNotifications"> & {
+  readonly activeWaveIdRef: RefObject<string | null>;
+}): ((waveId: string) => void) => {
+  const pendingDeliveredNotificationsRef = useRef<Promise<void> | null>(null);
+  const pendingReadNotificationsRef = useRef<Promise<void> | null>(null);
 
   const markWaveNotificationsRead = useMarkWaveNotificationsRead();
   const canSendReadForWave = useCallback((waveId: string): boolean => {
@@ -497,7 +510,10 @@ const useActiveWaveReadMarker = ({
 
   return useCallback(
     (waveId: string) => {
-      if (activeWaveId !== waveId || document.visibilityState !== "visible") {
+      if (
+        activeWaveIdRef.current !== waveId ||
+        document.visibilityState !== "visible"
+      ) {
         return;
       }
 
@@ -505,7 +521,7 @@ const useActiveWaveReadMarker = ({
         removeDeliveredNotifications(waveId);
       pendingReadNotificationsRef.current = markNotificationsRead(waveId);
     },
-    [activeWaveId, removeDeliveredNotifications, markNotificationsRead]
+    [activeWaveIdRef, removeDeliveredNotifications, markNotificationsRead]
   );
 };
 
@@ -643,8 +659,9 @@ const useProcessIncomingDrop = ({
     updateData,
     syncNewestMessages,
   });
+  const activeWaveIdRef = useLatestActiveWaveIdRef(activeWaveId);
   const markActiveWaveAsRead = useActiveWaveReadMarker({
-    activeWaveId,
+    activeWaveIdRef,
     removeWaveDeliveredNotifications,
   });
   const refreshEligibilityAfterVisibilityChange =
@@ -670,12 +687,19 @@ const useProcessIncomingDrop = ({
 
       updateCachedDrop({ drop, options, queryClient, type });
 
+      const shouldSkipMutedWave = () =>
+        isWaveMuted(waveId) && activeWaveIdRef.current !== waveId;
+
       // Mute suppresses inactive-Wave processing, not live content in the open Wave.
-      if (isWaveMuted(waveId) && activeWaveId !== waveId) {
+      if (shouldSkipMutedWave()) {
         return;
       }
 
       await refreshEligibilityAfterVisibilityChange(waveId);
+
+      if (shouldSkipMutedWave()) {
+        return;
+      }
 
       const currentData = getData(waveId);
       if (!currentData) {
@@ -741,7 +765,7 @@ const useProcessIncomingDrop = ({
       markActiveWaveAsRead(waveId);
     },
     [
-      activeWaveId,
+      activeWaveIdRef,
       getData,
       updateData,
       registerWave,

--- a/contexts/wave/hooks/useWaveRealtimeUpdater.ts
+++ b/contexts/wave/hooks/useWaveRealtimeUpdater.ts
@@ -670,7 +670,8 @@ const useProcessIncomingDrop = ({
 
       updateCachedDrop({ drop, options, queryClient, type });
 
-      if (isWaveMuted(waveId)) {
+      // Mute suppresses inactive-Wave processing, not live content in the open Wave.
+      if (isWaveMuted(waveId) && activeWaveId !== waveId) {
         return;
       }
 
@@ -740,6 +741,7 @@ const useProcessIncomingDrop = ({
       markActiveWaveAsRead(waveId);
     },
     [
+      activeWaveId,
       getData,
       updateData,
       registerWave,

--- a/ops/docs/waves/sidebars/feature-wave-notification-controls.md
+++ b/ops/docs/waves/sidebars/feature-wave-notification-controls.md
@@ -54,10 +54,10 @@ behavior across thread header controls and sidebar wave rows.
 - Muted rows suppress unread-count badges.
 - Muted waves sort after non-muted waves in wave and DM lists.
 - Muted waves skip websocket unread/new-drop accumulation.
-- Muted active threads also skip realtime drop processing and typing-indicator
-  subscription.
-- After mute changes, if the active thread looks stale, reopen the wave or
-  reload to resync.
+- Open muted threads still receive realtime drop updates, so visible content
+  stays current without a refresh.
+- Inactive muted threads skip Wave message-store processing and sync when opened.
+- Muted threads keep typing-indicator subscription disabled.
 
 ## Failure and Recovery
 

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -4581,7 +4581,8 @@
         "When all-message notifications are over the follower limit, the notification menu shows an inline follower-limit note; if the option is already enabled, users can still turn it off.",
         "The speaker control mutes waves before or after joining.",
         "When a wave is muted, the red speaker-muted Muted control unmutes it.",
-        "Muted waves suppress unread indicators and realtime unread accumulation but can still be opened manually."
+        "Muted waves suppress unread indicators and realtime unread accumulation but can still be opened manually.",
+        "When a muted wave is open, new drops still appear live while typing indicators remain disabled."
       ],
       "canonical_path": "/waves",
       "related_paths": ["/messages"],

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -4581,7 +4581,8 @@
         "When all-message notifications are over the follower limit, the notification menu shows an inline follower-limit note; if the option is already enabled, users can still turn it off.",
         "The speaker control mutes waves before or after joining.",
         "When a wave is muted, the red speaker-muted Muted control unmutes it.",
-        "Muted waves suppress unread indicators and realtime unread accumulation but can still be opened manually."
+        "Muted waves suppress unread indicators and realtime unread accumulation but can still be opened manually.",
+        "When a muted wave is open, new drops still appear live while typing indicators remain disabled."
       ],
       "canonical_path": "/waves",
       "related_paths": ["/messages"],


### PR DESCRIPTION
## Issue
- Some Wave content could appear only after a manual refresh.
- The confirmed frontend case was an open Wave that had been muted: the realtime updater returned before inserting new drops into the active Wave message store.

## Fix
- Continue processing realtime drops when the muted Wave is currently open.
- Preserve the existing muted behavior for inactive Waves so they do not accumulate unread/new-drop work in the background.
- Re-check the latest active-Wave value after async eligibility work so navigation cannot resume muted message-store processing with stale state.

## Changes
- Gate the muted early return on the Wave being inactive.
- Use a latest-value ref for active-Wave checks and delayed read-marking.
- Add focused coverage for inactive-muted skipping, active-muted processing/read behavior, and navigation during an eligibility refresh.
- Update Wave notification-control documentation and the Help Bot corpus to describe the behavior.
- Regenerate the public help index.

## Validation
- Focused Jest: 26 tests passed in `useWaveRealtimeUpdater.test.ts`.
- `./bin/6529 run lint:changed`.
- `./bin/6529 run typecheck:changed`.
- `./bin/6529 run react-doctor:diff` — 100/100, no issues.
- `./bin/6529 run help-index:sync`.
- `./bin/6529 run agent-files:sync`.
- `git diff --check`.
- Manual staging QA with two authenticated browser tabs:
  - unmuted post appeared live without refresh;
  - muted active Wave received a new post live without refresh;
  - muted Wave caught up after navigating away and reopening;
  - original unmuted state was restored.

## Risk
- Level: Low.
- Why: the change narrows an existing early-return condition for the active Wave and adds a latest-state guard after async work; inactive muted Waves keep their suppression behavior.
- Rollback: revert the two commits to restore the previous mute guard and documentation.

## Review Notes
- Please focus on the active/inactive mute boundary, delayed navigation during eligibility refresh, and the intended read-marking of visible active muted Waves.
- Apple/mobile reveal-queue behavior is separate and was not changed.