### PR TITLE
Staging validation for #3279

### DIFF
--- a/__tests__/components/community/members-table/CommunityMembersTableHeader.test.tsx
+++ b/__tests__/components/community/members-table/CommunityMembersTableHeader.test.tsx
@@ -54,10 +54,11 @@ describe("CommunityMembersTableHeader", () => {
       </table>
     );
 
-    const tdhHeader = screen
-      .getByText(ApiCommunityMembersSortOption.Tdh)
-      .closest("th")!;
-    fireEvent.click(tdhHeader);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: ApiCommunityMembersSortOption.Tdh,
+      })
+    );
 
     expect(onSort).toHaveBeenCalledWith(ApiCommunityMembersSortOption.Tdh);
   });

--- a/__tests__/components/mobile-wrapper-dialog/MobileWrapperDialog.test.tsx
+++ b/__tests__/components/mobile-wrapper-dialog/MobileWrapperDialog.test.tsx
@@ -72,6 +72,59 @@ describe("MobileWrapperDialog", () => {
         document.querySelector(".tw-flex-1.tw-overflow-visible")
       ).toBeInTheDocument();
     });
+
+    it.each([
+      {
+        name: "enables dragging without rendering a handle",
+        props: { enableDragToClose: true },
+        canDrag: true,
+        showsHandle: false,
+      },
+      {
+        name: "lets an explicit false override the handle fallback",
+        props: { enableDragToClose: false, showDragHandle: true },
+        canDrag: false,
+        showsHandle: true,
+      },
+      {
+        name: "falls back to the legacy handle behavior",
+        props: { showDragHandle: true },
+        canDrag: true,
+        showsHandle: true,
+      },
+      {
+        name: "disables dragging when the dialog is not dismissible",
+        props: { dismissible: false, enableDragToClose: true },
+        canDrag: false,
+        showsHandle: false,
+      },
+      {
+        name: "disables dragging for tablet modals",
+        props: { enableDragToClose: true, tabletModal: true },
+        canDrag: false,
+        showsHandle: false,
+      },
+    ])("$name", ({ props, canDrag, showsHandle }) => {
+      render(
+        <MobileWrapperDialog {...defaultProps} {...props} isOpen={true} />
+      );
+
+      const dragSurface = document.querySelector<HTMLElement>(
+        ".mobile-wrapper-dialog"
+      );
+      expect(dragSurface).toBeInTheDocument();
+      expect(dragSurface?.style.transform).toBe(
+        canDrag ? "translate3d(0, 0px, 0)" : ""
+      );
+      const dragHandle = document.querySelector(
+        ".tw-h-1.tw-w-10.tw-rounded-full"
+      );
+      if (showsHandle) {
+        expect(dragHandle).toBeInTheDocument();
+      } else {
+        expect(dragHandle).not.toBeInTheDocument();
+      }
+    });
   });
 
   describe("user interactions", () => {

--- a/components/6529Gradient/GradientPage.tsx
+++ b/components/6529Gradient/GradientPage.tsx
@@ -555,7 +555,7 @@ export default function GradientPageComponent({ id }: { readonly id: string }) {
                   />
                 </div>
                 <div className="tw-order-1 tw-min-w-0 tw-flex-1 md:tw-order-2">
-                  <h1 className="tw-mb-0 tw-min-w-0 tw-whitespace-normal tw-break-words tw-text-lg tw-font-semibold tw-leading-tight tw-text-iron-100 sm:tw-text-2xl md:tw-truncate">
+                  <h1 className="tw-m-0 tw-min-w-0 tw-whitespace-normal tw-break-words tw-text-lg tw-font-semibold tw-leading-tight tw-text-iron-100 sm:tw-text-2xl md:tw-truncate">
                     {nft.name}
                   </h1>
                 </div>

--- a/components/about/AboutContentsDropdown.tsx
+++ b/components/about/AboutContentsDropdown.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useAppWallets } from "@/components/app-wallets/AppWalletsContext";
+import { useLayout } from "@/components/brain/my-stream/layout/LayoutContext";
 import { CompactMenu, type CompactMenuItem } from "@/components/compact-menu";
 import { useOptionalCookieConsent } from "@/components/cookies/CookieConsentContext";
 import { shouldHideSubscriptions } from "@/components/user/layout/userPageVisibility";
@@ -36,6 +37,7 @@ export function AboutContentsDropdown({
   const capacitor = useCapacitor();
   const cookieConsent = useOptionalCookieConsent();
   const { appWalletsSupported } = useAppWallets();
+  const { spaces } = useLayout();
   const hideSubscriptions =
     cookieConsent === undefined
       ? false
@@ -104,8 +106,9 @@ export function AboutContentsDropdown({
 
   return (
     <div
+      style={{ top: spaces.headerSpace }}
       className={clsx(
-        "tw-sticky tw-top-16 tw-z-30 tw-mb-4 tw-flex tw-flex-col tw-gap-2 tw-bg-black/85 tw-py-2 tw-backdrop-blur-sm md:tw-top-0",
+        "tw-sticky tw-z-30 tw-mb-4 tw-flex tw-flex-col tw-gap-2 tw-bg-black/85 tw-py-2 tw-backdrop-blur-sm",
         leadingAction
           ? "sm:tw-flex-row sm:tw-items-center sm:tw-justify-between"
           : "tw-items-end sm:tw-flex-row sm:tw-justify-end",

--- a/components/about/AboutSubscriptionsReference.tsx
+++ b/components/about/AboutSubscriptionsReference.tsx
@@ -87,7 +87,7 @@ function HowItWorks({ locale }: { readonly locale: SupportedLocale }) {
             <p className="tw-m-0">
               {m(locale, "about.subscriptions.reference.funding.send")}
             </p>
-            <div className="tw-mt-4 tw-rounded-lg tw-border tw-border-solid tw-border-orange-500/20 tw-bg-orange-500/10 tw-p-4 tw-text-orange-400/80 sm:tw-mt-6">
+            <div className="tw-mt-4 tw-rounded-lg tw-border tw-border-solid tw-border-orange-500/20 tw-bg-orange-500/10 tw-p-4 tw-text-sm tw-text-orange-400/80 sm:tw-mt-6">
               <p className="tw-m-0 tw-flex tw-items-start tw-gap-2">
                 <FontAwesomeIcon
                   aria-hidden="true"

--- a/components/brain/content/BrainContent.tsx
+++ b/components/brain/content/BrainContent.tsx
@@ -70,7 +70,7 @@ const BrainContent: React.FC<BrainContentProps> = ({
     "--brain-content-composer-reserve": `${composerReserve}px`,
   };
   const composerMotionTransition = {
-    duration: shouldAnimateComposerEntrance ? 0.32 : 0,
+    duration: shouldAnimateComposerEntrance ? 0.24 : 0,
     ease: "easeOut",
   };
   const composerStyle = isApp

--- a/components/brain/content/input/BrainContentInput.tsx
+++ b/components/brain/content/input/BrainContentInput.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useCallback } from "react";
-import { m, useReducedMotion } from "framer-motion";
 import { useWaveData } from "@/hooks/useWaveData";
 import useCapacitor from "@/hooks/useCapacitor";
 import type { ActiveDropState } from "@/types/dropInteractionTypes";
@@ -19,7 +18,6 @@ const BrainContentInput: React.FC<BrainContentInputProps> = ({
   onCancelReplyQuote,
 }) => {
   const capacitor = useCapacitor();
-  const shouldReduceMotion = useReducedMotion();
   const handleWaveNotFound = useCallback(() => {
     onCancelReplyQuote();
   }, [onCancelReplyQuote]);
@@ -31,17 +29,6 @@ const BrainContentInput: React.FC<BrainContentInputProps> = ({
     ? "tw-max-h-[calc(100vh-14.7rem)]"
     : "tw-max-h-[calc(100vh-20rem)] lg:tw-max-h-[calc(100vh-20rem)]";
   const composerSurfaceClassName = `${containerClassName} tw-sticky tw-top-0 tw-z-30 tw-w-full tw-flex-none tw-overflow-y-auto tw-rounded-xl tw-bg-iron-950 tw-p-2 tw-shadow-lg tw-ring-1 tw-ring-inset tw-ring-iron-800 tw-transition-colors tw-duration-500 tw-scrollbar-thin tw-scrollbar-track-iron-800 tw-scrollbar-thumb-iron-500 hover:tw-scrollbar-thumb-iron-300 md:tw-p-4`;
-  const contentMotionInitial = shouldReduceMotion
-    ? { opacity: 1 }
-    : { opacity: 0, y: 8 };
-  const contentMotionAnimate = shouldReduceMotion
-    ? { opacity: 1 }
-    : { opacity: 1, y: 0 };
-  const contentMotionTransition = {
-    duration: shouldReduceMotion ? 0 : 0.18,
-    ease: "easeOut",
-  };
-
   if (!activeDrop) {
     return null;
   }
@@ -58,12 +45,7 @@ const BrainContentInput: React.FC<BrainContentInputProps> = ({
         <span className="tw-sr-only" role="status" aria-live="polite">
           Loading reply composer
         </span>
-        <m.div
-          initial={contentMotionInitial}
-          animate={contentMotionAnimate}
-          transition={contentMotionTransition}
-          aria-hidden="true"
-        >
+        <div aria-hidden="true">
           <div className="-tw-mt-2 tw-mb-1 tw-flex tw-h-8 tw-items-center tw-justify-between">
             <div className="tw-h-3 tw-w-28 tw-rounded tw-bg-iron-900" />
             <div className="tw-h-8 tw-w-8 tw-rounded-lg tw-bg-iron-900" />
@@ -77,18 +59,14 @@ const BrainContentInput: React.FC<BrainContentInputProps> = ({
               <div className="tw-h-10 tw-w-10 tw-rounded-lg tw-bg-iron-900" />
             </div>
           </div>
-        </m.div>
+        </div>
       </div>
     );
   }
 
   return (
     <div className={composerSurfaceClassName}>
-      <m.div
-        initial={contentMotionInitial}
-        animate={contentMotionAnimate}
-        transition={contentMotionTransition}
-      >
+      <div>
         <PrivilegedDropCreator
           key={wave.id}
           wave={wave}
@@ -100,7 +78,7 @@ const BrainContentInput: React.FC<BrainContentInputProps> = ({
           fixedDropMode={DropMode.CHAT}
           focusOnInitialActiveDrop
         />
-      </m.div>
+      </div>
     </div>
   );
 };

--- a/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.tsx
+++ b/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.tsx
@@ -487,9 +487,9 @@ export default function MyStreamWaveTabsHeader({
             aria-label={searchMessagesLabel}
             data-tooltip-id={headerActionsTooltipId}
             data-tooltip-content={searchMessagesLabel}
-            className="tw-text-primary-200 tw-flex tw-h-9 tw-w-9 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-solid tw-border-primary-500/30 tw-bg-primary-500/10 tw-transition tw-duration-150 hover:tw-border-primary-400/50 hover:tw-bg-primary-500/20 hover:tw-text-white focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-primary-400"
+            className="tw-flex tw-h-8 tw-w-8 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900 tw-text-iron-200 tw-transition tw-duration-150 hover:tw-border-iron-500 hover:tw-bg-iron-800 hover:tw-text-white focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-primary-400"
           >
-            <MagnifyingGlassIcon className="tw-size-4.5 tw-flex-shrink-0" />
+            <MagnifyingGlassIcon className="tw-h-4 tw-w-4 tw-flex-shrink-0" />
           </button>
           {!isCompact && (
             <button

--- a/components/community/CommunityMembers.tsx
+++ b/components/community/CommunityMembers.tsx
@@ -57,7 +57,7 @@ function NetworkHeaderActionButton({
   readonly onClick: () => void;
 }) {
   const buttonClassName = [
-    "tw-group tw-relative tw-inline-flex tw-items-center tw-justify-center tw-gap-1.5 tw-rounded-lg tw-border-0 tw-text-sm tw-font-semibold tw-transition tw-duration-200 tw-ease-out focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-primary-400/40 sm:tw-text-xs",
+    "tw-group tw-relative tw-inline-flex tw-items-center tw-justify-center tw-gap-1.5 tw-rounded-lg tw-border-0 tw-text-xs tw-font-semibold tw-transition tw-duration-200 tw-ease-out focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-primary-400/40",
     compact
       ? "tw-h-9 tw-w-9 tw-px-0 sm:tw-h-8 sm:tw-w-8"
       : "tw-h-9 tw-min-w-9 tw-px-2.5 sm:tw-h-8 sm:tw-min-w-8 sm:tw-px-2",
@@ -331,7 +331,7 @@ export default function CommunityMembers() {
   } else if (members) {
     membersContent = (
       <>
-        <div className="tw-rounded-lg tw-bg-iron-950 tw-shadow sm:tw-divide-y sm:tw-divide-solid sm:tw-divide-iron-800 sm:tw-overflow-auto sm:tw-border sm:tw-border-solid sm:tw-border-iron-700">
+        <div className="sm:tw-overflow-x-auto">
           <CommunityMembersTable
             members={members.data}
             activeSort={params.sort}
@@ -360,7 +360,7 @@ export default function CommunityMembers() {
     <div>
       <div className="tw-flex tw-items-center tw-justify-between tw-gap-2">
         <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-x-2">
-          <h1 className="tw-mb-0 tw-flex-shrink-0 tw-text-xl tw-font-semibold tw-text-iron-50">
+          <h1 className="tw-m-0 tw-flex-shrink-0 tw-text-xl tw-font-semibold tw-text-iron-50">
             Network
           </h1>
           <div className="tw-flex tw-flex-shrink-0 tw-items-center tw-gap-1 tw-rounded-xl tw-bg-iron-900/75 tw-p-1 tw-shadow-lg tw-shadow-black/30 tw-ring-1 tw-ring-inset tw-ring-white/10 tw-backdrop-blur">
@@ -411,7 +411,7 @@ export default function CommunityMembers() {
         tall
         fixedHeight
         noPadding
-        showDragHandle
+        enableDragToClose
         showHeaderCloseButton
         surfaceClassName="tw-bg-iron-950 tw-ring-1 tw-ring-inset tw-ring-iron-800 tw-shadow-2xl tw-shadow-black/60"
         titleClassName="tw-text-base !tw-font-bold !tw-text-white tw-tracking-tight"
@@ -426,7 +426,7 @@ export default function CommunityMembers() {
         isOpen={mobileSortOpen}
         onClose={() => setMobileSortOpen(false)}
         noPadding
-        showDragHandle
+        enableDragToClose
         showHeaderCloseButton
         surfaceClassName="tw-bg-iron-950 tw-ring-1 tw-ring-inset tw-ring-iron-800 tw-shadow-2xl tw-shadow-black/60"
         titleClassName="tw-text-base !tw-font-bold !tw-text-white tw-tracking-tight"

--- a/components/community/members-table/CommunityMembersMobileCard.tsx
+++ b/components/community/members-table/CommunityMembersMobileCard.tsx
@@ -31,7 +31,7 @@ export default function CommunityMembersMobileCard({
   return (
     <Link
       href={path}
-      className="tw-flex tw-flex-col tw-gap-y-3 tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-900/80 tw-p-3 tw-no-underline tw-shadow-sm tw-shadow-black/20 tw-backdrop-blur-md tw-transition-all tw-duration-200 active:tw-bg-iron-800"
+      className="tw-flex tw-flex-col tw-gap-y-3 tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-950 tw-p-3 tw-no-underline tw-transition-colors tw-duration-200 active:tw-bg-iron-900"
     >
       <div className="tw-flex tw-w-full tw-justify-between">
         <div className="tw-flex tw-items-center tw-gap-x-2">

--- a/components/community/members-table/CommunityMembersTable.tsx
+++ b/components/community/members-table/CommunityMembersTable.tsx
@@ -25,14 +25,14 @@ export default function CommunityMembersTable({
   return (
     <>
       <div className="tw-hidden sm:tw-block">
-        <table className="tw-min-w-full">
+        <table className="tw-min-w-full tw-border-collapse">
           <CommunityMembersTableHeader
             activeSort={activeSort}
             sortDirection={sortDirection}
             isLoading={isLoading}
             onSort={onSort}
           />
-          <tbody className="tw-divide-y tw-divide-solid tw-divide-iron-700">
+          <tbody>
             {members.map((member, index) => (
               <CommunityMembersTableRow
                 key={member.detail_view_key}

--- a/components/community/members-table/CommunityMembersTableHeader.tsx
+++ b/components/community/members-table/CommunityMembersTableHeader.tsx
@@ -1,12 +1,79 @@
 "use client";
 
-import type { SortDirection } from "@/entities/ISort";
+import { SortDirection } from "@/entities/ISort";
 import { ApiCommunityMembersSortOption } from "@/generated/models/ApiCommunityMembersSortOption";
 import { useState } from "react";
 import CommunityMembersTableHeaderSortableContent from "./CommunityMembersTableHeaderSortableContent";
 
 const HEADER_CELL_CLASS_NAME =
   "tw-whitespace-nowrap tw-border-0 tw-border-b tw-border-solid tw-border-iron-800 tw-px-2 tw-py-2 tw-text-xs tw-font-semibold tw-leading-4 tw-text-iron-400 md:tw-px-4 md:tw-py-3";
+const SORT_BUTTON_CLASS_NAME =
+  "tw-group tw-flex tw-min-h-6 tw-w-full tw-cursor-pointer tw-appearance-none tw-items-center tw-border-0 tw-bg-transparent tw-p-0 tw-text-xs tw-font-semibold tw-leading-4 tw-text-inherit focus-visible:tw-rounded-sm focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400";
+const SORTABLE_COLUMNS = [
+  { sort: ApiCommunityMembersSortOption.Level, centered: true },
+  { sort: ApiCommunityMembersSortOption.Tdh, centered: false },
+  { sort: ApiCommunityMembersSortOption.Xtdh, centered: false },
+  { sort: ApiCommunityMembersSortOption.Rep, centered: false },
+  { sort: ApiCommunityMembersSortOption.Cic, centered: false },
+] as const;
+
+function getAriaSort(
+  sort: ApiCommunityMembersSortOption,
+  activeSort: ApiCommunityMembersSortOption,
+  sortDirection: SortDirection
+): "ascending" | "descending" | undefined {
+  if (sort !== activeSort) {
+    return undefined;
+  }
+
+  return sortDirection === SortDirection.ASC ? "ascending" : "descending";
+}
+
+function SortableHeaderCell({
+  sort,
+  centered,
+  activeSort,
+  sortDirection,
+  isLoading,
+  onSort,
+}: {
+  readonly sort: ApiCommunityMembersSortOption;
+  readonly centered: boolean;
+  readonly activeSort: ApiCommunityMembersSortOption;
+  readonly sortDirection: SortDirection;
+  readonly isLoading: boolean;
+  readonly onSort: (sort: ApiCommunityMembersSortOption) => void;
+}) {
+  const [isHovered, setIsHovered] = useState(false);
+
+  return (
+    <th
+      scope="col"
+      aria-sort={getAriaSort(sort, activeSort, sortDirection)}
+      className={`${HEADER_CELL_CLASS_NAME} ${
+        centered ? "tw-text-center" : "tw-text-right"
+      }`}
+    >
+      <button
+        type="button"
+        className={`${SORT_BUTTON_CLASS_NAME} ${
+          centered ? "tw-justify-center" : "tw-justify-end"
+        }`}
+        onClick={() => onSort(sort)}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+      >
+        <CommunityMembersTableHeaderSortableContent
+          sort={sort}
+          activeSort={activeSort}
+          sortDirection={sortDirection}
+          isLoading={isLoading}
+          hoveringOption={isHovered ? sort : null}
+        />
+      </button>
+    </th>
+  );
+}
 
 export default function CommunityMembersTableHeader({
   activeSort,
@@ -19,8 +86,6 @@ export default function CommunityMembersTableHeader({
   readonly isLoading: boolean;
   readonly onSort: (sort: ApiCommunityMembersSortOption) => void;
 }) {
-  const [hoverOption, setHoverOption] =
-    useState<ApiCommunityMembersSortOption | null>(null);
   return (
     <thead>
       <tr>
@@ -30,85 +95,17 @@ export default function CommunityMembersTableHeader({
         <th scope="col" className={`${HEADER_CELL_CLASS_NAME} tw-text-left`}>
           Profile
         </th>
-        <th
-          scope="col"
-          className={`${HEADER_CELL_CLASS_NAME} tw-group tw-cursor-pointer tw-text-center`}
-          onClick={() => onSort(ApiCommunityMembersSortOption.Level)}
-          onMouseEnter={() =>
-            setHoverOption(ApiCommunityMembersSortOption.Level)
-          }
-          onMouseLeave={() => setHoverOption(null)}
-        >
-          <CommunityMembersTableHeaderSortableContent
-            sort={ApiCommunityMembersSortOption.Level}
+        {SORTABLE_COLUMNS.map(({ sort, centered }) => (
+          <SortableHeaderCell
+            key={sort}
+            sort={sort}
+            centered={centered}
             activeSort={activeSort}
             sortDirection={sortDirection}
             isLoading={isLoading}
-            hoveringOption={hoverOption}
+            onSort={onSort}
           />
-        </th>
-        <th
-          scope="col"
-          className={`${HEADER_CELL_CLASS_NAME} tw-group tw-cursor-pointer tw-text-right`}
-          onClick={() => onSort(ApiCommunityMembersSortOption.Tdh)}
-          onMouseEnter={() => setHoverOption(ApiCommunityMembersSortOption.Tdh)}
-          onMouseLeave={() => setHoverOption(null)}
-        >
-          <CommunityMembersTableHeaderSortableContent
-            sort={ApiCommunityMembersSortOption.Tdh}
-            activeSort={activeSort}
-            sortDirection={sortDirection}
-            isLoading={isLoading}
-            hoveringOption={hoverOption}
-          />
-        </th>
-        <th
-          scope="col"
-          className={`${HEADER_CELL_CLASS_NAME} tw-group tw-cursor-pointer tw-text-right`}
-          onClick={() => onSort(ApiCommunityMembersSortOption.Xtdh)}
-          onMouseEnter={() =>
-            setHoverOption(ApiCommunityMembersSortOption.Xtdh)
-          }
-          onMouseLeave={() => setHoverOption(null)}
-        >
-          <CommunityMembersTableHeaderSortableContent
-            sort={ApiCommunityMembersSortOption.Xtdh}
-            activeSort={activeSort}
-            sortDirection={sortDirection}
-            isLoading={isLoading}
-            hoveringOption={hoverOption}
-          />
-        </th>
-        <th
-          scope="col"
-          className={`${HEADER_CELL_CLASS_NAME} tw-group tw-cursor-pointer tw-text-right`}
-          onClick={() => onSort(ApiCommunityMembersSortOption.Rep)}
-          onMouseEnter={() => setHoverOption(ApiCommunityMembersSortOption.Rep)}
-          onMouseLeave={() => setHoverOption(null)}
-        >
-          <CommunityMembersTableHeaderSortableContent
-            sort={ApiCommunityMembersSortOption.Rep}
-            activeSort={activeSort}
-            sortDirection={sortDirection}
-            isLoading={isLoading}
-            hoveringOption={hoverOption}
-          />
-        </th>
-        <th
-          scope="col"
-          className={`${HEADER_CELL_CLASS_NAME} tw-group tw-cursor-pointer tw-text-right`}
-          onClick={() => onSort(ApiCommunityMembersSortOption.Cic)}
-          onMouseEnter={() => setHoverOption(ApiCommunityMembersSortOption.Cic)}
-          onMouseLeave={() => setHoverOption(null)}
-        >
-          <CommunityMembersTableHeaderSortableContent
-            sort={ApiCommunityMembersSortOption.Cic}
-            activeSort={activeSort}
-            sortDirection={sortDirection}
-            isLoading={isLoading}
-            hoveringOption={hoverOption}
-          />
-        </th>
+        ))}
         <th scope="col" className={`${HEADER_CELL_CLASS_NAME} tw-text-left`}>
           <span>Last Seen</span>
         </th>

--- a/components/community/members-table/CommunityMembersTableHeader.tsx
+++ b/components/community/members-table/CommunityMembersTableHeader.tsx
@@ -5,6 +5,9 @@ import { ApiCommunityMembersSortOption } from "@/generated/models/ApiCommunityMe
 import { useState } from "react";
 import CommunityMembersTableHeaderSortableContent from "./CommunityMembersTableHeaderSortableContent";
 
+const HEADER_CELL_CLASS_NAME =
+  "tw-whitespace-nowrap tw-border-0 tw-border-b tw-border-solid tw-border-iron-800 tw-px-2 tw-py-2 tw-text-xs tw-font-semibold tw-leading-4 tw-text-iron-400 md:tw-px-4 md:tw-py-3";
+
 export default function CommunityMembersTableHeader({
   activeSort,
   sortDirection,
@@ -19,23 +22,17 @@ export default function CommunityMembersTableHeader({
   const [hoverOption, setHoverOption] =
     useState<ApiCommunityMembersSortOption | null>(null);
   return (
-    <thead className="tw-border-x-0 tw-border-b tw-border-t-0 tw-border-iron-700 tw-bg-iron-900">
+    <thead>
       <tr>
-        <th
-          scope="col"
-          className="tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-left tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md"
-        >
+        <th scope="col" className={`${HEADER_CELL_CLASS_NAME} tw-text-center`}>
           Rank
         </th>
-        <th
-          scope="col"
-          className="tw-whitespace-nowrap tw-py-3 tw-pr-4 tw-text-left tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-text-md"
-        >
+        <th scope="col" className={`${HEADER_CELL_CLASS_NAME} tw-text-left`}>
           Profile
         </th>
         <th
           scope="col"
-          className="tw-group tw-cursor-pointer tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md"
+          className={`${HEADER_CELL_CLASS_NAME} tw-group tw-cursor-pointer tw-text-center`}
           onClick={() => onSort(ApiCommunityMembersSortOption.Level)}
           onMouseEnter={() =>
             setHoverOption(ApiCommunityMembersSortOption.Level)
@@ -52,7 +49,7 @@ export default function CommunityMembersTableHeader({
         </th>
         <th
           scope="col"
-          className="tw-group tw-cursor-pointer tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-right tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md"
+          className={`${HEADER_CELL_CLASS_NAME} tw-group tw-cursor-pointer tw-text-right`}
           onClick={() => onSort(ApiCommunityMembersSortOption.Tdh)}
           onMouseEnter={() => setHoverOption(ApiCommunityMembersSortOption.Tdh)}
           onMouseLeave={() => setHoverOption(null)}
@@ -67,7 +64,7 @@ export default function CommunityMembersTableHeader({
         </th>
         <th
           scope="col"
-          className="tw-group tw-cursor-pointer tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-right tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md"
+          className={`${HEADER_CELL_CLASS_NAME} tw-group tw-cursor-pointer tw-text-right`}
           onClick={() => onSort(ApiCommunityMembersSortOption.Xtdh)}
           onMouseEnter={() =>
             setHoverOption(ApiCommunityMembersSortOption.Xtdh)
@@ -84,7 +81,7 @@ export default function CommunityMembersTableHeader({
         </th>
         <th
           scope="col"
-          className="tw-group tw-cursor-pointer tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-right tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md"
+          className={`${HEADER_CELL_CLASS_NAME} tw-group tw-cursor-pointer tw-text-right`}
           onClick={() => onSort(ApiCommunityMembersSortOption.Rep)}
           onMouseEnter={() => setHoverOption(ApiCommunityMembersSortOption.Rep)}
           onMouseLeave={() => setHoverOption(null)}
@@ -99,7 +96,7 @@ export default function CommunityMembersTableHeader({
         </th>
         <th
           scope="col"
-          className="tw-group tw-cursor-pointer tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-right tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md"
+          className={`${HEADER_CELL_CLASS_NAME} tw-group tw-cursor-pointer tw-text-right`}
           onClick={() => onSort(ApiCommunityMembersSortOption.Cic)}
           onMouseEnter={() => setHoverOption(ApiCommunityMembersSortOption.Cic)}
           onMouseLeave={() => setHoverOption(null)}
@@ -112,10 +109,7 @@ export default function CommunityMembersTableHeader({
             hoveringOption={hoverOption}
           />
         </th>
-        <th
-          scope="col"
-          className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-pr-6 sm:tw-text-md"
-        >
+        <th scope="col" className={`${HEADER_CELL_CLASS_NAME} tw-text-left`}>
           <span>Last Seen</span>
         </th>
       </tr>

--- a/components/community/members-table/CommunityMembersTableHeaderSortableContent.tsx
+++ b/components/community/members-table/CommunityMembersTableHeaderSortableContent.tsx
@@ -41,7 +41,7 @@ export default function CommunityMembersTableHeaderSortableContent({
   );
   const showLoader = isLoading && isActive;
   return (
-    <>
+    <span className="tw-inline-flex tw-items-center tw-gap-1.5 tw-align-middle">
       <span
         className={`${
           isActive ? "tw-text-primary-400" : "group-hover:tw-text-iron-200"
@@ -50,11 +50,11 @@ export default function CommunityMembersTableHeaderSortableContent({
         {TITLE[sort]}
       </span>
       {showLoader ? (
-        <span className="tw-pl-2">
+        <span className="tw-flex tw-items-center">
           <CircleLoader size={CircleLoaderSize.SMALL} />
         </span>
       ) : (
-        <span className="-tw-mt-0.5 tw-ml-2">
+        <span className="tw-flex tw-items-center">
           <CommonTableSortIcon
             direction={direction}
             isActive={isActive}
@@ -62,6 +62,6 @@ export default function CommunityMembersTableHeaderSortableContent({
           />
         </span>
       )}
-    </>
+    </span>
   );
 }

--- a/components/community/members-table/CommunityMembersTableRow.tsx
+++ b/components/community/members-table/CommunityMembersTableRow.tsx
@@ -43,7 +43,7 @@ export default function CommunityMembersTableRow({
                 {member.pfp && (
                   <img
                     src={getScaledImageUri(member.pfp, ImageScale.W_AUTO_H_50)}
-                    alt="Network Table Profile Picture"
+                    alt=""
                     className="tw-h-full tw-w-full tw-bg-transparent tw-object-contain"
                   />
                 )}

--- a/components/community/members-table/CommunityMembersTableRow.tsx
+++ b/components/community/members-table/CommunityMembersTableRow.tsx
@@ -13,6 +13,9 @@ import { ImageScale, getScaledImageUri } from "@/helpers/image.helpers";
 import Link from "next/link";
 import { Tooltip } from "react-tooltip";
 
+const TABLE_CELL_CLASS_NAME =
+  "tw-whitespace-nowrap tw-border-0 tw-border-b tw-border-solid tw-border-iron-800 tw-px-2 tw-py-2 tw-text-xs tw-font-medium tw-leading-5 md:tw-px-4 md:tw-py-3 md:tw-text-sm";
+
 export default function CommunityMembersTableRow({
   member,
   rank,
@@ -26,33 +29,33 @@ export default function CommunityMembersTableRow({
   const textColorClass = isProfile ? "tw-text-iron-50" : "tw-text-iron-400";
   const path = `/${member.detail_view_key}`;
   return (
-    <tr className="tw-transition tw-duration-300 tw-ease-out even:tw-bg-iron-900">
-      <td className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-4 tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-pl-6 sm:tw-text-base">
+    <tr className="tw-group odd:tw-bg-transparent even:tw-bg-iron-900/45 hover:tw-bg-iron-900/70">
+      <td
+        className={`${TABLE_CELL_CLASS_NAME} tw-text-center tw-font-semibold tw-text-iron-100`}
+      >
         {rank}
       </td>
-      <td
-        className={`tw-group tw-whitespace-nowrap tw-py-4 tw-pr-4 tw-text-sm tw-font-medium sm:tw-text-base ${textColorClass}`}
-      >
-        <div className="tw-flex tw-items-center tw-gap-x-4">
-          <div className="tw-h-8 tw-w-8 tw-overflow-hidden tw-rounded-md tw-bg-iron-900 tw-ring-1 tw-ring-white/10">
+      <td className={`${TABLE_CELL_CLASS_NAME} tw-text-left ${textColorClass}`}>
+        <div className="tw-flex tw-items-center tw-gap-2 md:tw-gap-3">
+          <div className="tw-flex tw-h-8 tw-w-8 tw-shrink-0 tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-full tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-800 md:tw-h-10 md:tw-w-10">
             <div className="tw-h-full tw-w-full tw-max-w-full">
               <div className="tw-flex tw-h-full tw-items-center tw-justify-center tw-text-center">
                 {member.pfp && (
                   <img
                     src={getScaledImageUri(member.pfp, ImageScale.W_AUTO_H_50)}
                     alt="Network Table Profile Picture"
-                    className="tw-mx-auto tw-h-auto tw-max-h-full tw-w-auto tw-max-w-full tw-bg-transparent tw-object-contain"
+                    className="tw-h-full tw-w-full tw-bg-transparent tw-object-contain"
                   />
                 )}
               </div>
             </div>
           </div>
           <div
-            className={`tw-max-w-[6rem] tw-truncate sm:tw-max-w-[15rem] ${textColorClass}`}
+            className={`tw-max-w-[6rem] tw-truncate md:tw-max-w-[15rem] ${textColorClass}`}
           >
             <Link
               href={path}
-              className={`tw-no-underline tw-transition tw-duration-300 tw-ease-out group-hover:tw-text-iron-500 group-hover:tw-underline ${textColorClass}`}
+              className={`tw-text-[13px] tw-font-medium tw-leading-5 tw-no-underline tw-transition tw-duration-300 tw-ease-out group-hover:tw-text-iron-400 group-hover:tw-no-underline md:tw-text-sm ${textColorClass}`}
             >
               {member.display}
             </Link>
@@ -60,7 +63,7 @@ export default function CommunityMembersTableRow({
         </div>
       </td>
       <td
-        className={`tw-group tw-whitespace-nowrap tw-px-4 tw-py-4 tw-text-center tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-base ${
+        className={`${TABLE_CELL_CLASS_NAME} tw-text-center ${
           isNotProfile ? "tw-opacity-50" : ""
         }`}
       >
@@ -70,7 +73,7 @@ export default function CommunityMembersTableRow({
         />
       </td>
       <td
-        className={`tw-group tw-whitespace-nowrap tw-px-4 tw-py-4 tw-text-right tw-text-sm tw-font-medium tw-tabular-nums sm:tw-px-6 sm:tw-text-base ${textColorClass}`}
+        className={`${TABLE_CELL_CLASS_NAME} tw-text-right tw-tabular-nums ${textColorClass}`}
       >
         <span
           data-tooltip-id={`tdh-tooltip-${member.detail_view_key}`}
@@ -97,7 +100,7 @@ export default function CommunityMembersTableRow({
         </Tooltip>
       </td>
       <td
-        className={`tw-group tw-whitespace-nowrap tw-px-4 tw-py-4 tw-text-right tw-text-sm tw-font-medium tw-tabular-nums sm:tw-px-6 sm:tw-text-base ${textColorClass}`}
+        className={`${TABLE_CELL_CLASS_NAME} tw-text-right tw-tabular-nums ${textColorClass}`}
       >
         <span
           data-tooltip-id={`xtdh-tooltip-${member.detail_view_key}`}
@@ -126,12 +129,12 @@ export default function CommunityMembersTableRow({
         </Tooltip>
       </td>
       <td
-        className={`tw-group tw-whitespace-nowrap tw-px-4 tw-py-4 tw-text-right tw-text-sm tw-font-medium tw-tabular-nums sm:tw-px-6 sm:tw-text-base ${textColorClass}`}
+        className={`${TABLE_CELL_CLASS_NAME} tw-text-right tw-tabular-nums ${textColorClass}`}
       >
         {formatNumberWithCommasOrDash(member.rep)}
       </td>
       <td
-        className={`tw-group tw-whitespace-nowrap tw-px-4 tw-py-4 tw-text-right tw-text-sm tw-font-medium tw-tabular-nums sm:tw-text-base ${textColorClass}`}
+        className={`${TABLE_CELL_CLASS_NAME} tw-text-right tw-tabular-nums ${textColorClass}`}
       >
         <div className="tw-flex tw-items-center tw-justify-end tw-gap-x-2">
           {formatNumberWithCommasOrDash(member.cic)}
@@ -140,9 +143,7 @@ export default function CommunityMembersTableRow({
           </div>
         </div>
       </td>
-      <td
-        className={`tw-group tw-whitespace-nowrap tw-px-4 tw-py-4 tw-text-sm tw-font-medium sm:tw-pr-6 sm:tw-text-base ${textColorClass}`}
-      >
+      <td className={`${TABLE_CELL_CLASS_NAME} tw-text-left ${textColorClass}`}>
         {member.last_activity && (
           <span>
             {getTimeAgoShort(member.last_activity, Date.now(), true)} ago

--- a/components/community/members-table/CommunityMembersTableSkeleton.tsx
+++ b/components/community/members-table/CommunityMembersTableSkeleton.tsx
@@ -13,13 +13,13 @@ export default function CommunityMembersTableSkeleton({
 
   return (
     <output className="tw-block" aria-label="Loading Network members">
-      <div className="tw-hidden tw-overflow-hidden tw-rounded-lg tw-bg-iron-950 tw-shadow sm:tw-block sm:tw-border sm:tw-border-solid sm:tw-border-iron-700">
+      <div className="tw-hidden tw-overflow-hidden sm:tw-block">
         <div className="tw-animate-pulse">
-          <div className="tw-h-12 tw-border-b tw-border-iron-700 tw-bg-iron-900" />
+          <div className="tw-h-10 tw-border-b tw-border-iron-800" />
           {rowKeys.map((key) => (
             <div
               key={key}
-              className="tw-flex tw-h-16 tw-items-center tw-gap-4 tw-border-b tw-border-iron-800 tw-px-6"
+              className="tw-flex tw-h-16 tw-items-center tw-gap-4 tw-border-b tw-border-iron-800 tw-px-4 odd:tw-bg-iron-900/45"
             >
               <div className="tw-h-4 tw-w-8 tw-rounded tw-bg-iron-800" />
               <div className="tw-h-8 tw-w-8 tw-rounded-md tw-bg-iron-800" />
@@ -40,7 +40,7 @@ export default function CommunityMembersTableSkeleton({
         {rowKeys.map((key) => (
           <div
             key={key}
-            className="tw-flex tw-animate-pulse tw-flex-col tw-gap-y-3 tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-900/80 tw-p-3 tw-shadow-sm tw-shadow-black/20 tw-backdrop-blur-md"
+            className="tw-flex tw-animate-pulse tw-flex-col tw-gap-y-3 tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-950 tw-p-3"
           >
             <div className="tw-flex tw-w-full tw-justify-between">
               <div className="tw-flex tw-items-center tw-gap-x-2">

--- a/components/groups/header/GroupHeaderSelect.tsx
+++ b/components/groups/header/GroupHeaderSelect.tsx
@@ -82,7 +82,7 @@ export default function GroupHeaderSelect({
           ></path>
         </svg>
         <div className="tw-ml-3 tw-self-center">
-          <p className="tw-mb-0 tw-text-sm tw-font-semibold tw-text-primary-300">
+          <p className="tw-m-0 tw-text-sm tw-font-semibold tw-text-primary-300">
             {noProfileTitle}
           </p>
         </div>

--- a/components/groups/select/item/GroupItem.tsx
+++ b/components/groups/select/item/GroupItem.tsx
@@ -90,7 +90,7 @@ export default function GroupItem({
                     <span className="tw-size-1.5 tw-flex-shrink-0 tw-rounded-full tw-bg-primary-400" />
                   )}
                   <p
-                    className={`tw-mb-0 tw-truncate tw-text-sm tw-font-bold ${
+                    className={`tw-m-0 tw-truncate tw-text-sm tw-font-bold ${
                       isActive
                         ? "tw-text-iron-50"
                         : "tw-text-iron-100 group-hover:tw-text-iron-50"

--- a/components/memelab/MemeLabPage.tsx
+++ b/components/memelab/MemeLabPage.tsx
@@ -974,7 +974,7 @@ export default function MemeLabPageComponent({
                 </div>
                 <div className="tw-order-1 tw-min-w-0 tw-flex-1 md:tw-order-2">
                   <h1
-                    className="tw-mb-0 tw-flex tw-min-w-0 tw-flex-wrap tw-items-baseline tw-gap-x-2 tw-gap-y-1 md:tw-flex-nowrap md:tw-gap-x-0"
+                    className="tw-m-0 tw-flex tw-min-w-0 tw-flex-wrap tw-items-baseline tw-gap-x-2 tw-gap-y-1 md:tw-flex-nowrap md:tw-gap-x-0"
                     aria-label={t(locale, "memeLab.detail.heading.ariaLabel", {
                       tokenId: nft.id,
                       name: nft.name,

--- a/components/mobile-wrapper-dialog/MobileWrapperDialog.tsx
+++ b/components/mobile-wrapper-dialog/MobileWrapperDialog.tsx
@@ -48,6 +48,7 @@ type MobileWrapperDialogProps = {
   readonly headerActions?: ReactNode;
   readonly mobileCloseButtonClassName?: string | undefined;
   readonly showDragHandle?: boolean | undefined;
+  readonly enableDragToClose?: boolean | undefined;
   readonly showHeaderCloseButton?: boolean | undefined;
   readonly headerCloseButtonClassName?: string | undefined;
   readonly surfaceClassName?: string | undefined;
@@ -63,6 +64,7 @@ type DragTouchHandlers = Pick<
 type MobileDialogDragOptions = {
   readonly dismissible: boolean;
   readonly showDragHandle?: boolean | undefined;
+  readonly enableDragToClose?: boolean | undefined;
   readonly tabletModal?: boolean | undefined;
   readonly onClose: () => void;
   readonly onAfterLeave?: (() => void) | undefined;
@@ -438,6 +440,7 @@ function getDismissDragOffset(): number {
 function useMobileDialogDrag({
   dismissible,
   showDragHandle,
+  enableDragToClose,
   tabletModal,
   onClose,
   onAfterLeave,
@@ -456,7 +459,8 @@ function useMobileDialogDrag({
     }
   }, [dismissible, onClose]);
 
-  const canDragToClose = dismissible && !!showDragHandle && !tabletModal;
+  const canDragToClose =
+    dismissible && (enableDragToClose ?? !!showDragHandle) && !tabletModal;
 
   const cancelScheduledDragFrame = useCallback(() => {
     if (dragFrameRef.current === null) {
@@ -632,6 +636,7 @@ export default function MobileWrapperDialog({
   headerActions,
   mobileCloseButtonClassName,
   showDragHandle,
+  enableDragToClose,
   showHeaderCloseButton,
   headerCloseButtonClassName,
   surfaceClassName,
@@ -649,6 +654,7 @@ export default function MobileWrapperDialog({
   } = useMobileDialogDrag({
     dismissible,
     showDragHandle,
+    enableDragToClose,
     tabletModal,
     onClose,
     onAfterLeave,

--- a/components/the-memes/MemePage.tsx
+++ b/components/the-memes/MemePage.tsx
@@ -665,7 +665,7 @@ export default function MemePage({ nftId }: { readonly nftId: string }) {
                 </div>
                 <div className="tw-order-1 tw-min-w-0 tw-flex-1 md:tw-order-2">
                   <h1
-                    className="tw-mb-0 tw-flex tw-min-w-0 tw-flex-wrap tw-items-baseline tw-gap-x-2 tw-gap-y-1 md:tw-flex-nowrap md:tw-gap-x-0"
+                    className="tw-m-0 tw-flex tw-min-w-0 tw-flex-wrap tw-items-baseline tw-gap-x-2 tw-gap-y-1 md:tw-flex-nowrap md:tw-gap-x-0"
                     aria-label={t(locale, "theMemes.detail.heading.ariaLabel", {
                       tokenId: formatInteger(locale, nft.id),
                       name: nft.name,


### PR DESCRIPTION
## Staging release manifest

- Environment: staging
- Source branch: `codex/ui-ux-app-polish`
- Source SHA: `cf40bada05e0e09d19ba803a5b9fd3a50b2e2147`
- Production target: PR #3279 to `main` after staging passes
- Included work: Network table/mobile polish, sort accessibility and tests, responsive dialog/content refinements, Waves icon consistency, and smoother notification reply composition
- Risk: low-to-moderate UI-only change; Network sorting/filtering/pagination/data behavior is preserved
- Backend dependencies: none
- Fix-forward path: update the source branch, rerun PR checks, then merge the corrected head into `1a-staging`

## Pre-staging gates

- App PR CI: passed on the source SHA
- Debt Ratchet: passed
- Snyk: passed
- CodeRabbit: passed
- SonarCloud: passed with 0 new issues and 0 security hotspots
- 6529bot follow-up review: no new findings
- Unresolved review threads: none

## Staging validation

- Confirm the staging deployment reports the exact `1a-staging` merge SHA
- Wait for the automatic Staging E2E workflow
- Validate `/network` at desktop and mobile widths, including sorting, filter/sort sheets, pagination, and Nerd view
- Smoke-check the touched card headings, subscription warning/sticky navigation, Waves toolbar icon, and notification reply composer
- Check for new console or network errors on touched routes