### PR TITLE
Fix useMediaQuery update loop

### DIFF
--- a/__tests__/hooks/useMediaQuery.test.tsx
+++ b/__tests__/hooks/useMediaQuery.test.tsx
@@ -1,4 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
+import { hydrateRoot } from "react-dom/client";
 import { renderToString } from "react-dom/server";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 
@@ -109,17 +110,26 @@ describe("useMediaQuery", () => {
     }
   );
 
-  it("uses false as the server and hydration snapshot", () => {
+  it("uses false during SSR and updates to the browser snapshot after hydration", async () => {
     const mediaQuery = createMediaQueryListMock({ matches: true });
     installMatchMedia(mediaQuery.mediaQueryList);
 
     const Probe = () => <span>{String(useMediaQuery(QUERY))}</span>;
+    const container = document.createElement("div");
 
-    expect(renderToString(<Probe />)).toContain("<span>false</span>");
+    container.innerHTML = renderToString(<Probe />);
+    expect(container).toHaveTextContent("false");
     expect(mediaQuery.addEventListener).not.toHaveBeenCalled();
 
-    const { result } = renderHook(() => useMediaQuery(QUERY));
-    expect(result.current).toBe(true);
+    let root: ReturnType<typeof hydrateRoot> | undefined;
+    await act(async () => {
+      root = hydrateRoot(container, <Probe />);
+    });
+
+    expect(container).toHaveTextContent("true");
+    expect(mediaQuery.addEventListener).toHaveBeenCalledTimes(1);
+
+    act(() => root?.unmount());
   });
 
   it("updates when the media query snapshot changes", () => {

--- a/__tests__/hooks/useMediaQuery.test.tsx
+++ b/__tests__/hooks/useMediaQuery.test.tsx
@@ -1,0 +1,214 @@
+import { act, renderHook } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+
+const QUERY = "(max-width: 1023px)";
+
+type MediaQueryListMockOptions = {
+  readonly matches: boolean;
+  readonly modernListeners?: boolean;
+  readonly previousOnChange?: MediaQueryList["onchange"];
+};
+
+const createMediaQueryListMock = ({
+  matches,
+  modernListeners = true,
+  previousOnChange = null,
+}: MediaQueryListMockOptions) => {
+  let currentMatches = matches;
+  const listeners = new Set<EventListenerOrEventListenerObject>();
+  const addEventListener = jest.fn(
+    (type: string, listener: EventListenerOrEventListenerObject) => {
+      if (type === "change") {
+        listeners.add(listener);
+      }
+    }
+  );
+  const removeEventListener = jest.fn(
+    (type: string, listener: EventListenerOrEventListenerObject) => {
+      if (type === "change") {
+        listeners.delete(listener);
+      }
+    }
+  );
+
+  const mediaQueryList = {
+    get matches() {
+      return currentMatches;
+    },
+    media: QUERY,
+    onchange: previousOnChange,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    dispatchEvent: jest.fn(() => true),
+    ...(modernListeners ? { addEventListener, removeEventListener } : {}),
+  } as unknown as MediaQueryList;
+
+  const emitChange = (nextMatches: boolean) => {
+    currentMatches = nextMatches;
+    const event = Object.assign(new Event("change"), {
+      matches: nextMatches,
+      media: QUERY,
+    }) as MediaQueryListEvent;
+
+    listeners.forEach((listener) => {
+      if (typeof listener === "function") {
+        listener.call(mediaQueryList, event);
+      } else {
+        listener.handleEvent(event);
+      }
+    });
+    mediaQueryList.onchange?.call(mediaQueryList, event);
+  };
+
+  return {
+    addEventListener,
+    emitChange,
+    getListenerCount: () => listeners.size,
+    mediaQueryList,
+    removeEventListener,
+  };
+};
+
+const originalMatchMediaDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis.window,
+  "matchMedia"
+);
+
+const installMatchMedia = (mediaQueryList: MediaQueryList) => {
+  const matchMedia = jest.fn(() => mediaQueryList);
+  Object.defineProperty(globalThis.window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: matchMedia,
+  });
+  return matchMedia;
+};
+
+describe("useMediaQuery", () => {
+  afterEach(() => {
+    if (originalMatchMediaDescriptor !== undefined) {
+      Object.defineProperty(
+        globalThis.window,
+        "matchMedia",
+        originalMatchMediaDescriptor
+      );
+    }
+  });
+
+  it.each([false, true])(
+    "returns the initial browser snapshot when matches is %s",
+    (matches) => {
+      const mediaQuery = createMediaQueryListMock({ matches });
+      const matchMedia = installMatchMedia(mediaQuery.mediaQueryList);
+
+      const { result } = renderHook(() => useMediaQuery(QUERY));
+
+      expect(result.current).toBe(matches);
+      expect(matchMedia).toHaveBeenCalledWith(QUERY);
+    }
+  );
+
+  it("uses false as the server and hydration snapshot", () => {
+    const mediaQuery = createMediaQueryListMock({ matches: true });
+    installMatchMedia(mediaQuery.mediaQueryList);
+
+    const Probe = () => <span>{String(useMediaQuery(QUERY))}</span>;
+
+    expect(renderToString(<Probe />)).toContain("<span>false</span>");
+    expect(mediaQuery.addEventListener).not.toHaveBeenCalled();
+
+    const { result } = renderHook(() => useMediaQuery(QUERY));
+    expect(result.current).toBe(true);
+  });
+
+  it("updates when the media query snapshot changes", () => {
+    const mediaQuery = createMediaQueryListMock({ matches: false });
+    installMatchMedia(mediaQuery.mediaQueryList);
+    const { result } = renderHook(() => useMediaQuery(QUERY));
+
+    act(() => mediaQuery.emitChange(true));
+    expect(result.current).toBe(true);
+
+    act(() => mediaQuery.emitChange(false));
+    expect(result.current).toBe(false);
+  });
+
+  it("does not re-render for repeated synchronous same-value notifications", () => {
+    const mediaQuery = createMediaQueryListMock({ matches: false });
+    installMatchMedia(mediaQuery.mediaQueryList);
+    let renderCount = 0;
+    const { result } = renderHook(() => {
+      renderCount += 1;
+      return useMediaQuery(QUERY);
+    });
+    const initialRenderCount = renderCount;
+
+    act(() => {
+      mediaQuery.emitChange(false);
+      mediaQuery.emitChange(false);
+    });
+    expect(renderCount).toBe(initialRenderCount);
+
+    act(() => {
+      mediaQuery.emitChange(true);
+      mediaQuery.emitChange(true);
+    });
+    expect(result.current).toBe(true);
+    expect(renderCount).toBe(initialRenderCount + 1);
+  });
+
+  it("removes the modern change listener during cleanup", () => {
+    const mediaQuery = createMediaQueryListMock({ matches: false });
+    installMatchMedia(mediaQuery.mediaQueryList);
+    const { unmount } = renderHook(() => useMediaQuery(QUERY));
+    const listener = mediaQuery.addEventListener.mock.calls[0]?.[1];
+
+    expect(mediaQuery.getListenerCount()).toBe(1);
+    unmount();
+
+    expect(mediaQuery.removeEventListener).toHaveBeenCalledWith(
+      "change",
+      listener
+    );
+    expect(mediaQuery.getListenerCount()).toBe(0);
+  });
+
+  it("updates multiple consumers of the same query", () => {
+    const mediaQuery = createMediaQueryListMock({ matches: false });
+    installMatchMedia(mediaQuery.mediaQueryList);
+    const { result, unmount } = renderHook(
+      () => [useMediaQuery(QUERY), useMediaQuery(QUERY)] as const
+    );
+
+    expect(mediaQuery.addEventListener).toHaveBeenCalledTimes(2);
+
+    act(() => mediaQuery.emitChange(true));
+    expect(result.current).toEqual([true, true]);
+
+    unmount();
+    expect(mediaQuery.removeEventListener).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares and restores the legacy onchange fallback", () => {
+    const previousOnChange: NonNullable<MediaQueryList["onchange"]> = jest.fn();
+    const mediaQuery = createMediaQueryListMock({
+      matches: false,
+      modernListeners: false,
+      previousOnChange,
+    });
+    installMatchMedia(mediaQuery.mediaQueryList);
+    const { result, unmount } = renderHook(
+      () => [useMediaQuery(QUERY), useMediaQuery(QUERY)] as const
+    );
+
+    expect(mediaQuery.mediaQueryList.onchange).not.toBe(previousOnChange);
+
+    act(() => mediaQuery.emitChange(true));
+    expect(previousOnChange).toHaveBeenCalledTimes(1);
+    expect(result.current).toEqual([true, true]);
+
+    unmount();
+    expect(mediaQuery.mediaQueryList.onchange).toBe(previousOnChange);
+  });
+});

--- a/hooks/useMediaQuery.ts
+++ b/hooks/useMediaQuery.ts
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useState } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 
 type MediaQueryListOptionalListeners = {
   addEventListener?: MediaQueryList["addEventListener"];
@@ -8,6 +8,14 @@ type MediaQueryListOptionalListeners = {
 type BrowserWindowWithMatchMedia = {
   readonly matchMedia?: (query: string) => MediaQueryList;
 };
+
+type LegacySubscription = {
+  readonly listeners: Set<() => void>;
+  readonly handler: NonNullable<MediaQueryList["onchange"]>;
+  readonly previousOnChange: MediaQueryList["onchange"];
+};
+
+const legacySubscriptions = new WeakMap<MediaQueryList, LegacySubscription>();
 
 const getBrowserWindow = (): BrowserWindowWithMatchMedia | undefined =>
   (globalThis as { window?: BrowserWindowWithMatchMedia }).window;
@@ -24,54 +32,85 @@ const getMediaQueryList = (query: string): MediaQueryList | null => {
   return browserWindow.matchMedia(query);
 };
 
-export function useMediaQuery(query: string): boolean {
-  const [matches, setMatches] = useState(false);
-  const syncMatches = useEffectEvent((nextMatches: boolean) => {
-    setMatches((currentMatches) =>
-      currentMatches === nextMatches ? currentMatches : nextMatches
-    );
-  });
+const subscribeWithOnChange = (
+  mediaQueryList: MediaQueryList,
+  onStoreChange: () => void
+): (() => void) => {
+  let subscription = legacySubscriptions.get(mediaQueryList);
 
-  useEffect(() => {
-    const mediaQueryList = getMediaQueryList(query);
-    if (!mediaQueryList) {
+  if (subscription === undefined) {
+    const listeners = new Set<() => void>();
+    const previousOnChange = mediaQueryList.onchange;
+    const handler: NonNullable<MediaQueryList["onchange"]> = (event) => {
+      previousOnChange?.call(mediaQueryList, event);
+      listeners.forEach((listener) => listener());
+    };
+
+    subscription = { listeners, handler, previousOnChange };
+    legacySubscriptions.set(mediaQueryList, subscription);
+    mediaQueryList.onchange = handler;
+  }
+
+  subscription.listeners.add(onStoreChange);
+  let isSubscribed = true;
+
+  return () => {
+    if (!isSubscribed) {
       return;
     }
 
-    syncMatches(mediaQueryList.matches);
-
-    const handleChange = (event: MediaQueryListEvent) => {
-      syncMatches(event.matches);
-    };
-
-    const mediaQueryListListeners =
-      mediaQueryList as MediaQueryListOptionalListeners;
-
-    if (
-      typeof mediaQueryListListeners.addEventListener === "function" &&
-      typeof mediaQueryListListeners.removeEventListener === "function"
-    ) {
-      mediaQueryListListeners.addEventListener("change", handleChange);
-      return () =>
-        mediaQueryListListeners.removeEventListener?.("change", handleChange);
+    isSubscribed = false;
+    subscription.listeners.delete(onStoreChange);
+    if (subscription.listeners.size > 0) {
+      return;
     }
 
-    const previousOnChange = mediaQueryList.onchange;
-    const fallbackHandler: NonNullable<MediaQueryList["onchange"]> = (
-      event
-    ) => {
-      previousOnChange?.call(mediaQueryList, event);
-      syncMatches(mediaQueryList.matches);
-    };
+    legacySubscriptions.delete(mediaQueryList);
+    if (mediaQueryList.onchange === subscription.handler) {
+      mediaQueryList.onchange = subscription.previousOnChange;
+    }
+  };
+};
 
-    mediaQueryList.onchange = fallbackHandler;
+const subscribeToMediaQueryList = (
+  mediaQueryList: MediaQueryList | null,
+  onStoreChange: () => void
+): (() => void) => {
+  if (mediaQueryList === null) {
+    return () => undefined;
+  }
 
-    return () => {
-      if (mediaQueryList.onchange === fallbackHandler) {
-        mediaQueryList.onchange = previousOnChange;
-      }
+  const mediaQueryListListeners =
+    mediaQueryList as MediaQueryListOptionalListeners;
+
+  if (
+    typeof mediaQueryListListeners.addEventListener === "function" &&
+    typeof mediaQueryListListeners.removeEventListener === "function"
+  ) {
+    mediaQueryListListeners.addEventListener("change", onStoreChange);
+    return () =>
+      mediaQueryListListeners.removeEventListener?.("change", onStoreChange);
+  }
+
+  return subscribeWithOnChange(mediaQueryList, onStoreChange);
+};
+
+const getServerSnapshot = (): boolean => false;
+
+export function useMediaQuery(query: string): boolean {
+  const store = useMemo(() => {
+    const mediaQueryList = getMediaQueryList(query);
+
+    return {
+      getSnapshot: () => mediaQueryList?.matches ?? false,
+      subscribe: (onStoreChange: () => void) =>
+        subscribeToMediaQueryList(mediaQueryList, onStoreChange),
     };
   }, [query]);
 
-  return matches;
+  return useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    getServerSnapshot
+  );
 }


### PR DESCRIPTION
## Issue
- Sentry issue 6529-FRONTEND-A7 reports `Maximum update depth exceeded` on `/waves/:wave`, with the first-party stack entering `useMediaQuery` from a `MediaQueryList` change event.

## Fix
- Replace effect-driven React state updates with `useSyncExternalStore` over a primitive media-query snapshot.
- Duplicate or synchronous notifications now cause React to re-read the snapshot and only render when the boolean value actually changes.
- Keep a stable `false` server/hydration snapshot.

## Changes
- Preserve modern `addEventListener("change", ...)` subscription cleanup.
- Multiplex the legacy `onchange` fallback so multiple consumers share and safely restore the prior handler.
- Add regression coverage for initial true/false values, server snapshot, changes, duplicate same-value notifications, cleanup, multiple consumers, and legacy behavior.

## Validation
- `6529 run test:no-coverage __tests__/hooks/useMediaQuery.test.tsx --runInBand` (8 tests passed)
- `6529 run test:no-coverage __tests__/components/memes/drops/MemesLeaderboardDrop.test.tsx __tests__/components/waves/leaderboard/gallery/WaveLeaderboardGalleryItem.test.tsx --runInBand` (25 tests passed)
- `6529 run lint:changed`
- `6529 run typecheck:changed`
- `6529 run react-doctor:diff` (100/100, no issues)
- Focused Prettier check and `git diff --check`

## Risk
- Level: Low
- Why: The shared hook affects responsive behavior across several surfaces, but the return type and server snapshot stay unchanged and focused consumer tests pass.
- Rollback: Revert the single implementation commit.

## Review Notes
- Please focus on external-store snapshot stability under repeated synchronous notifications and legacy `onchange` cleanup with multiple consumers.
- No user-facing copy, docs, telemetry, generated files, or dependency metadata changed.