### PR TITLE
Classify transient push registration failures

### DIFF
--- a/__tests__/components/notifications/NotificationsContext.test.tsx
+++ b/__tests__/components/notifications/NotificationsContext.test.tsx
@@ -578,6 +578,70 @@ describe("push registration behavior", () => {
     );
   });
 
+  it("bounds retries for a persistent observed timeout and captures the final failure", async () => {
+    const { commonApiPost } = require("@/services/api/common-api");
+    const sentry = require("@sentry/nextjs");
+    const timeoutError = new Error("The request timed out.");
+
+    commonApiPost.mockRejectedValue(timeoutError);
+    const { registrationCallback } = await setupRegistrationCallback();
+
+    const setTimeoutSpy = jest
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation(((handler: TimerHandler) => {
+        if (typeof handler === "function") {
+          handler();
+        }
+        return 0 as unknown as NodeJS.Timeout;
+      }) as typeof globalThis.setTimeout);
+
+    try {
+      await act(async () => {
+        await registrationCallback({ value: "test-token" });
+      });
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+
+    expect(commonApiPost).toHaveBeenCalledTimes(3);
+    expect(sentry.addBreadcrumb).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        message: "Push registration attempt failed. Retrying.",
+        data: expect.objectContaining({
+          attempt: 1,
+          max_attempts: 3,
+          error_message: "The request timed out.",
+        }),
+      })
+    );
+    expect(sentry.addBreadcrumb).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        message: "Push registration attempt failed. Retrying.",
+        data: expect.objectContaining({
+          attempt: 2,
+          max_attempts: 3,
+          error_message: "The request timed out.",
+        }),
+      })
+    );
+    expect(sentry.captureException).toHaveBeenCalledWith(
+      timeoutError,
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          component: "NotificationsProvider",
+          operation: "registerPushNotification",
+        }),
+        extra: expect.objectContaining({
+          attempt: 3,
+          max_attempts: 3,
+          error_message: "The request timed out.",
+        }),
+      })
+    );
+  });
+
   it("skips duplicate registration for identical fingerprint", async () => {
     const { commonApiPost } = require("@/services/api/common-api");
     const sentry = require("@sentry/nextjs");
@@ -627,6 +691,75 @@ describe("push registration behavior", () => {
       })
     );
   });
+
+  it.each([
+    "The request timed out.",
+    "A server with the specified hostname could not be found.",
+  ])(
+    "records observed transient native registration error %s as a warning breadcrumb",
+    async (errorMessage) => {
+      const sentry = require("@sentry/nextjs");
+      const nativeError = new Error(errorMessage);
+      const { registrationErrorCallback } = await setupRegistrationCallback();
+
+      act(() => {
+        registrationErrorCallback(nativeError);
+      });
+
+      expect(sentry.captureException).not.toHaveBeenCalled();
+      expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          level: "warning",
+          message: "Push registration transient error.",
+          data: expect.objectContaining({
+            component: "NotificationsProvider",
+            operation: "pushRegistrationError",
+            retryable: true,
+            error_name: "Error",
+            error_message: errorMessage,
+          }),
+        })
+      );
+    }
+  );
+
+  it.each([
+    "Network error: push notification permission denied.",
+    "Network request failed: unauthorized.",
+    "The request timed out because the device token is invalid.",
+    "A server with the specified hostname could not be found because the push configuration is invalid.",
+  ])(
+    "captures permanent native registration near-miss %s",
+    async (errorMessage) => {
+      const sentry = require("@sentry/nextjs");
+      const nativeError = new Error(errorMessage);
+      const { registrationErrorCallback } = await setupRegistrationCallback();
+
+      act(() => {
+        registrationErrorCallback(nativeError);
+      });
+
+      expect(sentry.addBreadcrumb).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Push registration transient error.",
+        })
+      );
+      expect(sentry.captureException).toHaveBeenCalledWith(
+        nativeError,
+        expect.objectContaining({
+          tags: expect.objectContaining({
+            component: "NotificationsProvider",
+            operation: "pushRegistrationError",
+          }),
+          extra: expect.objectContaining({
+            retryable: false,
+            error_name: "Error",
+            error_message: errorMessage,
+          }),
+        })
+      );
+    }
+  );
 
   it.each(["-25291", "-25299"])(
     "records known low-value native registration error %s as an info breadcrumb",

--- a/__tests__/components/notifications/NotificationsContext.test.tsx
+++ b/__tests__/components/notifications/NotificationsContext.test.tsx
@@ -604,6 +604,7 @@ describe("push registration behavior", () => {
     }
 
     expect(commonApiPost).toHaveBeenCalledTimes(3);
+    expect(sentry.addBreadcrumb).toHaveBeenCalledTimes(2);
     expect(sentry.addBreadcrumb).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({

--- a/components/notifications/NotificationsContext.tsx
+++ b/components/notifications/NotificationsContext.tsx
@@ -91,7 +91,20 @@ const TRANSIENT_ERROR_PATTERNS = [
   "network connection was lost",
   "network request failed",
   "network error",
+  "server with the specified hostname could not be found",
+  "timed out",
   "timeout",
+];
+const PERMANENT_PUSH_REGISTRATION_ERROR_PATTERNS = [
+  "permission denied",
+  "permission not granted",
+  "not authorized",
+  "unauthorized",
+  "invalid configuration",
+  "configuration is invalid",
+  "invalid token",
+  "invalid device token",
+  "token is invalid",
 ];
 const LOW_VALUE_PUSH_REGISTRATION_ERROR_PATTERNS = [
   "com.google.iid error -25291",
@@ -294,6 +307,15 @@ const isUnauthorizedPushRegistrationError = (error: unknown): boolean =>
   extractErrorStatusCode(error) === 401;
 
 const isTransientPushRegistrationError = (error: unknown): boolean => {
+  const normalizedMessage = toErrorMessage(error).toLowerCase();
+  const isExplicitlyPermanent =
+    PERMANENT_PUSH_REGISTRATION_ERROR_PATTERNS.some((pattern) =>
+      normalizedMessage.includes(pattern)
+    );
+  if (isExplicitlyPermanent) {
+    return false;
+  }
+
   if (isRateLimitError(error)) {
     return true;
   }
@@ -303,7 +325,6 @@ const isTransientPushRegistrationError = (error: unknown): boolean => {
     return statusCode === 408 || (statusCode >= 500 && statusCode < 600);
   }
 
-  const normalizedMessage = toErrorMessage(error).toLowerCase();
   return TRANSIENT_ERROR_PATTERNS.some((pattern) =>
     normalizedMessage.includes(pattern)
   );


### PR DESCRIPTION
## Issue
- Native push registration reported expected iOS network failures to Sentry issue `6529-FRONTEND-DY` as `retryable=false` errors.
- The shared classifier recognized `timeout`, but not the observed `timed out` or hostname lookup wording.

## Fix
- Treat the two observed timeout/DNS messages as transient.
- Give explicit permanent registration wording precedence so permission denial, unauthorized, invalid configuration, and invalid token failures still reach error capture.

## Changes
- Extended the existing shared transient classifier with the observed production phrases.
- Added focused coverage for both production messages, permanent near-misses, retry exhaustion, and breadcrumb-versus-error telemetry outcomes.
- Preserved existing Sentry operation names and telemetry field shapes.

## Validation
- `./bin/6529 run test __tests__/components/notifications/NotificationsContext.test.tsx --runInBand --cacheDirectory=/tmp/codex-jest-push-registration-transient-errors`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff` (99/100; only existing provider-size and sequential-await warnings)
- `git diff --check`

## Risk
- Level: Low
- Why: The change is limited to push registration error classification and tests. Explicit permanent-error precedence protects permission, auth, configuration, and token failures.
- Rollback: Revert the single commit to restore the prior classifier.

## Review Notes
- Please focus on the transient/permanent precedence and the bounded retry exhaustion assertion.
- The Sentry issue remains unresolved pending merge and deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved push notification registration error handling with stricter transient vs. permanent classification.
  * Prevented retries for permanent authorization/config/token and device-token failures.
  * Expanded detection of temporary server/timeout issues and refined warning breadcrumb behavior.
  * Limited registration retries to a bounded number of attempts and improved final failure reporting after repeated timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->