### PR TITLE
Harden Sentry third-party noise filters

### DIFF
--- a/__tests__/fixtures/sentry-noise-filter-hardening.json
+++ b/__tests__/fixtures/sentry-noise-filter-hardening.json
@@ -2,7 +2,10 @@
   "cp": {
     "transaction": "/messages/:wave",
     "request": {
-      "url": "https://6529.io/messages/00000000-0000-4000-8000-000000000001"
+      "url": "https://6529.io/messages/00000000-0000-4000-8000-000000000001",
+      "headers": {
+        "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
+      }
     },
     "exception": {
       "values": [

--- a/__tests__/fixtures/sentry-noise-filter-hardening.json
+++ b/__tests__/fixtures/sentry-noise-filter-hardening.json
@@ -1,0 +1,201 @@
+{
+  "cp": {
+    "transaction": "/messages/:wave",
+    "request": {
+      "url": "https://6529.io/messages/00000000-0000-4000-8000-000000000001"
+    },
+    "exception": {
+      "values": [
+        {
+          "type": "TypeError",
+          "value": "JSON.stringify cannot serialize cyclic structures.",
+          "mechanism": {
+            "type": "auto.browser.browserapierrors.setTimeout",
+            "handled": false
+          },
+          "stacktrace": {
+            "frames": [
+              {
+                "filename": "node_modules/.pnpm/@sentry+nextjs@10.45.0/node_modules/@sentry/nextjs/src/client/routing/parameterization.ts",
+                "function": "n",
+                "in_app": true
+              },
+              {
+                "filename": "[native code]",
+                "function": "stringify",
+                "in_app": true
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "b9": {
+    "transaction": "/:user",
+    "request": {
+      "url": "https://6529.io/example-profile",
+      "headers": {
+        "User-Agent": "Twitter/12.3 (iPhone; iOS 16.7.14)"
+      }
+    },
+    "exception": {
+      "values": [
+        {
+          "type": "ReferenceError",
+          "value": "Can't find variable: CONFIG",
+          "mechanism": {
+            "type": "auto.browser.browserapierrors.addEventListener",
+            "handled": false
+          },
+          "stacktrace": {
+            "frames": [
+              {
+                "filename": "node_modules/.pnpm/@sentry+nextjs@10.45.0/node_modules/@sentry/nextjs/src/client/routing/parameterization.ts",
+                "function": "n",
+                "in_app": false
+              },
+              {
+                "filename": "app:///waves/00000000-0000-4000-8000-000000000002",
+                "function": "updateFooterPositions",
+                "in_app": true
+              },
+              {
+                "filename": "app:///waves/00000000-0000-4000-8000-000000000002",
+                "function": "updateGapFiller",
+                "in_app": true
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "nineN": {
+    "transaction": "/waves/:wave",
+    "request": {
+      "url": "https://6529.io/waves/00000000-0000-4000-8000-000000000002",
+      "headers": {
+        "User-Agent": "Twitter/12.3 (iPhone; iOS 16.7.14)"
+      }
+    },
+    "exception": {
+      "values": [
+        {
+          "type": "ReferenceError",
+          "value": "Can't find variable: currentInset",
+          "mechanism": {
+            "type": "auto.browser.global_handlers.onerror",
+            "handled": false
+          },
+          "stacktrace": {
+            "frames": [
+              {
+                "filename": "app:///waves/00000000-0000-4000-8000-000000000002",
+                "function": "global code",
+                "in_app": true
+              },
+              {
+                "filename": "app:///waves/00000000-0000-4000-8000-000000000002",
+                "function": "init",
+                "in_app": true
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "threeV": {
+    "transaction": "/waves/:wave",
+    "request": {
+      "url": "https://6529.io/waves/00000000-0000-4000-8000-000000000003"
+    },
+    "exception": {
+      "values": [
+        {
+          "type": "Error",
+          "value": "Cannot read properties of undefined (reading 'sendMessage')",
+          "mechanism": {
+            "type": "auto.browser.global_handlers.onunhandledrejection",
+            "handled": false
+          },
+          "stacktrace": {
+            "frames": [
+              {
+                "filename": "node_modules/.pnpm/@sentry+browser@10.45.0/node_modules/@sentry/browser/src/helpers.ts",
+                "function": "n",
+                "in_app": false
+              },
+              {
+                "filename": "app:///injectedScript.bundle.js",
+                "function": "n",
+                "in_app": true
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "dk": {
+    "transaction": "/waves/:wave",
+    "request": {
+      "url": "https://6529.io/waves/00000000-0000-4000-8000-000000000004"
+    },
+    "exception": {
+      "values": [
+        {
+          "type": "Error",
+          "value": "websocket error 1006: ",
+          "mechanism": {
+            "type": "auto.browser.global_handlers.onunhandledrejection",
+            "handled": false
+          },
+          "stacktrace": {
+            "frames": [
+              {
+                "filename": "app:///requestRelay.js",
+                "function": "i.onclose",
+                "in_app": true
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "twoY": {
+    "transaction": "/:user/subscriptions",
+    "level": "warning",
+    "tags": {
+      "errorType": "network",
+      "network_failure_kind": "browser_transport",
+      "network_noise_sampled": "true"
+    },
+    "request": {
+      "url": "https://6529.io/example-profile/subscriptions"
+    },
+    "exception": {
+      "values": [
+        {
+          "type": "Error",
+          "value": "Network request failed. Please check your connection and try again. (/api/subscriptions/consolidation/upcoming-memes/sample)",
+          "mechanism": {
+            "type": "auto.browser.global_handlers.onunhandledrejection",
+            "handled": false
+          },
+          "stacktrace": {
+            "frames": [
+              {
+                "filename": "services/api/common-api.ts",
+                "function": "executeApiRequest",
+                "in_app": true
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -1,3 +1,5 @@
+import noiseFilterFixtures from "@/__tests__/fixtures/sentry-noise-filter-hardening.json";
+
 const mockInit = jest.fn();
 const mockReplayIntegration = jest.fn(() => ({ name: "replay" }));
 const mockCaptureRouterTransitionStart = jest.fn();
@@ -999,6 +1001,139 @@ describe("instrumentation-client", () => {
         in_app: true,
       },
     ]);
+
+    const result = beforeSend(event);
+
+    expect(result).not.toBeNull();
+  });
+
+  it("drops the raw CP route-parameterization event before browser context enrichment", () => {
+    const beforeSend = loadBeforeSend();
+
+    const result = beforeSend(noiseFilterFixtures.cp);
+
+    expect(result).toBeNull();
+  });
+
+  it("drops the raw B9 Twitter CONFIG event with a Sentry wrapper frame", () => {
+    const beforeSend = loadBeforeSend();
+
+    const result = beforeSend(noiseFilterFixtures.b9);
+
+    expect(result).toBeNull();
+  });
+
+  it("drops the raw 9N Twitter currentInset event", () => {
+    const beforeSend = loadBeforeSend();
+
+    const result = beforeSend(noiseFilterFixtures.nineN);
+
+    expect(result).toBeNull();
+  });
+
+  it("drops the raw 3V injected sendMessage event with a Sentry helper frame", () => {
+    const beforeSend = loadBeforeSend();
+
+    const result = beforeSend(noiseFilterFixtures.threeV);
+
+    expect(result).toBeNull();
+  });
+
+  it("drops the raw DK Coinbase request-relay websocket event", () => {
+    const beforeSend = loadBeforeSend();
+
+    const result = beforeSend(noiseFilterFixtures.dk);
+
+    expect(result).toBeNull();
+  });
+
+  it("keeps the intentional raw 2Y sampled first-party network event", () => {
+    const beforeSend = loadBeforeSend();
+
+    const result = beforeSend(noiseFilterFixtures.twoY);
+
+    expect(result).not.toBeNull();
+    expect(result?.tags?.["network_noise_sampled"]).toBe("true");
+  });
+
+  it("keeps app-owned Twitter currentInset errors", () => {
+    const beforeSend = loadBeforeSend();
+    const event = {
+      ...noiseFilterFixtures.nineN,
+      exception: {
+        values: [
+          {
+            ...noiseFilterFixtures.nineN.exception.values[0],
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "webpack-internal:///(app-pages-browser)/./components/waves/WaveLayout.tsx",
+                  function: "updateCurrentInset",
+                  in_app: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result).not.toBeNull();
+  });
+
+  it("keeps app-owned sendMessage failures", () => {
+    const beforeSend = loadBeforeSend();
+    const event = {
+      ...noiseFilterFixtures.threeV,
+      exception: {
+        values: [
+          {
+            ...noiseFilterFixtures.threeV.exception.values[0],
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "webpack-internal:///(app-pages-browser)/./services/messaging/sendMessage.ts",
+                  function: "sendMessage",
+                  in_app: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result).not.toBeNull();
+  });
+
+  it("keeps app-owned requestRelay websocket failures", () => {
+    const beforeSend = loadBeforeSend();
+    const event = {
+      ...noiseFilterFixtures.dk,
+      exception: {
+        values: [
+          {
+            ...noiseFilterFixtures.dk.exception.values[0],
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "webpack-internal:///(app-pages-browser)/./services/websocket/requestRelay.ts",
+                  function: "handleRelayClose",
+                  in_app: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
 
     const result = beforeSend(event);
 

--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -993,14 +993,43 @@ describe("instrumentation-client", () => {
 
   it("keeps cyclic JSON errors with app-owned frames", () => {
     const beforeSend = loadBeforeSend();
-    const event = createSentryRouteParameterizationEvent([
-      nativeJsonStringifyFrame,
+    const event = createSentryRouteParameterizationEvent(
+      [
+        {
+          filename:
+            "node_modules/.pnpm/@sentry+nextjs@10.45.0/node_modules/@sentry/nextjs/src/client/routing/parameterization.ts",
+          function: "n",
+        },
+        nativeJsonStringifyFrame,
+        {
+          filename: "https://6529.io/_next/static/chunks/app-client.js",
+          function: "serializeWaveParams",
+          in_app: true,
+        },
+      ],
       {
-        filename: "https://6529.io/_next/static/chunks/app-client.js",
-        function: "serializeWaveParams",
-        in_app: true,
+        contexts: {},
+        tags: {},
+      }
+    );
+
+    const result = beforeSend(event);
+
+    expect(result).not.toBeNull();
+  });
+
+  it("keeps Sentry route-parameterization cyclic JSON errors outside iOS webviews", () => {
+    const beforeSend = loadBeforeSend();
+    const event = {
+      ...noiseFilterFixtures.cp,
+      request: {
+        ...noiseFilterFixtures.cp.request,
+        headers: {
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/126.0.0.0 Safari/537.36",
+        },
       },
-    ]);
+    };
 
     const result = beforeSend(event);
 
@@ -1021,6 +1050,23 @@ describe("instrumentation-client", () => {
     const result = beforeSend(noiseFilterFixtures.b9);
 
     expect(result).toBeNull();
+  });
+
+  it("keeps B9-shaped events from Twitter-lookalike user agents", () => {
+    const beforeSend = loadBeforeSend();
+    const event = {
+      ...noiseFilterFixtures.b9,
+      request: {
+        ...noiseFilterFixtures.b9.request,
+        headers: {
+          "User-Agent": "ExampleTwitter/12.3 (iPhone; iOS 16.7.14)",
+        },
+      },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result).not.toBeNull();
   });
 
   it("drops the raw 9N Twitter currentInset event", () => {

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -159,8 +159,18 @@ describe("sentry-client-filters", () => {
           value: "Can't find variable: CONFIG",
           stacktrace: {
             frames: [
-              { filename: "app:///", abs_path: "app:///" },
-              { filename: "app:///", abs_path: "app:///" },
+              {
+                filename:
+                  "app:///waves/00000000-0000-4000-8000-000000000002",
+                abs_path:
+                  "app:///waves/00000000-0000-4000-8000-000000000002",
+              },
+              {
+                filename:
+                  "app:///waves/00000000-0000-4000-8000-000000000002",
+                abs_path:
+                  "app:///waves/00000000-0000-4000-8000-000000000002",
+              },
             ],
           },
         },
@@ -3293,7 +3303,7 @@ describe("sentry-client-filters", () => {
     expect(getLowValueNetworkErrorDecision(event, 0)).toBe("not_applicable");
   });
 
-  it("filters Twitter CONFIG reference errors with app URI frames", () => {
+  it("filters Twitter CONFIG reference errors with injected wave document frames", () => {
     // Arrange
     const event = createTwitterConfigEvent();
 
@@ -6474,7 +6484,7 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(false);
   });
 
-  it("does not filter Twitter CONFIG errors when frames are not all app URIs", () => {
+  it("does not filter app-owned Twitter CONFIG errors", () => {
     // Arrange
     const event = createTwitterConfigEvent({
       exception: {
@@ -6484,10 +6494,11 @@ describe("sentry-client-filters", () => {
             value: "Can't find variable: CONFIG",
             stacktrace: {
               frames: [
-                { filename: "app:///", abs_path: "app:///" },
                 {
-                  filename: "https://example.com/main.js",
-                  abs_path: "https://example.com/main.js",
+                  filename:
+                    "webpack-internal:///(app-pages-browser)/./components/waves/WaveLayout.tsx",
+                  abs_path:
+                    "webpack-internal:///(app-pages-browser)/./components/waves/WaveLayout.tsx",
                 },
               ],
             },

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -20,6 +20,7 @@ import {
   shouldFilterAnonymousUnsafeEvalCspError,
   shouldFilterByFilenameExceptions,
   shouldFilterBrowserExtensionMessagingConnectionError,
+  shouldFilterBrowserExtensionSendMessageError,
   shouldFilterCoinbaseWalletLinkWebSocket1006,
   shouldFilterDisconnectedWalletProviderRejection,
   shouldFilterInjectedProviderProxyStartsWithError,
@@ -33,6 +34,7 @@ import {
   shouldFilterTalismanExtensionOnboardingError,
   shouldFilterThirdPartyTelemetryNetworkError,
   shouldFilterThirdPartyTelemetrySpan,
+  shouldFilterTwitterCurrentInsetReferenceError,
   shouldFilterTwitterConfigReferenceError,
   shouldFilterWalletConnectStaleSessionTopic,
   tagSampledLowValueNetworkError,
@@ -153,6 +155,10 @@ function shouldFilterEvent(
     return true;
   }
 
+  if (shouldFilterBrowserExtensionSendMessageError(event, hint)) {
+    return true;
+  }
+
   if (shouldFilterCoinbaseWalletLinkWebSocket1006(event, hint)) {
     return true;
   }
@@ -166,6 +172,10 @@ function shouldFilterEvent(
   }
 
   if (shouldFilterTwitterConfigReferenceError(event)) {
+    return true;
+  }
+
+  if (shouldFilterTwitterCurrentInsetReferenceError(event)) {
     return true;
   }
 

--- a/utils/sentry-client-filters.ts
+++ b/utils/sentry-client-filters.ts
@@ -23,9 +23,13 @@ export {
   shouldFilterReactDomInsertBeforeNotFoundError,
   shouldFilterReactDomRemoveChildNotFoundError,
   shouldFilterSentryRouteParameterizationError,
+  shouldFilterTwitterCurrentInsetReferenceError,
   shouldFilterTwitterConfigReferenceError,
 } from "./sentry-client-filters/errors";
-export { shouldFilterBrowserExtensionMessagingConnectionError } from "./sentry-client-filters/extension-messaging";
+export {
+  shouldFilterBrowserExtensionMessagingConnectionError,
+  shouldFilterBrowserExtensionSendMessageError,
+} from "./sentry-client-filters/extension-messaging";
 export {
   shouldFilterCoinbaseWalletLinkWebSocket1006,
   shouldFilterDisconnectedWalletProviderRejection,

--- a/utils/sentry-client-filters/constants.ts
+++ b/utils/sentry-client-filters/constants.ts
@@ -35,6 +35,8 @@ export const coinbaseWalletLinkWebSocketFile = "WalletLinkWebSocket.js";
 export const coinbaseWalletLinkWebSocketCloseFunction = "webSocket.onclose";
 export const browserUnhandledRejectionMechanism =
   "auto.browser.global_handlers.onunhandledrejection";
+export const browserGlobalHandlerOnErrorMechanism =
+  "auto.browser.global_handlers.onerror";
 export const coinbaseWalletLinkWebSocket1006MessagePrefix =
   "websocket error 1006";
 export const walletWebSocketBreadcrumbAppKitTokens = [
@@ -177,6 +179,10 @@ export const sentryRouteParameterizationMessage =
 export const sentryRouteParameterizationPathToken =
   "client/routing/parameterization.ts";
 export const sentryPackagePathTokens = ["@sentry/nextjs", "@sentry+nextjs"];
+export const twitterInjectedWaveDocumentPathPattern =
+  /^app:\/\/\/waves\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+export const twitterCurrentInsetReferenceErrorMessage =
+  "Can't find variable: currentInset";
 export const metaMaskMobileContextTokens = [
   "metamaskmobile",
   "metamask mobile",
@@ -218,6 +224,15 @@ export const extensionMessagingContentScriptPaths = new Set([
   "app:///content-scripts/content.js",
 ]);
 export const injectedScriptBundlePathToken = "injectedscript.bundle.js";
+export const injectedScriptSendMessageError =
+  "Cannot read properties of undefined (reading 'sendMessage')";
+export const sentryBrowserHelperPathToken = "/helpers.ts";
+export const sentryBrowserPackagePathTokens = [
+  "@sentry/browser",
+  "@sentry+browser",
+];
+export const coinbaseWalletRequestRelayPath = "app:///requestRelay.js";
+export const coinbaseWalletRequestRelayCloseFunction = "i.onclose";
 export const URL_IS_FIRST_PARTY_KEY = "url.is_first_party";
 export const URL_IS_FIRST_PARTY_API_KEY = "url.is_first_party_api";
 export const FNV_OFFSET_BASIS = 2166136261;

--- a/utils/sentry-client-filters/errors.ts
+++ b/utils/sentry-client-filters/errors.ts
@@ -1,4 +1,5 @@
 import {
+  browserGlobalHandlerOnErrorMechanism,
   browserUnhandledRejectionMechanism,
   filenameExceptions,
   gifPickerTenorFailureMessage,
@@ -10,6 +11,8 @@ import {
   sentryRouteParameterizationMechanismType,
   sentryRouteParameterizationMessage,
   tenorCategoriesPath,
+  twitterCurrentInsetReferenceErrorMessage,
+  twitterInjectedWaveDocumentPathPattern,
   webViewUserAgentTokens,
   routeParameterizationContextKeys,
   routeParameterizationTagKeys,
@@ -23,6 +26,7 @@ import {
   getBreadcrumbMessages,
   getBreadcrumbValues,
   getContextString,
+  getFramePaths,
   getHintExceptionMessage,
   getRequestHeaderString,
   getRequestPathname,
@@ -52,7 +56,6 @@ import {
   hasInjectedWasmCspFrameSignature,
   hasLikelyAppOwnedFrame,
   hasNativeJsonStringifyFrame,
-  hasOnlyAppUriFrames,
   hasReactDomNotFoundErrorSignature,
   hasSentryRouteParameterizationFrame,
   isSentryRouteParameterizationFrame,
@@ -351,7 +354,40 @@ export function isTwitterBrowser(event: SentryClientEvent): boolean {
   }
 
   const browserTag = event.tags?.["browser"];
-  return typeof browserTag === "string" && browserTag.startsWith("Twitter");
+  if (typeof browserTag === "string" && browserTag.startsWith("Twitter")) {
+    return true;
+  }
+
+  const userAgentValues = [
+    getRequestHeaderString(event, "user-agent"),
+    getRuntimeUserAgentString(),
+  ];
+  return userAgentValues.some(
+    (value) =>
+      typeof value === "string" && value.toLowerCase().includes("twitter")
+  );
+}
+
+function isTwitterInjectedWaveDocumentFrame(frame: SentryStackFrame): boolean {
+  const paths = getFramePaths(frame);
+  return (
+    paths.length > 0 &&
+    paths.every((path) => twitterInjectedWaveDocumentPathPattern.test(path))
+  );
+}
+
+function hasOnlyTwitterInjectedWaveDocumentFrames(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  return (
+    Array.isArray(frames) &&
+    frames.some(isTwitterInjectedWaveDocumentFrame) &&
+    frames.every(
+      (frame) =>
+        isTwitterInjectedWaveDocumentFrame(frame) ||
+        isSentryRouteParameterizationFrame(frame)
+    )
+  );
 }
 
 export function shouldFilterByFilenameExceptions(
@@ -379,7 +415,29 @@ export function shouldFilterTwitterConfigReferenceError(
     return false;
   }
 
-  return hasOnlyAppUriFrames(value.stacktrace?.frames);
+  return hasOnlyTwitterInjectedWaveDocumentFrames(value.stacktrace?.frames);
+}
+
+export function shouldFilterTwitterCurrentInsetReferenceError(
+  event: SentryClientEvent
+): boolean {
+  const value = event.exception?.values?.[0];
+  if (
+    value?.type !== "ReferenceError" ||
+    value.value !== twitterCurrentInsetReferenceErrorMessage
+  ) {
+    return false;
+  }
+
+  if (
+    value.mechanism?.type !== browserGlobalHandlerOnErrorMechanism ||
+    value.mechanism.handled !== false ||
+    !isTwitterBrowser(event)
+  ) {
+    return false;
+  }
+
+  return hasOnlyTwitterInjectedWaveDocumentFrames(value.stacktrace?.frames);
 }
 
 export function shouldFilterReactDomInsertBeforeNotFoundError(
@@ -473,9 +531,12 @@ export function shouldFilterSentryRouteParameterizationError(
     return false;
   }
 
+  if (hasSentryRouteParameterizationFrame(frames)) {
+    return true;
+  }
+
   return (
-    (hasRouteParameterizationRouteEvidence(event) ||
-      hasSentryRouteParameterizationFrame(frames)) &&
+    hasRouteParameterizationRouteEvidence(event) &&
     (hasMetaMaskMobileWebViewContext(event) ||
       hasMobileSafariWebViewContext(event))
   );

--- a/utils/sentry-client-filters/errors.ts
+++ b/utils/sentry-client-filters/errors.ts
@@ -62,6 +62,7 @@ import {
 } from "./app-frame-utils";
 
 const sentryBrowserPathTokens = ["@sentry/browser", "@sentry+browser"];
+const twitterUserAgentPattern = /(?:^|[\s;(])twitter(?:android)?\//i;
 
 function shouldFilterFilenameExceptions(
   frames: SentryStackFrame[] | undefined
@@ -205,6 +206,16 @@ function matchesContextToken(value: string, tokens: string[]): boolean {
   return tokens.some((token) => normalized.includes(token));
 }
 
+function isIosWebViewUserAgent(value: string): boolean {
+  const normalized = value.toLowerCase();
+  return (
+    /\b(?:iphone|ipad|ipod)\b/.test(normalized) &&
+    normalized.includes("applewebkit/") &&
+    normalized.includes("mobile/") &&
+    !normalized.includes("safari/")
+  );
+}
+
 export function hasMetaMaskMobileWebViewContext(
   event: SentryClientEvent
 ): boolean {
@@ -227,10 +238,15 @@ export function hasMetaMaskMobileWebViewContext(
 function hasMobileSafariWebViewContext(event: SentryClientEvent): boolean {
   const contextValues = getRouteParameterizationContextValues(event);
   const userAgentValues = getRouteParameterizationUserAgentValues(event);
-  const values = [...contextValues, ...userAgentValues];
-
-  return values.some((value) =>
-    matchesContextToken(value, mobileSafariWebViewContextTokens)
+  return (
+    contextValues.some((value) =>
+      matchesContextToken(value, mobileSafariWebViewContextTokens)
+    ) ||
+    userAgentValues.some(
+      (value) =>
+        matchesContextToken(value, mobileSafariWebViewContextTokens) ||
+        isIosWebViewUserAgent(value)
+    )
   );
 }
 
@@ -354,7 +370,10 @@ export function isTwitterBrowser(event: SentryClientEvent): boolean {
   }
 
   const browserTag = event.tags?.["browser"];
-  if (typeof browserTag === "string" && browserTag.startsWith("Twitter")) {
+  if (
+    typeof browserTag === "string" &&
+    (browserTag === "Twitter" || browserTag.startsWith("Twitter "))
+  ) {
     return true;
   }
 
@@ -363,8 +382,7 @@ export function isTwitterBrowser(event: SentryClientEvent): boolean {
     getRuntimeUserAgentString(),
   ];
   return userAgentValues.some(
-    (value) =>
-      typeof value === "string" && value.toLowerCase().includes("twitter")
+    (value) => typeof value === "string" && twitterUserAgentPattern.test(value)
   );
 }
 
@@ -531,12 +549,9 @@ export function shouldFilterSentryRouteParameterizationError(
     return false;
   }
 
-  if (hasSentryRouteParameterizationFrame(frames)) {
-    return true;
-  }
-
   return (
-    hasRouteParameterizationRouteEvidence(event) &&
+    (hasSentryRouteParameterizationFrame(frames) ||
+      hasRouteParameterizationRouteEvidence(event)) &&
     (hasMetaMaskMobileWebViewContext(event) ||
       hasMobileSafariWebViewContext(event))
   );

--- a/utils/sentry-client-filters/extension-messaging.ts
+++ b/utils/sentry-client-filters/extension-messaging.ts
@@ -1,8 +1,12 @@
 import {
+  browserUnhandledRejectionMechanism,
   browserExtensionUrlPrefixes,
   extensionMessagingConnectionFailureMessage,
   extensionMessagingContentScriptPaths,
   injectedScriptBundlePathToken,
+  injectedScriptSendMessageError,
+  sentryBrowserHelperPathToken,
+  sentryBrowserPackagePathTokens,
 } from "./constants";
 import type {
   SentryClientEvent,
@@ -31,6 +35,31 @@ function isExtensionMessagingFrame(frame: SentryStackFrame): boolean {
   const framePaths = getFramePaths(frame);
   return (
     framePaths.length > 0 && framePaths.every(isExtensionMessagingInjectedPath)
+  );
+}
+
+function isSentryBrowserHelperFrame(frame: SentryStackFrame): boolean {
+  const framePaths = getFramePaths(frame);
+  return (
+    framePaths.length > 0 &&
+    framePaths.every(
+      (path) =>
+        path.includes(sentryBrowserHelperPathToken) &&
+        sentryBrowserPackagePathTokens.some((token) => path.includes(token))
+    )
+  );
+}
+
+function hasOnlyInjectedSendMessageFrames(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  return (
+    Array.isArray(frames) &&
+    frames.some(isExtensionMessagingFrame) &&
+    frames.every(
+      (frame) =>
+        isExtensionMessagingFrame(frame) || isSentryBrowserHelperFrame(frame)
+    )
   );
 }
 
@@ -77,4 +106,27 @@ export function shouldFilterBrowserExtensionMessagingConnectionError(
   }
 
   return hasOnlyExtensionMessagingFrames(value?.stacktrace?.frames);
+}
+
+export function shouldFilterBrowserExtensionSendMessageError(
+  event: SentryClientEvent,
+  hint?: SentryEventHint
+): boolean {
+  const value = event.exception?.values?.[0];
+  if (
+    value?.type !== "Error" ||
+    normalizeErrorPrefix(value.value ?? "") !== injectedScriptSendMessageError
+  ) {
+    return false;
+  }
+
+  if (
+    value.mechanism?.type !== browserUnhandledRejectionMechanism ||
+    value.mechanism.handled !== false ||
+    hasAppOwnedSourceEvidence(event, value, hint)
+  ) {
+    return false;
+  }
+
+  return hasOnlyInjectedSendMessageFrames(value.stacktrace?.frames);
 }

--- a/utils/sentry-client-filters/walletlink-websocket.ts
+++ b/utils/sentry-client-filters/walletlink-websocket.ts
@@ -3,6 +3,8 @@ import {
   coinbaseWalletLinkWebSocketCloseFunction,
   coinbaseWalletLinkWebSocketFile,
   coinbaseWalletLinkWebSocket1006MessagePrefix,
+  coinbaseWalletRequestRelayCloseFunction,
+  coinbaseWalletRequestRelayPath,
   coinbaseWalletSdkPathTokens,
   nextStaticFramePathToken,
   walletWebSocketAppKitBootstrapBreadcrumbTokens,
@@ -53,6 +55,26 @@ function isCoinbaseWalletLinkWebSocketFrame(frame: SentryStackFrame): boolean {
   );
 }
 
+function isCoinbaseWalletRequestRelayFrame(frame: SentryStackFrame): boolean {
+  if (frame.function !== coinbaseWalletRequestRelayCloseFunction) {
+    return false;
+  }
+
+  const paths = [frame.filename, frame.abs_path].filter(
+    (path): path is string => typeof path === "string" && path.length > 0
+  );
+  return (
+    paths.length > 0 &&
+    paths.every((path) => path === coinbaseWalletRequestRelayPath)
+  );
+}
+
+export function hasCoinbaseWalletRequestRelayFrame(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  return Array.isArray(frames) && frames.some(isCoinbaseWalletRequestRelayFrame);
+}
+
 export function hasCoinbaseWalletLinkWebSocketFrame(
   frames: SentryStackFrame[] | undefined
 ): boolean {
@@ -101,6 +123,7 @@ function hasAppOwnedWalletLinkWebSocketInAppFrame(
       (frame) =>
         frame.in_app === true &&
         !isCoinbaseWalletLinkWebSocketFrame(frame) &&
+        !isCoinbaseWalletRequestRelayFrame(frame) &&
         !isCoinbaseWalletLinkWebSocketCloseFrame(frame) &&
         !isRawNextStaticFrame(frame)
     )
@@ -256,6 +279,7 @@ export function hasThirdPartyWalletLinkWebSocket1006Evidence(
 ): boolean {
   return (
     hasCoinbaseWalletLinkWebSocketFrame(value?.stacktrace?.frames) ||
+    hasCoinbaseWalletRequestRelayFrame(value?.stacktrace?.frames) ||
     hasCoinbaseWalletLinkWebSocketStack(hint) ||
     hasCoinbaseWalletLinkWebSocketSerializedStack(event) ||
     hasThirdPartyWalletAppKitBreadcrumbSignature(event)

--- a/utils/sentry-client-filters/wallets.ts
+++ b/utils/sentry-client-filters/wallets.ts
@@ -52,6 +52,7 @@ import {
   hasAppOwnedWalletLinkWebSocket1006Evidence,
   hasBrowserUnhandledRejectionMechanism,
   hasCoinbaseWalletLinkWebSocketFrame,
+  hasCoinbaseWalletRequestRelayFrame,
   hasCoinbaseWalletLinkWebSocketSerializedStack,
   hasCoinbaseWalletLinkWebSocketStack,
   hasRawNextStaticInAppFrame,
@@ -471,6 +472,7 @@ export function shouldFilterCoinbaseWalletLinkWebSocket1006(
 
   const hasExplicitCoinbaseWalletLinkStack =
     hasCoinbaseWalletLinkWebSocketFrame(value?.stacktrace?.frames) ||
+    hasCoinbaseWalletRequestRelayFrame(value?.stacktrace?.frames) ||
     hasCoinbaseWalletLinkWebSocketStack(hint) ||
     hasCoinbaseWalletLinkWebSocketSerializedStack(event);
 


### PR DESCRIPTION
## Issue
- Sentry issues 6529-FRONTEND-CP and 6529-FRONTEND-B9 continued receiving production events even though narrow filters were already deployed.
- CP leaked because `beforeSend` sees the raw client event before parsed browser context is available. B9 leaked because the production stack includes a Sentry route-parameterization wrapper frame, so the existing all-`app:///` predicate rejected it.
- 6529-FRONTEND-9N, 6529-FRONTEND-3V, and 6529-FRONTEND-DK are matching injected Twitter, extension, and wallet-relay noise shapes. 6529-FRONTEND-2Y is an intentional sampled first-party network event and must remain reportable.

## Fix
- Match each noise family with the narrowest stable raw-event evidence: exact exception value/type, mechanism where available, and tightly classified frames.
- Keep the existing app-owned source guards and add explicit preservation coverage for first-party cyclic JSON, Twitter, extension messaging, websocket, and network failures.

## Changes
- Accept CP only when the exact Sentry route-parameterization frame and native JSON stringify frame occur in an iOS webview, using the raw User-Agent before enriched browser context exists.
- Allow B9's known Sentry wrapper only alongside Twitter evidence and injected `app:///waves/<uuid>` document frames; reuse that strict family for 9N's exact `currentInset` error. Raw UA matching is anchored to `Twitter/` or `TwitterAndroid/` tokens.
- Add exact 3V filtering for an unhandled `sendMessage` rejection from `app:///injectedScript.bundle.js`, optionally wrapped by the known Sentry browser helper.
- Extend the Coinbase websocket 1006 predicate only for DK's exact `app:///requestRelay.js` / `i.onclose` frame. Repository search found no app-owned symbol.
- Add sanitized raw-event fixtures for CP, B9, 9N, 3V, DK, and 2Y. The 2Y fixture asserts `network_noise_sampled:true` remains unchanged.

## Validation
- `6529 run test --runInBand --runTestsByPath __tests__/utils/sentry-client-filters.test.ts __tests__/instrumentation-client.test.ts` — 282 tests passed.
- `6529 run lint:changed` — passed.
- `6529 run typecheck:changed` — passed.
- `6529 run react-doctor:diff` — 100/100, no issues.
- `git diff --check` — passed.

## Risk
- Level: Medium
- Why: The change intentionally drops additional monitoring events, but every new path requires an exact production signature and preservation tests cover nearby first-party failures. No telemetry fields, sampling policy, dependencies, generated files, or PII settings change.
- Rollback: Revert the scoped commits to restore the previous predicates.

## Review Notes
- Please focus on the CP raw User-Agent/webview gate, the strict Twitter wave-document classifier, and the exact Coinbase request-relay frame carve-out.
- No Sentry issues were updated or resolved; they should remain open until the fix is merged and deployed.
