### PR TITLE
Harden Wave reaction capability and timeout recovery

### DIFF
--- a/__tests__/components/waves/drops/WaveDropActionsAddReaction.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropActionsAddReaction.test.tsx
@@ -22,10 +22,19 @@ const mockLoadNativeEmojis = jest.fn(() => Promise.resolve({}));
 const mockLoadEmojiData = jest.fn(() => Promise.resolve());
 const mockFindNativeEmoji = jest.fn();
 const mockFindCustomEmoji = jest.fn();
+const mockGetEligibility = jest.fn();
+const mockUpdateEligibility = jest.fn();
 
 jest.mock("@/contexts/wave/MyStreamContext", () => ({
   useMyStream: jest.fn(() => ({
     applyOptimisticDropUpdate: applyOptimisticDropUpdateMock,
+  })),
+}));
+
+jest.mock("@/contexts/wave/WaveEligibilityContext", () => ({
+  useWaveEligibility: jest.fn(() => ({
+    getEligibility: mockGetEligibility,
+    updateEligibility: mockUpdateEligibility,
   })),
 }));
 
@@ -109,7 +118,7 @@ jest.mock("@/contexts/EmojiContext", () => ({
 
 const baseDrop = {
   id: "12345",
-  wave: { id: "wave-1" },
+  wave: { id: "wave-1", authenticated_user_eligible_to_chat: true },
   context_profile_context: { reaction: null },
   author: { handle: "author-handle" },
   parts: [],
@@ -146,6 +155,7 @@ const renderWithQueryClient = (ui: React.ReactElement) => {
 describe("WaveDropActionsAddReaction", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetEligibility.mockReturnValue(null);
   });
 
   it("renders desktop button", () => {
@@ -168,6 +178,20 @@ describe("WaveDropActionsAddReaction", () => {
     renderWithQueryClient(<WaveDropActionsAddReaction drop={tempDrop} />);
     const button = screen.getByRole("button", { name: /add reaction/i });
     expect(button).toBeDisabled();
+  });
+
+  it("disables the picker when the current wave capability is disabled", () => {
+    mockGetEligibility.mockReturnValue({
+      authenticated_user_eligible_to_chat: false,
+    });
+
+    renderWithQueryClient(<WaveDropActionsAddReaction drop={mockDrop} />);
+    const button = screen.getByRole("button", { name: /add reaction/i });
+
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(screen.queryByTestId("mock-picker")).not.toBeInTheDocument();
+    expect(commonApi.commonApiPost).not.toHaveBeenCalled();
   });
 
   it("opens and closes picker on desktop button click", async () => {

--- a/__tests__/components/waves/drops/WaveDropReactions.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropReactions.test.tsx
@@ -102,6 +102,15 @@ const mockUseEmoji = useEmoji as jest.Mock;
 const mockUseAuth = useAuth as jest.Mock;
 const { fetchDropByIdBatched } = require("@/services/api/drop-api");
 const setToastMock = jest.fn();
+const mockGetEligibility = jest.fn();
+const mockUpdateEligibility = jest.fn();
+
+jest.mock("@/contexts/wave/WaveEligibilityContext", () => ({
+  useWaveEligibility: jest.fn(() => ({
+    getEligibility: mockGetEligibility,
+    updateEligibility: mockUpdateEligibility,
+  })),
+}));
 const createStructuredReactionError = ({
   body,
   headers,
@@ -167,7 +176,7 @@ const createEmojiContextValue = (
 
 const createMockDrop = (overrides: Record<string, unknown> = {}) => ({
   id: "test-drop",
-  wave: { id: "test-wave" },
+  wave: { id: "test-wave", authenticated_user_eligible_to_chat: true },
   reactions: [],
   ...overrides,
 });
@@ -205,6 +214,7 @@ describe("WaveDropReactions", () => {
     mockQueryCacheFindAll.mockReset();
     mockQueryCacheFindAll.mockReturnValue([]);
     mockSetQueryData.mockReset();
+    mockGetEligibility.mockReturnValue(null);
     mockUseAuth.mockReturnValue({
       connectedProfile: { id: "profile-1", handle: "alice" },
       activeProfileProxy: null,
@@ -386,6 +396,44 @@ describe("WaveDropReactions", () => {
       endpoint: "drops/test-drop/reaction",
       errorMode: "structured",
     });
+  });
+
+  it("disables reaction chips when the current wave capability is disabled", () => {
+    mockGetEligibility.mockReturnValue({
+      authenticated_user_eligible_to_chat: false,
+    });
+    mockUseEmoji.mockReturnValue(
+      createEmojiContextValue(
+        [
+          {
+            category: "people",
+            emojis: [{ id: "gm", skins: [{ src: "/gm.png" }] }],
+          },
+        ],
+        () => null
+      )
+    );
+
+    render(
+      <WaveDropReactions
+        drop={
+          createMockDrop({
+            reactions: [
+              {
+                reaction: ":gm:",
+                profiles: [{ handle: "test-handle-1", id: "1" }],
+              },
+            ],
+          }) as any
+        }
+      />
+    );
+
+    const button = screen.getByRole("button");
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(commonApi.commonApiPost).not.toHaveBeenCalled();
+    expect(commonApi.commonApiDelete).not.toHaveBeenCalled();
   });
 
   it("updates cached notification drops when removing a chip reaction", async () => {

--- a/__tests__/components/waves/drops/reaction-utils.test.ts
+++ b/__tests__/components/waves/drops/reaction-utils.test.ts
@@ -158,6 +158,36 @@ describe("getReactionErrorMessage", () => {
     ).toBe("Unauthorized");
   });
 
+  it("maps the exact disabled-wave capability response", () => {
+    expect(
+      getReactionErrorMessage(
+        createStructuredReactionError({
+          body: JSON.stringify({
+            error: "Chatting and reacting is not enabled in this wave",
+          }),
+          message: "Chatting and reacting is not enabled in this wave",
+          status: 403,
+        }),
+        "Error adding reaction"
+      )
+    ).toBe("Reactions are disabled for this wave.");
+  });
+
+  it("maps a 504 to clear reconciliation guidance", () => {
+    expect(
+      getReactionErrorMessage(
+        createStructuredReactionError({
+          body: JSON.stringify({ error: "Endpoint request timed out" }),
+          message: "Endpoint request timed out",
+          status: 504,
+        }),
+        "Error adding reaction"
+      )
+    ).toBe(
+      "The reaction request timed out. Refreshing the latest reaction state; wait before trying again."
+    );
+  });
+
   it("maps rate-limit status when the structured body is blank", () => {
     expect(
       getReactionErrorMessage(

--- a/__tests__/hooks/useDropReaction.test.ts
+++ b/__tests__/hooks/useDropReaction.test.ts
@@ -6,6 +6,7 @@ import type { ApiDrop } from "@/generated/models/ApiDrop";
 import { QueryKey as AppQueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
 import { useAuth } from "@/components/auth/Auth";
 import { useMyStream } from "@/contexts/wave/MyStreamContext";
+import { ChatRestriction } from "@/hooks/useDropPriviledges";
 import * as commonApi from "@/services/api/common-api";
 import * as dropReactionMonitoring from "@/utils/monitoring/dropReactionMonitoring";
 import { act, renderHook } from "@testing-library/react";
@@ -17,6 +18,8 @@ const applyOptimisticDropUpdateMock = jest.fn(() => ({
 }));
 const mockQueryCacheFindAll = jest.fn(() => []);
 const mockSetQueryData = jest.fn();
+const mockGetEligibility = jest.fn();
+const mockUpdateEligibility = jest.fn();
 
 jest.mock("@/components/auth/Auth", () => ({
   useAuth: jest.fn(),
@@ -24,6 +27,13 @@ jest.mock("@/components/auth/Auth", () => ({
 
 jest.mock("@/contexts/wave/MyStreamContext", () => ({
   useMyStream: jest.fn(),
+}));
+
+jest.mock("@/contexts/wave/WaveEligibilityContext", () => ({
+  useWaveEligibility: jest.fn(() => ({
+    getEligibility: mockGetEligibility,
+    updateEligibility: mockUpdateEligibility,
+  })),
 }));
 
 jest.mock("@/services/api/common-api", () => ({
@@ -146,7 +156,7 @@ const createStructuredReactionError = ({
 
 const mockDrop = {
   id: "drop-1",
-  wave: { id: "wave-1" },
+  wave: { id: "wave-1", authenticated_user_eligible_to_chat: true },
   context_profile_context: { reaction: null },
   author: { handle: "author-handle" },
   parts: [],
@@ -193,6 +203,7 @@ describe("useDropReaction", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSetQueryData.mockReset();
+    mockGetEligibility.mockReturnValue(null);
     mockQueryCacheFindAll.mockReturnValue([]);
     applyOptimisticDropUpdateMock.mockReset();
     applyOptimisticDropUpdateMock.mockImplementation(() => ({
@@ -265,6 +276,143 @@ describe("useDropReaction", () => {
 
     expect(dropReactionMonitoring.beginReactionMutation).not.toHaveBeenCalled();
     expect(commonApi.commonApiPost).not.toHaveBeenCalled();
+    expect(commonApi.commonApiDelete).not.toHaveBeenCalled();
+  });
+
+  it("disables reactions when the current wave capability is disabled", async () => {
+    mockGetEligibility.mockReturnValue({
+      authenticated_user_eligible_to_chat: false,
+    });
+
+    const { result } = renderHook(() =>
+      useDropReaction(mockDrop, { source: "quick-react" })
+    );
+
+    expect(result.current.canReact).toBe(false);
+
+    await act(async () => {
+      await result.current.react(":smile:");
+    });
+
+    expect(dropReactionMonitoring.beginReactionMutation).not.toHaveBeenCalled();
+    expect(commonApi.commonApiPost).not.toHaveBeenCalled();
+    expect(commonApi.commonApiDelete).not.toHaveBeenCalled();
+  });
+
+  it("sends a normal reaction when the current wave capability is enabled", async () => {
+    mockGetEligibility.mockReturnValue({
+      authenticated_user_eligible_to_chat: true,
+    });
+    (commonApi.commonApiPost as jest.Mock).mockResolvedValueOnce({});
+
+    const { result } = renderHook(() =>
+      useDropReaction(mockDrop, { source: "quick-react" })
+    );
+
+    expect(result.current.canReact).toBe(true);
+
+    await act(async () => {
+      await result.current.react(":smile:");
+    });
+
+    expect(commonApi.commonApiPost).toHaveBeenCalledTimes(1);
+    expect(commonApi.commonApiPost).toHaveBeenCalledWith({
+      endpoint: "drops/drop-1/reaction",
+      body: { reaction: ":smile:" },
+      errorMode: "structured",
+    });
+  });
+
+  it("allows reactions when slow mode is the only chat restriction", async () => {
+    mockGetEligibility.mockReturnValue({
+      authenticated_user_eligible_to_chat: false,
+      authenticated_user_chat_restriction: ChatRestriction.SLOW_MODE,
+    });
+    (commonApi.commonApiPost as jest.Mock).mockResolvedValueOnce({});
+
+    const { result } = renderHook(() =>
+      useDropReaction(mockDrop, { source: "quick-react" })
+    );
+
+    expect(result.current.canReact).toBe(true);
+
+    await act(async () => {
+      await result.current.react(":smile:");
+    });
+
+    expect(commonApi.commonApiPost).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles an exact stale capability 403 and disables later reactions", async () => {
+    (commonApi.commonApiPost as jest.Mock).mockRejectedValueOnce(
+      createStructuredReactionError({
+        body: JSON.stringify({
+          error: "Chatting and reacting is not enabled in this wave",
+        }),
+        message: "Chatting and reacting is not enabled in this wave",
+        status: 403,
+      })
+    );
+
+    const { result } = renderHook(() =>
+      useDropReaction(mockDrop, { source: "quick-react" })
+    );
+
+    await act(async () => {
+      await result.current.react(":smile:");
+    });
+
+    expect(mockUpdateEligibility).toHaveBeenCalledWith("wave-1", {
+      authenticated_user_eligible_to_chat: false,
+    });
+    expect(setToastMock).toHaveBeenCalledWith({
+      message: "Reactions are disabled for this wave.",
+      type: "error",
+    });
+    expect(rollbackMock).toHaveBeenCalledTimes(1);
+    expect(fetchDropByIdBatched).toHaveBeenCalledWith("drop-1");
+  });
+
+  it("rolls back and reconciles a 504 without retrying the reaction write", async () => {
+    const canonicalDrop = {
+      ...(mockDrop as unknown as ApiDrop),
+      context_profile_context: {
+        ...(mockDrop.context_profile_context as NonNullable<
+          ApiDrop["context_profile_context"]
+        >),
+        reaction: null,
+      },
+      reactions: [],
+    };
+    (fetchDropByIdBatched as jest.Mock).mockResolvedValueOnce(canonicalDrop);
+    (commonApi.commonApiPost as jest.Mock).mockRejectedValueOnce(
+      createStructuredReactionError({
+        body: JSON.stringify({ error: "Endpoint request timed out" }),
+        message: "Endpoint request timed out",
+        status: 504,
+      })
+    );
+
+    const { result } = renderHook(() =>
+      useDropReaction(mockDrop, { source: "quick-react" })
+    );
+
+    await act(async () => {
+      await result.current.react(":smile:");
+    });
+
+    expect(setToastMock).toHaveBeenCalledWith({
+      message:
+        "The reaction request timed out. Refreshing the latest reaction state; wait before trying again.",
+      type: "error",
+    });
+    expect(rollbackMock).toHaveBeenCalledTimes(1);
+    expect(fetchDropByIdBatched).toHaveBeenCalledWith("drop-1");
+    expect(updateDropInCachedDrops).toHaveBeenCalledWith(
+      expect.anything(),
+      canonicalDrop
+    );
+    expect(commonApi.commonApiPost).toHaveBeenCalledTimes(1);
     expect(commonApi.commonApiDelete).not.toHaveBeenCalled();
   });
 

--- a/__tests__/utils/monitoring/dropReactionMonitoring.test.ts
+++ b/__tests__/utils/monitoring/dropReactionMonitoring.test.ts
@@ -214,6 +214,93 @@ describe("dropReactionMonitoring", () => {
     expect(captureExceptionMock).not.toHaveBeenCalled();
   });
 
+  it("breadcrumbs the exact disabled-wave capability 403 without capturing it", () => {
+    const mutation = beginReactionMutation({
+      dropId: "drop-disabled",
+      waveId: "wave-1",
+      source: "quick-react",
+      action: "add",
+      previousReaction: null,
+      intendedReaction: ":smile:",
+      optimisticReaction: ":smile:",
+      profileId: "profile-1",
+      websocketStatus: WebSocketStatus.CONNECTED,
+    });
+
+    recordReactionRequestSent(mutation, {
+      endpoint: "drops/drop-disabled/reaction",
+      method: "POST",
+    });
+
+    const error = Object.assign(
+      new Error("Chatting and reacting is not enabled in this wave"),
+      {
+        name: "ApiError",
+        status: 403,
+        response: { status: 403 },
+      }
+    );
+
+    dateNowSpy.mockReturnValue(1_200);
+    recordReactionRequestFailed(mutation, error);
+
+    expect(addBreadcrumbMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "reaction.wave_capability_disabled",
+        data: expect.objectContaining({
+          status_code: 403,
+          error_kind: "auth",
+          error_message: "Chatting and reacting is not enabled in this wave",
+          captured: false,
+        }),
+      })
+    );
+    expect(withScopeMock).not.toHaveBeenCalled();
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      caseName: "the disabled-wave message returned as 401",
+      message: "Chatting and reacting is not enabled in this wave",
+      status: 401,
+    },
+    {
+      caseName: "a different disabled-wave 403 message",
+      message: "Forbidden",
+      status: 403,
+    },
+  ])("captures $caseName", ({ message, status }) => {
+    const mutation = beginReactionMutation({
+      dropId: "drop-disabled-unexpected",
+      waveId: "wave-1",
+      source: "quick-react",
+      action: "add",
+      previousReaction: null,
+      intendedReaction: ":smile:",
+      optimisticReaction: ":smile:",
+      profileId: "profile-1",
+      websocketStatus: WebSocketStatus.CONNECTED,
+    });
+
+    recordReactionRequestSent(mutation, {
+      endpoint: "drops/drop-disabled-unexpected/reaction",
+      method: "POST",
+    });
+
+    const error = Object.assign(new Error(message), {
+      name: "ApiError",
+      status,
+      response: { status },
+    });
+
+    dateNowSpy.mockReturnValue(1_200);
+    recordReactionRequestFailed(mutation, error);
+
+    expect(withScopeMock).toHaveBeenCalled();
+    expect(captureExceptionMock).toHaveBeenCalledWith(error);
+  });
+
   it.each(
     [
       {

--- a/components/waves/drops/WaveDropReactions.tsx
+++ b/components/waves/drops/WaveDropReactions.tsx
@@ -384,6 +384,25 @@ function WaveDropReaction({
     Boolean(connectedProfile?.handle) &&
     !activeProfileProxy &&
     (isEligibleToChat !== false || isSlowModeOnlyBlock);
+  const updateEligibilityAfterExpectedDisabledReaction = useCallback(
+    (error: unknown, method: "DELETE" | "POST") => {
+      if (
+        !isExpectedWaveReactionDisabledError({
+          dropId: drop.id,
+          endpoint: `drops/${drop.id}/reaction`,
+          error,
+          method,
+        })
+      ) {
+        return;
+      }
+
+      updateEligibility(drop.wave.id, {
+        authenticated_user_eligible_to_chat: false,
+      });
+    },
+    [drop.id, drop.wave.id, updateEligibility]
+  );
   const applyOptimisticReactionToNotificationQueries =
     useOptimisticNotificationDropReaction({
       connectedProfile,
@@ -733,18 +752,7 @@ function WaveDropReaction({
         return;
       }
 
-      if (
-        isExpectedWaveReactionDisabledError({
-          dropId: drop.id,
-          endpoint,
-          error,
-          method,
-        })
-      ) {
-        updateEligibility(waveId, {
-          authenticated_user_eligible_to_chat: false,
-        });
-      }
+      updateEligibilityAfterExpectedDisabledReaction(error, method);
 
       const msg = getReactionErrorMessage(
         error,
@@ -772,7 +780,7 @@ function WaveDropReaction({
     refreshCanonicalDropAfterLatestFailure,
     selected,
     setToast,
-    updateEligibility,
+    updateEligibilityAfterExpectedDisabledReaction,
     waveId,
     websocketStatus,
   ]);

--- a/components/waves/drops/WaveDropReactions.tsx
+++ b/components/waves/drops/WaveDropReactions.tsx
@@ -4,9 +4,11 @@ import { useAuth } from "@/components/auth/Auth";
 import { updateDropInCachedDrops } from "@/components/react-query-wrapper/utils/updateAttachmentInCachedDrops";
 import { useEmoji } from "@/contexts/EmojiContext";
 import { useMyStream } from "@/contexts/wave/MyStreamContext";
+import { useWaveEligibility } from "@/contexts/wave/WaveEligibilityContext";
 import type { ApiAddReactionToDropRequest } from "@/generated/models/ApiAddReactionToDropRequest";
 import type { ApiDrop } from "@/generated/models/ApiDrop";
 import type { ApiDropContextProfileContext } from "@/generated/models/ApiDropContextProfileContext";
+import { ChatRestriction } from "@/hooks/useDropPriviledges";
 import type { ApiDropReaction } from "@/generated/models/ApiDropReaction";
 import { formatLargeNumber } from "@/helpers/Helpers";
 import { recordReaction } from "@/helpers/reactions/reactionHistory";
@@ -53,6 +55,7 @@ import {
   recordReactionRequestSucceeded,
   recordReactionRollbackApplied,
 } from "@/utils/monitoring/dropReactionMonitoring";
+import { isExpectedWaveReactionDisabledError } from "@/utils/monitoring/dropReactionErrorClassification";
 import styles from "./WaveDropReactions.module.css";
 import { fetchDropReactionDetailsV2 } from "@/services/api/wave-drops-v2-api";
 
@@ -364,11 +367,23 @@ function WaveDropReaction({
 }) {
   const { setToast, connectedProfile, activeProfileProxy } = useAuth();
   const { applyOptimisticDropUpdate } = useMyStream();
+  const { getEligibility, updateEligibility } = useWaveEligibility();
   const queryClient = useQueryClient();
   const websocketStatus = useWebsocketStatus();
   const locale = useBrowserLocale();
   const rollbackRef = useRef<OwnedOptimisticRollback>(null);
-  const canReact = Boolean(connectedProfile?.handle) && !activeProfileProxy;
+  const waveEligibility = getEligibility(drop.wave.id);
+  const isEligibleToChat =
+    waveEligibility?.authenticated_user_eligible_to_chat ??
+    drop.wave.authenticated_user_eligible_to_chat;
+  const isSlowModeOnlyBlock =
+    isEligibleToChat === false &&
+    waveEligibility?.authenticated_user_chat_restriction ===
+      ChatRestriction.SLOW_MODE;
+  const canReact =
+    Boolean(connectedProfile?.handle) &&
+    !activeProfileProxy &&
+    (isEligibleToChat !== false || isSlowModeOnlyBlock);
   const applyOptimisticReactionToNotificationQueries =
     useOptimisticNotificationDropReaction({
       connectedProfile,
@@ -655,6 +670,8 @@ function WaveDropReaction({
     }
 
     const intendedReaction = selected ? null : reaction.reaction;
+    const endpoint = `drops/${drop.id}/reaction`;
+    const method = selected ? "DELETE" : "POST";
 
     const mutation = beginReactionMutation({
       dropId: drop.id,
@@ -686,7 +703,6 @@ function WaveDropReaction({
 
     try {
       const body = { reaction: reaction.reaction };
-      const endpoint = `drops/${drop.id}/reaction`;
       if (selected) {
         recordReactionRequestSent(mutation, {
           endpoint,
@@ -717,6 +733,19 @@ function WaveDropReaction({
         return;
       }
 
+      if (
+        isExpectedWaveReactionDisabledError({
+          dropId: drop.id,
+          endpoint,
+          error,
+          method,
+        })
+      ) {
+        updateEligibility(waveId, {
+          authenticated_user_eligible_to_chat: false,
+        });
+      }
+
       const msg = getReactionErrorMessage(
         error,
         selected ? "Error removing reaction" : "Error adding reaction",
@@ -743,6 +772,7 @@ function WaveDropReaction({
     refreshCanonicalDropAfterLatestFailure,
     selected,
     setToast,
+    updateEligibility,
     waveId,
     websocketStatus,
   ]);

--- a/components/waves/drops/reaction-utils.ts
+++ b/components/waves/drops/reaction-utils.ts
@@ -6,6 +6,7 @@ import { extractRetryAfterMs } from "@/helpers/reactions/reactionRateLimit";
 import { formatInteger } from "@/i18n/format";
 import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
 import { t, type MessageKey } from "@/i18n/messages";
+import { isWaveReactionDisabledApiError } from "@/utils/monitoring/dropReactionErrorClassification";
 
 type ReactionEntry = {
   reaction: string;
@@ -428,8 +429,14 @@ export const getReactionErrorMessage = (
   if (error !== null && typeof error === "object") {
     const structuredError = error as StructuredReactionError;
     const structuredStatus = getStructuredReactionStatus(structuredError);
+    if (isWaveReactionDisabledApiError(error)) {
+      return t(locale, "drops.reactions.capabilityDisabled");
+    }
     if (structuredStatus === 429) {
       return getRateLimitReactionMessage(structuredError, locale);
+    }
+    if (structuredStatus === 504) {
+      return t(locale, "drops.reactions.requestTimedOut");
     }
 
     const structuredResponse = structuredError.response;

--- a/hooks/drops/useDropReaction.ts
+++ b/hooks/drops/useDropReaction.ts
@@ -4,9 +4,11 @@ import { useAuth } from "@/components/auth/Auth";
 import { QueryKey as AppQueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
 import { updateDropInCachedDrops } from "@/components/react-query-wrapper/utils/updateAttachmentInCachedDrops";
 import { useMyStream } from "@/contexts/wave/MyStreamContext";
+import { useWaveEligibility } from "@/contexts/wave/WaveEligibilityContext";
 import type { ApiDropReaction } from "@/generated/models/ApiDropReaction";
 import type { ApiAddReactionToDropRequest } from "@/generated/models/ApiAddReactionToDropRequest";
 import type { ApiDrop } from "@/generated/models/ApiDrop";
+import { ChatRestriction } from "@/hooks/useDropPriviledges";
 import type { ApiDropContextProfileContext } from "@/generated/models/ApiDropContextProfileContext";
 import { recordReaction } from "@/helpers/reactions/reactionHistory";
 import type { Drop, ExtendedDrop } from "@/helpers/waves/drop.helpers";
@@ -43,6 +45,7 @@ import {
   recordReactionRollbackApplied,
   type ReactionSource,
 } from "@/utils/monitoring/dropReactionMonitoring";
+import { isExpectedWaveReactionDisabledError } from "@/utils/monitoring/dropReactionErrorClassification";
 
 interface UseDropReactionResult {
   readonly react: (reactionCode: string) => Promise<void>;
@@ -465,6 +468,7 @@ export function useDropReaction(
 ): UseDropReactionResult {
   const { setToast, connectedProfile, activeProfileProxy } = useAuth();
   const { applyOptimisticDropUpdate } = useMyStream();
+  const { getEligibility, updateEligibility } = useWaveEligibility();
   const queryClient = useQueryClient();
   const websocketStatus = useWebsocketStatus();
   const locale = useBrowserLocale();
@@ -473,10 +477,20 @@ export function useDropReaction(
   const onSuccess = options?.onSuccess;
   const updateCurationCache = options?.updateCurationCache ?? false;
 
-  const canReact = !activeProfileProxy && !drop.id.startsWith("temp-");
-
   const waveId = drop.wave.id;
   const dropId = drop.id;
+  const waveEligibility = getEligibility(waveId);
+  const isEligibleToChat =
+    waveEligibility?.authenticated_user_eligible_to_chat ??
+    drop.wave.authenticated_user_eligible_to_chat;
+  const isSlowModeOnlyBlock =
+    isEligibleToChat === false &&
+    waveEligibility?.authenticated_user_chat_restriction ===
+      ChatRestriction.SLOW_MODE;
+  const canReact =
+    !activeProfileProxy &&
+    !drop.id.startsWith("temp-") &&
+    (isEligibleToChat !== false || isSlowModeOnlyBlock);
   const contextProfileContext = drop.context_profile_context;
   const applyOptimisticReaction = useOptimisticStreamDropReaction({
     applyOptimisticDropUpdate,
@@ -518,6 +532,8 @@ export function useDropReaction(
 
       const isRemoving = reactionCode === contextProfileContext?.reaction;
       const intendedReaction = isRemoving ? null : reactionCode;
+      const endpoint = `drops/${drop.id}/reaction`;
+      const method = isRemoving ? "DELETE" : "POST";
 
       const mutation = beginReactionMutation({
         dropId,
@@ -551,7 +567,6 @@ export function useDropReaction(
       let succeeded = false;
 
       try {
-        const endpoint = `drops/${drop.id}/reaction`;
         await sendReactionRequest({
           endpoint,
           isRemoving,
@@ -567,6 +582,19 @@ export function useDropReaction(
         const result = recordReactionRequestFailed(mutation, error);
         if (!result.isLatestMutation) {
           return;
+        }
+
+        if (
+          isExpectedWaveReactionDisabledError({
+            dropId,
+            endpoint,
+            error,
+            method,
+          })
+        ) {
+          updateEligibility(waveId, {
+            authenticated_user_eligible_to_chat: false,
+          });
         }
 
         const errorMessage = getReactionErrorMessage(
@@ -599,6 +627,7 @@ export function useDropReaction(
       onSuccess,
       refreshCanonicalDropAfterLatestFailure,
       source,
+      updateEligibility,
       waveId,
       websocketStatus,
     ]

--- a/i18n/messages/drop-reactions.ts
+++ b/i18n/messages/drop-reactions.ts
@@ -1,6 +1,8 @@
 import type { MessageKey } from "@/i18n/messages/en-US";
 
 const DROP_REACTION_MESSAGE_KEYS = [
+  "drops.reactions.capabilityDisabled",
+  "drops.reactions.requestTimedOut",
   "drops.reactions.rateLimit.retryAfter.moment",
   "drops.reactions.rateLimit.retryAfter.seconds.one",
   "drops.reactions.rateLimit.retryAfter.seconds.other",
@@ -10,6 +12,8 @@ const DROP_REACTION_MESSAGE_KEYS = [
 
 type DropReactionMessageKey = (typeof DROP_REACTION_MESSAGE_KEYS)[number];
 type DropReactionMessageValues = readonly [
+  string,
+  string,
   string,
   string,
   string,
@@ -25,6 +29,8 @@ const buildDropReactionMessages = (
   ) as Record<DropReactionMessageKey, string>;
 
 export const FR_FR_DROP_REACTION_MESSAGES = buildDropReactionMessages([
+  "Les réactions sont désactivées pour cette wave.",
+  "La demande de réaction a expiré. Actualisation du dernier état des réactions ; attendez avant de réessayer.",
   "Vous réagissez trop vite. Réessayez dans un instant.",
   "Vous réagissez trop vite. Réessayez dans {count} seconde.",
   "Vous réagissez trop vite. Réessayez dans {count} secondes.",
@@ -33,6 +39,8 @@ export const FR_FR_DROP_REACTION_MESSAGES = buildDropReactionMessages([
 ]);
 
 export const ES_ES_DROP_REACTION_MESSAGES = buildDropReactionMessages([
+  "Las reacciones están desactivadas en esta wave.",
+  "La solicitud de reacción agotó el tiempo de espera. Actualizando el estado más reciente; espera antes de volver a intentarlo.",
   "Estás reaccionando demasiado rápido. Inténtalo de nuevo en un momento.",
   "Estás reaccionando demasiado rápido. Inténtalo de nuevo en {count} segundo.",
   "Estás reaccionando demasiado rápido. Inténtalo de nuevo en {count} segundos.",
@@ -41,6 +49,8 @@ export const ES_ES_DROP_REACTION_MESSAGES = buildDropReactionMessages([
 ]);
 
 export const DE_DE_DROP_REACTION_MESSAGES = buildDropReactionMessages([
+  "Reaktionen sind für diese Wave deaktiviert.",
+  "Zeitüberschreitung bei der Reaktionsanfrage. Der aktuelle Reaktionsstatus wird aktualisiert; bitte warte, bevor du es erneut versuchst.",
   "Du reagierst zu schnell. Versuche es gleich erneut.",
   "Du reagierst zu schnell. Versuche es in {count} Sekunde erneut.",
   "Du reagierst zu schnell. Versuche es in {count} Sekunden erneut.",

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -332,6 +332,9 @@ const MEMES_WAVE_FOOTER_MESSAGES = objectMessages("memes.waveFooter", {
 } as const);
 
 const DROP_REACTION_MESSAGES = objectMessages("drops.reactions", {
+  capabilityDisabled: "Reactions are disabled for this wave.",
+  requestTimedOut:
+    "The reaction request timed out. Refreshing the latest reaction state; wait before trying again.",
   "rateLimit.retryAfter.moment":
     "You are reacting too quickly. Try again in a moment.",
   "rateLimit.retryAfter.seconds.one":

--- a/ops/docs/waves/drop-actions/feature-reactions-and-ratings.md
+++ b/ops/docs/waves/drop-actions/feature-reactions-and-ratings.md
@@ -54,6 +54,8 @@ rolls back if the request fails.
 
 - Temporary drops (`temp-*`) cannot be reacted to and do not show rating actions.
 - Reaction controls are disabled while a proxy profile is active.
+- Reaction controls are disabled when the current wave does not allow chatting
+  and reactions.
 - Light placeholder drops do not render reaction or rating controls.
 - Chat drops do not show clap rating controls.
 - Memes-wave participatory drops hide clap rating controls.
@@ -65,8 +67,10 @@ rolls back if the request fails.
 
 ## Failure and Recovery
 
-- If add/remove reaction fails, optimistic reaction state rolls back and users
-  can retry immediately.
+- If add/remove reaction fails, optimistic reaction state rolls back and the app
+  refreshes the canonical drop state.
+- If a reaction request times out, wait for that refresh and check the current
+  reaction before trying again; the app does not automatically retry the write.
 - If rating submit fails, optimistic rating state rolls back and users can retry.
 - Failures surface as toast errors while users stay in the same thread.
 

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -2025,6 +2025,8 @@
         "Drop actions include reactions, ratings, voting, boosting, curation, replies, link copy, and pinning where allowed.",
         "Posted full drops can support emoji reactions and clap rating with optimistic UI and rollback on failure.",
         "Reaction controls are disabled while a proxy profile is active.",
+        "Reaction controls are disabled when the current wave does not allow chatting and reactions.",
+        "If a reaction request times out, the app rolls back the optimistic state, refreshes the canonical drop state, and does not automatically retry the write.",
         "Rating controls clamp values to the drop's allowed min/max range and can be disabled when the viewer has no available credit.",
         "Rank/Approve waves expose voting controls such as vote sliders and vote summaries when the user is eligible.",
         "The normal vote dialog can optionally post a standard drop reply with a generated vote rationale prefix; Vote with reply starts off and can be enabled directly or by editing the prefilled text.",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -2025,6 +2025,8 @@
         "Drop actions include reactions, ratings, voting, boosting, curation, replies, link copy, and pinning where allowed.",
         "Posted full drops can support emoji reactions and clap rating with optimistic UI and rollback on failure.",
         "Reaction controls are disabled while a proxy profile is active.",
+        "Reaction controls are disabled when the current wave does not allow chatting and reactions.",
+        "If a reaction request times out, the app rolls back the optimistic state, refreshes the canonical drop state, and does not automatically retry the write.",
         "Rating controls clamp values to the drop's allowed min/max range and can be disabled when the viewer has no available credit.",
         "Rank/Approve waves expose voting controls such as vote sliders and vote summaries when the user is eligible.",
         "The normal vote dialog can optionally post a standard drop reply with a generated vote rationale prefix; Vote with reply starts off and can be enabled directly or by editing the prefilled text.",

--- a/utils/monitoring/dropReactionErrorClassification.ts
+++ b/utils/monitoring/dropReactionErrorClassification.ts
@@ -2,6 +2,8 @@ import { extractErrorStatusCode } from "@/utils/errorStatus";
 
 const PROXY_REACTION_PERMISSION_DENIED_MESSAGE =
   "Proxy doesn't have permission to add reactions";
+const WAVE_REACTION_DISABLED_MESSAGE =
+  "Chatting and reacting is not enabled in this wave";
 
 type ReactionErrorKind =
   | "network"
@@ -81,6 +83,31 @@ export function classifyReactionError(error: unknown): {
   }
 
   return { statusCode, errorKind: "server" };
+}
+
+export function isWaveReactionDisabledApiError(error: unknown): boolean {
+  return (
+    extractErrorStatusCode(error) === 403 &&
+    toErrorMessage(error) === WAVE_REACTION_DISABLED_MESSAGE
+  );
+}
+
+export function isExpectedWaveReactionDisabledError({
+  dropId,
+  endpoint,
+  error,
+  method,
+}: {
+  readonly dropId: string;
+  readonly endpoint: string | null | undefined;
+  readonly error: unknown;
+  readonly method: string | null | undefined;
+}): boolean {
+  return (
+    endpoint === `drops/${dropId}/reaction` &&
+    (method === "POST" || method === "DELETE") &&
+    isWaveReactionDisabledApiError(error)
+  );
 }
 
 export function isExpectedStaleDropNotFoundError({

--- a/utils/monitoring/dropReactionMonitoring.ts
+++ b/utils/monitoring/dropReactionMonitoring.ts
@@ -8,6 +8,7 @@ import {
   classifyReactionError,
   isExpectedProxyReactionPermissionDeniedError,
   isExpectedStaleDropNotFoundError,
+  isExpectedWaveReactionDisabledError,
   toCaptureExceptionInput,
   toErrorMessage,
 } from "./dropReactionErrorClassification";
@@ -386,6 +387,30 @@ export function recordReactionRequestFailed(
   }
 
   if (errorKind === "rate-limit") {
+    clearActiveIntentForContext(context);
+    return result;
+  }
+
+  if (
+    isExpectedWaveReactionDisabledError({
+      dropId: context.dropId,
+      endpoint: context.endpoint,
+      error,
+      method: context.method,
+    })
+  ) {
+    addReactionBreadcrumb(
+      "reaction.wave_capability_disabled",
+      context,
+      {
+        status_code: statusCode ?? undefined,
+        latency_ms: latencyMs,
+        error_kind: errorKind,
+        error_message: errorMessage,
+        captured: false,
+      },
+      "warning"
+    );
     clearActiveIntentForContext(context);
     return result;
   }


### PR DESCRIPTION
## Issue

- Sentry 6529-FRONTEND-AT records expected reaction 403s when a stale UI still offers a reaction after the wave stops allowing chat/reactions.
- Sentry 6529-FRONTEND-AN records a 504 from the same reaction endpoint after about 29.2 seconds. A timed-out write may still have reached the backend, so an automatic retry would risk duplicating a non-idempotent action.

## Fix

- Gate picker, quick-reaction, and reaction-chip actions with the live wave eligibility state, while preserving the existing slow-mode exception.
- Treat only the exact disabled-wave 403 on the reaction endpoint as an expected stale-state race: update live eligibility, show clear copy, and keep a breadcrumb without capturing it as a Sentry exception.
- Keep unexpected 401/403 responses visible to Sentry.
- Give 504s explicit timeout guidance while preserving the existing optimistic rollback and canonical drop refresh. The frontend does not retry the write.

## Notable Changes

- Added focused monitoring classification for the exact capability-disabled response.
- Added localized disabled/timeout messages.
- Updated reactions documentation and the Help Bot source/generated index.
- Added regression coverage for disabled rendering/actions, slow mode, normal writes, stale 403 handling, unexpected auth failures, and 504 rollback/reconciliation without retry.

## Validation

- `./bin/6529 run test:no-coverage --runTestsByPath ...` — 5 suites, 103 tests passed.
- `USE_TURBO=false ./bin/6529 run test:e2e:reaction-sandbox` — 2 tests passed.
- `./bin/6529 run lint:diff` — passed.
- `./bin/6529 run lint:changed` — passed.
- `./bin/6529 run typecheck` — passed.
- `./bin/6529 run typecheck:changed` — passed.
- `./bin/6529 run react-doctor:diff` — 99/100; one pre-existing component-length warning for `WaveDropReaction`.
- `./bin/6529 run help-index:sync` and `./bin/6529 run agent-files:sync` — passed.
- `git diff --check` — passed.
- `./bin/6529 run check:changed` was also run; its Knip phase reports existing unused-file/export findings outside this change. The scoped lint, typecheck, tests, generated-file sync, and browser checks above are green.

## Risk

- **Level:** Medium
- **Why:** This changes when reaction controls are actionable and how one exact 403 is reported, but leaves all unexpected auth failures observable and keeps the existing rollback/reconciliation flow.
- **Rollback:** Revert the commit.

## Review Notes

- Please review the exact-message/endpoint boundary around the expected 403 classification.
- No reaction POST retry was added because idempotency is not established.
- Residual backend action: investigate the production 504 trace and upstream/API Gateway latency around the observed ~29.2-second timeout. This PR intentionally does not touch the backend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reaction controls are now disabled when chatting and reacting are unavailable in a wave.
  * Slow-mode restrictions continue to allow reactions where applicable.
  * Added clearer messages for disabled reactions and timed-out requests.

* **Bug Fixes**
  * Failed reactions now roll back optimistic changes and refresh the latest drop state.
  * Timed-out requests no longer retry automatically, helping prevent duplicate actions.
  * Improved handling and monitoring of expected reaction permission errors.

* **Documentation**
  * Updated help content with reaction availability and timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->