### PR TITLE
Fix Wave composer Lexical selection lifecycle

### DIFF
--- a/__tests__/components/waves/CreateDropInput.lexical.test.tsx
+++ b/__tests__/components/waves/CreateDropInput.lexical.test.tsx
@@ -89,7 +89,9 @@ it("keeps an empty-selection click inside a Lexical block", async () => {
   fireEvent.click(editor);
   await act(async () => Promise.resolve());
 
-  const anchorNode = window.getSelection()?.anchorNode ?? null;
-  expect(anchorNode).not.toBe(editor);
-  expect(editor.contains(anchorNode)).toBe(true);
+  await waitFor(() => {
+    const anchorNode = window.getSelection()?.anchorNode ?? null;
+    expect(anchorNode).not.toBe(editor);
+    expect(editor.contains(anchorNode)).toBe(true);
+  });
 });

--- a/__tests__/components/waves/CreateDropInput.lexical.test.tsx
+++ b/__tests__/components/waves/CreateDropInput.lexical.test.tsx
@@ -1,0 +1,95 @@
+import React, { createRef } from "react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import CreateDropInput, {
+  type CreateDropInputHandles,
+} from "@/components/waves/CreateDropInput";
+
+jest.unmock("lexical");
+
+jest.mock("@/components/waves/CreateDropEmojiPicker", () => () => null);
+jest.mock("@/hooks/useCapacitor", () => ({
+  __esModule: true,
+  default: () => ({ isCapacitor: false }),
+}));
+
+function createNoopPluginMock() {
+  const { forwardRef } = jest.requireActual<typeof React>("react");
+  return {
+    __esModule: true,
+    default: forwardRef(() => null),
+  };
+}
+
+jest.mock(
+  "@/components/drops/create/lexical/plugins/ClearEditorPlugin",
+  createNoopPluginMock
+);
+jest.mock(
+  "@/components/drops/create/lexical/plugins/mentions/MentionsPlugin",
+  createNoopPluginMock
+);
+jest.mock(
+  "@/components/drops/create/lexical/plugins/hashtags/HashtagsPlugin",
+  createNoopPluginMock
+);
+jest.mock(
+  "@/components/drops/create/lexical/plugins/waves/WaveMentionsPlugin",
+  createNoopPluginMock
+);
+jest.mock(
+  "@/components/drops/create/lexical/plugins/MaxLengthPlugin",
+  () => ({ MaxLengthPlugin: () => null })
+);
+jest.mock(
+  "@/components/drops/create/lexical/plugins/DragDropPastePlugin",
+  createNoopPluginMock
+);
+jest.mock(
+  "@/components/drops/create/lexical/plugins/enter/EnterKeyPlugin",
+  createNoopPluginMock
+);
+jest.mock(
+  "@/components/drops/create/lexical/plugins/PlainTextPastePlugin",
+  createNoopPluginMock
+);
+jest.mock(
+  "@/components/drops/create/lexical/plugins/emoji/EmojiPlugin",
+  createNoopPluginMock
+);
+jest.mock("@/components/waves/EditLastDropArrowUpPlugin", () => () => null);
+
+const renderInput = (ref: React.RefObject<CreateDropInputHandles | null>) =>
+  render(
+    <CreateDropInput
+      ref={ref}
+      waveId="wave"
+      editorState={null}
+      type={null}
+      canSubmit={false}
+      isStormMode={false}
+      isDropMode={false}
+      submitting={false}
+      onEditorState={jest.fn()}
+      onReferencedNft={jest.fn()}
+      onMentionedUser={jest.fn()}
+      onMentionedWave={jest.fn()}
+    />
+  );
+
+it("keeps an empty-selection click inside a Lexical block", async () => {
+  const ref = createRef<CreateDropInputHandles>();
+  renderInput(ref);
+
+  const editor = screen.getByRole("textbox");
+  await waitFor(() => expect(editor.querySelector("p")).not.toBeNull());
+
+  window.getSelection()?.removeAllRanges();
+  act(() => ref.current?.focus());
+  fireEvent.click(editor);
+  await act(async () => Promise.resolve());
+
+  const anchorNode = window.getSelection()?.anchorNode ?? null;
+  expect(anchorNode).not.toBe(editor);
+  expect(editor.contains(anchorNode)).toBe(true);
+});

--- a/components/waves/CreateDropInput.tsx
+++ b/components/waves/CreateDropInput.tsx
@@ -294,17 +294,21 @@ const CreateDropInput = forwardRef<
 
     const clearEditorRef = useRef<ClearEditorPluginHandles | null>(null);
     const editorCommandsRef = useRef<EditorCommandsPluginHandles | null>(null);
-    const clearEditorState = () => {
+    const clearEditorState = useCallback(() => {
       clearEditorRef.current?.clearEditorState();
-    };
+    }, []);
 
-    useImperativeHandle(ref, () => ({
-      clearEditorState,
-      setMarkdown: (markdown: string) =>
-        editorCommandsRef.current?.setMarkdown(markdown),
-      focus: () => editorCommandsRef.current?.focus(),
-      blur: () => editorCommandsRef.current?.blur(),
-    }));
+    useImperativeHandle(
+      ref,
+      () => ({
+        clearEditorState,
+        setMarkdown: (markdown: string) =>
+          editorCommandsRef.current?.setMarkdown(markdown),
+        focus: () => editorCommandsRef.current?.focus(),
+        blur: () => editorCommandsRef.current?.blur(),
+      }),
+      [clearEditorState]
+    );
 
     const mentionsPluginRef = useRef<NewMentionsPluginHandles | null>(null);
     const hashtagPluginRef = useRef<NewHastagsPluginHandles | null>(null);

--- a/components/waves/CreateDropInput.tsx
+++ b/components/waves/CreateDropInput.tsx
@@ -101,12 +101,14 @@ function DisableEditPlugin({ disabled }: { disabled: boolean }) {
   return null;
 }
 
-interface SetMarkdownPluginHandles {
+interface EditorCommandsPluginHandles {
   setMarkdown: (markdown: string) => void;
+  focus: () => void;
+  blur: () => void;
 }
 
-const SetMarkdownPlugin = forwardRef<
-  SetMarkdownPluginHandles,
+const EditorCommandsPlugin = forwardRef<
+  EditorCommandsPluginHandles,
   { readonly canMentionAll: boolean }
 >(({ canMentionAll }, ref) => {
   const [editor] = useLexicalComposerContext();
@@ -114,6 +116,8 @@ const SetMarkdownPlugin = forwardRef<
   useImperativeHandle(
     ref,
     () => ({
+      focus: () => editor.focus(),
+      blur: () => editor.blur(),
       setMarkdown: (markdown: string) => {
         editor.update(() => {
           $convertFromMarkdownString(markdown, [
@@ -133,7 +137,7 @@ const SetMarkdownPlugin = forwardRef<
 
   return null;
 });
-SetMarkdownPlugin.displayName = "SetMarkdownPlugin";
+EditorCommandsPlugin.displayName = "EditorCommandsPlugin";
 
 function InitialMarkdownPlugin({
   initialMarkdown,
@@ -289,22 +293,17 @@ const CreateDropInput = forwardRef<
     }
 
     const clearEditorRef = useRef<ClearEditorPluginHandles | null>(null);
-    const setMarkdownRef = useRef<SetMarkdownPluginHandles | null>(null);
-    const editorRef = useRef<HTMLDivElement>(null);
+    const editorCommandsRef = useRef<EditorCommandsPluginHandles | null>(null);
     const clearEditorState = () => {
       clearEditorRef.current?.clearEditorState();
     };
-    const getEditorElement = () =>
-      editorRef.current?.querySelector<HTMLElement>(
-        '[contenteditable="true"]'
-      ) ?? null;
 
     useImperativeHandle(ref, () => ({
       clearEditorState,
       setMarkdown: (markdown: string) =>
-        setMarkdownRef.current?.setMarkdown(markdown),
-      focus: () => getEditorElement()?.focus(),
-      blur: () => getEditorElement()?.blur(),
+        editorCommandsRef.current?.setMarkdown(markdown),
+      focus: () => editorCommandsRef.current?.focus(),
+      blur: () => editorCommandsRef.current?.blur(),
     }));
 
     const mentionsPluginRef = useRef<NewMentionsPluginHandles | null>(null);
@@ -343,7 +342,7 @@ const CreateDropInput = forwardRef<
     const placeholderText = getPlaceHolderText();
 
     return (
-      <div className="tailwind-scope" ref={editorRef}>
+      <div className="tailwind-scope">
         <LexicalComposer initialConfig={editorConfig}>
           <div className="tw-flex tw-items-end tw-gap-x-3">
             <div className="tw-relative tw-w-full">
@@ -355,24 +354,6 @@ const CreateDropInput = forwardRef<
                       autoCorrect="on"
                       ariaLabel={placeholderText}
                       style={{ touchAction: "manipulation" }}
-                      onClick={(e) => {
-                        // Ensure the contenteditable is properly focused and ready for paste
-                        const target = e.currentTarget;
-                        if (!submitting) {
-                          // Use a microtask to ensure focus happens after any other handlers
-                          Promise.resolve().then(() => {
-                            target.focus();
-                            // If there's no selection, place cursor at end
-                            const selection = window.getSelection();
-                            if (selection?.rangeCount === 0) {
-                              const range = document.createRange();
-                              range.selectNodeContents(target);
-                              range.collapse(false);
-                              selection.addRange(range);
-                            }
-                          });
-                        }
-                      }}
                       onBlur={onEditorBlur}
                       className={`editor-input-one-liner tw-form-input tw-block tw-max-h-[40vh] tw-w-full tw-resize-none tw-rounded-lg tw-border-0 tw-bg-iron-900 tw-py-2.5 tw-pl-3 tw-text-base tw-font-normal tw-leading-6 tw-text-white tw-caret-primary-400 tw-shadow-sm tw-ring-1 tw-ring-inset tw-ring-iron-700 tw-transition tw-duration-300 tw-ease-out tw-scrollbar-thin tw-scrollbar-track-iron-900 tw-scrollbar-thumb-iron-600 placeholder:tw-text-iron-500 focus:tw-bg-iron-950 focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-inset focus:tw-ring-primary-400 sm:tw-text-sm ${
                         submitting ? "tw-cursor-default tw-opacity-50" : ""
@@ -419,8 +400,8 @@ const CreateDropInput = forwardRef<
               <TabIndentationPlugin />
               <LinkPlugin validateUrl={validateUrl} />
               <ClearEditorPlugin ref={clearEditorRef} />
-              <SetMarkdownPlugin
-                ref={setMarkdownRef}
+              <EditorCommandsPlugin
+                ref={editorCommandsRef}
                 canMentionAll={canMentionAll}
               />
               <DisableEditPlugin disabled={submitting} />


### PR DESCRIPTION
## Issue

Wave chat composers can enter an invalid Lexical selection state after an empty-selection focus/click sequence. Production reports for Sentry issues `6529-FRONTEND-C1`, `6529-FRONTEND-C0`, and `6529-FRONTEND-EN` share Lexical error #20 across keydown, click, and beforeinput handlers.

## Fix

- Route imperative composer focus and blur through Lexical's editor lifecycle.
- Remove the custom contenteditable click microtask that manually created a DOM range on the editor root.
- Keep Lexical errors visible; this does not suppress or filter the exception.
- Keep Lexical 0.14.5 because the defect is in the app's custom selection handling and does not require a dependency upgrade.

## Notable changes

- Consolidate the internal markdown/focus/blur commands behind a composer-context plugin.
- Add a regression test with the real Lexical 0.14.5 editor, contenteditable, and rich-text plugin. It clears the browser selection, invokes the public focus handle, clicks the composer, and verifies the caret remains inside a Lexical block rather than on the editor root.

## Validation

- `6529 run test __tests__/components/waves/CreateDropInput.lexical.test.tsx __tests__/components/waves/CreateDropInput.test.tsx __tests__/components/waves/CreateDropContent.refocus.test.tsx __tests__/components/drops/create/lexical/plugins/RootBlockGuardPlugin.test.tsx --runInBand --coverage=false` — 4 suites, 21 tests passed
- `6529 run lint:changed` — passed
- `6529 run lint:diff` — passed
- `6529 run typecheck:changed` — passed
- `6529 run react-doctor:diff` — 100/100, no issues
- `git diff --check` — passed
- Staging browser QA on head `4850dd9e9` — six tagged Memes-Chat posts passed across click/Enter submit, post-submit refocus, explicit blur/refocus, Shift+Enter multiline, Markdown, paste, emoji, route remount, desktop, and 390x844 layouts
- Browser and dev-server audit — zero Lexical #20, `Point.getNode`, or selection errors

## Risk

Low. The change removes app-owned DOM selection manipulation and delegates focus/blur to the editor that owns the selection. Reply, edit, mobile keyboard, and post-submit refocus paths keep the same public handle.

Rollback: revert the commit.

## Review notes

Please focus on the public focus/blur handle semantics and the empty-selection regression. No telemetry, generated files, dependencies, or user-facing documentation changed.

The responsiveness report on superseded head `e98ade8250f7` is deferred: its sole blocking finding concerns first-load native-mobile app-shell initialization, outside this two-file Lexical composer diff. Current-head editor-focused desktop/mobile QA passed.