### PR TITLE
Harden WalletConnect relay reconnection

### DIFF
--- a/__tests__/walletconnect-relay-resilience.test.ts
+++ b/__tests__/walletconnect-relay-resilience.test.ts
@@ -16,8 +16,14 @@ type PnpmWorkspace = {
   overrides?: Record<string, string>;
 };
 
+// Keep the regression boundary explicit so dependency upgrades must re-evaluate
+// whether AppKit still needs this override before changing the expected stack.
 const affectedProvider = "@walletconnect/universal-provider@2.23.7";
 const patchedVersion = "2.23.9";
+const appKitVersion = "1.8.19";
+const appKitSnapshotKey = new RegExp(
+  `^@reown/appkit(?:-[^@]+)?@${appKitVersion.replaceAll(".", "\\.")}(?:\\(|$)`
+);
 
 function readYaml<T>(filename: string): T {
   return parse(readFileSync(resolve(process.cwd(), filename), "utf8")) as T;
@@ -32,9 +38,7 @@ describe("WalletConnect relay resilience", () => {
     expect(lockfile.overrides?.[affectedProvider]).toBe(patchedVersion);
 
     const appKitProviderVersions = Object.entries(lockfile.snapshots ?? {})
-      .filter(
-        ([key]) => key.startsWith("@reown/appkit") && key.includes("@1.8.19")
-      )
+      .filter(([key]) => appKitSnapshotKey.test(key))
       .flatMap(([, snapshot]) => {
         const version =
           snapshot.dependencies?.["@walletconnect/universal-provider"];

--- a/__tests__/walletconnect-relay-resilience.test.ts
+++ b/__tests__/walletconnect-relay-resilience.test.ts
@@ -18,15 +18,24 @@ type PnpmWorkspace = {
 
 // Keep the regression boundary explicit so dependency upgrades must re-evaluate
 // whether AppKit still needs this override before changing the expected stack.
-const affectedProvider = "@walletconnect/universal-provider@2.23.7";
+const affectedVersion = "2.23.7";
+const affectedProvider = `@walletconnect/universal-provider@${affectedVersion}`;
 const patchedVersion = "2.23.9";
 const appKitVersion = "1.8.19";
 const appKitSnapshotKey = new RegExp(
   `^@reown/appkit(?:-[^@]+)?@${appKitVersion.replaceAll(".", "\\.")}(?:\\(|$)`
 );
+const alignedRelayPackages = [
+  "core",
+  "sign-client",
+  "types",
+  "universal-provider",
+  "utils",
+] as const;
+const repoRoot = resolve(__dirname, "..");
 
 function readYaml<T>(filename: string): T {
-  return parse(readFileSync(resolve(process.cwd(), filename), "utf8")) as T;
+  return parse(readFileSync(resolve(repoRoot, filename), "utf8")) as T;
 }
 
 describe("WalletConnect relay resilience", () => {
@@ -47,7 +56,14 @@ describe("WalletConnect relay resilience", () => {
 
     expect(appKitProviderVersions.length).toBeGreaterThan(0);
     expect(new Set(appKitProviderVersions)).toEqual(new Set([patchedVersion]));
-    expect(lockfile.packages?.["@walletconnect/core@2.23.9"]).toBeDefined();
-    expect(lockfile.packages?.["@walletconnect/core@2.23.7"]).toBeUndefined();
+
+    for (const packageName of alignedRelayPackages) {
+      expect(
+        lockfile.packages?.[`@walletconnect/${packageName}@${patchedVersion}`]
+      ).toBeDefined();
+      expect(
+        lockfile.packages?.[`@walletconnect/${packageName}@${affectedVersion}`]
+      ).toBeUndefined();
+    }
   });
 });

--- a/__tests__/walletconnect-relay-resilience.test.ts
+++ b/__tests__/walletconnect-relay-resilience.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parse } from "yaml";
+
+type LockfileSnapshot = {
+  dependencies?: Record<string, string>;
+};
+
+type PnpmLockfile = {
+  overrides?: Record<string, string>;
+  packages?: Record<string, unknown>;
+  snapshots?: Record<string, LockfileSnapshot>;
+};
+
+type PnpmWorkspace = {
+  overrides?: Record<string, string>;
+};
+
+const affectedProvider = "@walletconnect/universal-provider@2.23.7";
+const patchedVersion = "2.23.9";
+
+function readYaml<T>(filename: string): T {
+  return parse(readFileSync(resolve(process.cwd(), filename), "utf8")) as T;
+}
+
+describe("WalletConnect relay resilience", () => {
+  it("keeps AppKit on the relay reconnection fix", () => {
+    const workspace = readYaml<PnpmWorkspace>("pnpm-workspace.yaml");
+    const lockfile = readYaml<PnpmLockfile>("pnpm-lock.yaml");
+
+    expect(workspace.overrides?.[affectedProvider]).toBe(patchedVersion);
+    expect(lockfile.overrides?.[affectedProvider]).toBe(patchedVersion);
+
+    const appKitProviderVersions = Object.entries(lockfile.snapshots ?? {})
+      .filter(
+        ([key]) => key.startsWith("@reown/appkit") && key.includes("@1.8.19")
+      )
+      .flatMap(([, snapshot]) => {
+        const version =
+          snapshot.dependencies?.["@walletconnect/universal-provider"];
+        return version ? [version.split("(", 1)[0]] : [];
+      });
+
+    expect(appKitProviderVersions.length).toBeGreaterThan(0);
+    expect(new Set(appKitProviderVersions)).toEqual(new Set([patchedVersion]));
+    expect(lockfile.packages?.["@walletconnect/core@2.23.9"]).toBeDefined();
+    expect(lockfile.packages?.["@walletconnect/core@2.23.7"]).toBeUndefined();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,7 @@ overrides:
   react-toggle>react: 19.2.4
   react-toggle>react-dom: 19.2.4
   shell-quote@>=1.1.0 <=1.8.3: 1.8.4
+  '@walletconnect/universal-provider@2.23.7': 2.23.9
   uuid@<11.1.1: 11.1.1
   ws@>=8.0.0 <8.20.1: 8.20.1
 
@@ -4345,8 +4346,8 @@ packages:
     resolution: {integrity: sha512-Tp4MHJYcdWD846PH//2r+Mu4wz1/ZU/fr9av1UWFiaYQ2t2TPLDiZxjLw54AAEpMqlEHemwCgiRiAmjR1NDdTQ==}
     engines: {node: '>=18'}
 
-  '@walletconnect/core@2.23.7':
-    resolution: {integrity: sha512-yTyymn9mFaDZkUfLfZ3E9VyaSDPeHAXlrPxQRmNx2zFsEt/25GmTU2A848aomimLxZnAG2jNLhxbJ8I0gyNV+w==}
+  '@walletconnect/core@2.23.9':
+    resolution: {integrity: sha512-ws4WG8LeagUo2ERRo02HryXRcpwIRmCQ3pHLW5gWbVReLXXIpgk6ZAfID3fEGHevIwwnHSGww+nNhNpdXyiq0g==}
     engines: {node: '>=18.20.8'}
 
   '@walletconnect/environment@1.0.1':
@@ -4408,8 +4409,8 @@ packages:
     resolution: {integrity: sha512-QaXzmPsMnKGV6tc4UcdnQVNOz4zyXgarvdIQibJ4L3EmLat73r5ZVl4c0cCOcoaV7rgM9Wbphgu5E/7jNcd3Zg==}
     deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
 
-  '@walletconnect/sign-client@2.23.7':
-    resolution: {integrity: sha512-SX61lzb1bTl/LijlcHQttnoHPBzzoY5mW9ArR6qhFtDNDTS7yr2rcH7rCngxHlYeb4rAYcWLHgbiGSrdKxl/mg==}
+  '@walletconnect/sign-client@2.23.9':
+    resolution: {integrity: sha512-Xj+hw4E6mGRyhCdVOT/RMgnG+up/Y3v0ho5PlkVozvXWeVSqHNh9DmjLuU97a7OACoGd/oHBF6g3NVqD7MgCMQ==}
 
   '@walletconnect/time@1.0.2':
     resolution: {integrity: sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==}
@@ -4420,8 +4421,8 @@ packages:
   '@walletconnect/types@2.21.1':
     resolution: {integrity: sha512-UeefNadqP6IyfwWC1Yi7ux+ljbP2R66PLfDrDm8izmvlPmYlqRerJWJvYO4t0Vvr9wrG4Ko7E0c4M7FaPKT/sQ==}
 
-  '@walletconnect/types@2.23.7':
-    resolution: {integrity: sha512-6PAKK+iR2IntmlkCFLMAHjYeIaerCJJYRDmdRimhon0u+aNmQT+HyGM6zxDAth0rdpBD7qEvKP5IXZTE7KFUhw==}
+  '@walletconnect/types@2.23.9':
+    resolution: {integrity: sha512-IUl1PpD/Dig8IE2OZ9XtjbPohEyOZJ73xs92EDUzoIyzRtfm36g2D340pY3iu3AAdLv1yFiaZafB8Hf8RFze8A==}
 
   '@walletconnect/universal-provider@2.21.0':
     resolution: {integrity: sha512-mtUQvewt+X0VBQay/xOJBvxsB3Xsm1lTwFjZ6WUwSOTR1X+FNb71hSApnV5kbsdDIpYPXeQUbGt2se1n5E5UBg==}
@@ -4431,8 +4432,8 @@ packages:
     resolution: {integrity: sha512-Wjx9G8gUHVMnYfxtasC9poGm8QMiPCpXpbbLFT+iPoQskDDly8BwueWnqKs4Mx2SdIAWAwuXeZ5ojk5qQOxJJg==}
     deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
 
-  '@walletconnect/universal-provider@2.23.7':
-    resolution: {integrity: sha512-6UicU/Mhr/1bh7MNoajypz7BhigORbHpP1LFTf8FYLQGDqzmqHMqmMH2GDAImtaY2sFTi2jBvc22tLl8VMze/A==}
+  '@walletconnect/universal-provider@2.23.9':
+    resolution: {integrity: sha512-dNk6X1USUcIX1nx3H61V3pO15E/2ejyeBsKLBOo8YXrnYCrKGG/KB1LIqJXHpQlXT+9bJE9cOnn61ETdCXgkPw==}
 
   '@walletconnect/utils@2.21.0':
     resolution: {integrity: sha512-zfHLiUoBrQ8rP57HTPXW7rQMnYxYI4gT9yTACxVW6LhIFROTF6/ytm5SKNoIvi4a5nX5dfXG4D9XwQUCu8Ilig==}
@@ -4440,8 +4441,8 @@ packages:
   '@walletconnect/utils@2.21.1':
     resolution: {integrity: sha512-VPZvTcrNQCkbGOjFRbC24mm/pzbRMUq2DSQoiHlhh0X1U7ZhuIrzVtAoKsrzu6rqjz0EEtGxCr3K1TGRqDG4NA==}
 
-  '@walletconnect/utils@2.23.7':
-    resolution: {integrity: sha512-3p38gNrkVcIiQixVrlsWSa66Gjs5PqHOug2TxDgYUVBW5NcKjwQA08GkC6CKBQUfr5iaCtbfy6uZJW1LKSIvWQ==}
+  '@walletconnect/utils@2.23.9':
+    resolution: {integrity: sha512-C5TltCs8UPypNiteYnKSv8+ZDK2EjVDyXCxN6kA9bkA+j6KGsNIV7l9MUA8WBAvE5Gi5EcBdhD3R9Hpo/1HHqQ==}
 
   '@walletconnect/window-getters@1.0.1':
     resolution: {integrity: sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==}
@@ -11981,7 +11982,7 @@ snapshots:
       '@reown/appkit-utils': 1.8.19(@types/react@19.2.3)(bufferutil@4.1.0)(immer@11.1.4)(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(utf-8-validate@5.0.10)(valtio@2.1.7(@types/react@19.2.3)(react@19.2.4))(zod@3.25.76)
       '@reown/appkit-wallet': 1.8.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.95.2)(@types/react@19.2.3)(immer@11.1.4)(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
-      '@walletconnect/universal-provider': 2.23.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.23.9(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 2.1.7(@types/react@19.2.3)(react@19.2.4)
       viem: 2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       wagmi: 2.19.5(@tanstack/query-core@5.95.2)(@tanstack/react-query@5.95.2(react@19.2.4))(@types/react@19.2.3)(bufferutil@4.1.0)(immer@11.1.4)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
@@ -12108,7 +12109,7 @@ snapshots:
     dependencies:
       '@reown/appkit-common': 1.8.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-wallet': 1.8.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@walletconnect/universal-provider': 2.23.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.23.9(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 2.1.7(@types/react@19.2.3)(react@19.2.4)
       viem: 2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
@@ -12419,7 +12420,7 @@ snapshots:
       '@reown/appkit-wallet': 1.8.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@wallet-standard/wallet': 1.1.0
       '@walletconnect/logger': 3.0.2
-      '@walletconnect/universal-provider': 2.23.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.23.9(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 2.1.7(@types/react@19.2.3)(react@19.2.4)
       viem: 2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     optionalDependencies:
@@ -12533,7 +12534,7 @@ snapshots:
       '@reown/appkit-ui': 1.8.19(@types/react@19.2.3)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-utils': 1.8.19(@types/react@19.2.3)(bufferutil@4.1.0)(immer@11.1.4)(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(utf-8-validate@5.0.10)(valtio@2.1.7(@types/react@19.2.3)(react@19.2.4))(zod@3.25.76)
       '@reown/appkit-wallet': 1.8.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@walletconnect/universal-provider': 2.23.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.23.9(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       bs58: 6.0.0
       semver: 7.7.2
       valtio: 2.1.7(@types/react@19.2.3)(react@19.2.4)
@@ -14198,7 +14199,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/core@2.23.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/core@2.23.9(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -14211,8 +14212,8 @@ snapshots:
       '@walletconnect/relay-auth': 1.1.0
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.23.7
-      '@walletconnect/utils': 2.23.7(typescript@5.9.3)(zod@3.25.76)
+      '@walletconnect/types': 2.23.9
+      '@walletconnect/utils': 2.23.9(typescript@5.9.3)(zod@3.25.76)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.44.0
       events: 3.3.0
@@ -14457,16 +14458,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/sign-client@2.23.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/sign-client@2.23.9(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@walletconnect/core': 2.23.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/core': 2.23.9(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 3.0.2
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.23.7
-      '@walletconnect/utils': 2.23.7(typescript@5.9.3)(zod@3.25.76)
+      '@walletconnect/types': 2.23.9
+      '@walletconnect/utils': 2.23.9(typescript@5.9.3)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -14555,7 +14556,7 @@ snapshots:
       - ioredis
       - uploadthing
 
-  '@walletconnect/types@2.23.7':
+  '@walletconnect/types@2.23.9':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
@@ -14664,7 +14665,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/universal-provider@2.23.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/universal-provider@2.23.9(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/jsonrpc-http-connection': 1.0.8
@@ -14673,9 +14674,9 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
       '@walletconnect/logger': 3.0.2
-      '@walletconnect/sign-client': 2.23.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/types': 2.23.7
-      '@walletconnect/utils': 2.23.7(typescript@5.9.3)(zod@3.25.76)
+      '@walletconnect/sign-client': 2.23.9(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/types': 2.23.9
+      '@walletconnect/utils': 2.23.9(typescript@5.9.3)(zod@3.25.76)
       es-toolkit: 1.44.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -14792,7 +14793,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.23.7(typescript@5.9.3)(zod@3.25.76)':
+  '@walletconnect/utils@2.23.9(typescript@5.9.3)(zod@3.25.76)':
     dependencies:
       '@msgpack/msgpack': 3.1.3
       '@noble/ciphers': 1.3.0
@@ -14806,7 +14807,7 @@ snapshots:
       '@walletconnect/relay-auth': 1.1.0
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.23.7
+      '@walletconnect/types': 2.23.9
       '@walletconnect/window-getters': 1.0.1
       '@walletconnect/window-metadata': 1.0.1
       blakejs: 1.2.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,6 +29,8 @@ overrides:
   react-toggle>react: $react
   react-toggle>react-dom: $react-dom
   shell-quote@>=1.1.0 <=1.8.3: 1.8.4
+  # AppKit 1.8.19 pins the affected relay client. WalletConnect 2.23.9 serializes reconnects and closes leaked sockets.
+  "@walletconnect/universal-provider@2.23.7": 2.23.9
   # uuid <11.1.1 has active advisories; 11.x keeps patched CJS-compatible APIs for wallet transitive deps.
   uuid@<11.1.1: 11.1.1
   ws@>=8.0.0 <8.20.1: 8.20.1


### PR DESCRIPTION
## Issue
- Production Sentry issue `6529-FRONTEND-EG` records WalletConnect relay WebSocket failures as unhandled rejections during the `/join-6529` connect flow.
- Event breadcrumbs show the modal opens normally, the user selects WalletConnect, then relay retries accumulate disconnect listeners before a side promise rejects outside AppKit's handled connection promise.

## Fix
- Override only `@walletconnect/universal-provider@2.23.7` to `2.23.9`.
- WalletConnect 2.23.9 contains the upstream relayer fix that serializes and bounds reconnect attempts, prevents unsupervised background connection work, and closes leaked sockets: [WalletConnect PR #7206](https://github.com/WalletConnect/walletconnect-monorepo/pull/7206).
- Keep AppKit's existing WalletConnect error UI and primary connect-promise handling; this does not add a Sentry filter or change app-owned auth/provider behavior.

## Changes
- Add the exact-version pnpm override with an ownership comment.
- Regenerate the lockfile so Reown AppKit 1.8.19 resolves to the aligned WalletConnect 2.23.9 provider/sign-client/core stack.
- Add a regression test that verifies every AppKit 1.8.19 relay edge stays on the patched stack and that none of the aligned 2.23.7 relay packages can re-enter the lockfile.
- Leave the separate WalletConnect 2.21.x connector stack unchanged.

## Validation
- Focused relay regression test: 1 passed.
- Existing AppKit initialization, Wagmi bootstrap, and connect-context suites: 76 passed.
- `./bin/6529 install:frozen`
- `./bin/6529 run lint:diff`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- Scoped Prettier check for the authored test and workspace config.
- Production build passed with the standard public endpoint configuration used by PR CI; generated-file sync left no unrelated diff.
- Dependency graph inspection confirms AppKit resolves the aligned 2.23.9 stack while the separate 2.21.x connector stack remains unchanged.
- Full-repository `format:check` still reports pre-existing formatting warnings outside this change; the authored files pass the scoped check.
- React Doctor was not run because no React, Next.js route, hook, or UI source changed.
- A live relay outage was not forced locally; the failure/retry implementation and its runtime regression coverage are owned by WalletConnect's patched release.

## Risk
- Level: Medium
- Why: this changes a runtime wallet transport stack, but only as a patch-level override of the exact affected 2.23.7 provider line. Direct AppKit/wagmi dependencies and older connector versions are unchanged.
- Rollback: remove the exact override and regenerate the lockfile.

## Review Notes
- Confirm the override remains scoped to `@walletconnect/universal-provider@2.23.7` and does not collapse the separate 2.21.x dependency graph.
- The dependency risk gate correctly requires manual review because five patched transitive package entries replace 2.23.7 without a direct dependency declaration.
- WalletConnect 2.23.9 predates the repository's seven-day minimum release-age window.
- No CSP, RPC, auth, connector configuration, telemetry filter, or user-facing UI change is included.