### PR TITLE
Show revealed next Meme on detail page

### DIFF
--- a/__tests__/components/distribution/Distribution.test.tsx
+++ b/__tests__/components/distribution/Distribution.test.tsx
@@ -154,8 +154,18 @@ jest.mock("@/components/scrollTo/ScrollToButton", () => {
 
 jest.mock("@/components/the-memes/UpcomingMemePage", () => ({
   __esModule: true,
-  default: ({ id }: { id: string }) => (
-    <div data-testid="upcoming-meme-page" data-id={id} />
+  default: ({
+    id,
+    showRevealedDrop,
+  }: {
+    id: string;
+    showRevealedDrop?: boolean;
+  }) => (
+    <div
+      data-testid="upcoming-meme-page"
+      data-id={id}
+      data-show-revealed-drop={String(showRevealedDrop)}
+    />
   ),
 }));
 
@@ -266,6 +276,10 @@ describe("DistributionPage", () => {
         const upcomingMemePage = screen.getByTestId("upcoming-meme-page");
         expect(upcomingMemePage).toBeInTheDocument();
         expect(upcomingMemePage).toHaveAttribute("data-id", "123");
+        expect(upcomingMemePage).toHaveAttribute(
+          "data-show-revealed-drop",
+          "false"
+        );
       });
     });
 

--- a/__tests__/components/home/LatestDropNextMintSection.test.tsx
+++ b/__tests__/components/home/LatestDropNextMintSection.test.tsx
@@ -74,6 +74,23 @@ describe("LatestDropNextMintSection", () => {
     expect(screen.getByText("Mint date")).toBeInTheDocument();
   });
 
+  it("shows submitted and rating before the mint date", () => {
+    render(<LatestDropNextMintSection drop={createDrop(488)} />);
+
+    const submitted = screen.getByText("Submitted");
+    const rating = screen.getByText("Rating");
+    const mintDate = screen.getByText("Mint date");
+
+    expect(
+      submitted.compareDocumentPosition(mintDate) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(
+      rating.compareDocumentPosition(mintDate) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
   it("keeps the schedule label and does not infer a card link when unmapped", () => {
     render(<LatestDropNextMintSection drop={createDrop()} />);
 

--- a/__tests__/components/home/LatestDropNextMintSection.test.tsx
+++ b/__tests__/components/home/LatestDropNextMintSection.test.tsx
@@ -1,3 +1,4 @@
+import LatestDropNextMintPanel from "@/components/home/now-minting/LatestDropNextMintPanel";
 import LatestDropNextMintSection from "@/components/home/now-minting/LatestDropNextMintSection";
 import type { ApiDropV2View } from "@/services/api/drop-v2-view.types";
 import { render, screen } from "@testing-library/react";
@@ -7,9 +8,15 @@ jest.mock("@/hooks/useDeviceInfo", () => ({
   default: () => ({ hasTouchScreen: false }),
 }));
 
+jest.mock("@/hooks/useBrowserLocale", () => ({
+  useBrowserLocale: () => "en-US",
+}));
+
 jest.mock("@/components/home/now-minting/LatestDropNextMintSubscribe", () => ({
   __esModule: true,
-  default: () => <div data-testid="subscribe" />,
+  default: ({ tokenId }: { readonly tokenId?: number }) => (
+    <div data-testid="subscribe" data-token-id={tokenId} />
+  ),
 }));
 
 jest.mock("next/image", () => ({
@@ -60,6 +67,11 @@ describe("LatestDropNextMintSection", () => {
       screen.getByRole("link", { name: "The Memes #488" })
     ).toHaveAttribute("href", "/the-memes/488");
     expect(screen.queryByText(/Card #/)).not.toBeInTheDocument();
+    expect(screen.getByTestId("subscribe")).toHaveAttribute(
+      "data-token-id",
+      "488"
+    );
+    expect(screen.getByText("Mint date")).toBeInTheDocument();
   });
 
   it("keeps the schedule label and does not infer a card link when unmapped", () => {
@@ -69,5 +81,17 @@ describe("LatestDropNextMintSection", () => {
       screen.queryByRole("link", { name: /The Memes #/ })
     ).not.toBeInTheDocument();
     expect(screen.getByText(/Card #/)).toBeInTheDocument();
+  });
+
+  it("renders the mapped Meme pill as static text on its own detail page", () => {
+    render(
+      <LatestDropNextMintPanel drop={createDrop(488)} linkMemeCard={false} />
+    );
+
+    const pill = screen.getByText("The Memes #488");
+    expect(pill.tagName).toBe("SPAN");
+    expect(
+      screen.queryByRole("link", { name: "The Memes #488" })
+    ).not.toBeInTheDocument();
   });
 });

--- a/__tests__/components/home/LatestDropNextMintSection.test.tsx
+++ b/__tests__/components/home/LatestDropNextMintSection.test.tsx
@@ -91,13 +91,13 @@ describe("LatestDropNextMintSection", () => {
     ).toBeTruthy();
   });
 
-  it("keeps the schedule label and does not infer a card link when unmapped", () => {
+  it("does not infer a card link when the next drop is unmapped", () => {
     render(<LatestDropNextMintSection drop={createDrop()} />);
 
     expect(
       screen.queryByRole("link", { name: /The Memes #/ })
     ).not.toBeInTheDocument();
-    expect(screen.getByText(/Card #/)).toBeInTheDocument();
+    expect(screen.queryByText(/Card #/)).not.toBeInTheDocument();
   });
 
   it("renders the mapped Meme pill as static text on its own detail page", () => {

--- a/__tests__/components/meme-calendar/meme-calendar.helpers.test.ts
+++ b/__tests__/components/meme-calendar/meme-calendar.helpers.test.ts
@@ -1,6 +1,7 @@
 import type { ZoomLevel } from "@/components/meme-calendar/meme-calendar.helpers";
 import {
   displayedSeasonNumberFromIndex,
+  formatFullDateTime,
   formatToFullDivision,
   getCardsRemainingUntilEndOf,
   getMintNumberForMintDate,
@@ -68,6 +69,25 @@ const getDivisionRows = (node: unknown): ReactElement<any>[] => {
 
   return Children.toArray(tbody.props.children).map(asElement);
 };
+
+describe("formatFullDateTime", () => {
+  const localDate = new Date(2026, 6, 15, 17, 40);
+
+  it("uses a 24-hour clock without changing locale-specific date order", () => {
+    const enUs = formatFullDateTime(localDate, "local", "en-US", {
+      hour12: false,
+    });
+    const enGb = formatFullDateTime(localDate, "local", "en-GB", {
+      hour12: false,
+    });
+
+    expect(enUs).toContain("Jul 15");
+    expect(enUs).toContain("17:40");
+    expect(enUs).not.toMatch(/\b(?:AM|PM)\b/);
+    expect(enGb).toContain("15 Jul");
+    expect(enGb).toContain("17:40");
+  });
+});
 
 describe("formatToFullDivision", () => {
   it("renders each division with a date range", () => {

--- a/__tests__/components/the-memes/UpcomingMemePage.test.tsx
+++ b/__tests__/components/the-memes/UpcomingMemePage.test.tsx
@@ -161,4 +161,21 @@ describe("UpcomingMemePage", () => {
     ).toBeInTheDocument();
     expect(screen.getByTestId("upcoming-mint-calendar")).toBeInTheDocument();
   });
+
+  it("reserves the artwork panel until the Main Stage settings load", () => {
+    mockGetCanonicalNextMintNumber.mockReturnValue(519);
+    mockUseNextMintDrop.mockReturnValue({
+      nextMint: null,
+      waveId: null,
+      isFetching: false,
+      isSettingsLoaded: false,
+    });
+
+    render(<UpcomingMemePage id="519" />);
+
+    expect(
+      screen.getByTestId("revealed-next-mint-panel-skeleton")
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("upcoming-mint-calendar")).toBeInTheDocument();
+  });
 });

--- a/__tests__/components/the-memes/UpcomingMemePage.test.tsx
+++ b/__tests__/components/the-memes/UpcomingMemePage.test.tsx
@@ -122,6 +122,30 @@ describe("UpcomingMemePage", () => {
     ).toEqual(["revealed-next-mint-panel", "upcoming-mint-calendar"]);
   });
 
+  it("keeps the generic view when reveal presentation is disabled", () => {
+    mockGetCanonicalNextMintNumber.mockReturnValue(519);
+    mockUseNowMintingStatus.mockReturnValue({
+      isFetching: false,
+      isDropComplete: true,
+      isStatusLoading: false,
+    });
+    mockUseNextMintDrop.mockReturnValue({
+      nextMint: createDrop(519),
+      waveId: "main-stage-wave",
+      isFetching: false,
+      isSettingsLoaded: true,
+    });
+
+    render(<UpcomingMemePage id="519" showRevealedDrop={false} />);
+
+    expect(
+      screen.getByTestId("upcoming-subscription-widget")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("revealed-next-mint-panel")
+    ).not.toBeInTheDocument();
+  });
+
   it("keeps the generic view when the revealed drop maps to another meme", () => {
     mockGetCanonicalNextMintNumber.mockReturnValue(519);
     mockUseNowMintingStatus.mockReturnValue({

--- a/__tests__/components/the-memes/UpcomingMemePage.test.tsx
+++ b/__tests__/components/the-memes/UpcomingMemePage.test.tsx
@@ -1,5 +1,23 @@
 import UpcomingMemePage from "@/components/the-memes/UpcomingMemePage";
+import type { ApiDropV2View } from "@/services/api/drop-v2-view.types";
 import { render, screen } from "@testing-library/react";
+
+const mockGetCanonicalNextMintNumber = jest.fn();
+const mockUseNextMintDrop = jest.fn();
+const mockUseNowMintingStatus = jest.fn();
+
+jest.mock("@/components/meme-calendar/meme-calendar.helpers", () => ({
+  ...jest.requireActual("@/components/meme-calendar/meme-calendar.helpers"),
+  getCanonicalNextMintNumber: () => mockGetCanonicalNextMintNumber(),
+}));
+
+jest.mock("@/hooks/useNextMintDrop", () => ({
+  useNextMintDrop: () => mockUseNextMintDrop(),
+}));
+
+jest.mock("@/hooks/useNowMintingStatus", () => ({
+  useNowMintingStatus: () => mockUseNowMintingStatus(),
+}));
 
 jest.mock("@/components/meme-calendar/MemeCalendarOverview", () => ({
   MemeCalendarOverviewNextMint: ({ id }: { readonly id?: number }) => (
@@ -14,7 +32,48 @@ jest.mock("@/components/home/now-minting/LatestDropNextMintSubscribe", () => ({
   ),
 }));
 
+jest.mock("@/components/home/now-minting/LatestDropNextMintPanel", () => ({
+  __esModule: true,
+  default: ({
+    drop,
+    linkMemeCard,
+  }: {
+    readonly drop: ApiDropV2View;
+    readonly linkMemeCard?: boolean;
+  }) => (
+    <div
+      data-testid="revealed-next-mint-panel"
+      data-drop-id={drop.id}
+      data-link-meme-card={String(linkMemeCard)}
+    />
+  ),
+  LatestDropNextMintPanelSkeleton: () => (
+    <div data-testid="revealed-next-mint-panel-skeleton" />
+  ),
+}));
+
+const createDrop = (memeCardId: number): ApiDropV2View =>
+  ({
+    id: "drop-1",
+    submission_context: { meme_card_id: memeCardId },
+  }) as ApiDropV2View;
+
 describe("UpcomingMemePage", () => {
+  beforeEach(() => {
+    mockGetCanonicalNextMintNumber.mockReturnValue(520);
+    mockUseNowMintingStatus.mockReturnValue({
+      isFetching: false,
+      isDropComplete: false,
+      isStatusLoading: false,
+    });
+    mockUseNextMintDrop.mockReturnValue({
+      nextMint: null,
+      waveId: "main-stage-wave",
+      isFetching: false,
+      isSettingsLoaded: true,
+    });
+  });
+
   it("shows mint timing and subscription awareness for unresolved meme ids", () => {
     const { container } = render(<UpcomingMemePage id="519" />);
 
@@ -31,5 +90,75 @@ describe("UpcomingMemePage", () => {
         element.getAttribute("data-testid")
       )
     ).toEqual(["upcoming-subscription-widget", "upcoming-mint-calendar"]);
+  });
+
+  it("shows the revealed drop and calendar for the mapped canonical next meme", () => {
+    mockGetCanonicalNextMintNumber.mockReturnValue(519);
+    mockUseNowMintingStatus.mockReturnValue({
+      isFetching: false,
+      isDropComplete: true,
+      isStatusLoading: false,
+    });
+    mockUseNextMintDrop.mockReturnValue({
+      nextMint: createDrop(519),
+      waveId: "main-stage-wave",
+      isFetching: false,
+      isSettingsLoaded: true,
+    });
+
+    const { container } = render(<UpcomingMemePage id="519" />);
+
+    expect(screen.getByTestId("revealed-next-mint-panel")).toHaveAttribute(
+      "data-link-meme-card",
+      "false"
+    );
+    expect(
+      screen.queryByTestId("upcoming-subscription-widget")
+    ).not.toBeInTheDocument();
+    expect(
+      [...container.querySelectorAll("[data-testid]")].map((element) =>
+        element.getAttribute("data-testid")
+      )
+    ).toEqual(["revealed-next-mint-panel", "upcoming-mint-calendar"]);
+  });
+
+  it("keeps the generic view when the revealed drop maps to another meme", () => {
+    mockGetCanonicalNextMintNumber.mockReturnValue(519);
+    mockUseNowMintingStatus.mockReturnValue({
+      isFetching: false,
+      isDropComplete: true,
+      isStatusLoading: false,
+    });
+    mockUseNextMintDrop.mockReturnValue({
+      nextMint: createDrop(520),
+      waveId: "main-stage-wave",
+      isFetching: false,
+      isSettingsLoaded: true,
+    });
+
+    render(<UpcomingMemePage id="519" />);
+
+    expect(
+      screen.getByTestId("upcoming-subscription-widget")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("revealed-next-mint-panel")
+    ).not.toBeInTheDocument();
+  });
+
+  it("reserves the artwork panel while the canonical reveal state loads", () => {
+    mockGetCanonicalNextMintNumber.mockReturnValue(519);
+    mockUseNowMintingStatus.mockReturnValue({
+      isFetching: true,
+      isDropComplete: false,
+      isStatusLoading: false,
+    });
+
+    render(<UpcomingMemePage id="519" />);
+
+    expect(
+      screen.getByTestId("revealed-next-mint-panel-skeleton")
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("upcoming-mint-calendar")).toBeInTheDocument();
   });
 });

--- a/components/distribution/Distribution.tsx
+++ b/components/distribution/Distribution.tsx
@@ -490,7 +490,11 @@ export default function DistributionPage(props: Readonly<Props>) {
       <div>
         {nftId && (
           <div className="tw-w-full">
-            <UpcomingMemePage id={nftId} locale={locale} />
+            <UpcomingMemePage
+              id={nftId}
+              locale={locale}
+              showRevealedDrop={false}
+            />
           </div>
         )}
         <div className="tw-flex tw-w-full tw-justify-center tw-pt-8">

--- a/components/home/now-minting/LatestDropNextMintPanel.tsx
+++ b/components/home/now-minting/LatestDropNextMintPanel.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import MediaTypeBadge from "@/components/drops/media/MediaTypeBadge";
+import DropListItemContentMedia from "@/components/drops/view/item/content/media/DropListItemContentMedia";
+import {
+  isValidMemeCardId,
+  MainStageMemeCardPill,
+} from "@/components/memes/drops/MainStageMemeCardLink";
+import {
+  formatFullDateTime,
+  getCanonicalNextMintNumber,
+  getNextMintStart,
+} from "@/components/meme-calendar/meme-calendar.helpers";
+import type { ApiDropV2View } from "@/services/api/drop-v2-view.types";
+import { formatNumberWithCommas } from "@/helpers/Helpers";
+import { getScaledImageUri, ImageScale } from "@/helpers/image.helpers";
+import { getDropPreviewImageUrl } from "@/helpers/waves/drop.helpers";
+import useDeviceInfo from "@/hooks/useDeviceInfo";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import type { SupportedLocale } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
+import Image from "next/image";
+import Link from "next/link";
+import ArtistPill from "./ArtistPill";
+import LatestDropNextMintSubscribe from "./LatestDropNextMintSubscribe";
+import NowMintingStatsItem from "./NowMintingStatsItem";
+
+interface LatestDropNextMintPanelProps {
+  readonly drop: ApiDropV2View;
+  readonly linkMemeCard?: boolean;
+  readonly locale?: SupportedLocale;
+}
+
+const formatDropTimestamp = (
+  timestamp: number,
+  locale: SupportedLocale
+): string | null => {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  const dateLabel = new Intl.DateTimeFormat(locale, {
+    month: "short",
+    day: "numeric",
+  }).format(date);
+  const timeLabel = new Intl.DateTimeFormat(locale, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(date);
+
+  return `${dateLabel} · ${timeLabel}`;
+};
+
+export function LatestDropNextMintPanelSkeleton() {
+  return (
+    <div className="tw-relative tw-overflow-hidden tw-rounded-2xl tw-border tw-border-solid tw-border-white/5 tw-bg-iron-950">
+      <div className="tw-grid tw-grid-cols-1 tw-gap-y-6 lg:tw-grid-cols-12 xl:tw-grid-cols-9">
+        <div className="tw-p-0 lg:tw-col-span-6 xl:tw-col-span-5">
+          <div className="tw-relative tw-h-[clamp(360px,65vw,640px)] tw-w-full tw-animate-pulse tw-bg-iron-800/50" />
+        </div>
+        <div className="tw-p-5 md:tw-p-6 lg:tw-col-span-6 xl:tw-col-span-4">
+          <div className="tw-flex tw-flex-col tw-gap-5">
+            <div className="tw-space-y-2">
+              <div className="tw-h-4 tw-w-24 tw-animate-pulse tw-rounded tw-bg-iron-800/50" />
+              <div className="tw-h-7 tw-w-3/4 tw-animate-pulse tw-rounded tw-bg-iron-800/50" />
+              <div className="tw-h-4 tw-w-32 tw-animate-pulse tw-rounded tw-bg-iron-800/50" />
+            </div>
+            <div className="tw-h-32 tw-w-full tw-animate-pulse tw-rounded-lg tw-bg-iron-800/50" />
+            <div className="tw-grid tw-grid-cols-2 tw-gap-3">
+              {Array.from({ length: 4 }, (_, index) => (
+                <div key={index} className="tw-space-y-2">
+                  <div className="tw-h-4 tw-w-16 tw-animate-pulse tw-rounded tw-bg-iron-800/50" />
+                  <div className="tw-h-6 tw-w-24 tw-animate-pulse tw-rounded tw-bg-iron-800/50" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function LatestDropNextMintPanel({
+  drop,
+  linkMemeCard = true,
+  locale: requestedLocale,
+}: LatestDropNextMintPanelProps) {
+  const { hasTouchScreen } = useDeviceInfo();
+  const browserLocale = useBrowserLocale();
+  const locale = requestedLocale ?? browserLocale;
+  const media = drop.parts[0]?.media[0];
+  const isHtml = media?.mime_type === "text/html";
+  const htmlPreviewImageUrl =
+    hasTouchScreen && isHtml
+      ? (getDropPreviewImageUrl(drop.metadata) ?? undefined)
+      : undefined;
+  const title =
+    drop.title ??
+    drop.metadata.find((metadata) => metadata.data_key === "title")
+      ?.data_value ??
+    "Untitled";
+  const author = drop.author;
+  const authorHandle = author.handle ?? author.primary_address;
+  const authorName = author.handle ?? "Anonymous";
+  const submittedAt = formatDropTimestamp(drop.created_at, locale);
+  const description =
+    drop.metadata.find((metadata) => metadata.data_key === "description")
+      ?.data_value ?? null;
+  const now = new Date();
+  const nextMintStart = getNextMintStart(now);
+  const canonicalNextMintNumber = getCanonicalNextMintNumber(now);
+  const nextMintDateTime = formatFullDateTime(nextMintStart, "local", locale);
+  const mappedMemeCardId = drop.submission_context?.meme_card_id;
+  const hasMappedMemeCard = isValidMemeCardId(mappedMemeCardId);
+  const subscriptionTokenId = hasMappedMemeCard
+    ? mappedMemeCardId
+    : canonicalNextMintNumber;
+  const nextMintLabel = hasMappedMemeCard
+    ? nextMintDateTime
+    : `Card #${canonicalNextMintNumber} - ${nextMintDateTime}`;
+
+  return (
+    <div className="tw-relative tw-overflow-hidden tw-rounded-2xl tw-border tw-border-solid tw-border-white/[0.03] tw-bg-iron-950">
+      <div className="tw-grid tw-grid-cols-1 tw-items-center tw-gap-x-6 tw-gap-y-6 lg:tw-grid-cols-12 xl:tw-grid-cols-9">
+        <div className="tw-p-0 lg:tw-col-span-6 xl:tw-col-span-5">
+          <div className="tw-relative tw-flex tw-h-[clamp(360px,65vw,640px)] tw-w-full tw-items-center tw-justify-center tw-overflow-hidden tw-bg-black/50">
+            <div className="tw-[&>div]:tw-mx-0 tw-flex tw-h-full tw-w-full tw-items-center tw-justify-center">
+              {media ? (
+                <DropListItemContentMedia
+                  media_mime_type={media.mime_type}
+                  media_url={media.url}
+                  imageObjectPosition="center"
+                  imageScale={ImageScale.AUTOx600}
+                  disableAutoPlay={hasTouchScreen}
+                  disableModal={hasTouchScreen}
+                  htmlIframeContainerClassName="tw-w-full"
+                  htmlPreviewImageUrl={htmlPreviewImageUrl}
+                />
+              ) : (
+                <div className="tw-flex tw-size-full tw-items-center tw-justify-center tw-bg-black/40">
+                  <span className="tw-text-sm tw-text-white/40">No image</span>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="tw-p-5 md:tw-p-6 lg:tw-col-span-6 xl:tw-col-span-4">
+          <div className="tw-flex tw-flex-col tw-gap-5">
+            <div className="tw-flex tw-flex-col">
+              <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
+                <div className="tw-flex tw-items-center tw-gap-2">
+                  <span className="tw-size-1.5 tw-rounded-full tw-bg-emerald-500" />
+                  <span className="tw-text-[11px] tw-font-semibold tw-uppercase tw-leading-5 tw-tracking-wide tw-text-emerald-400">
+                    NEXT MINT
+                  </span>
+                </div>
+                <MainStageMemeCardPill
+                  memeCardId={mappedMemeCardId}
+                  href={
+                    linkMemeCard && hasMappedMemeCard
+                      ? `/the-memes/${mappedMemeCardId}`
+                      : undefined
+                  }
+                />
+              </div>
+              <span className="tw-mt-1 tw-font-mono tw-text-xs tw-text-white/50">
+                {nextMintLabel}
+              </span>
+
+              <Link
+                href={`/waves?wave=${drop.wave.id}&drop=${drop.id}`}
+                className="tw-mt-3 tw-text-xl tw-font-semibold tw-leading-tight tw-text-iron-50 tw-no-underline tw-transition-colors tw-duration-300 desktop-hover:hover:tw-text-iron-200 sm:tw-text-2xl md:tw-text-3xl"
+              >
+                {title}
+              </Link>
+
+              {description && (
+                <p className="tw-mt-3 tw-line-clamp-2 tw-text-sm tw-leading-relaxed tw-text-iron-300">
+                  {description}
+                </p>
+              )}
+
+              <div className="tw-mt-3 tw-flex tw-flex-wrap tw-items-center tw-gap-2">
+                {media?.mime_type && (
+                  <MediaTypeBadge
+                    mimeType={media.mime_type}
+                    dropId={drop.id}
+                    size="sm"
+                    iconClassName="tw-size-[26px]"
+                  />
+                )}
+                <ArtistPill
+                  pfp={author.pfp}
+                  label={authorName}
+                  href={authorHandle ? `/${authorHandle}` : undefined}
+                  profileHandle={author.handle ?? undefined}
+                />
+              </div>
+
+              <div className="tw-mt-4">
+                <LatestDropNextMintSubscribe tokenId={subscriptionTokenId} />
+              </div>
+            </div>
+
+            <div className="tw-grid tw-grid-cols-2 tw-gap-x-6 tw-gap-y-4">
+              <div className="tw-col-span-2">
+                <NowMintingStatsItem
+                  label="Wave"
+                  allowWrap
+                  value={
+                    <Link
+                      href={`/waves/${drop.wave.id}`}
+                      className="tw-inline-flex tw-items-center tw-gap-2 tw-text-iron-100 tw-no-underline desktop-hover:hover:tw-text-iron-200"
+                    >
+                      {drop.wave.picture && (
+                        <Image
+                          src={getScaledImageUri(
+                            drop.wave.picture,
+                            ImageScale.W_AUTO_H_50
+                          )}
+                          alt={drop.wave.name}
+                          width={20}
+                          height={20}
+                          className="tw-size-5 tw-shrink-0 tw-rounded-full tw-object-cover tw-ring-1 tw-ring-white/10"
+                        />
+                      )}
+                      <span className="tw-min-w-0 tw-break-words">
+                        {drop.wave.name}
+                      </span>
+                    </Link>
+                  }
+                />
+              </div>
+              <div className="tw-col-span-2">
+                <NowMintingStatsItem
+                  label={t(locale, "theMemes.detail.live.artwork.mintDate")}
+                  value={nextMintDateTime}
+                  allowWrap
+                />
+              </div>
+              <NowMintingStatsItem
+                label="Submitted"
+                value={submittedAt ?? "—"}
+              />
+              <NowMintingStatsItem
+                label="Rating"
+                value={`${formatNumberWithCommas(drop.rating)} TDH`}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/home/now-minting/LatestDropNextMintPanel.tsx
+++ b/components/home/now-minting/LatestDropNextMintPanel.tsx
@@ -9,18 +9,19 @@ import {
 import {
   formatFullDateTime,
   getCanonicalNextMintNumber,
-  getNextMintStart,
+  getMintTimelineDetails,
 } from "@/components/meme-calendar/meme-calendar.helpers";
 import type { ApiDropV2View } from "@/services/api/drop-v2-view.types";
-import { formatNumberWithCommas } from "@/helpers/Helpers";
 import { getScaledImageUri, ImageScale } from "@/helpers/image.helpers";
 import { getDropPreviewImageUrl } from "@/helpers/waves/drop.helpers";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
 import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import { formatDate, formatInteger, formatTime } from "@/i18n/format";
 import type { SupportedLocale } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
 import Image from "next/image";
 import Link from "next/link";
+import { useSyncExternalStore } from "react";
 import ArtistPill from "./ArtistPill";
 import LatestDropNextMintSubscribe from "./LatestDropNextMintSubscribe";
 import NowMintingStatsItem from "./NowMintingStatsItem";
@@ -40,17 +41,24 @@ const formatDropTimestamp = (
     return null;
   }
 
-  const dateLabel = new Intl.DateTimeFormat(locale, {
+  const dateLabel = formatDate(locale, date, {
     month: "short",
     day: "numeric",
-  }).format(date);
-  const timeLabel = new Intl.DateTimeFormat(locale, {
+  });
+  const timeLabel = formatTime(locale, date, {
     hour: "2-digit",
     minute: "2-digit",
     hour12: false,
-  }).format(date);
+  });
 
   return `${dateLabel} · ${timeLabel}`;
+};
+
+const getMinuteClockSnapshot = () => Math.floor(Date.now() / 60_000);
+const getServerMinuteClockSnapshot = () => null;
+const subscribeToMinuteClock = (onStoreChange: () => void) => {
+  const intervalId = globalThis.setInterval(onStoreChange, 60_000);
+  return () => globalThis.clearInterval(intervalId);
 };
 
 export function LatestDropNextMintPanelSkeleton() {
@@ -69,8 +77,8 @@ export function LatestDropNextMintPanelSkeleton() {
             </div>
             <div className="tw-h-32 tw-w-full tw-animate-pulse tw-rounded-lg tw-bg-iron-800/50" />
             <div className="tw-grid tw-grid-cols-2 tw-gap-3">
-              {Array.from({ length: 4 }, (_, index) => (
-                <div key={index} className="tw-space-y-2">
+              {["wave", "mint-date", "submitted", "rating"].map((stat) => (
+                <div key={stat} className="tw-space-y-2">
                   <div className="tw-h-4 tw-w-16 tw-animate-pulse tw-rounded tw-bg-iron-800/50" />
                   <div className="tw-h-6 tw-w-24 tw-animate-pulse tw-rounded tw-bg-iron-800/50" />
                 </div>
@@ -101,26 +109,42 @@ export default function LatestDropNextMintPanel({
     drop.title ??
     drop.metadata.find((metadata) => metadata.data_key === "title")
       ?.data_value ??
-    "Untitled";
+    t(locale, "home.nextMint.untitled");
   const author = drop.author;
   const authorHandle = author.handle ?? author.primary_address;
-  const authorName = author.handle ?? "Anonymous";
+  const authorName = author.handle ?? t(locale, "home.nextMint.anonymous");
   const submittedAt = formatDropTimestamp(drop.created_at, locale);
   const description =
     drop.metadata.find((metadata) => metadata.data_key === "description")
       ?.data_value ?? null;
-  const now = new Date();
-  const nextMintStart = getNextMintStart(now);
-  const canonicalNextMintNumber = getCanonicalNextMintNumber(now);
-  const nextMintDateTime = formatFullDateTime(nextMintStart, "local", locale);
   const mappedMemeCardId = drop.submission_context?.meme_card_id;
   const hasMappedMemeCard = isValidMemeCardId(mappedMemeCardId);
+  const minuteClock = useSyncExternalStore(
+    subscribeToMinuteClock,
+    getMinuteClockSnapshot,
+    getServerMinuteClockSnapshot
+  );
+  const fallbackNow =
+    minuteClock === null ? null : new Date(minuteClock * 60_000);
   const subscriptionTokenId = hasMappedMemeCard
     ? mappedMemeCardId
-    : canonicalNextMintNumber;
+    : fallbackNow
+      ? getCanonicalNextMintNumber(fallbackNow)
+      : null;
+  const nextMintStart = subscriptionTokenId
+    ? getMintTimelineDetails(subscriptionTokenId).instantUtc
+    : null;
+  const nextMintDateTime = nextMintStart
+    ? formatFullDateTime(nextMintStart, "local", locale)
+    : "—";
   const nextMintLabel = hasMappedMemeCard
     ? nextMintDateTime
-    : `Card #${canonicalNextMintNumber} - ${nextMintDateTime}`;
+    : subscriptionTokenId
+      ? t(locale, "home.nextMint.cardSchedule", {
+          number: formatInteger(locale, subscriptionTokenId),
+          date: nextMintDateTime,
+        })
+      : "—";
 
   return (
     <div className="tw-relative tw-overflow-hidden tw-rounded-2xl tw-border tw-border-solid tw-border-white/[0.03] tw-bg-iron-950">
@@ -141,7 +165,9 @@ export default function LatestDropNextMintPanel({
                 />
               ) : (
                 <div className="tw-flex tw-size-full tw-items-center tw-justify-center tw-bg-black/40">
-                  <span className="tw-text-sm tw-text-white/40">No image</span>
+                  <span className="tw-text-sm tw-text-white/40">
+                    {t(locale, "home.nextMint.noImage")}
+                  </span>
                 </div>
               )}
             </div>
@@ -155,7 +181,7 @@ export default function LatestDropNextMintPanel({
                 <div className="tw-flex tw-items-center tw-gap-2">
                   <span className="tw-size-1.5 tw-rounded-full tw-bg-emerald-500" />
                   <span className="tw-text-[11px] tw-font-semibold tw-uppercase tw-leading-5 tw-tracking-wide tw-text-emerald-400">
-                    NEXT MINT
+                    {t(locale, "home.nextMint.status")}
                   </span>
                 </div>
                 <MainStageMemeCardPill
@@ -201,15 +227,17 @@ export default function LatestDropNextMintPanel({
                 />
               </div>
 
-              <div className="tw-mt-4">
-                <LatestDropNextMintSubscribe tokenId={subscriptionTokenId} />
-              </div>
+              {subscriptionTokenId && (
+                <div className="tw-mt-4">
+                  <LatestDropNextMintSubscribe tokenId={subscriptionTokenId} />
+                </div>
+              )}
             </div>
 
             <div className="tw-grid tw-grid-cols-2 tw-gap-x-6 tw-gap-y-4">
               <div className="tw-col-span-2">
                 <NowMintingStatsItem
-                  label="Wave"
+                  label={t(locale, "home.nextMint.stats.wave")}
                   allowWrap
                   value={
                     <Link
@@ -243,12 +271,12 @@ export default function LatestDropNextMintPanel({
                 />
               </div>
               <NowMintingStatsItem
-                label="Submitted"
+                label={t(locale, "home.nextMint.stats.submitted")}
                 value={submittedAt ?? "—"}
               />
               <NowMintingStatsItem
-                label="Rating"
-                value={`${formatNumberWithCommas(drop.rating)} TDH`}
+                label={t(locale, "home.nextMint.stats.rating")}
+                value={`${formatInteger(locale, drop.rating)} TDH`}
               />
             </div>
           </div>

--- a/components/home/now-minting/LatestDropNextMintPanel.tsx
+++ b/components/home/now-minting/LatestDropNextMintPanel.tsx
@@ -136,7 +136,7 @@ export default function LatestDropNextMintPanel({
     ? getMintTimelineDetails(subscriptionTokenId).instantUtc
     : null;
   const nextMintDateTime = nextMintStart
-    ? formatFullDateTime(nextMintStart, "local", locale)
+    ? formatFullDateTime(nextMintStart, "local", locale, { hour12: false })
     : "—";
   let nextMintLabel = "—";
   if (hasMappedMemeCard) {

--- a/components/home/now-minting/LatestDropNextMintPanel.tsx
+++ b/components/home/now-minting/LatestDropNextMintPanel.tsx
@@ -126,25 +126,27 @@ export default function LatestDropNextMintPanel({
   );
   const fallbackNow =
     minuteClock === null ? null : new Date(minuteClock * 60_000);
-  const subscriptionTokenId = hasMappedMemeCard
-    ? mappedMemeCardId
-    : fallbackNow
-      ? getCanonicalNextMintNumber(fallbackNow)
-      : null;
+  let subscriptionTokenId: number | null = null;
+  if (hasMappedMemeCard) {
+    subscriptionTokenId = mappedMemeCardId;
+  } else if (fallbackNow) {
+    subscriptionTokenId = getCanonicalNextMintNumber(fallbackNow);
+  }
   const nextMintStart = subscriptionTokenId
     ? getMintTimelineDetails(subscriptionTokenId).instantUtc
     : null;
   const nextMintDateTime = nextMintStart
     ? formatFullDateTime(nextMintStart, "local", locale)
     : "—";
-  const nextMintLabel = hasMappedMemeCard
-    ? nextMintDateTime
-    : subscriptionTokenId
-      ? t(locale, "home.nextMint.cardSchedule", {
-          number: formatInteger(locale, subscriptionTokenId),
-          date: nextMintDateTime,
-        })
-      : "—";
+  let nextMintLabel = "—";
+  if (hasMappedMemeCard) {
+    nextMintLabel = nextMintDateTime;
+  } else if (subscriptionTokenId) {
+    nextMintLabel = t(locale, "home.nextMint.cardSchedule", {
+      number: formatInteger(locale, subscriptionTokenId),
+      date: nextMintDateTime,
+    });
+  }
 
   return (
     <div className="tw-relative tw-overflow-hidden tw-rounded-2xl tw-border tw-border-solid tw-border-white/[0.03] tw-bg-iron-950">

--- a/components/home/now-minting/LatestDropNextMintPanel.tsx
+++ b/components/home/now-minting/LatestDropNextMintPanel.tsx
@@ -32,6 +32,8 @@ interface LatestDropNextMintPanelProps {
   readonly locale?: SupportedLocale;
 }
 
+const NEXT_MINT_DATE_LOCALE = "en-GB";
+
 const formatDropTimestamp = (
   timestamp: number,
   locale: SupportedLocale
@@ -126,24 +128,27 @@ export default function LatestDropNextMintPanel({
   );
   const fallbackNow =
     minuteClock === null ? null : new Date(minuteClock * 60_000);
-  let subscriptionTokenId: number | null = null;
+  let nextMintCardId: number | null = null;
   if (hasMappedMemeCard) {
-    subscriptionTokenId = mappedMemeCardId;
+    nextMintCardId = mappedMemeCardId;
   } else if (fallbackNow) {
-    subscriptionTokenId = getCanonicalNextMintNumber(fallbackNow);
+    nextMintCardId = getCanonicalNextMintNumber(fallbackNow);
   }
-  const nextMintStart = subscriptionTokenId
-    ? getMintTimelineDetails(subscriptionTokenId).instantUtc
+  // Once a drop is mapped, its Meme Card ID is authoritative for its mint schedule.
+  const nextMintStart = nextMintCardId
+    ? getMintTimelineDetails(nextMintCardId).instantUtc
     : null;
   const nextMintDateTime = nextMintStart
-    ? formatFullDateTime(nextMintStart, "local", locale, { hour12: false })
+    ? formatFullDateTime(nextMintStart, "local", NEXT_MINT_DATE_LOCALE, {
+        hour12: false,
+      })
     : "—";
   let nextMintLabel = "—";
   if (hasMappedMemeCard) {
     nextMintLabel = nextMintDateTime;
-  } else if (subscriptionTokenId) {
+  } else if (nextMintCardId) {
     nextMintLabel = t(locale, "home.nextMint.cardSchedule", {
-      number: formatInteger(locale, subscriptionTokenId),
+      number: formatInteger(locale, nextMintCardId),
       date: nextMintDateTime,
     });
   }
@@ -229,9 +234,9 @@ export default function LatestDropNextMintPanel({
                 />
               </div>
 
-              {subscriptionTokenId && (
+              {nextMintCardId && (
                 <div className="tw-mt-4">
-                  <LatestDropNextMintSubscribe tokenId={subscriptionTokenId} />
+                  <LatestDropNextMintSubscribe tokenId={nextMintCardId} />
                 </div>
               )}
             </div>

--- a/components/home/now-minting/LatestDropNextMintPanel.tsx
+++ b/components/home/now-minting/LatestDropNextMintPanel.tsx
@@ -265,13 +265,6 @@ export default function LatestDropNextMintPanel({
                   }
                 />
               </div>
-              <div className="tw-col-span-2">
-                <NowMintingStatsItem
-                  label={t(locale, "theMemes.detail.live.artwork.mintDate")}
-                  value={nextMintDateTime}
-                  allowWrap
-                />
-              </div>
               <NowMintingStatsItem
                 label={t(locale, "home.nextMint.stats.submitted")}
                 value={submittedAt ?? "—"}
@@ -280,6 +273,13 @@ export default function LatestDropNextMintPanel({
                 label={t(locale, "home.nextMint.stats.rating")}
                 value={`${formatInteger(locale, drop.rating)} TDH`}
               />
+              <div className="tw-col-span-2">
+                <NowMintingStatsItem
+                  label={t(locale, "theMemes.detail.live.artwork.mintDate")}
+                  value={nextMintDateTime}
+                  allowWrap
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/components/home/now-minting/LatestDropNextMintPanel.tsx
+++ b/components/home/now-minting/LatestDropNextMintPanel.tsx
@@ -143,16 +143,6 @@ export default function LatestDropNextMintPanel({
         hour12: false,
       })
     : "—";
-  let nextMintLabel = "—";
-  if (hasMappedMemeCard) {
-    nextMintLabel = nextMintDateTime;
-  } else if (nextMintCardId) {
-    nextMintLabel = t(locale, "home.nextMint.cardSchedule", {
-      number: formatInteger(locale, nextMintCardId),
-      date: nextMintDateTime,
-    });
-  }
-
   return (
     <div className="tw-relative tw-overflow-hidden tw-rounded-2xl tw-border tw-border-solid tw-border-white/[0.03] tw-bg-iron-950">
       <div className="tw-grid tw-grid-cols-1 tw-items-center tw-gap-x-6 tw-gap-y-6 lg:tw-grid-cols-12 xl:tw-grid-cols-9">
@@ -200,10 +190,6 @@ export default function LatestDropNextMintPanel({
                   }
                 />
               </div>
-              <span className="tw-mt-1 tw-font-mono tw-text-xs tw-text-white/50">
-                {nextMintLabel}
-              </span>
-
               <Link
                 href={`/waves?wave=${drop.wave.id}&drop=${drop.id}`}
                 className="tw-mt-3 tw-text-xl tw-font-semibold tw-leading-tight tw-text-iron-50 tw-no-underline tw-transition-colors tw-duration-300 desktop-hover:hover:tw-text-iron-200 sm:tw-text-2xl md:tw-text-3xl"

--- a/components/home/now-minting/LatestDropNextMintSection.tsx
+++ b/components/home/now-minting/LatestDropNextMintSection.tsx
@@ -1,205 +1,20 @@
-"use client";
-
-import MediaTypeBadge from "@/components/drops/media/MediaTypeBadge";
-import MainStageMemeCardLink, {
-  isValidMemeCardId,
-} from "@/components/memes/drops/MainStageMemeCardLink";
-import {
-  getCanonicalNextMintNumber,
-  formatFullDateTime,
-  getNextMintStart,
-} from "@/components/meme-calendar/meme-calendar.helpers";
-import DropListItemContentMedia from "@/components/drops/view/item/content/media/DropListItemContentMedia";
 import type { ApiDropV2View } from "@/services/api/drop-v2-view.types";
-import { formatNumberWithCommas } from "@/helpers/Helpers";
-import { getScaledImageUri, ImageScale } from "@/helpers/image.helpers";
-import { getDropPreviewImageUrl } from "@/helpers/waves/drop.helpers";
-import useDeviceInfo from "@/hooks/useDeviceInfo";
-import Image from "next/image";
-import Link from "next/link";
-import ArtistPill from "./ArtistPill";
-import LatestDropNextMintSubscribe from "./LatestDropNextMintSubscribe";
-import NowMintingStatsItem from "./NowMintingStatsItem";
+import LatestDropNextMintPanel from "./LatestDropNextMintPanel";
 
 interface LatestDropNextMintSectionProps {
   readonly drop: ApiDropV2View;
 }
 
-const formatDropTimestamp = (timestamp: number): string | null => {
-  const date = new Date(timestamp);
-  if (Number.isNaN(date.getTime())) {
-    return null;
-  }
-
-  const dateLabel = new Intl.DateTimeFormat(undefined, {
-    month: "short",
-    day: "numeric",
-  }).format(date);
-  const timeLabel = new Intl.DateTimeFormat(undefined, {
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  }).format(date);
-
-  return `${dateLabel} · ${timeLabel}`;
-};
-
 export default function LatestDropNextMintSection({
   drop,
 }: LatestDropNextMintSectionProps) {
-  const { hasTouchScreen } = useDeviceInfo();
-  const media = drop.parts[0]?.media[0];
-  const isHtml = media?.mime_type === "text/html";
-  const htmlPreviewImageUrl =
-    hasTouchScreen && isHtml
-      ? (getDropPreviewImageUrl(drop.metadata) ?? undefined)
-      : undefined;
-  const title =
-    drop.title ??
-    drop.metadata.find((m) => m.data_key === "title")?.data_value ??
-    "Untitled";
-  const author = drop.author;
-  const authorHandle = author.handle ?? author.primary_address;
-  const authorName = author.handle ?? "Anonymous";
-  const submittedAt = formatDropTimestamp(drop.created_at);
-  const description =
-    drop.metadata.find((m) => m.data_key === "description")?.data_value ?? null;
-  const now = new Date();
-  const nextMintStart = getNextMintStart(now);
-  const nextMintCardNumber = getCanonicalNextMintNumber(now);
-  const nextMintDateTime = formatFullDateTime(nextMintStart, "local");
-  const mappedMemeCardId = drop.submission_context?.meme_card_id;
-  const hasMappedMemeCard = isValidMemeCardId(mappedMemeCardId);
-  const nextMintLabel = hasMappedMemeCard
-    ? nextMintDateTime
-    : `Card #${nextMintCardNumber} - ${nextMintDateTime}`;
-
   return (
     <section className="tw-relative tw-z-50 tw-px-4 tw-pb-4 tw-pt-6 md:tw-px-6 md:tw-pb-8 md:tw-pt-10 lg:tw-px-8">
       <span className="tw-mb-3 tw-block tw-text-xl tw-font-semibold tw-tracking-tight tw-text-iron-100 md:tw-mb-4 md:tw-text-2xl">
         Next Drop
       </span>
 
-      <div className="tw-relative tw-overflow-hidden tw-rounded-2xl tw-border tw-border-solid tw-border-white/[0.03] tw-bg-iron-950">
-        <div className="tw-grid tw-grid-cols-1 tw-items-center tw-gap-x-6 tw-gap-y-6 lg:tw-grid-cols-12 xl:tw-grid-cols-9">
-          <div className="tw-p-0 lg:tw-col-span-6 xl:tw-col-span-5">
-            <div className="tw-relative tw-flex tw-h-[clamp(360px,65vw,640px)] tw-w-full tw-items-center tw-justify-center tw-overflow-hidden tw-bg-black/50">
-              <div className="tw-[&>div]:tw-mx-0 tw-flex tw-h-full tw-w-full tw-items-center tw-justify-center">
-                {media ? (
-                  <DropListItemContentMedia
-                    media_mime_type={media.mime_type}
-                    media_url={media.url}
-                    imageObjectPosition="center"
-                    imageScale={ImageScale.AUTOx600}
-                    disableAutoPlay={hasTouchScreen}
-                    disableModal={hasTouchScreen}
-                    htmlIframeContainerClassName="tw-w-full"
-                    htmlPreviewImageUrl={htmlPreviewImageUrl}
-                  />
-                ) : (
-                  <div className="tw-flex tw-size-full tw-items-center tw-justify-center tw-bg-black/40">
-                    <span className="tw-text-sm tw-text-white/40">
-                      No image
-                    </span>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
-
-          <div className="tw-p-5 md:tw-p-6 lg:tw-col-span-6 xl:tw-col-span-4">
-            <div className="tw-flex tw-flex-col tw-gap-5">
-              <div className="tw-flex tw-flex-col">
-                <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
-                  <div className="tw-flex tw-items-center tw-gap-2">
-                    <span className="tw-size-1.5 tw-rounded-full tw-bg-emerald-500" />
-                    <span className="tw-text-[11px] tw-font-semibold tw-uppercase tw-leading-5 tw-tracking-wide tw-text-emerald-400">
-                      NEXT MINT
-                    </span>
-                  </div>
-                  <MainStageMemeCardLink memeCardId={mappedMemeCardId} />
-                </div>
-                <span className="tw-mt-1 tw-font-mono tw-text-xs tw-text-white/50">
-                  {nextMintLabel}
-                </span>
-
-                <Link
-                  href={`/waves?wave=${drop.wave.id}&drop=${drop.id}`}
-                  className="tw-mt-3 tw-text-xl tw-font-semibold tw-leading-tight tw-text-iron-50 tw-no-underline tw-transition-colors tw-duration-300 desktop-hover:hover:tw-text-iron-200 sm:tw-text-2xl md:tw-text-3xl"
-                >
-                  {title}
-                </Link>
-
-                {description && (
-                  <p className="tw-mt-3 tw-line-clamp-2 tw-text-sm tw-leading-relaxed tw-text-iron-300">
-                    {description}
-                  </p>
-                )}
-
-                <div className="tw-mt-3 tw-flex tw-flex-wrap tw-items-center tw-gap-2">
-                  {media?.mime_type && (
-                    <MediaTypeBadge
-                      mimeType={media.mime_type}
-                      dropId={drop.id}
-                      size="sm"
-                      iconClassName="tw-size-[26px]"
-                    />
-                  )}
-                  <ArtistPill
-                    pfp={author.pfp}
-                    label={authorName}
-                    href={authorHandle ? `/${authorHandle}` : undefined}
-                    profileHandle={author.handle ?? undefined}
-                  />
-                </div>
-
-                <div className="tw-mt-4">
-                  <LatestDropNextMintSubscribe tokenId={nextMintCardNumber} />
-                </div>
-              </div>
-
-              <div className="tw-grid tw-grid-cols-2 tw-gap-x-6 tw-gap-y-4">
-                <div className="tw-col-span-2">
-                  <NowMintingStatsItem
-                    label="Wave"
-                    allowWrap
-                    value={
-                      <Link
-                        href={`/waves/${drop.wave.id}`}
-                        className="tw-inline-flex tw-items-center tw-gap-2 tw-text-iron-100 tw-no-underline desktop-hover:hover:tw-text-iron-200"
-                      >
-                        {drop.wave.picture && (
-                          <Image
-                            src={getScaledImageUri(
-                              drop.wave.picture,
-                              ImageScale.W_AUTO_H_50
-                            )}
-                            alt={drop.wave.name}
-                            width={20}
-                            height={20}
-                            className="tw-size-5 tw-shrink-0 tw-rounded-full tw-object-cover tw-ring-1 tw-ring-white/10"
-                          />
-                        )}
-                        <span className="tw-min-w-0 tw-break-words">
-                          {drop.wave.name}
-                        </span>
-                      </Link>
-                    }
-                  />
-                </div>
-                <NowMintingStatsItem
-                  label="Submitted"
-                  value={submittedAt ?? "—"}
-                />
-                <NowMintingStatsItem
-                  label="Rating"
-                  value={`${formatNumberWithCommas(drop.rating)} TDH`}
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      <LatestDropNextMintPanel drop={drop} />
     </section>
   );
 }

--- a/components/meme-calendar/meme-calendar-grid/MemeCalendarContent.tsx
+++ b/components/meme-calendar/meme-calendar-grid/MemeCalendarContent.tsx
@@ -242,7 +242,7 @@ export default function MemeCalendar({
     <div className="tw-rounded-md tw-border tw-border-solid tw-border-[#222222] tw-bg-[#0c0c0d] tw-p-4">
       {/* Division (zoom) selector buttons */}
       <div className="tw-mb-8 tw-grid tw-grid-cols-3 tw-gap-2 lg:tw-grid-cols-[repeat(6,minmax(0,1fr))_auto]">
-        <fieldset className="tw-col-span-3 tw-grid tw-grid-cols-3 tw-gap-2 lg:tw-col-span-6 lg:tw-grid-cols-6">
+        <fieldset className="tw-col-span-3 tw-grid tw-grid-cols-3 tw-gap-2 tw-border-0 tw-p-0 lg:tw-col-span-6 lg:tw-grid-cols-6">
           <legend className="tw-sr-only">
             {t(locale, "memeCalendar.grid.zoomGroup")}
           </legend>

--- a/components/meme-calendar/meme-calendar.helpers.tsx
+++ b/components/meme-calendar/meme-calendar.helpers.tsx
@@ -651,8 +651,10 @@ export function formatFullDate(
 export const formatFullDateTime = (
   d: Date,
   mode: DisplayTz = "local",
-  locale = "en-US"
+  locale = "en-US",
+  options: Readonly<{ hour12?: boolean }> = {}
 ): string => {
+  const hour12 = options.hour12 ?? (mode === "utc" ? false : undefined);
   const s = d.toLocaleString(locale, {
     weekday: "short",
     year: "numeric",
@@ -660,7 +662,8 @@ export const formatFullDateTime = (
     day: "numeric",
     hour: "2-digit",
     minute: "2-digit",
-    ...(mode === "utc" ? { timeZone: "UTC", hour12: false } : {}),
+    ...(mode === "utc" ? { timeZone: "UTC" } : {}),
+    ...(hour12 === undefined ? {} : { hour12 }),
   });
   return mode === "utc" ? `${s} UTC` : s;
 };

--- a/components/memes/drops/MainStageMemeCardLink.tsx
+++ b/components/memes/drops/MainStageMemeCardLink.tsx
@@ -5,6 +5,10 @@ interface MainStageMemeCardLinkProps {
   readonly variant?: "compact" | "prominent";
 }
 
+interface MainStageMemeCardPillProps extends MainStageMemeCardLinkProps {
+  readonly href?: string | undefined;
+}
+
 export function isValidMemeCardId(
   memeCardId: number | null | undefined
 ): memeCardId is number {
@@ -15,26 +19,49 @@ export function isValidMemeCardId(
   );
 }
 
-export default function MainStageMemeCardLink({
+export function MainStageMemeCardPill({
   memeCardId,
+  href,
   variant = "compact",
-}: MainStageMemeCardLinkProps) {
+}: MainStageMemeCardPillProps) {
   if (!isValidMemeCardId(memeCardId)) {
     return null;
   }
 
+  const className = `tw-inline-flex tw-flex-shrink-0 tw-items-center tw-rounded-full tw-border tw-border-solid tw-border-primary-400/40 tw-bg-primary-500/10 tw-font-semibold tw-text-primary-300 ${
+    variant === "prominent"
+      ? "tw-min-h-9 tw-px-4 tw-py-1.5 tw-text-base tw-leading-5"
+      : "tw-px-2.5 tw-py-0.5 tw-text-xs"
+  }`;
+  const label = `The Memes #${memeCardId}`;
+
+  if (!href) {
+    return <span className={className}>{label}</span>;
+  }
+
   return (
     <Link
-      href={`/the-memes/${memeCardId}`}
+      href={href}
       onClick={(event) => event.stopPropagation()}
       scroll={false}
-      className={`tw-inline-flex tw-flex-shrink-0 tw-items-center tw-rounded-full tw-border tw-border-solid tw-border-primary-400/40 tw-bg-primary-500/10 tw-font-semibold tw-text-primary-300 tw-no-underline tw-transition-colors focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-iron-950 desktop-hover:hover:tw-border-primary-300/60 desktop-hover:hover:tw-text-white ${
-        variant === "prominent"
-          ? "tw-min-h-9 tw-px-4 tw-py-1.5 tw-text-base tw-leading-5"
-          : "tw-px-2.5 tw-py-0.5 tw-text-xs"
-      }`}
+      className={`${className} tw-no-underline tw-transition-colors focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-iron-950 desktop-hover:hover:tw-border-primary-300/60 desktop-hover:hover:tw-text-white`}
     >
-      The Memes #{memeCardId}
+      {label}
     </Link>
+  );
+}
+
+export default function MainStageMemeCardLink({
+  memeCardId,
+  variant = "compact",
+}: MainStageMemeCardLinkProps) {
+  return (
+    <MainStageMemeCardPill
+      memeCardId={memeCardId}
+      href={
+        isValidMemeCardId(memeCardId) ? `/the-memes/${memeCardId}` : undefined
+      }
+      variant={variant}
+    />
   );
 }

--- a/components/the-memes/UpcomingMemePage.tsx
+++ b/components/the-memes/UpcomingMemePage.tsx
@@ -95,7 +95,11 @@ function CanonicalUpcomingMemePage({
     );
   }
 
-  return <GenericUpcomingMemePage id={id} locale={locale} />;
+  return (
+    <UpcomingMemeLayout id={id} locale={locale}>
+      <LatestDropNextMintSubscribe tokenId={id} />
+    </UpcomingMemeLayout>
+  );
 }
 
 export default function UpcomingMemePage({

--- a/components/the-memes/UpcomingMemePage.tsx
+++ b/components/the-memes/UpcomingMemePage.tsx
@@ -1,7 +1,86 @@
 import { MemeCalendarOverviewNextMint } from "@/components/meme-calendar/MemeCalendarOverview";
+import { getCanonicalNextMintNumber } from "@/components/meme-calendar/meme-calendar.helpers";
 import LatestDropNextMintSubscribe from "@/components/home/now-minting/LatestDropNextMintSubscribe";
+import LatestDropNextMintPanel, {
+  LatestDropNextMintPanelSkeleton,
+} from "@/components/home/now-minting/LatestDropNextMintPanel";
+import { shouldShowNextMintInLatestDrop } from "@/helpers/mint-visibility.helpers";
+import { useNextMintDrop } from "@/hooks/useNextMintDrop";
+import { useNowMintingStatus } from "@/hooks/useNowMintingStatus";
 import NotFound from "@/components/not-found/NotFound";
 import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
+
+function GenericUpcomingMemePage({
+  id,
+  locale,
+}: {
+  readonly id: number;
+  readonly locale: SupportedLocale;
+}) {
+  return (
+    <div className="tw-flex tw-w-full tw-flex-col tw-gap-4">
+      <LatestDropNextMintSubscribe tokenId={id} />
+      <MemeCalendarOverviewNextMint displayTz="local" id={id} locale={locale} />
+    </div>
+  );
+}
+
+function CanonicalUpcomingMemePage({
+  id,
+  locale,
+}: {
+  readonly id: number;
+  readonly locale: SupportedLocale;
+}) {
+  const { isFetching, isDropComplete, isStatusLoading } = useNowMintingStatus();
+  const {
+    nextMint,
+    waveId,
+    isFetching: isNextMintFetching,
+    isSettingsLoaded,
+  } = useNextMintDrop();
+
+  const isNextMintReady = isSettingsLoaded && (!waveId || !isNextMintFetching);
+  const isDecisionReady = !isFetching && !isStatusLoading && isNextMintReady;
+  const shouldShowNextMint = shouldShowNextMintInLatestDrop({
+    isMintEnded: isDropComplete,
+    nextMintExists: !!nextMint,
+  });
+  const mappedMemeCardId = nextMint?.submission_context?.meme_card_id;
+  const isMatchingRevealedDrop = shouldShowNextMint && mappedMemeCardId === id;
+
+  if (!isDecisionReady) {
+    return (
+      <div className="tw-flex tw-w-full tw-flex-col tw-gap-4">
+        <LatestDropNextMintPanelSkeleton />
+        <MemeCalendarOverviewNextMint
+          displayTz="local"
+          id={id}
+          locale={locale}
+        />
+      </div>
+    );
+  }
+
+  if (isMatchingRevealedDrop && nextMint) {
+    return (
+      <div className="tw-flex tw-w-full tw-flex-col tw-gap-4">
+        <LatestDropNextMintPanel
+          drop={nextMint}
+          linkMemeCard={false}
+          locale={locale}
+        />
+        <MemeCalendarOverviewNextMint
+          displayTz="local"
+          id={id}
+          locale={locale}
+        />
+      </div>
+    );
+  }
+
+  return <GenericUpcomingMemePage id={id} locale={locale} />;
+}
 
 export default function UpcomingMemePage({
   id,
@@ -12,16 +91,14 @@ export default function UpcomingMemePage({
 }) {
   const numId = Number(id);
   if (Number.isInteger(numId)) {
-    return (
-      <div className="tw-mt-6 tw-flex tw-w-full tw-flex-col tw-gap-4">
-        <LatestDropNextMintSubscribe tokenId={numId} />
-        <MemeCalendarOverviewNextMint
-          displayTz="local"
-          id={numId}
-          locale={locale}
-        />
-      </div>
-    );
+    const content =
+      numId === getCanonicalNextMintNumber() ? (
+        <CanonicalUpcomingMemePage id={numId} locale={locale} />
+      ) : (
+        <GenericUpcomingMemePage id={numId} locale={locale} />
+      );
+
+    return <div className="tw-mt-6">{content}</div>;
   }
   return <NotFound label="MEME" />;
 }

--- a/components/the-memes/UpcomingMemePage.tsx
+++ b/components/the-memes/UpcomingMemePage.tsx
@@ -9,6 +9,11 @@ import { useNextMintDrop } from "@/hooks/useNextMintDrop";
 import { useNowMintingStatus } from "@/hooks/useNowMintingStatus";
 import NotFound from "@/components/not-found/NotFound";
 import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
+import { useSyncExternalStore } from "react";
+
+const subscribeToClientRender = () => () => {};
+const getClientRenderSnapshot = () => true;
+const getServerRenderSnapshot = () => false;
 
 function GenericUpcomingMemePage({
   id,
@@ -47,7 +52,12 @@ function CanonicalUpcomingMemePage({
     nextMintExists: !!nextMint,
   });
   const mappedMemeCardId = nextMint?.submission_context?.meme_card_id;
-  const isMatchingRevealedDrop = shouldShowNextMint && mappedMemeCardId === id;
+  const normalizedMemeCardId = Number(mappedMemeCardId);
+  const isMatchingRevealedDrop =
+    shouldShowNextMint &&
+    Number.isSafeInteger(normalizedMemeCardId) &&
+    normalizedMemeCardId >= 1 &&
+    normalizedMemeCardId === id;
 
   if (!isDecisionReady) {
     return (
@@ -90,9 +100,14 @@ export default function UpcomingMemePage({
   readonly locale?: SupportedLocale;
 }) {
   const numId = Number(id);
+  const isClientHydrated = useSyncExternalStore(
+    subscribeToClientRender,
+    getClientRenderSnapshot,
+    getServerRenderSnapshot
+  );
   if (Number.isInteger(numId)) {
     const content =
-      numId === getCanonicalNextMintNumber() ? (
+      isClientHydrated && numId === getCanonicalNextMintNumber() ? (
         <CanonicalUpcomingMemePage id={numId} locale={locale} />
       ) : (
         <GenericUpcomingMemePage id={numId} locale={locale} />

--- a/components/the-memes/UpcomingMemePage.tsx
+++ b/components/the-memes/UpcomingMemePage.tsx
@@ -4,16 +4,34 @@ import LatestDropNextMintSubscribe from "@/components/home/now-minting/LatestDro
 import LatestDropNextMintPanel, {
   LatestDropNextMintPanelSkeleton,
 } from "@/components/home/now-minting/LatestDropNextMintPanel";
+import { isValidMemeCardId } from "@/components/memes/drops/MainStageMemeCardLink";
 import { shouldShowNextMintInLatestDrop } from "@/helpers/mint-visibility.helpers";
 import { useNextMintDrop } from "@/hooks/useNextMintDrop";
 import { useNowMintingStatus } from "@/hooks/useNowMintingStatus";
 import NotFound from "@/components/not-found/NotFound";
 import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
-import { useSyncExternalStore } from "react";
+import { type ReactNode, useSyncExternalStore } from "react";
 
 const subscribeToClientRender = () => () => {};
 const getClientRenderSnapshot = () => true;
 const getServerRenderSnapshot = () => false;
+
+function UpcomingMemeLayout({
+  children,
+  id,
+  locale,
+}: {
+  readonly children: ReactNode;
+  readonly id: number;
+  readonly locale: SupportedLocale;
+}) {
+  return (
+    <div className="tw-flex tw-w-full tw-flex-col tw-gap-4">
+      {children}
+      <MemeCalendarOverviewNextMint displayTz="local" id={id} locale={locale} />
+    </div>
+  );
+}
 
 function GenericUpcomingMemePage({
   id,
@@ -23,10 +41,9 @@ function GenericUpcomingMemePage({
   readonly locale: SupportedLocale;
 }) {
   return (
-    <div className="tw-flex tw-w-full tw-flex-col tw-gap-4">
+    <UpcomingMemeLayout id={id} locale={locale}>
       <LatestDropNextMintSubscribe tokenId={id} />
-      <MemeCalendarOverviewNextMint displayTz="local" id={id} locale={locale} />
-    </div>
+    </UpcomingMemeLayout>
   );
 }
 
@@ -55,37 +72,26 @@ function CanonicalUpcomingMemePage({
   const normalizedMemeCardId = Number(mappedMemeCardId);
   const isMatchingRevealedDrop =
     shouldShowNextMint &&
-    Number.isSafeInteger(normalizedMemeCardId) &&
-    normalizedMemeCardId >= 1 &&
+    isValidMemeCardId(normalizedMemeCardId) &&
     normalizedMemeCardId === id;
 
   if (!isDecisionReady) {
     return (
-      <div className="tw-flex tw-w-full tw-flex-col tw-gap-4">
+      <UpcomingMemeLayout id={id} locale={locale}>
         <LatestDropNextMintPanelSkeleton />
-        <MemeCalendarOverviewNextMint
-          displayTz="local"
-          id={id}
-          locale={locale}
-        />
-      </div>
+      </UpcomingMemeLayout>
     );
   }
 
   if (isMatchingRevealedDrop && nextMint) {
     return (
-      <div className="tw-flex tw-w-full tw-flex-col tw-gap-4">
+      <UpcomingMemeLayout id={id} locale={locale}>
         <LatestDropNextMintPanel
           drop={nextMint}
           linkMemeCard={false}
           locale={locale}
         />
-        <MemeCalendarOverviewNextMint
-          displayTz="local"
-          id={id}
-          locale={locale}
-        />
-      </div>
+      </UpcomingMemeLayout>
     );
   }
 

--- a/components/the-memes/UpcomingMemePage.tsx
+++ b/components/the-memes/UpcomingMemePage.tsx
@@ -101,9 +101,11 @@ function CanonicalUpcomingMemePage({
 export default function UpcomingMemePage({
   id,
   locale = DEFAULT_LOCALE,
+  showRevealedDrop = true,
 }: {
   readonly id: string;
   readonly locale?: SupportedLocale;
+  readonly showRevealedDrop?: boolean;
 }) {
   const numId = Number(id);
   const isClientHydrated = useSyncExternalStore(
@@ -113,7 +115,9 @@ export default function UpcomingMemePage({
   );
   if (Number.isInteger(numId)) {
     const content =
-      isClientHydrated && numId === getCanonicalNextMintNumber() ? (
+      showRevealedDrop &&
+      isClientHydrated &&
+      numId === getCanonicalNextMintNumber() ? (
         <CanonicalUpcomingMemePage id={numId} locale={locale} />
       ) : (
         <GenericUpcomingMemePage id={numId} locale={locale} />

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -1341,6 +1341,14 @@ export const EN_US_MESSAGES = {
     "You are not subscribed for this drop.",
   "home.mintSubscriptions.tooltip.proxy":
     "Manage subscriptions from your own profile, not a proxy session.",
+  "home.nextMint.status": "Next mint",
+  "home.nextMint.cardSchedule": "Card #{number} - {date}",
+  "home.nextMint.noImage": "No image",
+  "home.nextMint.untitled": "Untitled",
+  "home.nextMint.anonymous": "Anonymous",
+  "home.nextMint.stats.wave": "Wave",
+  "home.nextMint.stats.submitted": "Submitted",
+  "home.nextMint.stats.rating": "Rating",
   "waveChat.boostedDrops.display.description":
     "How boosted-drop cards show in chat.",
   "waveChat.boostedDrops.display.expanded": "Expanded",

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -1342,7 +1342,6 @@ export const EN_US_MESSAGES = {
   "home.mintSubscriptions.tooltip.proxy":
     "Manage subscriptions from your own profile, not a proxy session.",
   "home.nextMint.status": "Next mint",
-  "home.nextMint.cardSchedule": "Card #{number} - {date}",
   "home.nextMint.noImage": "No image",
   "home.nextMint.untitled": "Untitled",
   "home.nextMint.anonymous": "Anonymous",

--- a/ops/docs/home/feature-home-latest-drop-and-coming-up.md
+++ b/ops/docs/home/feature-home-latest-drop-and-coming-up.md
@@ -95,6 +95,8 @@ Use this page for visibility rules, state switches, and route targets.
   trimmed), `Coming up` suppresses the `NEXT MINT` card.
 - Main Stage submission and Meme card links are omitted when their explicit
   backend mapping is unavailable; home does not infer a relationship.
+- The home `Next Drop` artwork panel includes a labeled local-time `Mint Date`
+  alongside its wave, submission time, and rating details.
 - On iOS outside the US, the countdown `Mint` button is hidden.
 - On iOS outside the US, The Memes subscription row is hidden.
 - Latest Drop subscription awareness is read-only and links to subscription
@@ -102,8 +104,12 @@ Use this page for visibility rules, state switches, and route targets.
   for the current or already-dropped card.
 - The current/latest `/the-memes/{id}` detail page uses the same awareness-only
   subscription row beside the mint countdown.
-- Unresolved upcoming `/the-memes/{id}` pages show the next-mint calendar panel
-  plus the same subscription awareness widget for that card.
+- When an unresolved `/the-memes/{id}` URL is the explicitly mapped next Meme
+  and home is in `Next Drop` mode, the page reuses the same artwork panel above
+  the calendar. Its Meme pill is static because the user is already on that
+  card route, and subscription awareness stays inside the artwork panel.
+- Other unresolved upcoming `/the-memes/{id}` pages keep the standalone
+  subscription awareness widget followed by the next-mint calendar panel.
 - Awareness-only rows do not embed the profile subscription editor. They show a
   blue read-only `Subscription Minting` box, a non-mutating on/off toggle,
   optional `xN` user subscribed count when already subscribed, an

--- a/ops/docs/media/memes/feature-minting-calendar.md
+++ b/ops/docs/media/memes/feature-minting-calendar.md
@@ -54,8 +54,10 @@ distribution routes.
 7. Open mint-day cells to view details, export links, and any override note.
 8. On fallback routes, the compact panel auto-selects the URL id and stays
    local-time read-only (no timezone toggle, no `Next Mint` button, no `Meme #`
-   input, no upcoming table). On unresolved positive `/the-memes/{id}` pages,
-   use the header-row `Distribution Plan` link to open
+   input, no upcoming table). When an unresolved route is the mapped next Meme
+   while home is in `Next Drop` mode, its revealed artwork panel appears above
+   the compact calendar. On unresolved positive `/the-memes/{id}` pages, use
+   the header-row `Distribution Plan` link to open
    `/the-memes/{id}/distribution`.
 
 ## Common Scenarios
@@ -65,8 +67,8 @@ distribution routes.
 - Export any upcoming mint to calendar from the top panel or day tooltip.
 - Compare `Local` vs `UTC` renderings for cross-time-zone coordination.
 - Open unresolved future card URLs and still see timing details in the fallback
-  panel; positive ids also show a header-row `Distribution Plan` link for that
-  card.
+  panel. The mapped next Meme also shows its winning artwork and drop details;
+  positive ids show a header-row `Distribution Plan` link for that card.
 - Open early distribution URLs and still see the same fallback timing panel
   above the centered "Distribution Plan will be made available soon!" message.
 - Query `/api/meme-calendar/{id}` for a mint timeline summary.

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -3218,7 +3218,7 @@
       "facts": [
         "Current and upcoming Meme Card mint information is surfaced from home and The Memes-related pages.",
         "Home uses explicit Main Stage mappings for its submission and Meme-card links and omits those links when a mapping is unavailable.",
-        "Unresolved upcoming /the-memes/{id} pages show the next-mint calendar panel plus subscription awareness for that card.",
+        "When an unresolved /the-memes/{id} route is the explicitly mapped next Meme and home is in Next Drop mode, it shows the same winning artwork panel with Mint Date and subscription awareness above the calendar; other upcoming Meme routes keep the standalone subscription and calendar view.",
         "Meme calendar and meme gas routes provide additional minting context.",
         "Subscription minting is a separate optional mechanism and does not grant extra eligibility."
       ],

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -3218,7 +3218,7 @@
       "facts": [
         "Current and upcoming Meme Card mint information is surfaced from home and The Memes-related pages.",
         "Home uses explicit Main Stage mappings for its submission and Meme-card links and omits those links when a mapping is unavailable.",
-        "Unresolved upcoming /the-memes/{id} pages show the next-mint calendar panel plus subscription awareness for that card.",
+        "When an unresolved /the-memes/{id} route is the explicitly mapped next Meme and home is in Next Drop mode, it shows the same winning artwork panel with Mint Date and subscription awareness above the calendar; other upcoming Meme routes keep the standalone subscription and calendar view.",
         "Meme calendar and meme gas routes provide additional minting context.",
         "Subscription minting is a separate optional mechanism and does not grant extra eligibility."
       ],


### PR DESCRIPTION
## Issue
- Upcoming `/the-memes/{id}` pages only showed standalone subscription and calendar content even when the homepage already knew and displayed the explicitly mapped next winning drop.
- The homepage artwork panel also lacked a labeled Mint Date in its details.

## Fix
- Reuse the homepage Next Drop artwork panel for the canonical mapped upcoming Meme while the homepage is in Next Drop mode.
- Keep the existing generic upcoming view for every other future Meme ID.

## Changes
- Extracted a shared responsive Next Drop artwork panel.
- Added a localized Mint Date detail to the shared panel on home and Meme detail pages.
- Rendered the Meme pill as static text on its own detail route.
- Kept subscription awareness inside the revealed artwork panel and placed the compact calendar below it.
- Added a stable loading skeleton and retained the generic fallback for missing or mismatched mappings.
- Updated user documentation and the Help Bot index.

## Validation
- Focused Jest coverage for the homepage panel and upcoming Meme state matrix.
- Changed-file quality, strict lint, full TypeScript, and changed-file TypeScript checks passed.
- Help index regenerated successfully.
- React Doctor scored 99/100; its sole warning is the existing intentional Next Image test mock.
- Browser screenshots were not collected because this work did not start a local server or deploy an environment.

## Risk
- Level: Low
- Why: The new presentation is restricted to the canonical upcoming Meme with an explicit matching mapping and reuses the homepage's existing completion gate. All other upcoming and minted states retain their existing paths.
- Rollback: Revert the feature commit to restore the standalone subscription-and-calendar fallback.

## Review Notes
- Confirm that the canonical/mapping/completion gates remain aligned with the homepage Next Drop decision.
- Check responsive spacing for the extracted shared panel and the static Meme pill semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added/expanded the Next Drop panel with artwork, localized title/author/details, Mint Date, timing, wave/submitted/rating stats, and subscription options.
  - Improved upcoming Meme page behavior to show the revealed next mint panel only when applicable; otherwise, the subscription + calendar view remains.
  - Meme card pills now render as non-clickable labels when no link target is available.
- **Documentation**
  - Updated help/feature docs to clarify Next Drop vs upcoming routing edge-case layouts and ordering.
- **Tests**
  - Strengthened coverage for Next Drop/revealed next mint rendering and loading states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->