### PR TITLE
fix: Extended the narrowly guarded React DOM removeChild Sentry filter to cover /6529-gradient and nested toke

### DIFF
--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -310,7 +310,7 @@ describe("instrumentation-client", () => {
     const beforeSend = loadBeforeSend();
     const event = {
       event_id: "react-dom-remove-child-event",
-      transaction: "/the-memes/mint",
+      transaction: "/6529-gradient",
       exception: {
         values: [
           {
@@ -323,8 +323,8 @@ describe("instrumentation-client", () => {
         ],
       },
       tags: {
-        transaction: "/the-memes/mint",
-        url: "/the-memes/mint",
+        transaction: "/6529-gradient",
+        url: "/6529-gradient",
       },
     };
 

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -1545,6 +1545,23 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(true);
   });
 
+  it.each(["/6529-gradient", "/6529-gradient/42"])(
+    "filters exact React DOM removeChild NotFoundError events on gradient route %s with only runtime frames",
+    (route) => {
+      const result = shouldFilterReactDomRemoveChildNotFoundError(
+        createReactDomRemoveChildEvent({
+          transaction: route,
+          tags: {
+            transaction: route,
+            url: route,
+          },
+        })
+      );
+
+      expect(result).toBe(true);
+    }
+  );
+
   it("filters React DOM removeChild NotFoundError events when request URL identifies a waves route", () => {
     const result = shouldFilterReactDomRemoveChildNotFoundError(
       createReactDomRemoveChildEvent({

--- a/utils/sentry-client-filters/constants.ts
+++ b/utils/sentry-client-filters/constants.ts
@@ -163,6 +163,7 @@ export const REACT_DOM_INSERT_BEFORE_RUNTIME_FUNCTIONS = new Set([
   "recursivelyTraverseMutationEffects",
 ]);
 export const WAVES_ROUTE_PATH = "/waves";
+export const GRADIENT_ROUTE_PATH = "/6529-gradient";
 export const gifPickerTenorUndefinedTagsMessage =
   "undefined is not an object (evaluating 'e.tags')";
 export const gifPickerReactPackageToken = "gif-picker-react";

--- a/utils/sentry-client-filters/value-utils.ts
+++ b/utils/sentry-client-filters/value-utils.ts
@@ -1,5 +1,6 @@
 import {
   FILTERED_URL_TOKENS,
+  GRADIENT_ROUTE_PATH,
   objectCapturedPromiseRejectionMessages,
   THE_MEMES_MINT_ROUTE_PATH,
   WAVES_ROUTE_PATH,
@@ -137,7 +138,12 @@ export function hasRouteParameterizationRoute(
 }
 
 export function hasReactDomRemoveChildRoute(event: SentryClientEvent): boolean {
-  return hasMatchingRoute(event, isRouteParameterizationRoutePath);
+  return hasMatchingRoute(
+    event,
+    (path) =>
+      isRouteParameterizationRoutePath(path) ||
+      isRoutePathAtOrBelow(path, GRADIENT_ROUTE_PATH)
+  );
 }
 
 export function getUrlCandidatesFromText(value: string): string[] {


### PR DESCRIPTION
<!-- sentry-fix-job:3 issue:7083151951 -->
## Issue

- Sentry: [6529-FRONTEND-2V](https://seize-ff.sentry.io/issues/7083151951/)
- First seen: 2025-12-03T04:46:38.623Z
- Latest occurrence: 2026-07-14T16:52:07.000Z
- Automatic triage confidence: 91%

The event matches an existing, narrowly filtered React DOM removeChild noise class, but /6529-gradient is not included in that filter's affected routes. A bounded monitoring-filter extension is appropriate.

## Fix

The existing exact-message, runtime-only removeChild filter covered waves and The Memes mint routes but excluded /6529-gradient.

## Changes

- Added a gradient route constant.
- Added gradient base and nested paths to the dedicated removeChild route predicate without broadening route-parameterization filtering.
- Added focused regression tests and gradient-route beforeSend coverage.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Focused Jest suites: 2 passed, 284 tests passed.
- lint:changed passed.
- typecheck:changed passed.
- git diff --check passed.

## Risk

- Assessed risk: low
- Changed files: 4
- Changed lines: 32
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

The external DOM mutator is inferred from the runtime-only stack and translated UI evidence, but application-frame events, different messages, and unrelated routes continue to be reported.

The automation will wait for every GitHub check and recognized review bot, repair actionable findings, push a new commit, and repeat until the latest head is clean. Human feedback is shown in the Sentry automation dashboard and is not applied automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error filtering for React DOM `removeChild` errors on gradient routes.
  * Added coverage for both the main gradient page and nested gradient routes.
  * Prevented affected, non-actionable errors from being reported on these routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->