### PR TITLE
Normalize AWS RUM page identifiers

### DIFF
--- a/__tests__/components/monitoring/AwsRumProvider.test.tsx
+++ b/__tests__/components/monitoring/AwsRumProvider.test.tsx
@@ -4,8 +4,20 @@ import { publicEnv } from "@/config/env";
 import AwsRumProvider from "@/components/monitoring/AwsRumProvider";
 import { AwsRum } from "aws-rum-web";
 
+const WAVE_ID = `${"a".repeat(8)}-${"b".repeat(4)}-4${"c".repeat(3)}-a${"d".repeat(3)}-${"e".repeat(12)}`;
+const OTHER_WAVE_ID = `${"f".repeat(8)}-${"1".repeat(4)}-4${"2".repeat(3)}-a${"3".repeat(3)}-${"4".repeat(12)}`;
+let mockPathname = `/waves/${WAVE_ID}`;
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+}));
+
 jest.mock("aws-rum-web", () => ({
-  AwsRum: jest.fn(() => ({ disable: jest.fn(), recordEvent: jest.fn() })),
+  AwsRum: jest.fn(() => ({
+    disable: jest.fn(),
+    recordEvent: jest.fn(),
+    recordPageView: jest.fn(),
+  })),
 }));
 
 const mockAwsRum = AwsRum as jest.Mock;
@@ -18,6 +30,12 @@ type AwsRumHttpTelemetry = [
   },
 ];
 
+type MockAwsRumInstance = {
+  readonly disable: jest.Mock;
+  readonly recordEvent: jest.Mock;
+  readonly recordPageView: jest.Mock;
+};
+
 describe("AwsRumProvider", () => {
   let warnSpy: jest.SpyInstance;
 
@@ -29,6 +47,7 @@ describe("AwsRumProvider", () => {
       AWS_RUM_SAMPLE_RATE: "0.5",
       VERSION: "test-version",
     });
+    mockPathname = `/waves/${WAVE_ID}`;
     mockAwsRum.mockClear();
     delete window.awsRum;
     warnSpy = jest.spyOn(console, "warn").mockImplementation();
@@ -57,6 +76,7 @@ describe("AwsRumProvider", () => {
       expect.objectContaining({
         sessionSampleRate: 0.5,
         releaseId: "test-version",
+        disableAutoPageView: true,
         telemetries: [
           "performance",
           "errors",
@@ -70,6 +90,51 @@ describe("AwsRumProvider", () => {
       })
     );
     expect(window.awsRum).toBe(mockAwsRum.mock.results[0]?.value);
+    expect(getMockAwsRumInstance().recordPageView).toHaveBeenCalledWith(
+      "/waves/[wave]"
+    );
+  });
+
+  it("records client navigations once per normalized page family", async () => {
+    const { rerender } = render(
+      <AwsRumProvider>
+        <div>Child content</div>
+      </AwsRumProvider>
+    );
+
+    await waitFor(() => expect(mockAwsRum).toHaveBeenCalledTimes(1));
+    const awsRumInstance = getMockAwsRumInstance();
+    await waitFor(() =>
+      expect(awsRumInstance.recordPageView).toHaveBeenCalledTimes(1)
+    );
+
+    mockPathname = `/waves/${OTHER_WAVE_ID}`;
+    rerender(
+      <AwsRumProvider>
+        <div>Child content</div>
+      </AwsRumProvider>
+    );
+
+    expect(awsRumInstance.recordPageView).toHaveBeenCalledTimes(1);
+
+    mockPathname = "/notifications";
+    rerender(
+      <AwsRumProvider>
+        <div>Child content</div>
+      </AwsRumProvider>
+    );
+
+    await waitFor(() =>
+      expect(awsRumInstance.recordPageView).toHaveBeenCalledTimes(2)
+    );
+    expect(awsRumInstance.recordPageView.mock.calls).toEqual([
+      ["/waves/[wave]"],
+      ["/notifications"],
+    ]);
+
+    const payload = JSON.stringify(awsRumInstance.recordPageView.mock.calls);
+    expect(payload).not.toContain(WAVE_ID);
+    expect(payload).not.toContain(OTHER_WAVE_ID);
   });
 
   it("excludes third-party analytics noise without excluding app-owned APIs", async () => {
@@ -252,9 +317,7 @@ describe("AwsRumProvider", () => {
 
     await waitFor(() => expect(mockAwsRum).toHaveBeenCalledTimes(1));
 
-    const awsRumInstance = mockAwsRum.mock.results[0]?.value as {
-      disable: jest.Mock;
-    };
+    const awsRumInstance = getMockAwsRumInstance();
 
     unmount();
 
@@ -277,4 +340,16 @@ const getHttpUrlsToExclude = (): RegExp[] => {
   expect(httpTelemetry).toBeDefined();
 
   return httpTelemetry?.[1].urlsToExclude ?? [];
+};
+
+const getMockAwsRumInstance = (): MockAwsRumInstance => {
+  const instance = mockAwsRum.mock.results[0]?.value as
+    | MockAwsRumInstance
+    | undefined;
+
+  if (!instance) {
+    throw new Error("AWS RUM mock was not initialized");
+  }
+
+  return instance;
 };

--- a/__tests__/utils/monitoring/awsRumPageId.test.ts
+++ b/__tests__/utils/monitoring/awsRumPageId.test.ts
@@ -1,0 +1,54 @@
+import { getAwsRumPageId } from "@/utils/monitoring/mobileLaunchTimingSanitizers";
+
+const WAVE_ID = `${"a".repeat(8)}-${"b".repeat(4)}-4${"c".repeat(3)}-a${"d".repeat(3)}-${"e".repeat(12)}`;
+const OTHER_WAVE_ID = `${"f".repeat(8)}-${"1".repeat(4)}-4${"2".repeat(3)}-a${"3".repeat(3)}-${"4".repeat(12)}`;
+const WALLET = `0x${"1".repeat(40)}`;
+
+describe("getAwsRumPageId", () => {
+  it.each([
+    ["/", "/"],
+    ["/notifications", "/notifications"],
+    ["/waves", "/waves"],
+    [`/waves/${WAVE_ID}`, "/waves/[wave]"],
+    [`/messages/${WAVE_ID}`, "/messages/[wave]"],
+    [`/tools/app-wallets/${WALLET}`, "/tools/app-wallets/[app-wallet-address]"],
+    [`/${WALLET}`, "/[user]"],
+    [`/${WALLET}/collected`, "/[user]/collected"],
+    [`/${WALLET}/private-cms-page`, "/[user]/[...cmsPath]"],
+  ])("normalizes %s to the stable page ID %s", (route, expectedPageId) => {
+    expect(getAwsRumPageId(route)).toBe(expectedPageId);
+  });
+
+  it("strips query strings and hashes before creating the page ID", () => {
+    expect(
+      getAwsRumPageId(
+        `https://6529.io/waves/${WAVE_ID}?drop=${OTHER_WAVE_ID}&wallet=${WALLET}#${OTHER_WAVE_ID}`
+      )
+    ).toBe("/waves/[wave]");
+  });
+
+  it("uses bounded fallbacks for unknown routes", () => {
+    expect(getAwsRumPageId(`/waves/${WAVE_ID}/unexpected/${WALLET}`)).toBe(
+      "/waves"
+    );
+    expect(getAwsRumPageId(`/api/private/${WALLET}`)).toBe("/unknown");
+    expect(getAwsRumPageId("/unknown-profile/private-cms-page")).toBe(
+      "/[user]/[...cmsPath]"
+    );
+  });
+
+  it("never includes raw identifiers in the page ID payload", () => {
+    const pageIds = [
+      getAwsRumPageId(`/waves/${WAVE_ID}?drop=${OTHER_WAVE_ID}`),
+      getAwsRumPageId(`/${WALLET}/collected#${WAVE_ID}`),
+      getAwsRumPageId(`/tools/app-wallets/${WALLET}`),
+    ];
+    const payload = JSON.stringify(pageIds);
+
+    expect(payload).not.toContain(WAVE_ID);
+    expect(payload).not.toContain(OTHER_WAVE_ID);
+    expect(payload).not.toContain(WALLET);
+    expect(payload).not.toContain("?");
+    expect(payload).not.toContain("#");
+  });
+});

--- a/components/monitoring/AwsRumProvider.tsx
+++ b/components/monitoring/AwsRumProvider.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { publicEnv } from "@/config/env";
+import { getAwsRumPageId } from "@/utils/monitoring/mobileLaunchTimingSanitizers";
 import type { AwsRum as AwsRumInstance, AwsRumConfig } from "aws-rum-web";
-import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+import { useEffect, useRef } from "react";
 
 const AWS_RUM_HTTP_URLS_TO_EXCLUDE: readonly RegExp[] = [
   // Per-telemetry config replaces aws-rum-web defaults, so keep AWS service noise explicit.
@@ -29,6 +31,11 @@ interface AwsRumProviderProps {
 export default function AwsRumProvider({
   children,
 }: Readonly<AwsRumProviderProps>) {
+  const pathname = usePathname();
+  const latestPathnameRef = useRef(pathname);
+  const awsRumRef = useRef<AwsRumInstance | undefined>(undefined);
+  const lastRecordedPageIdRef = useRef<string | undefined>(undefined);
+
   useEffect(() => {
     // Skip initialization in development mode to avoid noise
     if (publicEnv.NODE_ENV === "development") {
@@ -85,7 +92,7 @@ export default function AwsRumProvider({
           sessionEventLimit: 200,
           batchLimit: 10,
           dispatchInterval: 5000,
-          disableAutoPageView: false,
+          disableAutoPageView: true,
           retries: 2,
           useBeacon: true,
           releaseId: APPLICATION_VERSION,
@@ -98,8 +105,14 @@ export default function AwsRumProvider({
           APPLICATION_REGION,
           config
         );
+        awsRumRef.current = awsRum;
         // Optional: Store the instance globally for manual tracking if needed
         window.awsRum = awsRum;
+        lastRecordedPageIdRef.current = recordAwsRumPageView(
+          awsRum,
+          latestPathnameRef.current,
+          lastRecordedPageIdRef.current
+        );
       } catch (error) {
         // Silently handle errors to prevent breaking the application
         console.warn("AWS RUM: Failed to initialize", error);
@@ -112,11 +125,31 @@ export default function AwsRumProvider({
       cancelled = true;
       awsRum?.disable();
 
+      if (awsRumRef.current === awsRum) {
+        awsRumRef.current = undefined;
+        lastRecordedPageIdRef.current = undefined;
+      }
+
       if (window.awsRum === awsRum) {
         delete window.awsRum;
       }
     };
   }, []);
+
+  useEffect(() => {
+    latestPathnameRef.current = pathname;
+
+    const awsRum = awsRumRef.current;
+    if (!awsRum) {
+      return;
+    }
+
+    lastRecordedPageIdRef.current = recordAwsRumPageView(
+      awsRum,
+      pathname,
+      lastRecordedPageIdRef.current
+    );
+  }, [pathname]);
 
   return <>{children}</>;
 }
@@ -127,6 +160,25 @@ const envValueOrFallback = (
 ): string => (value === undefined || value === "" ? fallback : value);
 
 const DEFAULT_SAMPLE_RATE = 0.2;
+
+const recordAwsRumPageView = (
+  awsRum: AwsRumInstance,
+  pathname: string,
+  lastRecordedPageId: string | undefined
+): string | undefined => {
+  const pageId = getAwsRumPageId(pathname);
+  if (pageId === lastRecordedPageId) {
+    return lastRecordedPageId;
+  }
+
+  try {
+    awsRum.recordPageView(pageId);
+    return pageId;
+  } catch {
+    console.warn("AWS RUM: Failed to record page view");
+    return lastRecordedPageId;
+  }
+};
 
 const parseSampleRate = (sampleRate: string | undefined): number => {
   const parsedSampleRate = Number.parseFloat(

--- a/components/monitoring/README.md
+++ b/components/monitoring/README.md
@@ -39,7 +39,8 @@ The AWS RUM service will automatically create:
 - **JavaScript Errors**: Unhandled exceptions and error boundaries
 - **Performance Metrics**: Core Web Vitals (LCP, FID, CLS)
 - **HTTP Requests**: API calls and resource loading
-- **Page Views**: SPA navigation tracking with hash and path changes
+- **Page Views**: initial and client-side navigation grouped by stable App
+  Router families
 
 ## Configuration Details
 
@@ -64,14 +65,23 @@ The AWS RUM service will automatically create:
 
 ### Page Tracking
 
-- Automatic page views are enabled for browser performance analysis.
+- The SDK's automatic page-view plugin is disabled because it derives page IDs
+  from raw browser paths. `AwsRumProvider` records the initial page and later
+  Next.js client navigations with allowlisted route families such as `/waves`
+  and `/waves/[wave]`.
+- Query strings, hashes, profile/wallet values, UUIDs, and other dynamic route
+  parameters are never included in the page ID. Unknown subroutes collapse to a
+  known top-level family, profile CMS paths use `/[user]/[...cmsPath]`, and
+  non-page roots use `/unknown`.
+- Consecutive navigations with the same normalized family are deduplicated.
 
 ## Production Considerations
 
 1. **Adjust Sample Rate**: Consider reducing `sessionSampleRate` to 0.1 (10%) for high-traffic sites
 2. **Cost Management**: Monitor your CloudWatch RUM costs and adjust `sessionEventLimit`
 3. **Regional Deployment**: Ensure the RUM region matches your primary AWS region
-4. **Privacy Compliance**: AWS RUM automatically handles PII scrubbing
+4. **Privacy Compliance**: Keep page IDs and custom-event attributes bounded in
+   application code; do not rely on provider-side scrubbing for route values
 
 ## Troubleshooting
 
@@ -102,6 +112,7 @@ const rumClient = window.awsRum;
 // Record custom events (if custom events are enabled in AppMonitor)
 rumClient?.recordEvent('custom_event', { key: 'value' });
 
-// Manual page view tracking
-rumClient?.recordPageView('/custom-page');
 ```
+
+Page views are owned centrally by `AwsRumProvider`. Do not call
+`recordPageView` with a raw URL or route parameter from feature code.

--- a/ops/telemetry/README.md
+++ b/ops/telemetry/README.md
@@ -31,15 +31,24 @@ stable event-name list; destination ownership has one source of truth here.
 Wave feed success now adds exact `duration_ms` only to Sentry; Mixpanel keeps
 the existing bounded duration bucket and product outcome.
 
-Automatic page-view overlap is intentional for now: AWS RUM answers browser
-performance questions, Mixpanel answers product adoption questions, and the
-Google/Mixpanel product overlap remains unverified. Mixpanel's `path` property
-now carries the normalized `route_pattern` value instead of a raw pathname.
+Page-view provider overlap is intentional for now: manually normalized AWS RUM
+page views answer browser performance questions, Mixpanel answers product
+adoption questions, and the Google/Mixpanel product overlap remains unverified.
+Mixpanel's `path` property now carries the normalized `route_pattern` value
+instead of a raw pathname.
 Known Waves/profile aliases retain their existing colon-parameter contracts;
 fallback routes use the existing App Router-style bracket families. Fallback
 `logical_page` values are derived from the same safe family. This preserves the
 property names while removing handles and route identifiers; dashboards
 grouping by literal paths or raw fallback logical pages may need migration.
+
+AWS RUM page views are recorded manually by the provider because the pinned
+SDK's automatic page-view plugin uses raw browser paths. The provider keeps the
+SDK's performance, error, and HTTP telemetry enabled, but supplies allowlisted
+App Router families for the initial page and client-side navigation. Query
+strings, hashes, profile/wallet values, UUIDs, and dynamic route parameters are
+excluded. Unknown subroutes collapse to a bounded top-level family, and
+consecutive equal families are deduplicated.
 
 The AWS RUM compatibility event `drop_popup_ready` and the legacy AWS RUM-owned
 events `ab_card_impression`, `ab_card_link_out`, and `ab_card_live_open` keep

--- a/ops/telemetry/registry.json
+++ b/ops/telemetry/registry.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastReviewed": "2026-07-13",
+  "lastReviewed": "2026-07-15",
   "operationalOwner": "frontend-platform",
   "providers": [
     {
@@ -11,10 +11,10 @@
         "page-views",
         "browser-http-health"
       ],
-      "automatic": ["performance", "errors", "http", "page-views"],
+      "automatic": ["performance", "errors", "http"],
       "sampling": "AWS_RUM_SAMPLE_RATE per browser session; default 0.2",
       "release": "public VERSION as releaseId",
-      "notes": "X-Ray and interaction telemetry are disabled"
+      "notes": "X-Ray, interaction telemetry, and raw automatic page views are disabled; the provider manually records allowlisted App Router page families with query, hash, and dynamic identifiers removed"
     },
     {
       "id": "sentry",

--- a/utils/monitoring/mobileLaunchTimingSanitizers.ts
+++ b/utils/monitoring/mobileLaunchTimingSanitizers.ts
@@ -154,6 +154,11 @@ const STATIC_THE_MEMES_SEGMENTS = new Set(["mint"]);
 const STATIC_MEME_LAB_SEGMENTS = new Set(["collection"]);
 const STATIC_NEXTGEN_SEGMENTS = new Set(["collection", "manager", "token"]);
 
+const AWS_RUM_NON_PAGE_ROUTE_SEGMENTS = new Set(["api"]);
+const AWS_RUM_ADDITIONAL_PAGE_ROUTE_SEGMENTS = new Set(["rep"]);
+const AWS_RUM_PROFILE_CMS_PAGE_ID = "/[user]/[...cmsPath]";
+const AWS_RUM_UNKNOWN_PAGE_ID = "/unknown";
+
 type RoutePatternSegment =
   | string
   | {
@@ -281,6 +286,32 @@ export function sanitizeEndpointGroup(endpoint: string): string {
 
 export function sanitizeRouteFamily(route: string): string {
   return getAppRouteFamilyTemplate(route) ?? sanitizePathLikeValue(route);
+}
+
+export function getAwsRumPageId(route: string): string {
+  const segments = getRouteSegments(route);
+
+  if (segments.length === 0) {
+    return "/";
+  }
+
+  const firstSegment = segments[0] ?? "";
+  if (AWS_RUM_NON_PAGE_ROUTE_SEGMENTS.has(firstSegment)) {
+    return AWS_RUM_UNKNOWN_PAGE_ID;
+  }
+
+  const routeTemplate = getAppRouteFamilyTemplate(route);
+  if (routeTemplate) {
+    return routeTemplate;
+  }
+
+  const isKnownStaticPageRoot =
+    STATIC_TOP_LEVEL_ROUTE_SEGMENTS.has(firstSegment) ||
+    AWS_RUM_ADDITIONAL_PAGE_ROUTE_SEGMENTS.has(firstSegment);
+
+  return isKnownStaticPageRoot
+    ? `/${firstSegment}`
+    : AWS_RUM_PROFILE_CMS_PAGE_ID;
 }
 
 function sanitizePathLikeValue(value: string): string {


### PR DESCRIPTION
## Issue

- AWS RUM automatic page IDs derive from raw browser paths, exposing dynamic route identifiers and creating high-cardinality page groups.

## Fix

- Disable only the SDK's automatic page-view plugin and record normalized App Router families from the frontend provider for the initial page and Next.js client navigations.

## Changes

- Reuse the existing route-template sanitizer for known dynamic routes and use bounded top-level, profile, and unknown fallbacks.
- Deduplicate consecutive navigations that resolve to the same page family.
- Keep AWS RUM performance, error, and HTTP telemetry enabled and leave Sentry `route_family` semantics unchanged.
- Document manual page-view ownership and privacy behavior in the telemetry registry and runbooks.

## Validation

- Focused Jest run — 4 suites and 41 tests passed.
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff` — 100/100, no issues.
- Production `./bin/6529 run build` with safe public endpoint placeholders — passed.
- Local CodeRabbit review — zero findings after one documentation wording fix.

## Risk

- Level: Medium
- Why: changes page-view grouping and client navigation telemetry, but does not change user routing, UI, or other RUM telemetry categories.
- Rollback: revert the commit to restore SDK automatic page IDs.

## Review Notes

- Focus on route-family fallback coverage, initial/navigation deduplication, and the manual page-view lifecycle around asynchronous SDK initialization.
- No external AWS dashboard or production configuration change is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AWS RUM now records page views manually as users navigate.
  * Page views are grouped into stable route families, excluding query strings, hashes, and dynamic identifiers.
  * Duplicate consecutive page views are avoided.

* **Documentation**
  * Updated telemetry guidance to clarify page-view ownership, privacy protections, and route normalization.
  * Updated the telemetry registry to reflect the revised AWS RUM behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->