### PR TITLE
Stop notification polling after terminal auth

### DIFF
--- a/__tests__/components/auth/Auth.test.tsx
+++ b/__tests__/components/auth/Auth.test.tsx
@@ -22,6 +22,7 @@ const mockRouterPush = jest.fn();
 const mockUsePathname = jest.fn(() => "/");
 const mockTrackAuthSessionRefreshProductImpact = jest.fn();
 const mockTrackAuthSessionRefreshSucceeded = jest.fn();
+const mockResetAuthSessionRefreshProductImpactDedupe = jest.fn();
 const mockTrackAuthValidationCancelled = jest.fn();
 const mockTrackAuthImpactEvent = jest.fn();
 
@@ -175,6 +176,11 @@ jest.mock("@/services/auth/immediate-validation.utils", () => ({
 }));
 
 jest.mock("@/services/analytics/productImpactTelemetry", () => ({
+  resetAuthSessionRefreshProductImpactDedupe: (
+    ...args: Parameters<
+      typeof mockResetAuthSessionRefreshProductImpactDedupe
+    >
+  ) => mockResetAuthSessionRefreshProductImpactDedupe(...args),
   trackAuthSessionRefreshProductImpact: (
     ...args: Parameters<typeof mockTrackAuthSessionRefreshProductImpact>
   ) => mockTrackAuthSessionRefreshProductImpact(...args),
@@ -1260,6 +1266,9 @@ describe("Auth component", () => {
         });
       });
       expect(mockTrackAuthSessionRefreshProductImpact).not.toHaveBeenCalled();
+      expect(
+        mockResetAuthSessionRefreshProductImpactDedupe
+      ).toHaveBeenCalledWith(expect.any(String));
     });
 
     it("treats an empty local jwt as absent in auth validation telemetry", async () => {
@@ -1317,6 +1326,7 @@ describe("Auth component", () => {
       await waitFor(() => {
         expect(mockTrackAuthSessionRefreshProductImpact).toHaveBeenCalledWith({
           clientType: "web",
+          dedupeScope: expect.any(String),
           hadLocalJwt: true,
           outcome: "reauth_required",
           refreshOutcome: "empty",
@@ -1969,6 +1979,26 @@ describe("Auth component", () => {
         reason: "session_upgrade_required",
         route_pattern: "/",
         was_connected_wallet: true,
+      });
+      expect(mockValidateAuthImmediate).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        window.dispatchEvent(new Event("6529-wallet-accounts-updated"));
+      });
+
+      await waitFor(() => {
+        expect(mockValidateAuthImmediate).toHaveBeenCalledTimes(1);
+      });
+
+      const mockGetAuthJwt = require("@/services/auth/auth.utils")
+        .getAuthJwt as jest.MockedFunction<any>;
+      mockGetAuthJwt.mockReturnValue("reauthenticated-jwt");
+      act(() => {
+        window.dispatchEvent(new Event("6529-auth-token-changed"));
+      });
+
+      await waitFor(() => {
+        expect(mockValidateAuthImmediate).toHaveBeenCalledTimes(2);
       });
 
       rerender(

--- a/__tests__/components/auth/Auth.test.tsx
+++ b/__tests__/components/auth/Auth.test.tsx
@@ -2018,6 +2018,63 @@ describe("Auth component", () => {
       ).toHaveLength(1);
     });
 
+    it("retries validation after JWT removal fails", async () => {
+      walletAddress = "0x1111111111111111111111111111111111111111";
+      const authUtils = require("@/services/auth/auth.utils");
+      const mockGetAuthJwt = authUtils.getAuthJwt as jest.MockedFunction<any>;
+      const mockRemoveAuthJwt =
+        authUtils.removeAuthJwt as jest.MockedFunction<any>;
+      const mockValidateAuthImmediate =
+        require("@/services/auth/immediate-validation.utils").validateAuthImmediate;
+      mockGetAuthJwt.mockReturnValue("invalid-jwt");
+      mockRemoveAuthJwt.mockRejectedValueOnce(new Error("storage failure"));
+      mockValidateAuthImmediate
+        .mockImplementationOnce(async ({ callbacks }) => {
+          try {
+            await callbacks.onRemoveJwt();
+          } catch {
+            return {
+              isValid: false,
+              validationCompleted: true,
+              authRefreshOutcome: "failed",
+              wasCancelled: false,
+              shouldShowModal: true,
+            };
+          }
+          throw new Error("Expected JWT removal to fail");
+        })
+        .mockResolvedValueOnce({
+          isValid: true,
+          validationCompleted: true,
+          authRefreshOutcome: "not_attempted",
+          wasCancelled: false,
+          shouldShowModal: false,
+        });
+
+      render(
+        <ReactQueryWrapperContext.Provider
+          value={{ invalidateAll: jest.fn() } as any}
+        >
+          <Auth>
+            <div data-testid="auth-component">Auth Component</div>
+          </Auth>
+        </ReactQueryWrapperContext.Provider>
+      );
+
+      await waitFor(() => {
+        expect(mockValidateAuthImmediate).toHaveBeenCalledTimes(1);
+      });
+
+      act(() => {
+        window.dispatchEvent(new Event("6529-wallet-accounts-updated"));
+      });
+
+      await waitFor(() => {
+        expect(mockValidateAuthImmediate).toHaveBeenCalledTimes(2);
+      });
+      expect(mockRemoveAuthJwt).toHaveBeenCalledTimes(1);
+    });
+
     it("tracks forced logout when the session upgrade deadline has expired", async () => {
       const validAddress = "0x1111111111111111111111111111111111111111";
       walletAddress = validAddress;

--- a/__tests__/components/auth/Auth.test.tsx
+++ b/__tests__/components/auth/Auth.test.tsx
@@ -2018,6 +2018,81 @@ describe("Auth component", () => {
       ).toHaveLength(1);
     });
 
+    it("revalidates a terminal auth scope after another session recovers", async () => {
+      const validAddress = "0x1111111111111111111111111111111111111111";
+      walletAddress = validAddress;
+      enableAuthMigrationDeadline();
+      const mockGetAuthJwt = require("@/services/auth/auth.utils")
+        .getAuthJwt as jest.MockedFunction<any>;
+      const mockValidateAuthImmediate =
+        require("@/services/auth/immediate-validation.utils").validateAuthImmediate;
+      let currentJwt = "session-a-jwt";
+      mockGetAuthJwt.mockImplementation(() => currentJwt);
+      const requireSessionUpgrade = async ({ callbacks }: any) => {
+        callbacks.onSessionUpgradeRequired();
+        return {
+          isValid: false,
+          validationCompleted: true,
+          authRefreshOutcome: "empty",
+          requiresSessionUpgrade: true,
+          wasCancelled: false,
+          shouldShowModal: true,
+        };
+      };
+      mockValidateAuthImmediate
+        .mockImplementationOnce(requireSessionUpgrade)
+        .mockResolvedValueOnce({
+          isValid: true,
+          validationCompleted: true,
+          authRefreshOutcome: "not_attempted",
+          wasCancelled: false,
+          shouldShowModal: false,
+        })
+        .mockImplementationOnce(requireSessionUpgrade);
+
+      render(
+        <ReactQueryWrapperContext.Provider
+          value={{ invalidateAll: jest.fn() } as any}
+        >
+          <Auth>
+            <div data-testid="auth-component">Auth Component</div>
+          </Auth>
+        </ReactQueryWrapperContext.Provider>
+      );
+
+      await waitFor(() => {
+        expect(mockTrackAuthSessionRefreshProductImpact).toHaveBeenCalledTimes(
+          1
+        );
+      });
+      const firstTerminalScope =
+        mockTrackAuthSessionRefreshProductImpact.mock.calls[0]?.[0]
+          .dedupeScope;
+      expect(firstTerminalScope).toEqual(expect.any(String));
+
+      currentJwt = "session-b-jwt";
+      act(() => {
+        window.dispatchEvent(new Event("6529-auth-token-changed"));
+      });
+
+      await waitFor(() => {
+        expect(mockValidateAuthImmediate).toHaveBeenCalledTimes(2);
+      });
+      expect(
+        mockResetAuthSessionRefreshProductImpactDedupe
+      ).toHaveBeenCalledWith(firstTerminalScope);
+
+      currentJwt = "session-a-jwt";
+      act(() => {
+        window.dispatchEvent(new Event("6529-auth-token-changed"));
+      });
+
+      await waitFor(() => {
+        expect(mockValidateAuthImmediate).toHaveBeenCalledTimes(3);
+      });
+      expect(mockTrackAuthSessionRefreshProductImpact).toHaveBeenCalledTimes(2);
+    });
+
     it("retries validation after JWT removal fails", async () => {
       walletAddress = "0x1111111111111111111111111111111111111111";
       const authUtils = require("@/services/auth/auth.utils");

--- a/__tests__/components/react-query-wrapper/utils/query-utils.test.ts
+++ b/__tests__/components/react-query-wrapper/utils/query-utils.test.ts
@@ -2,6 +2,7 @@ import {
   getDefaultQueryRetry,
   getWaveDropsInitialLimit,
   isRateLimitQueryError,
+  isTerminalNotificationAuthQueryError,
   shouldStopPollingRetry,
   WAVE_DROPS_NATIVE_INITIAL_PARAMS,
   WAVE_DROPS_PARAMS,
@@ -42,6 +43,27 @@ describe("default query retry policy", () => {
     expect(shouldStopPollingRetry({ status: 401 })).toBe(true);
     expect(shouldStopPollingRetry({ status: 429 })).toBe(true);
     expect(shouldStopPollingRetry({ status: 500 })).toBe(false);
+  });
+
+  it("scopes terminal 403 and session-upgrade handling to notification polling", () => {
+    expect(isTerminalNotificationAuthQueryError({ status: 401 })).toBe(true);
+    expect(isTerminalNotificationAuthQueryError({ status: 403 })).toBe(true);
+    expect(
+      isTerminalNotificationAuthQueryError({
+        status: 409,
+        response: { body: '{"error":"session_upgrade_required"}' },
+      })
+    ).toBe(true);
+    expect(
+      isTerminalNotificationAuthQueryError({
+        status: 409,
+        response: { body: "Conflict" },
+      })
+    ).toBe(false);
+    expect(isTerminalNotificationAuthQueryError({ status: 429 })).toBe(false);
+    expect(isTerminalNotificationAuthQueryError({ status: 503 })).toBe(false);
+
+    expect(shouldStopPollingRetry({ status: 403 })).toBe(false);
   });
 
   it("keeps retrying non-rate-limit failures until the default retry count", () => {

--- a/__tests__/hooks/notificationAuthPolling.integration.test.tsx
+++ b/__tests__/hooks/notificationAuthPolling.integration.test.tsx
@@ -1,0 +1,196 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { useConnectedAccountsUnreadNotifications } from "@/hooks/useConnectedAccountsUnreadNotifications";
+import { useUnreadNotifications } from "@/hooks/useUnreadNotifications";
+
+const commonApiFetchMock = jest.fn();
+let activeJwt = "active-jwt-before-terminal";
+
+jest.mock("@/hooks/useCapacitor", () => ({
+  __esModule: true,
+  default: () => ({ isCapacitor: false }),
+}));
+
+jest.mock("@/services/api/common-api", () => ({
+  commonApiFetch: (...args: unknown[]) => commonApiFetchMock(...args),
+}));
+
+jest.mock("@/services/auth/auth.utils", () => ({
+  getAuthJwt: () => activeJwt,
+  isAuthJwtUsable: (jwt: string | null | undefined) => Boolean(jwt),
+}));
+
+const createWrapper = (queryClient: QueryClient) =>
+  function Wrapper({ children }: { readonly children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    );
+  };
+
+const flushQueryWork = async (): Promise<void> => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await jest.advanceTimersByTimeAsync(0);
+    await Promise.resolve();
+  });
+};
+
+const getAuthorizationHeader = (call: readonly unknown[]): string | null => {
+  const params = call[0] as
+    | { readonly headers?: Readonly<Record<string, string>> }
+    | undefined;
+  return params?.headers?.Authorization ?? null;
+};
+
+describe("notification terminal auth polling", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    commonApiFetchMock.mockReset();
+    activeJwt = "active-jwt-before-terminal";
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          gcTime: Number.POSITIVE_INFINITY,
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it("deduplicates observers, stops all terminal timers, and resumes after reauth", async () => {
+    commonApiFetchMock.mockImplementation(() => {
+      if (activeJwt === "active-jwt-before-terminal") {
+        return Promise.reject({ status: 403 });
+      }
+      return Promise.resolve({ unread_count: 3 });
+    });
+
+    const { rerender, result, unmount } = renderHook(
+      () => {
+        const first = useUnreadNotifications("alice");
+        const second = useUnreadNotifications("alice");
+        return { first, second };
+      },
+      { wrapper: createWrapper(queryClient) }
+    );
+    await flushQueryWork();
+
+    expect(commonApiFetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(120_000);
+    });
+    expect(commonApiFetchMock).toHaveBeenCalledTimes(1);
+
+    activeJwt = "active-jwt-after-reauth";
+    rerender();
+    await flushQueryWork();
+
+    expect(commonApiFetchMock).toHaveBeenCalledTimes(2);
+    expect(result.current.first.haveUnreadNotifications).toBe(true);
+    expect(result.current.second.haveUnreadNotifications).toBe(true);
+    unmount();
+  });
+
+  it("retries transient failures and keeps the timer active after recovery", async () => {
+    commonApiFetchMock
+      .mockRejectedValueOnce({ status: 503 })
+      .mockResolvedValue({ unread_count: 1 });
+
+    const { result, unmount } = renderHook(
+      () => useUnreadNotifications("alice"),
+      { wrapper: createWrapper(queryClient) }
+    );
+    await flushQueryWork();
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(1);
+    });
+
+    expect(commonApiFetchMock).toHaveBeenCalledTimes(2);
+    expect(result.current.haveUnreadNotifications).toBe(true);
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(30_000);
+    });
+    expect(commonApiFetchMock).toHaveBeenCalledTimes(3);
+    unmount();
+  });
+
+  it("keeps account failures isolated and retries only after that token changes", async () => {
+    const accountA = {
+      address: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      refreshToken: "refresh-a",
+      role: null,
+      jwt: "jwt-a-before-terminal",
+      profileId: null,
+      profileHandle: "alice",
+    };
+    const accountB = {
+      address: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+      refreshToken: "refresh-b",
+      role: null,
+      jwt: "jwt-b",
+      profileId: null,
+      profileHandle: "bob",
+    };
+    commonApiFetchMock.mockImplementation(
+      (params: { readonly headers?: Readonly<Record<string, string>> }) => {
+        const authorization = params.headers?.Authorization;
+        if (authorization === "Bearer jwt-a-before-terminal") {
+          return Promise.reject({ status: 403 });
+        }
+        return Promise.resolve({ unread_count: 1 });
+      }
+    );
+
+    const { rerender, unmount } = renderHook(
+      ({ accounts }) => useConnectedAccountsUnreadNotifications(accounts),
+      {
+        initialProps: { accounts: [accountA, accountB] },
+        wrapper: createWrapper(queryClient),
+      }
+    );
+    await flushQueryWork();
+    await flushQueryWork();
+
+    const countRequestsFor = (authorization: string): number =>
+      commonApiFetchMock.mock.calls.filter(
+        (call) => getAuthorizationHeader(call) === authorization
+      ).length;
+    const accountBRequestsBeforeTimer = countRequestsFor("Bearer jwt-b");
+
+    expect(countRequestsFor("Bearer jwt-a-before-terminal")).toBe(1);
+    expect(accountBRequestsBeforeTimer).toBeGreaterThan(0);
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(30_000);
+    });
+    expect(countRequestsFor("Bearer jwt-a-before-terminal")).toBe(1);
+    expect(countRequestsFor("Bearer jwt-b")).toBeGreaterThan(
+      accountBRequestsBeforeTimer
+    );
+
+    rerender({
+      accounts: [
+        { ...accountA, jwt: "jwt-a-after-reauth" },
+        accountB,
+      ],
+    });
+    await flushQueryWork();
+
+    expect(countRequestsFor("Bearer jwt-a-after-reauth")).toBe(1);
+    expect(countRequestsFor("Bearer jwt-a-before-terminal")).toBe(1);
+    unmount();
+  });
+});

--- a/__tests__/hooks/notificationAuthPolling.integration.test.tsx
+++ b/__tests__/hooks/notificationAuthPolling.integration.test.tsx
@@ -127,6 +127,30 @@ describe("notification terminal auth polling", () => {
     unmount();
   });
 
+  it("uses a silently rotated token on the next poll without a rerender", async () => {
+    commonApiFetchMock.mockResolvedValue({ unread_count: 1 });
+
+    const { unmount } = renderHook(() => useUnreadNotifications("alice"), {
+      wrapper: createWrapper(queryClient),
+    });
+    await flushQueryWork();
+
+    expect(getAuthorizationHeader(commonApiFetchMock.mock.calls[0])).toBe(
+      "Bearer active-jwt-before-terminal"
+    );
+
+    activeJwt = "silently-rotated-jwt";
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(30_000);
+    });
+
+    expect(commonApiFetchMock).toHaveBeenCalledTimes(2);
+    expect(getAuthorizationHeader(commonApiFetchMock.mock.calls[1])).toBe(
+      "Bearer silently-rotated-jwt"
+    );
+    unmount();
+  });
+
   it("keeps account failures isolated and retries only after that token changes", async () => {
     const accountA = {
       address: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",

--- a/__tests__/hooks/useConnectedAccountsUnreadNotifications.test.ts
+++ b/__tests__/hooks/useConnectedAccountsUnreadNotifications.test.ts
@@ -1,6 +1,6 @@
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
 import { useConnectedAccountsUnreadNotifications } from "@/hooks/useConnectedAccountsUnreadNotifications";
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 
 const useQueryMock = jest.fn();
 const getQueryDataMock = jest.fn();
@@ -94,7 +94,7 @@ describe("useConnectedAccountsUnreadNotifications", () => {
     );
   });
 
-  it("does not retry unauthorized connected-account notification failures", () => {
+  it("does not retry terminal connected-account notification failures", () => {
     useQueryMock.mockReturnValue({ data: {} });
 
     renderHook(() =>
@@ -112,10 +112,12 @@ describe("useConnectedAccountsUnreadNotifications", () => {
 
     const queryOptions = useQueryMock.mock.calls[0]?.[0];
     expect(queryOptions.retry(0, { status: 401 })).toBe(false);
+    expect(queryOptions.retry(0, { status: 403 })).toBe(false);
+    expect(queryOptions.retry(0, { status: 503 })).toBe(true);
   });
 
-  it("surfaces unauthorized connected-account failures instead of hiding them as successful polling", async () => {
-    commonApiFetchMock.mockRejectedValue({ status: 401 });
+  it("surfaces terminal connected-account failures instead of hiding them as successful polling", async () => {
+    commonApiFetchMock.mockRejectedValue({ status: 403 });
     useQueryMock.mockReturnValue({ data: {} });
 
     renderHook(() =>
@@ -132,7 +134,91 @@ describe("useConnectedAccountsUnreadNotifications", () => {
     );
 
     const queryOptions = useQueryMock.mock.calls[0]?.[0];
-    await expect(queryOptions.queryFn()).rejects.toMatchObject({ status: 401 });
+    await expect(queryOptions.queryFn()).rejects.toMatchObject({
+      status: 403,
+      terminalNotificationAuth: true,
+    });
+  });
+
+  it("keeps transient connected-account failures best-effort", async () => {
+    commonApiFetchMock.mockRejectedValue({ status: 503 });
+    getQueryDataMock.mockReturnValue({
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": 4,
+    });
+    useQueryMock.mockReturnValue({ data: {} });
+
+    renderHook(() =>
+      useConnectedAccountsUnreadNotifications([
+        {
+          address: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          refreshToken: "refresh-token",
+          role: null,
+          jwt: "jwt-token",
+          profileId: null,
+          profileHandle: "alice",
+        },
+      ])
+    );
+
+    const queryOptions = useQueryMock.mock.calls[0]?.[0];
+    await expect(queryOptions.queryFn()).resolves.toEqual({
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": 4,
+    });
+  });
+
+  it("blocks only the failed account until that account gets a new token", async () => {
+    const accounts = [
+      {
+        address: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        refreshToken: "refresh-token-a",
+        role: null,
+        jwt: "jwt-a",
+        profileId: null,
+        profileHandle: "alice",
+      },
+      {
+        address: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+        refreshToken: "refresh-token-b",
+        role: null,
+        jwt: "jwt-b",
+        profileId: null,
+        profileHandle: "bob",
+      },
+    ];
+    commonApiFetchMock
+      .mockRejectedValueOnce({ status: 403 })
+      .mockResolvedValueOnce({ unread_count: 2 });
+    useQueryMock.mockReturnValue({ data: {} });
+
+    const { rerender } = renderHook(
+      ({ connectedAccounts }) =>
+        useConnectedAccountsUnreadNotifications(connectedAccounts),
+      { initialProps: { connectedAccounts: accounts } }
+    );
+
+    const firstQueryOptions = useQueryMock.mock.calls[0]?.[0];
+    const terminalError = await firstQueryOptions.queryFn().catch(
+      (error: unknown) => error
+    );
+    act(() => {
+      expect(firstQueryOptions.retry(0, terminalError)).toBe(false);
+    });
+
+    expect(useQueryMock.mock.calls.at(-1)?.[0].queryKey.at(-1)).toEqual([
+      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    ]);
+
+    rerender({
+      connectedAccounts: [
+        { ...accounts[0], jwt: "jwt-a-after-reauth" },
+        accounts[1],
+      ],
+    });
+
+    expect(useQueryMock.mock.calls.at(-1)?.[0].queryKey.at(-1)).toEqual([
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    ]);
   });
 
   it("blocks connected-account fetches when the JWT expires between renders", async () => {

--- a/__tests__/hooks/useUnreadNotifications.test.ts
+++ b/__tests__/hooks/useUnreadNotifications.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import { useUnreadNotifications } from "@/hooks/useUnreadNotifications";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
+import { getAuthTokenFingerprint } from "@/services/auth/auth-token-fingerprint";
 
 const useQueryMock = jest.fn();
 const commonApiFetchMock = jest.fn();
@@ -41,7 +42,12 @@ describe("useUnreadNotifications", () => {
       expect.objectContaining({
         queryKey: [
           QueryKey.IDENTITY_NOTIFICATIONS,
-          { identity: "bob", limit: "1", version: "v2" },
+          {
+            auth: getAuthTokenFingerprint("valid-jwt"),
+            identity: "bob",
+            limit: "1",
+            version: "v2",
+          },
         ],
         enabled: true,
       })
@@ -79,14 +85,74 @@ describe("useUnreadNotifications", () => {
     );
   });
 
-  it("does not retry unauthorized notification failures", () => {
+  it("does not retry terminal notification auth failures", () => {
     useQueryMock.mockReturnValue({ data: undefined });
 
     renderHook(() => useUnreadNotifications("bob"));
 
     const queryOptions = useQueryMock.mock.calls[0]?.[0];
     expect(queryOptions.retry(0, { status: 401 })).toBe(false);
+    expect(queryOptions.retry(0, { status: 403 })).toBe(false);
+    expect(
+      queryOptions.retry(0, {
+        status: 409,
+        response: { body: "session-v2 upgrade required" },
+      })
+    ).toBe(false);
     expect(queryOptions.retry(0, new Error("temporary failure"))).toBe(true);
+  });
+
+  it("disables timer and lifecycle refetches only after terminal auth errors", () => {
+    useQueryMock.mockReturnValue({ data: undefined });
+
+    renderHook(() => useUnreadNotifications("bob"));
+
+    const queryOptions = useQueryMock.mock.calls[0]?.[0];
+    const terminalQuery = { state: { error: { status: 403 } } };
+    const transientQuery = { state: { error: { status: 503 } } };
+
+    expect(queryOptions.refetchInterval(terminalQuery)).toBe(false);
+    expect(queryOptions.refetchOnWindowFocus(terminalQuery)).toBe(false);
+    expect(queryOptions.refetchOnMount(terminalQuery)).toBe(false);
+    expect(queryOptions.refetchOnReconnect(terminalQuery)).toBe(false);
+
+    expect(queryOptions.refetchInterval(transientQuery)).toBe(30000);
+    expect(queryOptions.refetchOnWindowFocus(transientQuery)).toBe(true);
+    expect(queryOptions.refetchOnMount(transientQuery)).toBe(true);
+    expect(queryOptions.refetchOnReconnect(transientQuery)).toBe(true);
+  });
+
+  it("uses a fresh query after the auth token materially changes", () => {
+    useQueryMock.mockReturnValue({ data: undefined });
+    getAuthJwtMock.mockReturnValue("first-jwt");
+
+    const { rerender } = renderHook(() => useUnreadNotifications("bob"));
+    const firstQueryKey = useQueryMock.mock.calls[0]?.[0].queryKey;
+
+    getAuthJwtMock.mockReturnValue("reauthenticated-jwt");
+    rerender();
+
+    const secondQueryKey = useQueryMock.mock.calls.at(-1)?.[0].queryKey;
+    expect(firstQueryKey).not.toEqual(secondQueryKey);
+    expect(secondQueryKey[1]).toEqual(
+      expect.objectContaining({
+        auth: getAuthTokenFingerprint("reauthenticated-jwt"),
+        identity: "bob",
+      })
+    );
+  });
+
+  it("surfaces 403 as terminal query state without hiding transient failures", async () => {
+    useQueryMock.mockReturnValue({ data: undefined });
+    commonApiFetchMock.mockRejectedValue({ status: 403 });
+
+    renderHook(() => useUnreadNotifications("bob"));
+
+    const queryOptions = useQueryMock.mock.calls[0]?.[0];
+    await expect(queryOptions.queryFn()).rejects.toMatchObject({ status: 403 });
+
+    commonApiFetchMock.mockRejectedValueOnce({ status: 503 });
+    await expect(queryOptions.queryFn()).rejects.toMatchObject({ status: 503 });
   });
 
   it("blocks polling before fetch when the token expires between renders", async () => {

--- a/__tests__/services/analytics/productImpactTelemetry.test.ts
+++ b/__tests__/services/analytics/productImpactTelemetry.test.ts
@@ -159,6 +159,38 @@ describe("productImpactTelemetry", () => {
     );
   });
 
+  it("deduplicates one auth impact condition until that session recovers", async () => {
+    const { telemetry, sentry } = await loadProductImpactTelemetry();
+    const impact = {
+      clientType: "web" as const,
+      dedupeScope: "session-a",
+      hadLocalJwt: true,
+      outcome: "session_upgrade_required" as const,
+      refreshOutcome: "empty" as const,
+      requiresReauth: true,
+    };
+
+    telemetry.trackAuthSessionRefreshProductImpact(impact);
+    telemetry.trackAuthSessionRefreshProductImpact(impact);
+
+    expect(trackAnalyticsEventMock).toHaveBeenCalledTimes(1);
+    expect(sentry.logger.warn).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(trackAnalyticsEventMock.mock.calls)).not.toContain(
+      "session-a"
+    );
+
+    telemetry.trackAuthSessionRefreshProductImpact({
+      ...impact,
+      dedupeScope: "session-b",
+    });
+    expect(trackAnalyticsEventMock).toHaveBeenCalledTimes(2);
+
+    telemetry.resetAuthSessionRefreshProductImpactDedupe("session-a");
+    telemetry.trackAuthSessionRefreshProductImpact(impact);
+    expect(trackAnalyticsEventMock).toHaveBeenCalledTimes(3);
+    expect(sentry.logger.warn).toHaveBeenCalledTimes(3);
+  });
+
   it("classifies wave feed HTTP failures into status and error buckets", async () => {
     const { telemetry } = await loadProductImpactTelemetry();
     const serviceError = Object.assign(new Error("Service unavailable"), {

--- a/components/auth/AuthProvider.tsx
+++ b/components/auth/AuthProvider.tsx
@@ -70,7 +70,10 @@ import type {
   SessionUpgradePromptMode,
   SignModalReason,
 } from "./authTypes";
-import { runImmediateAuthValidation } from "./authValidation";
+import {
+  getAuthTerminalTransitionScope,
+  runImmediateAuthValidation,
+} from "./authValidation";
 import { useSeizeConnectContext } from "./SeizeConnectContext";
 
 export default function Auth({
@@ -140,6 +143,7 @@ export default function Auth({
   const abortControllerRef = useRef<AbortController | null>(null);
   const latestAddressRef = useRef<string | undefined>(address);
   const activeValidationOperationIdRef = useRef<string | null>(null);
+  const terminalAuthTransitionScopeRef = useRef<string | null>(null);
   const validationOperationCounterRef = useRef(0);
   const [pendingProfileSwitch, setPendingProfileSwitch] = useState<{
     readonly targetAddress: string | null;
@@ -426,6 +430,21 @@ export default function Auth({
 
     // Capture current address at validation time to prevent race conditions
     const currentAddress = address;
+    const currentAuthJwt = getAuthJwt();
+    const terminalAuthTransitionScope = getAuthTerminalTransitionScope({
+      activeProfileProxyId: activeProfileProxy?.id ?? null,
+      authJwt: currentAuthJwt,
+      authRolloutSettings,
+      canSignActiveWallet,
+      currentAddress,
+      hasActiveWalletAddress,
+      hasSessionV2Auth: hasActiveSessionV2Auth({ address: currentAddress }),
+    });
+    if (
+      terminalAuthTransitionScopeRef.current === terminalAuthTransitionScope
+    ) {
+      return undefined;
+    }
     authPromptTrackingReasonRef.current = "auth_validation_failed";
     setSessionUpgradeRequired(false);
 
@@ -441,6 +460,7 @@ export default function Auth({
       latestAddressRef,
       activeValidationOperationIdRef,
       abortControllerRef,
+      terminalAuthTransitionScopeRef,
       activeProfileProxy,
       hasActiveWalletAddress,
       canSignActiveWallet,

--- a/components/auth/AuthProvider.tsx
+++ b/components/auth/AuthProvider.tsx
@@ -71,7 +71,7 @@ import type {
   SignModalReason,
 } from "./authTypes";
 import {
-  getAuthTerminalTransitionScope,
+  getCurrentAuthTerminalTransitionScope,
   runImmediateAuthValidation,
 } from "./authValidation";
 import { useSeizeConnectContext } from "./SeizeConnectContext";
@@ -428,17 +428,13 @@ export default function Auth({
       setActiveWalletAccount(address);
     }
 
-    // Capture current address at validation time to prevent race conditions
     const currentAddress = address;
-    const currentAuthJwt = getAuthJwt();
-    const terminalAuthTransitionScope = getAuthTerminalTransitionScope({
-      activeProfileProxyId: activeProfileProxy?.id ?? null,
-      authJwt: currentAuthJwt,
+    const terminalAuthTransitionScope = getCurrentAuthTerminalTransitionScope({
+      activeProfileProxy,
       authRolloutSettings,
       canSignActiveWallet,
       currentAddress,
       hasActiveWalletAddress,
-      hasSessionV2Auth: hasActiveSessionV2Auth({ address: currentAddress }),
     });
     if (
       terminalAuthTransitionScopeRef.current === terminalAuthTransitionScope

--- a/components/auth/authTypes.ts
+++ b/components/auth/authTypes.ts
@@ -59,6 +59,7 @@ export interface RunImmediateAuthValidationParams {
   readonly latestAddressRef: MutableCurrentRef<string | undefined>;
   readonly activeValidationOperationIdRef: MutableCurrentRef<string | null>;
   readonly abortControllerRef: MutableCurrentRef<AbortController | null>;
+  readonly terminalAuthTransitionScopeRef: MutableCurrentRef<string | null>;
   readonly activeProfileProxy: ApiProfileProxy | null;
   readonly hasActiveWalletAddress: boolean;
   readonly canSignActiveWallet: boolean;

--- a/components/auth/authValidation.ts
+++ b/components/auth/authValidation.ts
@@ -1,6 +1,12 @@
-import { getAuthJwt, removeAuthJwt } from "@/services/auth/auth.utils";
+import {
+  getAuthJwt,
+  hasActiveSessionV2Auth,
+  removeAuthJwt,
+} from "@/services/auth/auth.utils";
+import { getAuthTokenFingerprint } from "@/services/auth/auth-token-fingerprint";
 import { validateAuthImmediate } from "@/services/auth/immediate-validation.utils";
 import {
+  resetAuthSessionRefreshProductImpactDedupe,
   trackAuthSessionRefreshProductImpact,
   trackAuthSessionRefreshSucceeded,
   trackAuthValidationCancelled,
@@ -19,6 +25,36 @@ type ImmediateAuthValidationResult = Awaited<
   ReturnType<typeof validateAuthImmediate>
 >;
 
+export const getAuthTerminalTransitionScope = ({
+  activeProfileProxyId,
+  authJwt,
+  authRolloutSettings,
+  canSignActiveWallet,
+  currentAddress,
+  hasActiveWalletAddress,
+  hasSessionV2Auth,
+}: {
+  readonly activeProfileProxyId: string | null;
+  readonly authJwt: string | null;
+  readonly authRolloutSettings: RunImmediateAuthValidationParams["authRolloutSettings"];
+  readonly canSignActiveWallet: boolean;
+  readonly currentAddress: string;
+  readonly hasActiveWalletAddress: boolean;
+  readonly hasSessionV2Auth: boolean;
+}): string =>
+  getAuthTokenFingerprint(
+    [
+      currentAddress.toLowerCase(),
+      getAuthTokenFingerprint(authJwt),
+      activeProfileProxyId ?? "none",
+      authRolloutSettings.structuredSignaturesRequired,
+      authRolloutSettings.sessionV2MigrationDeadline ?? "none",
+      canSignActiveWallet,
+      hasActiveWalletAddress,
+      hasSessionV2Auth,
+    ].join(":")
+  );
+
 const isCurrentValidationOperation = ({
   latestAddressRef,
   activeValidationOperationIdRef,
@@ -35,10 +71,12 @@ const isCurrentValidationOperation = ({
 
 const trackImmediateAuthValidationTelemetry = ({
   result,
+  dedupeScope,
   hadLocalJwt,
   hasActiveWalletAddress,
 }: {
   readonly result: ImmediateAuthValidationResult;
+  readonly dedupeScope: string;
   readonly hadLocalJwt: boolean;
   readonly hasActiveWalletAddress: boolean;
 }): void => {
@@ -55,22 +93,24 @@ const trackImmediateAuthValidationTelemetry = ({
   }
 
   if (result.isValid) {
+    if (refreshOutcome === "local_valid_after_failure") {
+      trackAuthSessionRefreshProductImpact({
+        clientType,
+        dedupeScope,
+        hadLocalJwt,
+        outcome: "failed_without_prompt",
+        refreshOutcome,
+        requiresReauth: false,
+      });
+      return;
+    }
+
+    resetAuthSessionRefreshProductImpactDedupe(dedupeScope);
     if (refreshOutcome === "success") {
       trackAuthSessionRefreshSucceeded({
         clientType,
         hadLocalJwt,
         refreshOutcome,
-      });
-      return;
-    }
-
-    if (refreshOutcome === "local_valid_after_failure") {
-      trackAuthSessionRefreshProductImpact({
-        clientType,
-        hadLocalJwt,
-        outcome: "failed_without_prompt",
-        refreshOutcome,
-        requiresReauth: false,
       });
     }
     return;
@@ -79,6 +119,7 @@ const trackImmediateAuthValidationTelemetry = ({
   if (result.requiresSessionUpgrade) {
     trackAuthSessionRefreshProductImpact({
       clientType,
+      dedupeScope,
       hadLocalJwt,
       outcome: "session_upgrade_required",
       refreshOutcome,
@@ -90,6 +131,7 @@ const trackImmediateAuthValidationTelemetry = ({
   if (result.shouldShowModal) {
     trackAuthSessionRefreshProductImpact({
       clientType,
+      dedupeScope,
       hadLocalJwt,
       outcome: "reauth_required",
       refreshOutcome,
@@ -101,6 +143,7 @@ const trackImmediateAuthValidationTelemetry = ({
   if (!hasActiveWalletAddress) {
     trackAuthSessionRefreshProductImpact({
       clientType,
+      dedupeScope,
       hadLocalJwt,
       outcome: "logout_required",
       refreshOutcome,
@@ -112,6 +155,7 @@ const trackImmediateAuthValidationTelemetry = ({
   if (refreshOutcome !== "not_attempted") {
     trackAuthSessionRefreshProductImpact({
       clientType,
+      dedupeScope,
       hadLocalJwt,
       outcome: "failed_without_prompt",
       refreshOutcome,
@@ -126,6 +170,7 @@ export const runImmediateAuthValidation = async ({
   latestAddressRef,
   activeValidationOperationIdRef,
   abortControllerRef,
+  terminalAuthTransitionScopeRef,
   activeProfileProxy,
   hasActiveWalletAddress,
   canSignActiveWallet,
@@ -158,8 +203,29 @@ export const runImmediateAuthValidation = async ({
   setAuthLoadingState("validating");
   const authJwt = getAuthJwt();
   const hadLocalJwt = Boolean(authJwt);
+  const terminalAuthTransitionScope = getAuthTerminalTransitionScope({
+    activeProfileProxyId: activeProfileProxy?.id ?? null,
+    authJwt,
+    authRolloutSettings,
+    canSignActiveWallet,
+    currentAddress,
+    hasActiveWalletAddress,
+    hasSessionV2Auth: hasActiveSessionV2Auth({ address: currentAddress }),
+  });
+  const telemetryDedupeScope = terminalAuthTransitionScope;
+
+  const beginTerminalAuthTransition = (): boolean => {
+    if (terminalAuthTransitionScopeRef.current === terminalAuthTransitionScope) {
+      return false;
+    }
+    terminalAuthTransitionScopeRef.current = terminalAuthTransitionScope;
+    return true;
+  };
 
   const markSessionUpgradeRequired = () => {
+    if (!beginTerminalAuthTransition()) {
+      return;
+    }
     resetSessionUpgradeExpiryDedupe(currentAddress);
     setSessionUpgradeRequired(true);
     if (!hasSessionUpgradeRollout(authRolloutSettings)) {
@@ -199,8 +265,25 @@ export const runImmediateAuthValidation = async ({
             onShowSignModal: setShowSignModal,
             onSessionUpgradeRequired: markSessionUpgradeRequired,
             onInvalidateCache: invalidateAll,
-            onReset: reset,
-            onRemoveJwt: () => removeAuthJwt(),
+            onReset: () => {
+              if (beginTerminalAuthTransition()) {
+                reset();
+              }
+            },
+            onRemoveJwt: () => {
+              if (!beginTerminalAuthTransition()) {
+                return;
+              }
+              return removeAuthJwt().catch((error: unknown) => {
+                if (
+                  terminalAuthTransitionScopeRef.current ===
+                  terminalAuthTransitionScope
+                ) {
+                  terminalAuthTransitionScopeRef.current = null;
+                }
+                throw error;
+              });
+            },
             onLogError: logErrorSecurely,
           },
         })
@@ -209,6 +292,7 @@ export const runImmediateAuthValidation = async ({
     if (result.wasCancelled) {
       trackImmediateAuthValidationTelemetry({
         result,
+        dedupeScope: telemetryDedupeScope,
         hadLocalJwt,
         hasActiveWalletAddress,
       });
@@ -228,9 +312,16 @@ export const runImmediateAuthValidation = async ({
 
     trackImmediateAuthValidationTelemetry({
       result,
+      dedupeScope: telemetryDedupeScope,
       hadLocalJwt,
       hasActiveWalletAddress,
     });
+    if (
+      result.isValid &&
+      terminalAuthTransitionScopeRef.current === terminalAuthTransitionScope
+    ) {
+      terminalAuthTransitionScopeRef.current = null;
+    }
   } finally {
     if (
       abortControllerRef.current === abortController &&

--- a/components/auth/authValidation.ts
+++ b/components/auth/authValidation.ts
@@ -55,6 +55,30 @@ export const getAuthTerminalTransitionScope = ({
     ].join(":")
   );
 
+export const getCurrentAuthTerminalTransitionScope = ({
+  activeProfileProxy,
+  authRolloutSettings,
+  canSignActiveWallet,
+  currentAddress,
+  hasActiveWalletAddress,
+}: Pick<
+  RunImmediateAuthValidationParams,
+  | "activeProfileProxy"
+  | "authRolloutSettings"
+  | "canSignActiveWallet"
+  | "currentAddress"
+  | "hasActiveWalletAddress"
+>): string =>
+  getAuthTerminalTransitionScope({
+    activeProfileProxyId: activeProfileProxy?.id ?? null,
+    authJwt: getAuthJwt(),
+    authRolloutSettings,
+    canSignActiveWallet,
+    currentAddress,
+    hasActiveWalletAddress,
+    hasSessionV2Auth: hasActiveSessionV2Auth({ address: currentAddress }),
+  });
+
 const isCurrentValidationOperation = ({
   latestAddressRef,
   activeValidationOperationIdRef,
@@ -215,7 +239,9 @@ export const runImmediateAuthValidation = async ({
   const telemetryDedupeScope = terminalAuthTransitionScope;
 
   const beginTerminalAuthTransition = (): boolean => {
-    if (terminalAuthTransitionScopeRef.current === terminalAuthTransitionScope) {
+    if (
+      terminalAuthTransitionScopeRef.current === terminalAuthTransitionScope
+    ) {
       return false;
     }
     terminalAuthTransitionScopeRef.current = terminalAuthTransitionScope;

--- a/components/auth/authValidation.ts
+++ b/components/auth/authValidation.ts
@@ -25,7 +25,7 @@ type ImmediateAuthValidationResult = Awaited<
   ReturnType<typeof validateAuthImmediate>
 >;
 
-export const getAuthTerminalTransitionScope = ({
+const getAuthTerminalTransitionScope = ({
   activeProfileProxyId,
   authJwt,
   authRolloutSettings,

--- a/components/auth/authValidation.ts
+++ b/components/auth/authValidation.ts
@@ -342,10 +342,14 @@ export const runImmediateAuthValidation = async ({
       hadLocalJwt,
       hasActiveWalletAddress,
     });
-    if (
-      result.isValid &&
-      terminalAuthTransitionScopeRef.current === terminalAuthTransitionScope
-    ) {
+    if (result.isValid) {
+      const previousTerminalScope = terminalAuthTransitionScopeRef.current;
+      if (
+        previousTerminalScope &&
+        previousTerminalScope !== telemetryDedupeScope
+      ) {
+        resetAuthSessionRefreshProductImpactDedupe(previousTerminalScope);
+      }
       terminalAuthTransitionScopeRef.current = null;
     }
   } finally {

--- a/components/react-query-wrapper/utils/query-utils.ts
+++ b/components/react-query-wrapper/utils/query-utils.ts
@@ -34,16 +34,19 @@ export const WAVE_LOGS_PARAMS = {
 };
 
 type QueryErrorWithStatus = {
+  readonly message?: unknown;
   readonly status?: unknown;
   readonly response?: {
+    readonly body?: unknown;
     readonly status?: unknown;
   };
   readonly cause?: {
     readonly status?: unknown;
   };
+  readonly terminalNotificationAuth?: unknown;
 };
 
-const getQueryErrorStatus = (error: unknown): number | null => {
+export const getQueryErrorStatus = (error: unknown): number | null => {
   if (typeof error !== "object" || error === null) {
     return null;
   }
@@ -59,6 +62,53 @@ const getQueryErrorStatus = (error: unknown): number | null => {
 
 export const isRateLimitQueryError = (error: unknown): boolean => {
   return getQueryErrorStatus(error) === 429;
+};
+
+const SESSION_UPGRADE_ERROR_PATTERN =
+  /(?:session[-_ ]?v2|session[-_ ]?upgrade|upgrade[^.]{0,40}session|structured[-_ ]?signature)/i;
+
+const hasSessionUpgradeErrorMarker = (error: unknown): boolean => {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+
+  const queryError = error as QueryErrorWithStatus;
+  const candidates = [queryError.message, queryError.response?.body];
+  return candidates.some(
+    (candidate) =>
+      typeof candidate === "string" &&
+      SESSION_UPGRADE_ERROR_PATTERN.test(candidate)
+  );
+};
+
+/**
+ * Notification polling is authenticated and viewer-specific. A 401 or 403 on
+ * that endpoint is terminal for the exact session that made the request. Some
+ * session-upgrade responses use another 4xx status, so accept only explicit
+ * upgrade markers there instead of treating every authorization denial across
+ * the app as an expired session.
+ */
+export const isTerminalNotificationAuthQueryError = (
+  error: unknown
+): boolean => {
+  if (typeof error === "object" && error !== null) {
+    const marker = (error as QueryErrorWithStatus).terminalNotificationAuth;
+    if (marker === true) {
+      return true;
+    }
+  }
+
+  const status = getQueryErrorStatus(error);
+  if (status === 401 || status === 403) {
+    return true;
+  }
+
+  return (
+    status !== null &&
+    status >= 400 &&
+    status < 500 &&
+    hasSessionUpgradeErrorMarker(error)
+  );
 };
 
 export const shouldStopPollingRetry = (error: unknown): boolean => {

--- a/hooks/useConnectedAccountsUnreadNotifications.ts
+++ b/hooks/useConnectedAccountsUnreadNotifications.ts
@@ -4,7 +4,8 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
 import {
-  isUnauthorizedQueryError,
+  getQueryErrorStatus,
+  isTerminalNotificationAuthQueryError,
   shouldStopPollingRetry,
 } from "@/components/react-query-wrapper/utils/query-utils";
 import type { ApiNotificationsResponseV2 } from "@/generated/models/ApiNotificationsResponseV2";
@@ -21,32 +22,40 @@ type ConnectedAccountUnreadCounts = Readonly<Record<string, number>>;
 const POLL_INTERVAL_MS = 15000;
 
 const toAddressKey = (address: string): string => address.toLowerCase();
+const toAccountAuthKey = (address: string): string =>
+  getAuthTokenFingerprint(toAddressKey(address));
 
-type UnauthorizedConnectedAccountFailure = {
-  readonly addressKey: string;
+type TerminalConnectedAccountAuthFailure = {
+  readonly accountAuthKey: string;
   readonly jwtFingerprint: string;
 };
 
-type ConnectedAccountAuthPollingError = Error & {
-  readonly status: 401;
-  readonly unauthorizedFailures: readonly UnauthorizedConnectedAccountFailure[];
+type ConnectedAccountTerminalAuthPollingError = Error & {
+  readonly status: number;
+  readonly terminalNotificationAuth: true;
+  readonly terminalAuthFailures: readonly TerminalConnectedAccountAuthFailure[];
   readonly cause?: unknown;
 };
 
-const createConnectedAccountAuthPollingError = (
-  unauthorizedFailures: readonly UnauthorizedConnectedAccountFailure[],
+const createConnectedAccountTerminalAuthPollingError = (
+  terminalAuthFailures: readonly TerminalConnectedAccountAuthFailure[],
+  status: number,
   cause?: unknown
-): ConnectedAccountAuthPollingError => {
+): ConnectedAccountTerminalAuthPollingError => {
   const error = new Error(
     "Connected account unread notification polling requires valid auth"
-  ) as ConnectedAccountAuthPollingError;
+  ) as ConnectedAccountTerminalAuthPollingError;
   Object.defineProperty(error, "status", {
-    value: 401,
+    value: status,
     enumerable: true,
   });
-  Object.defineProperty(error, "unauthorizedFailures", {
-    value: unauthorizedFailures,
+  Object.defineProperty(error, "terminalNotificationAuth", {
+    value: true,
     enumerable: true,
+  });
+  Object.defineProperty(error, "terminalAuthFailures", {
+    value: terminalAuthFailures,
+    enumerable: false,
   });
   if (cause !== undefined) {
     Object.defineProperty(error, "cause", {
@@ -57,26 +66,26 @@ const createConnectedAccountAuthPollingError = (
   return error;
 };
 
-const getUnauthorizedFailuresFromError = (
+const getTerminalAuthFailuresFromError = (
   error: unknown
-): readonly UnauthorizedConnectedAccountFailure[] => {
-  if (!isUnauthorizedQueryError(error)) {
+): readonly TerminalConnectedAccountAuthFailure[] => {
+  if (!isTerminalNotificationAuthQueryError(error)) {
     return [];
   }
   if (typeof error !== "object" || error === null) {
     return [];
   }
 
-  const failures = (error as { readonly unauthorizedFailures?: unknown })
-    .unauthorizedFailures;
+  const failures = (error as { readonly terminalAuthFailures?: unknown })
+    .terminalAuthFailures;
   return Array.isArray(failures)
     ? failures.filter(
-        (failure): failure is UnauthorizedConnectedAccountFailure =>
+        (failure): failure is TerminalConnectedAccountAuthFailure =>
           typeof failure === "object" &&
           failure !== null &&
-          typeof (failure as UnauthorizedConnectedAccountFailure).addressKey ===
-            "string" &&
-          typeof (failure as UnauthorizedConnectedAccountFailure)
+          typeof (failure as TerminalConnectedAccountAuthFailure)
+            .accountAuthKey === "string" &&
+          typeof (failure as TerminalConnectedAccountAuthFailure)
             .jwtFingerprint === "string"
       )
     : [];
@@ -95,13 +104,14 @@ const fetchUnreadCountForAccount = async (
   if (!account.jwt) {
     return 0;
   }
-  const addressKey = toAddressKey(account.address);
+  const accountAuthKey = toAccountAuthKey(account.address);
   const jwtFingerprint = getAuthTokenFingerprint(account.jwt);
 
   if (!isAuthJwtUsable(account.jwt)) {
-    throw createConnectedAccountAuthPollingError([
-      { addressKey, jwtFingerprint },
-    ]);
+    throw createConnectedAccountTerminalAuthPollingError(
+      [{ accountAuthKey, jwtFingerprint }],
+      401
+    );
   }
 
   try {
@@ -115,9 +125,10 @@ const fetchUnreadCountForAccount = async (
     });
     return clampUnreadCount(notifications.unread_count);
   } catch (error) {
-    if (isUnauthorizedQueryError(error)) {
-      throw createConnectedAccountAuthPollingError(
-        [{ addressKey, jwtFingerprint }],
+    if (isTerminalNotificationAuthQueryError(error)) {
+      throw createConnectedAccountTerminalAuthPollingError(
+        [{ accountAuthKey, jwtFingerprint }],
+        getQueryErrorStatus(error) ?? 401,
         error
       );
     }
@@ -130,12 +141,8 @@ export function useConnectedAccountsUnreadNotifications(
 ): ConnectedAccountUnreadCounts {
   const { isCapacitor } = useCapacitor();
   const queryClient = useQueryClient();
-  const [
-    unauthorizedJwtFingerprintByAddress,
-    setUnauthorizedJwtFingerprintByAddress,
-  ] = useState<
-    Readonly<Record<string, string>>
-  >({});
+  const [terminalJwtFingerprintByAccount, setTerminalJwtFingerprintByAccount] =
+    useState<Readonly<Record<string, string>>>({});
   const pollableAccounts = useMemo(
     () =>
       accounts.filter((account) => {
@@ -145,11 +152,11 @@ export function useConnectedAccountsUnreadNotifications(
         }
 
         return (
-          unauthorizedJwtFingerprintByAddress[toAddressKey(account.address)] !==
+          terminalJwtFingerprintByAccount[toAccountAuthKey(account.address)] !==
           getAuthTokenFingerprint(jwt)
         );
       }),
-    [accounts, unauthorizedJwtFingerprintByAddress]
+    [accounts, terminalJwtFingerprintByAccount]
   );
   const queryKey = [
     QueryKey.CONNECTED_ACCOUNT_UNREAD_NOTIFICATIONS,
@@ -171,9 +178,10 @@ export function useConnectedAccountsUnreadNotifications(
         pollableAccounts.map((account) => fetchUnreadCountForAccount(account))
       );
       const nextCounts: Record<string, number> = {};
-      const unauthorizedFailures: {
-        readonly addressKey: string;
+      const terminalAuthFailures: {
+        readonly accountAuthKey: string;
         readonly jwtFingerprint: string;
+        readonly status: number;
         readonly error: unknown;
       }[] = [];
 
@@ -194,22 +202,27 @@ export function useConnectedAccountsUnreadNotifications(
           return;
         }
 
-        if (account.jwt && isUnauthorizedQueryError(result.reason)) {
-          const nestedUnauthorizedFailures =
-            getUnauthorizedFailuresFromError(result.reason);
-          if (nestedUnauthorizedFailures.length > 0) {
-            nestedUnauthorizedFailures.forEach((failure) => {
-              unauthorizedFailures.push({
+        if (
+          account.jwt &&
+          isTerminalNotificationAuthQueryError(result.reason)
+        ) {
+          const nestedTerminalAuthFailures =
+            getTerminalAuthFailuresFromError(result.reason);
+          if (nestedTerminalAuthFailures.length > 0) {
+            nestedTerminalAuthFailures.forEach((failure) => {
+              terminalAuthFailures.push({
                 ...failure,
+                status: getQueryErrorStatus(result.reason) ?? 401,
                 error: result.reason,
               });
             });
             return;
           }
 
-          unauthorizedFailures.push({
-            addressKey,
+          terminalAuthFailures.push({
+            accountAuthKey: toAccountAuthKey(account.address),
             jwtFingerprint: getAuthTokenFingerprint(account.jwt),
+            status: getQueryErrorStatus(result.reason) ?? 401,
             error: result.reason,
           });
           return;
@@ -221,14 +234,15 @@ export function useConnectedAccountsUnreadNotifications(
         }
       });
 
-      const firstUnauthorizedFailure = unauthorizedFailures[0];
-      if (firstUnauthorizedFailure) {
-        throw createConnectedAccountAuthPollingError(
-          unauthorizedFailures.map(({ addressKey, jwtFingerprint }) => ({
-            addressKey,
+      const firstTerminalAuthFailure = terminalAuthFailures[0];
+      if (firstTerminalAuthFailure) {
+        throw createConnectedAccountTerminalAuthPollingError(
+          terminalAuthFailures.map(({ accountAuthKey, jwtFingerprint }) => ({
+            accountAuthKey,
             jwtFingerprint,
           })),
-          firstUnauthorizedFailure.error
+          firstTerminalAuthFailure.status,
+          firstTerminalAuthFailure.error
         );
       }
 
@@ -241,19 +255,22 @@ export function useConnectedAccountsUnreadNotifications(
     refetchOnReconnect: true,
     refetchIntervalInBackground: !isCapacitor,
     retry: (failureCount: number, error: unknown) => {
-      const unauthorizedFailures = getUnauthorizedFailuresFromError(error);
-      if (unauthorizedFailures.length > 0) {
-        setUnauthorizedJwtFingerprintByAddress((previous) => {
+      const terminalAuthFailures = getTerminalAuthFailuresFromError(error);
+      if (terminalAuthFailures.length > 0) {
+        setTerminalJwtFingerprintByAccount((previous) => {
           let didChange = false;
           const next = { ...previous };
-          for (const failure of unauthorizedFailures) {
-            if (next[failure.addressKey] !== failure.jwtFingerprint) {
-              next[failure.addressKey] = failure.jwtFingerprint;
+          for (const failure of terminalAuthFailures) {
+            if (next[failure.accountAuthKey] !== failure.jwtFingerprint) {
+              next[failure.accountAuthKey] = failure.jwtFingerprint;
               didChange = true;
             }
           }
           return didChange ? next : previous;
         });
+        return false;
+      }
+      if (isTerminalNotificationAuthQueryError(error)) {
         return false;
       }
       if (shouldStopPollingRetry(error)) {

--- a/hooks/useConnectedAccountsUnreadNotifications.ts
+++ b/hooks/useConnectedAccountsUnreadNotifications.ts
@@ -53,6 +53,7 @@ const createConnectedAccountTerminalAuthPollingError = (
     value: true,
     enumerable: true,
   });
+  // Keep account/token fingerprints away from generic error serializers.
   Object.defineProperty(error, "terminalAuthFailures", {
     value: terminalAuthFailures,
     enumerable: false,

--- a/hooks/useUnreadNotifications.ts
+++ b/hooks/useUnreadNotifications.ts
@@ -53,14 +53,15 @@ export function useUnreadNotifications(
       },
     ],
     queryFn: async () => {
-      if (!authJwt || !isAuthJwtUsable(authJwt) || getAuthJwt() !== authJwt) {
+      const requestAuthJwt = getAuthJwt();
+      if (!requestAuthJwt || !isAuthJwtUsable(requestAuthJwt)) {
         throw createMissingAuthPollingError();
       }
 
       return await commonApiFetch<ApiNotificationsResponseV2>({
         endpoint: `v2/notifications`,
         headers: {
-          Authorization: `Bearer ${authJwt}`,
+          Authorization: `Bearer ${requestAuthJwt}`,
         },
         params: {
           limit: "1",

--- a/hooks/useUnreadNotifications.ts
+++ b/hooks/useUnreadNotifications.ts
@@ -1,13 +1,12 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
 import type { ApiNotificationsResponseV2 } from "@/generated/models/ApiNotificationsResponseV2";
 import { commonApiFetch } from "@/services/api/common-api";
 import useCapacitor from "./useCapacitor";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
 import {
-  isUnauthorizedQueryError,
+  isTerminalNotificationAuthQueryError,
   shouldStopPollingRetry,
 } from "@/components/react-query-wrapper/utils/query-utils";
 import { getAuthJwt, isAuthJwtUsable } from "@/services/auth/auth.utils";
@@ -17,47 +16,19 @@ interface UseUnreadNotificationsOptions {
   readonly enabled?: boolean | undefined;
 }
 
-type AuthPollingError = Error & {
+type MissingAuthPollingError = Error & {
   readonly status: 401;
-  readonly authPollingKey: string;
-  readonly cause?: unknown;
 };
 
-const createAuthPollingError = (
-  authPollingKey: string,
-  cause?: unknown
-): AuthPollingError => {
+const createMissingAuthPollingError = (): MissingAuthPollingError => {
   const error = new Error(
     "Unread notification polling requires valid auth"
-  ) as AuthPollingError;
+  ) as MissingAuthPollingError;
   Object.defineProperty(error, "status", {
     value: 401,
     enumerable: true,
   });
-  Object.defineProperty(error, "authPollingKey", {
-    value: authPollingKey,
-    enumerable: true,
-  });
-  if (cause !== undefined) {
-    Object.defineProperty(error, "cause", {
-      value: cause,
-      enumerable: false,
-    });
-  }
   return error;
-};
-
-const getAuthPollingKeyFromError = (error: unknown): string | null => {
-  if (!isUnauthorizedQueryError(error)) {
-    return null;
-  }
-  if (typeof error !== "object" || error === null) {
-    return null;
-  }
-
-  const authPollingKey = (error as { readonly authPollingKey?: unknown })
-    .authPollingKey;
-  return typeof authPollingKey === "string" ? authPollingKey : null;
 };
 
 export function useUnreadNotifications(
@@ -67,54 +38,48 @@ export function useUnreadNotifications(
   const { isCapacitor } = useCapacitor();
   const authJwt = getAuthJwt();
   const hasUsableAuthJwt = isAuthJwtUsable(authJwt);
-  const authPollingKey = `${handle ?? ""}:${getAuthTokenFingerprint(authJwt)}`;
-  const [blockedAuthPollingKey, setBlockedAuthPollingKey] = useState<
-    string | null
-  >(null);
-  const isAuthPollingBlocked = blockedAuthPollingKey === authPollingKey;
+  const authFingerprint = getAuthTokenFingerprint(authJwt);
   const isEnabled =
-    !!handle &&
-    options.enabled !== false &&
-    hasUsableAuthJwt &&
-    !isAuthPollingBlocked;
+    !!handle && options.enabled !== false && hasUsableAuthJwt;
 
-  const { data: notifications } = useQuery<ApiNotificationsResponseV2>({
+  const { data: notifications, error } = useQuery<ApiNotificationsResponseV2>({
     queryKey: [
       QueryKey.IDENTITY_NOTIFICATIONS,
-      { identity: handle, limit: "1", version: "v2" },
+      {
+        auth: authFingerprint,
+        identity: handle,
+        limit: "1",
+        version: "v2",
+      },
     ],
     queryFn: async () => {
-      if (!isAuthJwtUsable(getAuthJwt())) {
-        throw createAuthPollingError(authPollingKey);
+      if (!authJwt || !isAuthJwtUsable(authJwt) || getAuthJwt() !== authJwt) {
+        throw createMissingAuthPollingError();
       }
 
-      try {
-        return await commonApiFetch<ApiNotificationsResponseV2>({
-          endpoint: `v2/notifications`,
-          params: {
-            limit: "1",
-          },
-          errorMode: "structured",
-        });
-      } catch (error) {
-        if (isUnauthorizedQueryError(error)) {
-          throw createAuthPollingError(authPollingKey, error);
-        }
-        throw error;
-      }
+      return await commonApiFetch<ApiNotificationsResponseV2>({
+        endpoint: `v2/notifications`,
+        headers: {
+          Authorization: `Bearer ${authJwt}`,
+        },
+        params: {
+          limit: "1",
+        },
+        errorMode: "structured",
+      });
     },
     enabled: isEnabled,
-    refetchInterval: 30000,
-    refetchOnWindowFocus: true,
-    refetchOnMount: true,
-    refetchOnReconnect: true,
+    refetchInterval: (query) =>
+      isTerminalNotificationAuthQueryError(query.state.error) ? false : 30000,
+    refetchOnWindowFocus: (query) =>
+      !isTerminalNotificationAuthQueryError(query.state.error),
+    refetchOnMount: (query) =>
+      !isTerminalNotificationAuthQueryError(query.state.error),
+    refetchOnReconnect: (query) =>
+      !isTerminalNotificationAuthQueryError(query.state.error),
     refetchIntervalInBackground: !isCapacitor,
     retry: (failureCount: number, error: unknown) => {
-      const blockedKey = getAuthPollingKeyFromError(error);
-      if (blockedKey) {
-        setBlockedAuthPollingKey((previous) =>
-          previous === blockedKey ? previous : blockedKey
-        );
+      if (isTerminalNotificationAuthQueryError(error)) {
         return false;
       }
       if (shouldStopPollingRetry(error)) {
@@ -128,7 +93,9 @@ export function useUnreadNotifications(
     },
   });
 
-  const effectiveNotifications = isEnabled ? notifications : undefined;
+  const isTerminalAuthError = isTerminalNotificationAuthQueryError(error);
+  const effectiveNotifications =
+    isEnabled && !isTerminalAuthError ? notifications : undefined;
   const haveUnreadNotifications =
     (effectiveNotifications?.unread_count ?? 0) > 0;
 

--- a/ops/docs/developer/product-impact-mixpanel-runbook.md
+++ b/ops/docs/developer/product-impact-mixpanel-runbook.md
@@ -145,3 +145,6 @@ After deployment and real traffic:
    Sentry for `wave_feed_load_failed`,
    `auth_session_refresh_product_impact`, and related product-impact logger
    entries.
+7. Confirm `auth_session_refresh_product_impact` records one copy of each
+   condition per account session, then records it again only after that session
+   recovers or materially changes.

--- a/ops/telemetry/registry.json
+++ b/ops/telemetry/registry.json
@@ -130,7 +130,7 @@
       "owner": "mixpanel",
       "producer": "services/analytics/productImpactTelemetry.ts",
       "destinations": ["mixpanel:owner", "sentry:diagnostic"],
-      "sampling": "Sentry log transport plus consented production Mixpanel sessions",
+      "sampling": "One event per auth condition and account session until recovery, sent to Sentry plus consented production Mixpanel sessions",
       "privacy": "auth outcome, client type, route family, endpoint family, and booleans only",
       "externalUsage": "repo Mixpanel runbook; live dashboard unverified",
       "lifecycle": "keep",

--- a/services/analytics/productImpactTelemetry.ts
+++ b/services/analytics/productImpactTelemetry.ts
@@ -78,6 +78,8 @@ interface AuthRefreshTelemetryBase {
 }
 
 interface AuthRefreshImpactTelemetry extends AuthRefreshTelemetryBase {
+  /** Internal-only scope used to suppress repeat logs for one auth session. */
+  readonly dedupeScope?: string | undefined;
   readonly outcome:
     | "failed_without_prompt"
     | "logout_required"
@@ -87,6 +89,8 @@ interface AuthRefreshImpactTelemetry extends AuthRefreshTelemetryBase {
 }
 
 const TELEMETRY_VERSION = 1;
+const DEFAULT_AUTH_REFRESH_IMPACT_DEDUPE_SCOPE = "default";
+const authRefreshImpactDedupeKeysByScope = new Map<string, Set<string>>();
 
 const ABORT_ERROR_MESSAGES = [
   "aborterror",
@@ -389,6 +393,47 @@ function logProductImpactEvent(
   }
 }
 
+const getAuthRefreshImpactDedupeScope = (
+  dedupeScope: string | undefined
+): string => dedupeScope ?? DEFAULT_AUTH_REFRESH_IMPACT_DEDUPE_SCOPE;
+
+const getAuthRefreshImpactDedupeKey = (
+  telemetry: AuthRefreshImpactTelemetry
+): string =>
+  [
+    telemetry.clientType,
+    telemetry.hadLocalJwt,
+    telemetry.outcome,
+    telemetry.refreshOutcome,
+    telemetry.requiresReauth,
+  ].join(":");
+
+const shouldTrackAuthRefreshImpact = (
+  telemetry: AuthRefreshImpactTelemetry
+): boolean => {
+  const scope = getAuthRefreshImpactDedupeScope(telemetry.dedupeScope);
+  const dedupeKey = getAuthRefreshImpactDedupeKey(telemetry);
+  const existingKeys = authRefreshImpactDedupeKeysByScope.get(scope);
+  if (existingKeys?.has(dedupeKey)) {
+    return false;
+  }
+
+  if (existingKeys) {
+    existingKeys.add(dedupeKey);
+  } else {
+    authRefreshImpactDedupeKeysByScope.set(scope, new Set([dedupeKey]));
+  }
+  return true;
+};
+
+export function resetAuthSessionRefreshProductImpactDedupe(
+  dedupeScope?: string
+): void {
+  authRefreshImpactDedupeKeysByScope.delete(
+    getAuthRefreshImpactDedupeScope(dedupeScope)
+  );
+}
+
 function getWaveBaseProperties(
   telemetry: WaveFeedTelemetryBase
 ): ProductImpactProperties {
@@ -501,6 +546,10 @@ export function trackAuthSessionRefreshSucceeded(
 export function trackAuthSessionRefreshProductImpact(
   telemetry: AuthRefreshImpactTelemetry
 ): void {
+  if (!shouldTrackAuthRefreshImpact(telemetry)) {
+    return;
+  }
+
   logProductImpactEvent(
     "Auth Session Refresh Product Impact",
     {


### PR DESCRIPTION
## Issue

Authenticated notification polling could remain scheduled after a terminal 401, 403, or explicit session-upgrade response. Repeated same-session auth validation could also repeat terminal transition work and emit duplicate product-impact telemetry.

## Fix

- Stop active-account notification retries and timer/lifecycle refetches from shared React Query error state for the exact auth session.
- Isolate connected-account terminal failures by account and token so unaffected accounts continue polling.
- Allow polling and auth validation to recover only after a material token, account, profile, or session change.
- Deduplicate auth session refresh product-impact events per low-cardinality condition and material session until recovery.
- Preserve transient network and 5xx retries and the existing notification cache/invalidation path.

## Notable changes

- Added notification-specific terminal auth classification without changing the global authorization retry policy.
- Added a material-session guard around logout, reset, and session-upgrade transitions.
- Kept auth and account identifiers internal as fingerprints; telemetry payloads remain low-cardinality.
- Updated the telemetry registry and post-release verification runbook.
- Integrated the notification fan-out reduction from main, with no merge conflicts.

## Validation

- Focused notification, auth, telemetry, and auth-service suites: 11 suites, 211 tests passed.
- Notification integration: 7 suites, 103 tests passed, including the fan-out wrapper regression, terminal and transient polling, silent token rotation, re-login recovery, account isolation, auth transitions, and telemetry deduplication.
- Changed-file lint passed.
- Changed-file typecheck passed.
- React Doctor: 97/100; only pre-existing Auth provider structural warnings.
- Debt ratchet passed at the 38-file baseline.
- Diff whitespace check passed.

## Risk

Moderate and scoped to authenticated notification polling and immediate auth validation. Terminal handling is limited to notification 401/403 responses and explicitly marked session-upgrade 4xx responses. Transient network and 5xx behavior is unchanged.

## Review notes

Please focus on shared-observer timer shutdown, connected-account isolation, material-session recovery, and telemetry deduplication/reset behavior. No UI, dependency, backend, deployment, or production configuration changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unread-notification polling to treat terminal authentication errors (including session-upgrade-required cases) as non-retriable, stopping polling promptly while resuming after recovery.
  * Added more precise retry behavior for transient failures (e.g., 503) while preserving cached unread counts.
  * Ensured token changes and per-account recovery correctly restart polling without duplicate validation or analytics events.
  * Updated auth session refresh product-impact telemetry to deduplicate by scope and allow dedupe reset after recovery.
* **Documentation**
  * Clarified expected auth session refresh product-impact telemetry frequency and runbook verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

