### PR TITLE
Fix wave tab title navigation

### DIFF
--- a/__tests__/components/dynamic-head/DynamicHeadTitle.test.tsx
+++ b/__tests__/components/dynamic-head/DynamicHeadTitle.test.tsx
@@ -144,10 +144,10 @@ describe("DynamicHeadTitle", () => {
 
     // Leaving a wave without a pathname change: no metadata commit fires,
     // so the context's route-default reset must reach document.title.
-    mockTitle = "Messages | Brain";
+    mockTitle = "Messages";
     mockIsTitleOwned = false;
     view.rerender(<DynamicHeadTitle />);
-    expect(document.title).toBe("Messages | Brain");
+    expect(document.title).toBe("Messages");
 
     // But it is not sticky: a later external write stands.
     document.title = "External";

--- a/__tests__/components/dynamic-head/DynamicHeadTitle.test.tsx
+++ b/__tests__/components/dynamic-head/DynamicHeadTitle.test.tsx
@@ -137,17 +137,17 @@ describe("DynamicHeadTitle", () => {
     mockIsTitleOwned = true;
     mockTitlePathname = "/messages";
     mockPathname = "/messages";
-    document.title = "Messages";
+    document.title = "Messages | Brain";
 
     const view = render(<DynamicHeadTitle />);
     expect(document.title).toBe("Wave One | Brain");
 
     // Leaving a wave without a pathname change: no metadata commit fires,
     // so the context's route-default reset must reach document.title.
-    mockTitle = "Messages";
+    mockTitle = "Messages | Brain";
     mockIsTitleOwned = false;
     view.rerender(<DynamicHeadTitle />);
-    expect(document.title).toBe("Messages");
+    expect(document.title).toBe("Messages | Brain");
 
     // But it is not sticky: a later external write stands.
     document.title = "External";
@@ -194,7 +194,7 @@ describe("DynamicHeadTitle", () => {
     mockIsTitleOwned = true;
     mockTitlePathname = "/messages";
     mockPathname = "/messages";
-    document.title = "Messages";
+    document.title = "Messages | Brain";
 
     render(<DynamicHeadTitle />);
     expect(document.title).toBe("Wave One | Brain");

--- a/__tests__/contexts/TitleContext.locale.test.tsx
+++ b/__tests__/contexts/TitleContext.locale.test.tsx
@@ -1,0 +1,105 @@
+import { TitleProvider, useSetTitle, useTitle } from "@/contexts/TitleContext";
+import type { SupportedLocale } from "@/i18n/locales";
+import { act, render, screen, waitFor } from "@testing-library/react";
+
+let mockLocale: SupportedLocale = "en-US";
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/network",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+jest.mock("@/contexts/wave/MyStreamContext", () => ({
+  useMyStreamOptional: () => null,
+}));
+
+jest.mock("@/hooks/useBrowserLocale", () => ({
+  useBrowserLocale: () => mockLocale,
+}));
+
+jest.mock("@/i18n/messages", () => {
+  const actual =
+    jest.requireActual<typeof import("@/i18n/messages")>("@/i18n/messages");
+
+  return {
+    ...actual,
+    t: (
+      locale: SupportedLocale,
+      key: Parameters<typeof actual.t>[1],
+      params?: Parameters<typeof actual.t>[2]
+    ) =>
+      key === "titleContext.routes.network"
+        ? `${locale} Network`
+        : actual.t(locale, key, params),
+  };
+});
+
+function TitleReporter() {
+  const { title } = useTitle();
+  return <span data-testid="title">{title}</span>;
+}
+
+function ExplicitTitle() {
+  useSetTitle("Custom Network Title");
+  return null;
+}
+
+describe("TitleProvider locale changes", () => {
+  beforeEach(() => {
+    mockLocale = "en-US";
+  });
+
+  it("recomputes a route-default title when the browser locale changes", async () => {
+    const view = render(
+      <TitleProvider>
+        <TitleReporter />
+      </TitleProvider>
+    );
+
+    expect(screen.getByTestId("title")).toHaveTextContent("en-US Network");
+
+    act(() => {
+      mockLocale = "de-DE";
+    });
+    view.rerender(
+      <TitleProvider>
+        <TitleReporter />
+      </TitleProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("title")).toHaveTextContent("de-DE Network")
+    );
+  });
+
+  it("preserves an explicitly owned title when the locale changes", async () => {
+    const view = render(
+      <TitleProvider>
+        <ExplicitTitle />
+        <TitleReporter />
+      </TitleProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("title")).toHaveTextContent(
+        "Custom Network Title"
+      )
+    );
+
+    act(() => {
+      mockLocale = "de-DE";
+    });
+    view.rerender(
+      <TitleProvider>
+        <ExplicitTitle />
+        <TitleReporter />
+      </TitleProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("title")).toHaveTextContent(
+        "Custom Network Title"
+      )
+    );
+  });
+});

--- a/__tests__/contexts/TitleContext.ownership.test.tsx
+++ b/__tests__/contexts/TitleContext.ownership.test.tsx
@@ -42,8 +42,8 @@ function ExplicitTitleSetter({ pageTitle }: { readonly pageTitle: string }) {
   return null;
 }
 
-function WaveDataSetter() {
-  useSetWaveData({ name: "Wave One", newItemsCount: 0 });
+function WaveDataSetter({ waveId = "wave-1" }: { readonly waveId?: string }) {
+  useSetWaveData({ id: waveId, name: "Wave One", newItemsCount: 0 });
   return null;
 }
 
@@ -119,9 +119,7 @@ describe("TitleProvider ownership", () => {
       </TitleProvider>
     );
     expect(screen.getByTestId("owned").textContent).toBe("true");
-    expect(screen.getByTestId("title").textContent).toBe(
-      "Downloads | Network"
-    );
+    expect(screen.getByTestId("title").textContent).toBe("Downloads | Network");
     expect(screen.getByTestId("title-pathname").textContent).toBe("/network");
   });
 
@@ -135,6 +133,55 @@ describe("TitleProvider ownership", () => {
         <TitleReporter />
       </TitleProvider>
     );
+    expect(screen.getByTestId("owned").textContent).toBe("true");
+    expect(screen.getByTestId("title").textContent).toBe("Wave One | Brain");
+  });
+
+  it("does not let stale wave data own the waves index after navigation", () => {
+    mockNavigation.pathname = "/waves/wave-1";
+
+    const view = render(
+      <TitleProvider>
+        <WaveDataSetter />
+        <TitleReporter />
+      </TitleProvider>
+    );
+    expect(screen.getByTestId("owned").textContent).toBe("true");
+
+    act(() => {
+      mockNavigation.pathname = "/waves";
+    });
+    view.rerender(
+      <TitleProvider>
+        <WaveDataSetter />
+        <TitleReporter />
+      </TitleProvider>
+    );
+
+    expect(screen.getByTestId("owned").textContent).toBe("false");
+    expect(screen.getByTestId("title").textContent).toBe("Waves | Brain");
+  });
+
+  it("only lets data for the URL wave own a wave route title", () => {
+    mockNavigation.pathname = "/waves/wave-2";
+
+    const view = render(
+      <TitleProvider>
+        <WaveDataSetter waveId="wave-1" />
+        <TitleReporter />
+      </TitleProvider>
+    );
+
+    expect(screen.getByTestId("owned").textContent).toBe("false");
+    expect(screen.getByTestId("title").textContent).toBe("Waves | Brain");
+
+    view.rerender(
+      <TitleProvider>
+        <WaveDataSetter waveId="wave-2" />
+        <TitleReporter />
+      </TitleProvider>
+    );
+
     expect(screen.getByTestId("owned").textContent).toBe("true");
     expect(screen.getByTestId("title").textContent).toBe("Wave One | Brain");
   });

--- a/__tests__/contexts/TitleContext.ownership.test.tsx
+++ b/__tests__/contexts/TitleContext.ownership.test.tsx
@@ -34,6 +34,7 @@ import {
   useSetWaveData,
   useTitle,
 } from "@/contexts/TitleContext";
+import { isTitleUpdateCurrent } from "@/contexts/title.helpers";
 
 function TitleReporter() {
   const { title, isTitleOwned, titlePathname } = useTitle();
@@ -69,6 +70,12 @@ describe("TitleProvider ownership", () => {
     mockNavigation.pathname = "/open-data/network-metrics";
     mockNavigation.searchParams = new URLSearchParams();
     mockActiveWaveId = null;
+  });
+
+  it("allows the current title route to claim while the route ref catches up", () => {
+    expect(isTitleUpdateCurrent("/previous", "/network", "/network")).toBe(
+      true
+    );
   });
 
   it("route defaults are not owned; explicit titles are", () => {

--- a/__tests__/contexts/TitleContext.ownership.test.tsx
+++ b/__tests__/contexts/TitleContext.ownership.test.tsx
@@ -5,6 +5,7 @@ const mockNavigation = {
   pathname: "/open-data/network-metrics",
   searchParams: new URLSearchParams(),
 };
+let mockActiveWaveId: string | null = null;
 
 jest.mock("next/navigation", () => ({
   usePathname: () => mockNavigation.pathname,
@@ -12,7 +13,15 @@ jest.mock("next/navigation", () => ({
 }));
 
 jest.mock("@/contexts/wave/MyStreamContext", () => ({
-  useMyStreamOptional: () => null,
+  useMyStreamOptional: () =>
+    mockActiveWaveId
+      ? {
+          activeWave: {
+            id: mockActiveWaveId,
+            set: jest.fn(),
+          },
+        }
+      : null,
 }));
 
 jest.mock("@/config/env", () => ({
@@ -42,8 +51,16 @@ function ExplicitTitleSetter({ pageTitle }: { readonly pageTitle: string }) {
   return null;
 }
 
-function WaveDataSetter({ waveId = "wave-1" }: { readonly waveId?: string }) {
-  useSetWaveData({ id: waveId, name: "Wave One", newItemsCount: 0 });
+function WaveDataSetter({
+  waveId = "wave-1",
+  newItemsCount = 0,
+}: {
+  readonly waveId?: string | null;
+  readonly newItemsCount?: number;
+}) {
+  useSetWaveData(
+    waveId ? { id: waveId, name: "Wave One", newItemsCount } : null
+  );
   return null;
 }
 
@@ -51,6 +68,7 @@ describe("TitleProvider ownership", () => {
   beforeEach(() => {
     mockNavigation.pathname = "/open-data/network-metrics";
     mockNavigation.searchParams = new URLSearchParams();
+    mockActiveWaveId = null;
   });
 
   it("route defaults are not owned; explicit titles are", () => {
@@ -182,6 +200,54 @@ describe("TitleProvider ownership", () => {
       </TitleProvider>
     );
 
+    expect(screen.getByTestId("owned").textContent).toBe("true");
+    expect(screen.getByTestId("title").textContent).toBe("Wave One | Brain");
+  });
+
+  it("clears the previous wave title data while the destination is loading", () => {
+    mockNavigation.pathname = "/waves/wave-1";
+
+    const view = render(
+      <TitleProvider>
+        <WaveDataSetter newItemsCount={3} />
+        <TitleReporter />
+      </TitleProvider>
+    );
+    expect(screen.getByTestId("title").textContent).toBe(
+      "(3 new messages) Wave One | Brain"
+    );
+
+    view.rerender(
+      <TitleProvider>
+        <WaveDataSetter waveId={null} />
+        <TitleReporter />
+      </TitleProvider>
+    );
+
+    expect(screen.getByTestId("owned").textContent).toBe("false");
+    expect(screen.getByTestId("title").textContent).toBe("Waves | Brain");
+  });
+
+  it("matches wave data against the active-wave fallback on the root view", () => {
+    mockNavigation.pathname = "/";
+    mockNavigation.searchParams = new URLSearchParams("view=waves");
+    mockActiveWaveId = "wave-1";
+
+    const view = render(
+      <TitleProvider>
+        <WaveDataSetter waveId="wave-2" />
+        <TitleReporter />
+      </TitleProvider>
+    );
+    expect(screen.getByTestId("owned").textContent).toBe("false");
+    expect(screen.getByTestId("title").textContent).toBe("6529.io");
+
+    view.rerender(
+      <TitleProvider>
+        <WaveDataSetter waveId="wave-1" />
+        <TitleReporter />
+      </TitleProvider>
+    );
     expect(screen.getByTestId("owned").textContent).toBe("true");
     expect(screen.getByTestId("title").textContent).toBe("Wave One | Brain");
   });

--- a/__tests__/contexts/TitleContext.test.tsx
+++ b/__tests__/contexts/TitleContext.test.tsx
@@ -30,7 +30,11 @@ jest.mock("@/contexts/wave/MyStreamContext", () => ({
 function TitleHarness({
   waveData,
 }: {
-  readonly waveData: { name: string; newItemsCount: number } | null;
+  readonly waveData: {
+    id: string;
+    name: string;
+    newItemsCount: number;
+  } | null;
 }) {
   useSetWaveData(waveData);
   const { title } = useTitle();
@@ -50,7 +54,11 @@ describe("TitleContext", () => {
       <TitleProvider>
         <DynamicHeadTitle />
         <TitleHarness
-          waveData={{ name: "6529 Dev Daily Standup", newItemsCount: 0 }}
+          waveData={{
+            id: "wave-1",
+            name: "6529 Dev Daily Standup",
+            newItemsCount: 0,
+          }}
         />
       </TitleProvider>
     );
@@ -95,7 +103,9 @@ describe("TitleContext", () => {
     const view = render(
       <TitleProvider>
         <DynamicHeadTitle />
-        <TitleHarness waveData={{ name: "Wave One", newItemsCount: 0 }} />
+        <TitleHarness
+          waveData={{ id: "wave-1", name: "Wave One", newItemsCount: 0 }}
+        />
       </TitleProvider>
     );
 
@@ -122,6 +132,35 @@ describe("TitleContext", () => {
     await waitFor(() => {
       expect(document.title).toBe("Messages | Brain");
     });
+  });
+
+  it("preserves freshly loaded title data when the wave route changes", async () => {
+    mockPathname = "/waves/wave-1";
+
+    const view = render(
+      <TitleProvider>
+        <DynamicHeadTitle />
+        <TitleHarness
+          waveData={{ id: "wave-1", name: "Wave One", newItemsCount: 0 }}
+        />
+      </TitleProvider>
+    );
+
+    await waitFor(() => expect(document.title).toBe("Wave One | Brain"));
+
+    mockPathname = "/waves/wave-2";
+    mockActiveWaveId = "wave-2";
+
+    view.rerender(
+      <TitleProvider>
+        <DynamicHeadTitle />
+        <TitleHarness
+          waveData={{ id: "wave-2", name: "Wave Two", newItemsCount: 0 }}
+        />
+      </TitleProvider>
+    );
+
+    await waitFor(() => expect(document.title).toBe("Wave Two | Brain"));
   });
 
   it("uses the discovery route title instead of the profile fallback", async () => {
@@ -151,7 +190,9 @@ describe("TitleContext", () => {
     const view = render(
       <TitleProvider>
         <DynamicHeadTitle />
-        <TitleHarness waveData={{ name: "Wave One", newItemsCount: 0 }} />
+        <TitleHarness
+          waveData={{ id: "wave-1", name: "Wave One", newItemsCount: 0 }}
+        />
       </TitleProvider>
     );
 

--- a/__tests__/contexts/TitleContext.test.tsx
+++ b/__tests__/contexts/TitleContext.test.tsx
@@ -127,10 +127,10 @@ describe("TitleContext", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Messages | Brain")).toBeInTheDocument();
+      expect(screen.getByText("Messages")).toBeInTheDocument();
     });
     await waitFor(() => {
-      expect(document.title).toBe("Messages | Brain");
+      expect(document.title).toBe("Messages");
     });
   });
 
@@ -219,6 +219,35 @@ describe("TitleContext", () => {
     );
 
     await waitFor(() => expect(document.title).toBe("Waves | Brain"));
+  });
+
+  it("restores the messages index title when the selected DM is deselected", async () => {
+    mockPathname = "/messages/dm-1";
+    mockActiveWaveId = "dm-1";
+
+    const view = render(
+      <TitleProvider>
+        <DynamicHeadTitle />
+        <TitleHarness
+          waveData={{ id: "dm-1", name: "Alice", newItemsCount: 0 }}
+        />
+      </TitleProvider>
+    );
+
+    await waitFor(() => expect(document.title).toBe("Alice | Brain"));
+
+    mockPathname = "/messages";
+    mockSearchParams = new URLSearchParams();
+    mockActiveWaveId = null;
+
+    view.rerender(
+      <TitleProvider>
+        <DynamicHeadTitle />
+        <TitleHarness waveData={null} />
+      </TitleProvider>
+    );
+
+    await waitFor(() => expect(document.title).toBe("Messages"));
   });
 
   it("uses the discovery route title instead of the profile fallback", async () => {

--- a/__tests__/contexts/TitleContext.test.tsx
+++ b/__tests__/contexts/TitleContext.test.tsx
@@ -127,10 +127,10 @@ describe("TitleContext", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Messages")).toBeInTheDocument();
+      expect(screen.getByText("Messages | Brain")).toBeInTheDocument();
     });
     await waitFor(() => {
-      expect(document.title).toBe("Messages");
+      expect(document.title).toBe("Messages | Brain");
     });
   });
 
@@ -247,7 +247,7 @@ describe("TitleContext", () => {
       </TitleProvider>
     );
 
-    await waitFor(() => expect(document.title).toBe("Messages"));
+    await waitFor(() => expect(document.title).toBe("Messages | Brain"));
   });
 
   it("uses the discovery route title instead of the profile fallback", async () => {

--- a/__tests__/contexts/TitleContext.test.tsx
+++ b/__tests__/contexts/TitleContext.test.tsx
@@ -155,12 +155,38 @@ describe("TitleContext", () => {
       <TitleProvider>
         <DynamicHeadTitle />
         <TitleHarness
-          waveData={{ id: "wave-2", name: "Wave Two", newItemsCount: 0 }}
+          waveData={{ id: "wave-2", name: "Wave Two", newItemsCount: 2 }}
         />
       </TitleProvider>
     );
 
-    await waitFor(() => expect(document.title).toBe("Wave Two | Brain"));
+    await waitFor(() =>
+      expect(document.title).toBe("(2 new messages) Wave Two | Brain")
+    );
+  });
+
+  it("clears the owned wave title when wave data becomes unavailable", async () => {
+    const view = render(
+      <TitleProvider>
+        <DynamicHeadTitle />
+        <TitleHarness
+          waveData={{ id: "wave-1", name: "Wave One", newItemsCount: 4 }}
+        />
+      </TitleProvider>
+    );
+
+    await waitFor(() =>
+      expect(document.title).toBe("(4 new messages) Wave One | Brain")
+    );
+
+    view.rerender(
+      <TitleProvider>
+        <DynamicHeadTitle />
+        <TitleHarness waveData={null} />
+      </TitleProvider>
+    );
+
+    await waitFor(() => expect(document.title).toBe("Waves | Brain"));
   });
 
   it("uses the discovery route title instead of the profile fallback", async () => {

--- a/__tests__/contexts/TitleContext.test.tsx
+++ b/__tests__/contexts/TitleContext.test.tsx
@@ -189,6 +189,38 @@ describe("TitleContext", () => {
     await waitFor(() => expect(document.title).toBe("Waves | Brain"));
   });
 
+  it("restores the waves index title when the selected wave is deselected", async () => {
+    const view = render(
+      <TitleProvider>
+        <DynamicHeadTitle />
+        <TitleHarness
+          waveData={{
+            id: "wave-1",
+            name: "The Memes - Main Stage",
+            newItemsCount: 0,
+          }}
+        />
+      </TitleProvider>
+    );
+
+    await waitFor(() =>
+      expect(document.title).toBe("The Memes - Main Stage | Brain")
+    );
+
+    mockPathname = "/waves";
+    mockSearchParams = new URLSearchParams();
+    mockActiveWaveId = null;
+
+    view.rerender(
+      <TitleProvider>
+        <DynamicHeadTitle />
+        <TitleHarness waveData={null} />
+      </TitleProvider>
+    );
+
+    await waitFor(() => expect(document.title).toBe("Waves | Brain"));
+  });
+
   it("uses the discovery route title instead of the profile fallback", async () => {
     mockPathname = "/discover";
     mockSearchParams = new URLSearchParams();

--- a/__tests__/i18n/messages.test.ts
+++ b/__tests__/i18n/messages.test.ts
@@ -420,6 +420,36 @@ describe("frontend i18n helpers", () => {
     expect(formatTime("en-US", null)).toBe("");
   });
 
+  it("backs title-context copy with messages and locale-formatted counts", () => {
+    for (const locale of SUPPORTED_LOCALES) {
+      const count = formatInteger(locale, 1234);
+      expect(
+        t(locale, "titleContext.wave.newMessages.other", {
+          count,
+          waveName: "Wave One",
+        })
+      ).toBe(`(${count} new messages) Wave One | Brain`);
+      expect(
+        t(locale, "titleContext.notifications.other", {
+          count,
+          title: t(locale, "titleContext.routes.waves"),
+        })
+      ).toBe(`(${count} notifications) Waves | Brain`);
+    }
+    expect(
+      t("en-US", "titleContext.wave.newMessages.one", {
+        count: formatInteger("en-US", 1),
+        waveName: "Wave One",
+      })
+    ).toBe("(1 new message) Wave One | Brain");
+    expect(
+      t("en-US", "titleContext.notifications.one", {
+        count: formatInteger("en-US", 1),
+        title: "Waves | Brain",
+      })
+    ).toBe("(1 notification) Waves | Brain");
+  });
+
   it("translates the wave drop copy action messages", () => {
     expect(t("en-US", "waves.drop.actions.copyFailed")).toBe("Copy failed");
     expect(t("en-GB", "waves.drop.actions.copyFailed")).toBe("Copy failed");

--- a/__tests__/i18n/messages.test.ts
+++ b/__tests__/i18n/messages.test.ts
@@ -423,7 +423,9 @@ describe("frontend i18n helpers", () => {
   it("backs title-context copy with messages and locale-formatted counts", () => {
     for (const locale of SUPPORTED_LOCALES) {
       const count = formatInteger(locale, 1234);
-      expect(t(locale, "titleContext.routes.messages")).toBe("Messages");
+      expect(t(locale, "titleContext.routes.messages")).toBe(
+        "Messages | Brain"
+      );
       expect(
         t(locale, "titleContext.wave.newMessages.other", {
           count,

--- a/__tests__/i18n/messages.test.ts
+++ b/__tests__/i18n/messages.test.ts
@@ -423,6 +423,7 @@ describe("frontend i18n helpers", () => {
   it("backs title-context copy with messages and locale-formatted counts", () => {
     for (const locale of SUPPORTED_LOCALES) {
       const count = formatInteger(locale, 1234);
+      expect(t(locale, "titleContext.routes.messages")).toBe("Messages");
       expect(
         t(locale, "titleContext.wave.newMessages.other", {
           count,

--- a/components/brain/my-stream/MyStreamWaveContent.tsx
+++ b/components/brain/my-stream/MyStreamWaveContent.tsx
@@ -268,7 +268,7 @@ const MyStreamWaveContent: React.FC<MyStreamWaveProps> = ({ waveId }) => {
       wave?.id === waveId
         ? { id: wave.id, name: wave.name, newItemsCount: newDropsCount }
         : null,
-    [newDropsCount, wave, waveId]
+    [newDropsCount, wave?.id, wave?.name, waveId]
   );
   useSetWaveData(waveTitleData);
 

--- a/components/brain/my-stream/MyStreamWaveContent.tsx
+++ b/components/brain/my-stream/MyStreamWaveContent.tsx
@@ -263,9 +263,14 @@ const MyStreamWaveContent: React.FC<MyStreamWaveProps> = ({ waveId }) => {
   const newDropsCount = enhancedData.newDropsCount;
 
   // Update wave data in title context
-  useSetWaveData(
-    wave ? { id: wave.id, name: wave.name, newItemsCount: newDropsCount } : null
+  const waveTitleData = useMemo(
+    () =>
+      wave?.id === waveId
+        ? { id: wave.id, name: wave.name, newItemsCount: newDropsCount }
+        : null,
+    [newDropsCount, wave, waveId]
   );
+  useSetWaveData(waveTitleData);
 
   // Create a stable key for proper remounting
   const stableWaveKey = `wave-${waveId}`;

--- a/components/brain/my-stream/MyStreamWaveContent.tsx
+++ b/components/brain/my-stream/MyStreamWaveContent.tsx
@@ -264,7 +264,7 @@ const MyStreamWaveContent: React.FC<MyStreamWaveProps> = ({ waveId }) => {
 
   // Update wave data in title context
   useSetWaveData(
-    wave ? { name: wave.name, newItemsCount: newDropsCount } : null
+    wave ? { id: wave.id, name: wave.name, newItemsCount: newDropsCount } : null
   );
 
   // Create a stable key for proper remounting

--- a/components/dynamic-head/DynamicHeadTitle.tsx
+++ b/components/dynamic-head/DynamicHeadTitle.tsx
@@ -38,7 +38,17 @@ export default function DynamicHeadTitle() {
         previousObservation !== null &&
         previousObservation.pathname === pathname &&
         previousObservation.title !== normalizedTitle;
-      if (!normalizeDocumentTitle(document.title) || isSameRouteTransition) {
+      const isWaveDeselectionTransition =
+        isTitleForCurrentRoute &&
+        pathname === "/waves" &&
+        previousObservation !== null &&
+        previousObservation.pathname?.startsWith("/waves/") === true &&
+        previousObservation.title !== normalizedTitle;
+      if (
+        !normalizeDocumentTitle(document.title) ||
+        isSameRouteTransition ||
+        isWaveDeselectionTransition
+      ) {
         document.title = normalizedTitle;
       }
       return;

--- a/components/dynamic-head/DynamicHeadTitle.tsx
+++ b/components/dynamic-head/DynamicHeadTitle.tsx
@@ -39,9 +39,7 @@ export default function DynamicHeadTitle() {
         previousObservation !== null &&
         previousObservation.pathname === pathname &&
         previousObservation.title !== normalizedTitle;
-      const isStreamIndex = STREAM_INDEX_ROUTES.some(
-        (route) => pathname === route
-      );
+      const isStreamIndex = STREAM_INDEX_ROUTES.includes(pathname);
       const isStreamDeselectionTransition =
         isTitleForCurrentRoute &&
         isStreamIndex &&

--- a/components/dynamic-head/DynamicHeadTitle.tsx
+++ b/components/dynamic-head/DynamicHeadTitle.tsx
@@ -38,16 +38,17 @@ export default function DynamicHeadTitle() {
         previousObservation !== null &&
         previousObservation.pathname === pathname &&
         previousObservation.title !== normalizedTitle;
-      const isWaveDeselectionTransition =
+      const isStreamIndex = pathname === "/waves" || pathname === "/messages";
+      const isStreamDeselectionTransition =
         isTitleForCurrentRoute &&
-        pathname === "/waves" &&
+        isStreamIndex &&
         previousObservation !== null &&
-        previousObservation.pathname?.startsWith("/waves/") === true &&
+        previousObservation.pathname?.startsWith(`${pathname}/`) === true &&
         previousObservation.title !== normalizedTitle;
       if (
         !normalizeDocumentTitle(document.title) ||
         isSameRouteTransition ||
-        isWaveDeselectionTransition
+        isStreamDeselectionTransition
       ) {
         document.title = normalizedTitle;
       }

--- a/components/dynamic-head/DynamicHeadTitle.tsx
+++ b/components/dynamic-head/DynamicHeadTitle.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { DEFAULT_TITLE, useTitle } from "@/contexts/TitleContext";
+import { STREAM_INDEX_ROUTES } from "@/contexts/title.helpers";
 import { usePathname } from "next/navigation";
 import { useEffect, useRef } from "react";
 
@@ -38,7 +39,9 @@ export default function DynamicHeadTitle() {
         previousObservation !== null &&
         previousObservation.pathname === pathname &&
         previousObservation.title !== normalizedTitle;
-      const isStreamIndex = pathname === "/waves" || pathname === "/messages";
+      const isStreamIndex = STREAM_INDEX_ROUTES.some(
+        (route) => pathname === route
+      );
       const isStreamDeselectionTransition =
         isTitleForCurrentRoute &&
         isStreamIndex &&

--- a/contexts/TitleContext.tsx
+++ b/contexts/TitleContext.tsx
@@ -26,7 +26,13 @@ type TitleContextType = {
   setTitle: (title: string) => void;
   notificationCount: number;
   setNotificationCount: (count: number) => void;
-  setWaveData: (data: { name: string; newItemsCount: number } | null) => void;
+  setWaveData: (data: WaveTitleData | null) => void;
+};
+
+type WaveTitleData = {
+  id: string;
+  name: string;
+  newItemsCount: number;
 };
 
 const TitleContext = createContext<TitleContextType | undefined>(undefined);
@@ -97,20 +103,17 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
     string | null
   >(null);
   const [notificationCount, setNotificationCount] = useState<number>(0);
-  const [waveData, setWaveData] = useState<{
-    name: string;
-    newItemsCount: number;
-  } | null>(null);
+  const [waveData, setWaveData] = useState<WaveTitleData | null>(null);
   const routeRef = useRef(pathname);
   const queryRef = useRef(searchParams);
   const isWaveRoute =
     pathname?.startsWith("/waves") ||
     pathname?.startsWith("/messages") ||
     (pathname === "/" && searchParams?.get("view") === "waves");
+  const waveInUrl = getActiveWaveIdFromUrl({ pathname, searchParams });
   const waveParam = isWaveRoute
-    ? (myStream?.activeWave.id ??
-      getActiveWaveIdFromUrl({ pathname, searchParams }) ??
-      null)
+    ? (waveInUrl ??
+      (pathname === "/" ? (myStream?.activeWave.id ?? null) : null))
     : null;
 
   useEffect(() => {
@@ -130,12 +133,16 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
       setTitle(getDefaultTitleForRoute(pathname));
       setTitlePathname(pathname);
       setExplicitTitlePathname(null);
-      setWaveData(null);
+      setWaveData((current) =>
+        current?.id === currentWaveInUrl ? current : null
+      );
       return;
     }
 
     if (!isWaveRoute) {
-      setWaveData(null);
+      setWaveData((current) =>
+        current?.id === currentWaveInUrl ? current : null
+      );
       return;
     }
 
@@ -146,7 +153,9 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
       setTitle(getDefaultTitleForRoute(pathname));
       setTitlePathname(pathname);
       setExplicitTitlePathname(null);
-      setWaveData(null);
+      setWaveData((current) =>
+        current?.id === currentWaveInUrl ? current : null
+      );
     }
   }, [pathname, searchParams]);
 
@@ -161,7 +170,7 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
   // Compute the title based on current state
   const computedTitle = useMemo(() => {
     const waveTitle = (() => {
-      if (!waveParam || !waveData) return null;
+      if (!waveParam || !waveData || waveData.id !== waveParam) return null;
       let newItemsText = "";
       if (waveData.newItemsCount > 0 && notificationCount === 0) {
         const messageText =
@@ -180,7 +189,7 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const isTitleOwned =
     (explicitTitlePathname !== null && explicitTitlePathname === pathname) ||
-    Boolean(isWaveRoute && waveParam && waveData);
+    Boolean(isWaveRoute && waveParam && waveData && waveData.id === waveParam);
 
   // Memoize the context value to prevent unnecessary re-renders
   const contextValue = useMemo(() => {
@@ -231,9 +240,7 @@ export const useSetTitle = (pageTitle: string) => {
 };
 
 // Hook to set wave data for title
-export const useSetWaveData = (
-  data: { name: string; newItemsCount: number } | null
-) => {
+export const useSetWaveData = (data: WaveTitleData | null) => {
   const { setWaveData } = useTitle();
 
   useEffect(() => {

--- a/contexts/TitleContext.tsx
+++ b/contexts/TitleContext.tsx
@@ -3,6 +3,7 @@
 import { usePathname, useSearchParams } from "next/navigation";
 import React, {
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -11,6 +12,10 @@ import React, {
 } from "react";
 import { publicEnv } from "@/config/env";
 import { getActiveWaveIdFromUrl } from "@/helpers/navigation.helpers";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import { formatInteger } from "@/i18n/format";
+import type { SupportedLocale } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import { useMyStreamOptional } from "./wave/MyStreamContext";
 
 type TitleContextType = {
@@ -41,23 +46,32 @@ export const DEFAULT_TITLE = publicEnv.BASE_ENDPOINT?.includes("staging")
   ? "6529 Staging"
   : "6529.io";
 
+const ROUTE_TITLE_KEYS = [
+  ["/waves", "titleContext.routes.waves"],
+  ["/notifications", "titleContext.routes.notifications"],
+  ["/messages", "titleContext.routes.messages"],
+  ["/meme-calendar", "titleContext.routes.memeCalendar"],
+  ["/the-memes", "titleContext.routes.theMemes"],
+  ["/meme-lab", "titleContext.routes.memeLab"],
+  ["/network", "titleContext.routes.network"],
+  ["/6529-gradient", "titleContext.routes.gradient"],
+  ["/nextgen", "titleContext.routes.nextGen"],
+  ["/rememes", "titleContext.routes.rememes"],
+  ["/open-data", "titleContext.routes.openData"],
+  ["/discover", "titleContext.routes.discovery"],
+] as const;
+
 // Default titles for routes
-const getDefaultTitleForRoute = (pathname: string | null): string => {
+const getDefaultTitleForRoute = (
+  pathname: string | null,
+  locale: SupportedLocale
+): string => {
   if (!pathname) return DEFAULT_TITLE;
   if (pathname === "/") return "6529.io";
-  if (pathname.startsWith("/waves")) return "Waves | Brain";
-  if (pathname.startsWith("/notifications")) return "Notifications | Brain";
-  if (pathname.startsWith("/messages")) return "Messages | Brain";
-  if (pathname.startsWith("/meme-calendar")) return "Memes Minting Calendar";
-  if (pathname.startsWith("/the-memes")) return "The Memes | Collections";
-  if (pathname.startsWith("/meme-lab")) return "Meme Lab | Collections";
-  if (pathname.startsWith("/network")) return "Network";
-  if (pathname.startsWith("/6529-gradient"))
-    return "6529 Gradient | Collections";
-  if (pathname.startsWith("/nextgen")) return "NextGen | Collections";
-  if (pathname.startsWith("/rememes")) return "Rememes | Collections";
-  if (pathname.startsWith("/open-data")) return "Open Data | Tools";
-  if (pathname.startsWith("/discover")) return "Discovery";
+  const routeTitle = ROUTE_TITLE_KEYS.find(([prefix]) =>
+    pathname.startsWith(prefix)
+  );
+  if (routeTitle) return t(locale, routeTitle[1]);
   // Handle profile pages (e.g., /username)
   if (pathname !== "/" && pathname.split("/").length === 2) {
     const segments = pathname.split("/");
@@ -80,7 +94,7 @@ const getDefaultTitleForRoute = (pathname: string | null): string => {
       "drop-forge",
     ];
     if (!knownRoutes.includes(firstSegment!)) {
-      return `Profile | 6529.io`;
+      return t(locale, "titleContext.routes.profile");
     }
   }
   return DEFAULT_TITLE;
@@ -92,8 +106,9 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
   const myStream = useMyStreamOptional();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const locale = useBrowserLocale();
   const [title, setTitle] = useState<string>(() =>
-    getDefaultTitleForRoute(pathname)
+    getDefaultTitleForRoute(pathname, locale)
   );
   // Pathname the current title text was computed for.
   const [titlePathname, setTitlePathname] = useState<string | null>(pathname);
@@ -111,16 +126,15 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
     pathname?.startsWith("/messages") ||
     (pathname === "/" && searchParams?.get("view") === "waves");
   const waveInUrl = getActiveWaveIdFromUrl({ pathname, searchParams });
-  const waveParam = isWaveRoute
-    ? (waveInUrl ??
-      (pathname === "/" ? (myStream?.activeWave.id ?? null) : null))
-    : null;
+  const fallbackActiveWaveId =
+    pathname === "/" ? (myStream?.activeWave.id ?? null) : null;
+  const waveParam = isWaveRoute ? (waveInUrl ?? fallbackActiveWaveId) : null;
 
   useEffect(() => {
     const previousPathname = routeRef.current;
     const previousSearchParams = queryRef.current;
     const pathnameChanged = previousPathname !== pathname;
-    const currentWaveInUrl = getActiveWaveIdFromUrl({ pathname, searchParams });
+    const currentWaveInUrl = waveInUrl;
     const previousWaveInUrl = getActiveWaveIdFromUrl({
       pathname: previousPathname,
       searchParams: previousSearchParams,
@@ -130,7 +144,7 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
     queryRef.current = searchParams;
 
     if (pathnameChanged) {
-      setTitle(getDefaultTitleForRoute(pathname));
+      setTitle(getDefaultTitleForRoute(pathname, locale));
       setTitlePathname(pathname);
       setExplicitTitlePathname(null);
       setWaveData((current) =>
@@ -150,34 +164,47 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
       previousWaveInUrl &&
       (!currentWaveInUrl || previousWaveInUrl !== currentWaveInUrl)
     ) {
-      setTitle(getDefaultTitleForRoute(pathname));
+      setTitle(getDefaultTitleForRoute(pathname, locale));
       setTitlePathname(pathname);
       setExplicitTitlePathname(null);
       setWaveData((current) =>
         current?.id === currentWaveInUrl ? current : null
       );
     }
-  }, [pathname, searchParams]);
+  }, [isWaveRoute, locale, pathname, searchParams, waveInUrl]);
 
-  const updateTitle = (newTitle: string) => {
-    if (routeRef.current === pathname) {
-      setTitle(newTitle);
-      setTitlePathname(pathname);
-      setExplicitTitlePathname(pathname);
-    }
-  };
+  const isTitleRouteCurrent = titlePathname === pathname;
+  const updateTitle = useCallback(
+    (newTitle: string) => {
+      if (routeRef.current === pathname || isTitleRouteCurrent) {
+        setTitle(newTitle);
+        setTitlePathname(pathname);
+        setExplicitTitlePathname(pathname);
+      }
+    },
+    [isTitleRouteCurrent, pathname]
+  );
 
   // Compute the title based on current state
   const computedTitle = useMemo(() => {
     const waveTitle = (() => {
-      if (!waveParam || !waveData || waveData.id !== waveParam) return null;
-      let newItemsText = "";
+      if (!waveParam || waveData?.id !== waveParam) return null;
       if (waveData.newItemsCount > 0 && notificationCount === 0) {
-        const messageText =
-          waveData.newItemsCount === 1 ? "message" : "messages";
-        newItemsText = `(${waveData.newItemsCount} new ${messageText}) `;
+        const pluralCategory = new Intl.PluralRules(locale).select(
+          waveData.newItemsCount
+        );
+        const messageKey =
+          pluralCategory === "one"
+            ? "titleContext.wave.newMessages.one"
+            : "titleContext.wave.newMessages.other";
+        return t(locale, messageKey, {
+          count: formatInteger(locale, waveData.newItemsCount),
+          waveName: waveData.name,
+        });
       }
-      return `${newItemsText}${waveData.name} | Brain`;
+      return t(locale, "titleContext.wave.default", {
+        waveName: waveData.name,
+      });
     })();
 
     if (isWaveRoute && waveTitle) {
@@ -185,23 +212,28 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
     }
 
     return title;
-  }, [isWaveRoute, waveParam, waveData, title, notificationCount]);
+  }, [isWaveRoute, locale, waveParam, waveData, title, notificationCount]);
 
   const isTitleOwned =
     (explicitTitlePathname !== null && explicitTitlePathname === pathname) ||
-    Boolean(isWaveRoute && waveParam && waveData && waveData.id === waveParam);
+    Boolean(isWaveRoute && waveParam && waveData?.id === waveParam);
 
   // Memoize the context value to prevent unnecessary re-renders
   const contextValue = useMemo(() => {
-    let notificationText = "";
-    if (notificationCount === 1) {
-      notificationText = "1 notification";
-    } else if (notificationCount > 1) {
-      notificationText = `${notificationCount} notifications`;
-    }
-    const finalTitle = notificationText
-      ? `(${notificationText}) ${computedTitle}`
-      : computedTitle;
+    const notificationPluralCategory = new Intl.PluralRules(locale).select(
+      notificationCount
+    );
+    const notificationKey =
+      notificationPluralCategory === "one"
+        ? "titleContext.notifications.one"
+        : "titleContext.notifications.other";
+    const finalTitle =
+      notificationCount > 0
+        ? t(locale, notificationKey, {
+            count: formatInteger(locale, notificationCount),
+            title: computedTitle,
+          })
+        : computedTitle;
     return {
       title: finalTitle,
       isTitleOwned,
@@ -211,7 +243,14 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
       setNotificationCount,
       setWaveData,
     };
-  }, [computedTitle, isTitleOwned, notificationCount, titlePathname]);
+  }, [
+    computedTitle,
+    isTitleOwned,
+    locale,
+    notificationCount,
+    titlePathname,
+    updateTitle,
+  ]);
 
   return (
     <TitleContext.Provider value={contextValue}>

--- a/contexts/TitleContext.tsx
+++ b/contexts/TitleContext.tsx
@@ -16,7 +16,7 @@ import { useBrowserLocale } from "@/hooks/useBrowserLocale";
 import { formatInteger } from "@/i18n/format";
 import type { SupportedLocale } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
-import { isTitleUpdateCurrent } from "./title.helpers";
+import { isTitleUpdateCurrent, STREAM_INDEX_ROUTES } from "./title.helpers";
 import { useMyStreamOptional } from "./wave/MyStreamContext";
 
 type TitleContextType = {
@@ -122,9 +122,9 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
   const [waveData, setWaveData] = useState<WaveTitleData | null>(null);
   const routeRef = useRef(pathname);
   const queryRef = useRef(searchParams);
+  const localeRef = useRef(locale);
   const isWaveRoute =
-    pathname?.startsWith("/waves") ||
-    pathname?.startsWith("/messages") ||
+    STREAM_INDEX_ROUTES.some((route) => pathname?.startsWith(route)) ||
     (pathname === "/" && searchParams?.get("view") === "waves");
   const waveInUrl = getActiveWaveIdFromUrl({ pathname, searchParams });
   const fallbackActiveWaveId =
@@ -134,7 +134,9 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
   useEffect(() => {
     const previousPathname = routeRef.current;
     const previousSearchParams = queryRef.current;
+    const previousLocale = localeRef.current;
     const pathnameChanged = previousPathname !== pathname;
+    const localeChanged = previousLocale !== locale;
     const currentWaveInUrl = waveInUrl;
     const previousWaveInUrl = getActiveWaveIdFromUrl({
       pathname: previousPathname,
@@ -143,6 +145,7 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
 
     routeRef.current = pathname;
     queryRef.current = searchParams;
+    localeRef.current = locale;
 
     if (pathnameChanged) {
       setTitle(getDefaultTitleForRoute(pathname, locale));
@@ -152,6 +155,14 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
         current?.id === currentWaveInUrl ? current : null
       );
       return;
+    }
+
+    if (
+      localeChanged &&
+      titlePathname === pathname &&
+      explicitTitlePathname !== pathname
+    ) {
+      setTitle(getDefaultTitleForRoute(pathname, locale));
     }
 
     if (!isWaveRoute) {
@@ -172,7 +183,15 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
         current?.id === currentWaveInUrl ? current : null
       );
     }
-  }, [isWaveRoute, locale, pathname, searchParams, waveInUrl]);
+  }, [
+    explicitTitlePathname,
+    isWaveRoute,
+    locale,
+    pathname,
+    searchParams,
+    titlePathname,
+    waveInUrl,
+  ]);
 
   const updateTitle = useCallback(
     (newTitle: string) => {

--- a/contexts/TitleContext.tsx
+++ b/contexts/TitleContext.tsx
@@ -16,6 +16,7 @@ import { useBrowserLocale } from "@/hooks/useBrowserLocale";
 import { formatInteger } from "@/i18n/format";
 import type { SupportedLocale } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
+import { isTitleUpdateCurrent } from "./title.helpers";
 import { useMyStreamOptional } from "./wave/MyStreamContext";
 
 type TitleContextType = {
@@ -67,7 +68,7 @@ const getDefaultTitleForRoute = (
   locale: SupportedLocale
 ): string => {
   if (!pathname) return DEFAULT_TITLE;
-  if (pathname === "/") return "6529.io";
+  if (pathname === "/") return DEFAULT_TITLE;
   const routeTitle = ROUTE_TITLE_KEYS.find(([prefix]) =>
     pathname.startsWith(prefix)
   );
@@ -173,16 +174,15 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
     }
   }, [isWaveRoute, locale, pathname, searchParams, waveInUrl]);
 
-  const isTitleRouteCurrent = titlePathname === pathname;
   const updateTitle = useCallback(
     (newTitle: string) => {
-      if (routeRef.current === pathname || isTitleRouteCurrent) {
+      if (isTitleUpdateCurrent(routeRef.current, titlePathname, pathname)) {
         setTitle(newTitle);
         setTitlePathname(pathname);
         setExplicitTitlePathname(pathname);
       }
     },
-    [isTitleRouteCurrent, pathname]
+    [pathname, titlePathname]
   );
 
   // Compute the title based on current state

--- a/contexts/title.helpers.ts
+++ b/contexts/title.helpers.ts
@@ -1,3 +1,5 @@
+export const STREAM_INDEX_ROUTES = ["/waves", "/messages"] as const;
+
 export const isTitleUpdateCurrent = (
   currentPathname: string | null,
   titlePathname: string | null,

--- a/contexts/title.helpers.ts
+++ b/contexts/title.helpers.ts
@@ -1,0 +1,5 @@
+export const isTitleUpdateCurrent = (
+  currentPathname: string | null,
+  titlePathname: string | null,
+  pathname: string | null
+) => currentPathname === pathname || titlePathname === pathname;

--- a/contexts/title.helpers.ts
+++ b/contexts/title.helpers.ts
@@ -1,4 +1,4 @@
-export const STREAM_INDEX_ROUTES = ["/waves", "/messages"] as const;
+export const STREAM_INDEX_ROUTES: readonly string[] = ["/waves", "/messages"];
 
 export const isTitleUpdateCurrent = (
   currentPathname: string | null,

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -301,7 +301,7 @@ const NAVIGATION_MESSAGES = objectMessages("navigation", {
 const TITLE_CONTEXT_MESSAGES = objectMessages("titleContext", {
   "routes.waves": "Waves | Brain",
   "routes.notifications": "Notifications | Brain",
-  "routes.messages": "Messages | Brain",
+  "routes.messages": "Messages",
   "routes.memeCalendar": "Memes Minting Calendar",
   "routes.theMemes": "The Memes | Collections",
   "routes.memeLab": "Meme Lab | Collections",

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -298,6 +298,27 @@ const NAVIGATION_MESSAGES = objectMessages("navigation", {
   "subsection.developerOpenData": "Data & Developer Tools",
 } as const);
 
+const TITLE_CONTEXT_MESSAGES = objectMessages("titleContext", {
+  "routes.waves": "Waves | Brain",
+  "routes.notifications": "Notifications | Brain",
+  "routes.messages": "Messages | Brain",
+  "routes.memeCalendar": "Memes Minting Calendar",
+  "routes.theMemes": "The Memes | Collections",
+  "routes.memeLab": "Meme Lab | Collections",
+  "routes.network": "Network",
+  "routes.gradient": "6529 Gradient | Collections",
+  "routes.nextGen": "NextGen | Collections",
+  "routes.rememes": "Rememes | Collections",
+  "routes.openData": "Open Data | Tools",
+  "routes.discovery": "Discovery",
+  "routes.profile": "Profile | 6529.io",
+  "wave.default": "{waveName} | Brain",
+  "wave.newMessages.one": "({count} new message) {waveName} | Brain",
+  "wave.newMessages.other": "({count} new messages) {waveName} | Brain",
+  "notifications.one": "({count} notification) {title}",
+  "notifications.other": "({count} notifications) {title}",
+} as const);
+
 const WAVE_NAVIGATION_MESSAGES = objectMessages("wave.navigation", {
   waveSections: "Wave sections",
   appSections: "App sections",
@@ -1903,6 +1924,7 @@ export const EN_US_MESSAGES = {
   ...HEADER_SEARCH_MESSAGES,
   ...NEW_VERSION_TOAST_MESSAGES,
   ...NAVIGATION_MESSAGES,
+  ...TITLE_CONTEXT_MESSAGES,
   ...WAVE_NAVIGATION_MESSAGES,
   ...WAVE_SCORE_NAVIGATION_MESSAGES,
   ...MEMES_QUICK_VOTE_MESSAGES,

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -301,7 +301,7 @@ const NAVIGATION_MESSAGES = objectMessages("navigation", {
 const TITLE_CONTEXT_MESSAGES = objectMessages("titleContext", {
   "routes.waves": "Waves | Brain",
   "routes.notifications": "Notifications | Brain",
-  "routes.messages": "Messages",
+  "routes.messages": "Messages | Brain",
   "routes.memeCalendar": "Memes Minting Calendar",
   "routes.theMemes": "The Memes | Collections",
   "routes.memeLab": "Meme Lab | Collections",

--- a/pr-reports/3300.md
+++ b/pr-reports/3300.md
@@ -13,8 +13,10 @@ Keeps the browser tab title synchronized with the selected wave or direct messag
 - Keys wave title data to the wave ID so stale data cannot own a different route.
 - Resets title ownership and wave data as the URL wave changes or is cleared.
 - Applies the correct index title once when `/waves/:id` returns to `/waves` or `/messages/:id` returns to `/messages` without a server metadata update.
+- Recomputes route-default titles after browser-locale changes while preserving explicitly owned titles.
 - Localizes fixed title structure, plural messages, and formatted counts through the message system.
-- Adds focused coverage for route ownership, loading, rapid navigation, root-view fallback, and wave deselection.
+- Shares the Waves/Messages stream-route definitions and limits wave-title updates to title-relevant data changes.
+- Adds focused coverage for route ownership, locale changes, loading, rapid navigation, root-view fallback, and wave deselection.
 
 ## Frontend Impact
 

--- a/pr-reports/3300.md
+++ b/pr-reports/3300.md
@@ -6,13 +6,13 @@ Related PRs: None
 
 ## Summary
 
-Keeps the browser tab title synchronized with the selected wave during client-side navigation, including rapid wave changes, loading transitions, and deselecting a wave back to the Waves index.
+Keeps the browser tab title synchronized with the selected wave or direct message during client-side navigation, including rapid changes, loading transitions, and deselecting back to the Waves or Messages index.
 
 ## What Changed
 
 - Keys wave title data to the wave ID so stale data cannot own a different route.
 - Resets title ownership and wave data as the URL wave changes or is cleared.
-- Applies the Waves index title once when `/waves/:id` returns to `/waves` without a server metadata update.
+- Applies the correct index title once when `/waves/:id` returns to `/waves` or `/messages/:id` returns to `/messages` without a server metadata update.
 - Localizes fixed title structure, plural messages, and formatted counts through the message system.
 - Adds focused coverage for route ownership, loading, rapid navigation, root-view fallback, and wave deselection.
 
@@ -21,7 +21,7 @@ Keeps the browser tab title synchronized with the selected wave during client-si
 - Routes/views: Waves, Messages, and the root Waves view.
 - Components: title context, dynamic document-title writer, and wave content title data.
 - Generated API/client: Not affected.
-- User-visible behavior: browser tab titles follow the current wave and return to `Waves | Brain` when the wave is unselected.
+- User-visible behavior: browser tab titles follow the current wave or DM, return to `Waves | Brain` when a wave is unselected, and return to `Messages` when a DM is unselected.
 
 ## Config / Env
 
@@ -29,7 +29,7 @@ No changes.
 
 ## Release Notes
 
-Browser tab titles now stay aligned with Waves navigation, including returning from an open wave to the Waves index.
+Browser tab titles now stay aligned with Waves and Messages navigation, including returning from an open wave or DM to its index.
 
 ## Risks / Follow-Ups
 

--- a/pr-reports/3300.md
+++ b/pr-reports/3300.md
@@ -21,7 +21,7 @@ Keeps the browser tab title synchronized with the selected wave or direct messag
 - Routes/views: Waves, Messages, and the root Waves view.
 - Components: title context, dynamic document-title writer, and wave content title data.
 - Generated API/client: Not affected.
-- User-visible behavior: browser tab titles follow the current wave or DM, return to `Waves | Brain` when a wave is unselected, and return to `Messages` when a DM is unselected.
+- User-visible behavior: browser tab titles follow the current wave or DM, return to `Waves | Brain` when a wave is unselected, and return to `Messages | Brain` when a DM is unselected.
 
 ## Config / Env
 

--- a/pr-reports/3300.md
+++ b/pr-reports/3300.md
@@ -1,0 +1,36 @@
+# PR Report: Reliable wave browser titles
+
+PR: https://github.com/6529-Collections/6529seize-frontend/pull/3300
+Branch: `agent/fix-wave-tab-title-navigation` -> `main`
+Related PRs: None
+
+## Summary
+
+Keeps the browser tab title synchronized with the selected wave during client-side navigation, including rapid wave changes, loading transitions, and deselecting a wave back to the Waves index.
+
+## What Changed
+
+- Keys wave title data to the wave ID so stale data cannot own a different route.
+- Resets title ownership and wave data as the URL wave changes or is cleared.
+- Applies the Waves index title once when `/waves/:id` returns to `/waves` without a server metadata update.
+- Localizes fixed title structure, plural messages, and formatted counts through the message system.
+- Adds focused coverage for route ownership, loading, rapid navigation, root-view fallback, and wave deselection.
+
+## Frontend Impact
+
+- Routes/views: Waves, Messages, and the root Waves view.
+- Components: title context, dynamic document-title writer, and wave content title data.
+- Generated API/client: Not affected.
+- User-visible behavior: browser tab titles follow the current wave and return to `Waves | Brain` when the wave is unselected.
+
+## Config / Env
+
+No changes.
+
+## Release Notes
+
+Browser tab titles now stay aligned with Waves navigation, including returning from an open wave to the Waves index.
+
+## Risks / Follow-Ups
+
+- The new document-title messages currently use the existing English fallback for non-English locales. Product localization owns adding translated `titleContext.*` values in a future localization pass.


### PR DESCRIPTION
## Issue
- Client-side navigation between the Waves index and individual waves could leave the browser tab title on the previous route.
- Full page loads were correct; the inconsistency appeared only after clicking between routes.

## Fix
- Associate client-side wave title data with its wave ID and only let it own the tab title when that ID matches the current URL.
- Prefer the URL wave ID over lagging in-memory active-wave state on canonical Waves and Messages routes.
- Preserve newly loaded destination-wave title data when the provider's navigation reset effect runs.

## Changes
- Add the wave ID to title-context wave metadata and guard stale async wave responses.
- Memoize wave title payloads and clear them while destination data is unavailable.
- Move route, wave, and notification title copy into the i18n message system with locale-aware plural and integer formatting.
- Address the reported Sonar maintainability findings.
- Add regressions for wave-to-index, mismatched-wave, wave-to-wave, loading cleanup, new-item counts, and root Waves fallback navigation.

## Validation
- 37 focused title-context, dynamic-title, and i18n tests passed.
- Changed-file lint and TypeScript checks passed.
- Rebased onto the latest `origin/main` before push.

## Risk
- Level: Low
- Why: The change is isolated to client-side browser title selection and does not alter routing or wave data fetching.
- Rollback: Revert the two feature commits.

## Review Notes
- Please focus on URL-versus-active-wave precedence, stale async wave payload rejection, and destination-data preservation during provider reset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser tab titles now reliably reflect the selected wave or direct message during navigation.
  * Titles support localized route names, notification counts, and singular/plural wording.
  * Titles correctly reset when changing, deselecting, or leaving waves and messages.

* **Bug Fixes**
  * Prevented stale wave data from appearing in titles after navigation or during loading.
  * Improved title updates when returning to wave and message index pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->