### PR TITLE
Fix HTML NFT media width and iframe borders

### DIFF
--- a/__tests__/components/nft-image/renderers/NFTHTMLRenderer.test.tsx
+++ b/__tests__/components/nft-image/renderers/NFTHTMLRenderer.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import NFTHTMLRenderer from "@/components/nft-image/renderers/NFTHTMLRenderer";
 import type { BaseRendererProps } from "@/components/nft-image/types/renderer-props";
 import type { BaseNFT } from "@/entities/INFT";
@@ -71,6 +73,15 @@ const createDefaultProps = (
 
 describe("NFTHTMLRenderer", () => {
   describe("Basic Rendering", () => {
+    it("removes the browser default iframe border", () => {
+      const styles = readFileSync(
+        join(process.cwd(), "components/nft-image/NFTImage.module.css"),
+        "utf8"
+      );
+
+      expect(styles).toMatch(/\.nftAnimation iframe\s*\{[^}]*border:\s*0;/s);
+    });
+
     it("renders iframe with correct structure", () => {
       const props = createDefaultProps({ id: "test-iframe" });
       render(<NFTHTMLRenderer {...props} />);
@@ -332,7 +343,10 @@ describe("NFTHTMLRenderer", () => {
 
       const iframe = screen.getByTitle("test-iframe");
       expect(iframe).toBeInTheDocument();
-      expect(iframe).toHaveAttribute("src", "https://example.com/animation.html");
+      expect(iframe).toHaveAttribute(
+        "src",
+        "https://example.com/animation.html"
+      );
     });
 
     it("handles minimal NFT properties", () => {

--- a/__tests__/components/the-memes/MemePageArtViewer.test.tsx
+++ b/__tests__/components/the-memes/MemePageArtViewer.test.tsx
@@ -149,6 +149,12 @@ afterEach(() => {
 });
 
 describe("MemePageArtViewer", () => {
+  it("fills the available width in row and column layout wrappers", () => {
+    const { container } = render(<MemePageArtViewer nft={baseNft as any} />);
+
+    expect(container.firstElementChild).toHaveClass("tw-w-full");
+  });
+
   it("sizes carousel renderer wrappers without depending on Bootstrap Col", () => {
     const styles = readFileSync(
       join(process.cwd(), "components/the-memes/TheMemes.module.css"),

--- a/components/nft-image/NFTImage.module.css
+++ b/components/nft-image/NFTImage.module.css
@@ -12,6 +12,10 @@
   width: 100%;
 }
 
+.nftAnimation iframe {
+  border: 0;
+}
+
 .nftAnimation video {
   max-width: 100%;
 }

--- a/components/the-memes/MemePageArtViewer.tsx
+++ b/components/the-memes/MemePageArtViewer.tsx
@@ -331,7 +331,7 @@ export function MemePageArtViewer({
   }
 
   return (
-    <div className="tw-flex tw-h-full tw-flex-col tw-p-0">
+    <div className="tw-flex tw-h-full tw-w-full tw-flex-col tw-p-0">
       <div className="tw-flex tw-flex-1 tw-flex-col">
         {hasAnimation ? (
           <>

--- a/pr-reports/3303.md
+++ b/pr-reports/3303.md
@@ -1,0 +1,30 @@
+# PR Report: Fix HTML NFT media layout
+
+PR: https://github.com/6529-Collections/6529seize-frontend/pull/3303
+Branch: `agent/fix-html-media-layout` -> `main`
+Related PRs: None
+
+## Summary
+
+HTML NFT artwork now fills its available viewer width consistently and no longer displays the browser's default iframe border.
+
+## What Changed
+
+- Made the shared artwork viewer explicitly full width so row- and column-flex parents produce the same media sizing.
+- Removed the default border from HTML animation iframes without affecting borders rendered by the NFT content itself.
+- Added focused regression coverage for both layout rules.
+
+## Frontend Impact
+
+- Routes/views: The Memes and Meme Lab NFT detail pages.
+- Components: Shared artwork viewer and HTML NFT renderer styling.
+- Generated API/client: Not affected.
+- User-visible behavior: HTML artwork uses the full media area and no longer has an unintended outer border.
+
+## Config / Env
+
+None.
+
+## Release Notes
+
+Fixed HTML NFT artwork sizing and removed unintended iframe borders across The Memes and Meme Lab detail pages.


### PR DESCRIPTION
## Issue
- HTML NFT artwork retained the browser's default iframe border.
- The shared artwork viewer could shrink to the iframe's intrinsic width inside Meme Lab's row-flex wrapper instead of filling the available media area.

## Fix
- Make `MemePageArtViewer` explicitly own a full-width layout contract.
- Reset the shared HTML animation iframe border to zero.

## Changes
- Add `tw-w-full` to the shared artwork viewer root so The Memes and Meme Lab size HTML media consistently.
- Add a scoped iframe border reset in `NFTImage.module.css`.
- Add focused regression assertions for viewer width and iframe border styling.

## Validation
- Focused Jest suite: 49 tests passed across the artwork viewer and HTML renderer tests.
- `6529 run check:changed` passed.
- React Doctor scored 99/100; its only warning is the pre-existing size of `MemePageArtViewer`.
- Source and supplied screenshot review covered both `/the-memes/7` and `/meme-lab/8`. No local development server was started.

## Risk
- Level: Low
- Why: The change is limited to shared NFT media sizing and the HTML iframe border reset, with no API, data, or interaction changes.
- Rollback: Revert the single feature commit.

## Review Notes
- Confirm HTML NFT embeds fill their containing artwork column in both row- and column-flex parents.
- Confirm removing the browser-default iframe border does not affect intentional borders rendered inside NFT HTML content.