### PR TITLE
fix: Prevented unnecessary large NextGen Merkle-response downloads while preserving active mint labels.

### DIFF
--- a/__tests__/components/nextGen/collections/collectionParts/NextGenCollectionHeader.test.tsx
+++ b/__tests__/components/nextGen/collections/collectionParts/NextGenCollectionHeader.test.tsx
@@ -1,8 +1,15 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import NextGenCollectionHeader, {
   NextGenBackToCollectionPageLink,
+  NextGenCountdown,
 } from '@/components/nextGen/collections/collectionParts/NextGenCollectionHeader';
+import { fetchUrl } from '@/services/6529api';
+import { usePathname } from 'next/navigation';
+import {
+  AllowlistType,
+  type CollectionWithMerkle,
+} from '@/components/nextGen/nextgen_entities';
 
 jest.mock('@/services/6529api', () => ({ fetchUrl: jest.fn(() => Promise.resolve({})) }));
 jest.mock('@/components/cookies/CookieConsentContext', () => ({ 
@@ -59,6 +66,11 @@ const collection: any = {
 };
 
 describe('NextGenCollectionHeader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(usePathname).mockReturnValue('/test/path');
+  });
+
   it('renders back link text depending on path', () => {
     window.history.pushState({}, '', '/x/art');
     render(<NextGenBackToCollectionPageLink collection={collection} />);
@@ -70,5 +82,54 @@ describe('NextGenCollectionHeader', () => {
     expect(screen.getByText(collection.name)).toBeInTheDocument();
     // countdown from allowlist_start should render
     expect(screen.getByText(/Allowlist Starting/)).toBeInTheDocument();
+  });
+
+  it('does not load the Merkle response after all mint phases complete', () => {
+    const completedCollection = {
+      ...collection,
+      allowlist_start: 1,
+      allowlist_end: 2,
+      public_start: 3,
+      public_end: 4,
+    };
+
+    render(<NextGenCountdown collection={completedCollection} />);
+
+    expect(fetchUrl).not.toHaveBeenCalled();
+  });
+
+  it('loads the Merkle response when a mint countdown is visible', async () => {
+    render(<NextGenCountdown collection={collection} />);
+
+    await waitFor(() => expect(fetchUrl).toHaveBeenCalledTimes(1));
+    expect(await screen.findByRole('button', { name: 'MINT' })).toBeInTheDocument();
+  });
+
+  it('keeps the burn-to-mint label for active external burn collections', async () => {
+    jest.mocked(fetchUrl).mockResolvedValueOnce({
+      collection_id: collection.id,
+      merkle_root: collection.merkle_root,
+      merkle_tree: [],
+      al_type: AllowlistType.EXTERNAL_BURN,
+      phase: 'allowlist',
+      burn_collection: '',
+      burn_collection_id: 0,
+      min_token_index: 0,
+      max_token_index: 0,
+      burn_address: '',
+      status: true,
+    } satisfies CollectionWithMerkle);
+
+    render(<NextGenCountdown collection={collection} />);
+
+    expect(await screen.findByRole('button', { name: 'BURN TO MINT' })).toBeInTheDocument();
+  });
+
+  it('does not load the Merkle response on the mint route', () => {
+    jest.mocked(usePathname).mockReturnValue('/nextgen/collection/my-collection/mint');
+
+    render(<NextGenCountdown collection={collection} />);
+
+    expect(fetchUrl).not.toHaveBeenCalled();
   });
 });

--- a/components/nextGen/collections/collectionParts/NextGenCollectionHeader.tsx
+++ b/components/nextGen/collections/collectionParts/NextGenCollectionHeader.tsx
@@ -85,11 +85,22 @@ export function NextGenCountdown(props: Readonly<CountdownProps>) {
     props.collection.public_start,
     props.collection.public_end
   );
+  const isMintRoute = pathname.split("/").at(-1) === "mint";
+  const hasActiveCountdown =
+    alStatus === Status.UPCOMING ||
+    alStatus === Status.LIVE ||
+    publicStatus === Status.UPCOMING ||
+    publicStatus === Status.LIVE;
+  const shouldLoadMintLabel = hasActiveCountdown && !isMintRoute;
 
   const [collection, setCollection] = useState<CollectionWithMerkle>();
   const [collectionLoaded, setCollectionLoaded] = useState(false);
 
   useEffect(() => {
+    if (!shouldLoadMintLabel) {
+      return;
+    }
+
     const url = `${publicEnv.API_ENDPOINT}/api/nextgen/merkle_roots/${props.collection.merkle_root}`;
     fetchUrl<CollectionWithMerkle>(url).then(
       (response: CollectionWithMerkle) => {
@@ -99,7 +110,7 @@ export function NextGenCountdown(props: Readonly<CountdownProps>) {
         setCollectionLoaded(true);
       }
     );
-  }, [props.collection]);
+  }, [props.collection.merkle_root, shouldLoadMintLabel]);
 
   function getButtonLabel() {
     if (collectionLoaded) {
@@ -112,13 +123,10 @@ export function NextGenCountdown(props: Readonly<CountdownProps>) {
   }
 
   function printCountdown(title: string, date: number) {
-    const pathParts = pathname.split("/");
-    const hideMintBtn = pathParts[pathParts.length - 1] === "mint";
-
     return (
       <span className={styles["countdownContainer"]}>
         <DateCountdown title={`${title} in`} date={new Date(date * 1000)} />
-        {!hideMintBtn && (
+        {!isMintRoute && (
           <Link
             href={`/nextgen/collection/${formatNameForUrl(
               props.collection.name


### PR DESCRIPTION
<!-- sentry-fix-job:8 issue:7470059338 -->
## Issue

- Sentry: [6529-FRONTEND-BD](https://seize-ff.sentry.io/issues/7470059338/)
- First seen: 2026-05-09T16:46:14.469Z
- Latest occurrence: 2026-07-16T20:37:39.000Z
- Automatic triage confidence: 99%

A bounded repository fix is useful. Current main still downloads the large NextGen Merkle response for the completed featured collection even though no countdown or mint-label button is rendered. Draft PR #3304 already implements the appropriate narrow gate and focused tests, but remains behind current main.

## Fix

NextGenCountdown fetched the full Merkle response on every mount, including completed phases that render no countdown and mint routes where the label-dependent button is hidden.

## Changes

- Gated the Merkle request to upcoming or live mint phases where the mint-label button is visible.
- Kept effect dependencies limited to the Merkle root and eligibility boolean.
- Added regression coverage for completed phases, active countdowns, mint routes, and external-burn labels.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Focused Jest suite passed: 6 tests.
- Changed-file lint passed.
- Changed-file typecheck passed.
- Branch diff check passed.
- React Doctor exited successfully but skipped because the committed branch matches its upstream; the React diff was reviewed manually.
- Live draft-PR checks are successful, and current main has not changed either touched file.

## Risk

- Assessed risk: low
- Changed files: 2
- Changed lines: 81
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

Active countdowns still require the large backend response to determine the mint label. No browser network trace was run.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
