### PR TITLE
Unblock app shell before full AppKit initialization

### DIFF
--- a/__tests__/components/auth/AppKitModalBridge.test.ts
+++ b/__tests__/components/auth/AppKitModalBridge.test.ts
@@ -50,4 +50,56 @@ describe("AppKitModalBridge store", () => {
       "Wallet connection services became unavailable"
     );
   });
+
+  it("invalidates a cached handle and state on bootstrap failure", async () => {
+    const store = createAppKitModalBridgeStore();
+    const openAppKit = jest.fn().mockResolvedValue(undefined);
+    store.setOpen(openAppKit);
+    store.setState({
+      isOpen: true,
+      walletName: "Test wallet",
+      walletIcon: undefined,
+      isSafeWallet: false,
+    });
+
+    store.failBootstrap();
+
+    await expect(store.waitForOpen()).rejects.toThrow(
+      "Wallet connection services failed to initialize"
+    );
+    expect(store.getSnapshot()).toEqual({
+      isOpen: false,
+      walletName: undefined,
+      walletIcon: undefined,
+      isSafeWallet: false,
+    });
+
+    store.setOpen(openAppKit);
+    store.setState({
+      isOpen: true,
+      walletName: "Stale wallet",
+      walletIcon: undefined,
+      isSafeWallet: false,
+    });
+    await expect(store.waitForOpen()).rejects.toThrow(
+      "Wallet connection services failed to initialize"
+    );
+    expect(store.getSnapshot().isOpen).toBe(false);
+  });
+
+  it("invalidates a cached handle on disposal", async () => {
+    const store = createAppKitModalBridgeStore();
+    const openAppKit = jest.fn().mockResolvedValue(undefined);
+    store.setOpen(openAppKit);
+
+    store.dispose();
+
+    await expect(store.waitForOpen()).rejects.toThrow(
+      "Wallet connection services became unavailable"
+    );
+    store.setOpen(openAppKit);
+    await expect(store.waitForOpen()).rejects.toThrow(
+      "Wallet connection services became unavailable"
+    );
+  });
 });

--- a/__tests__/components/auth/AppKitModalBridge.test.ts
+++ b/__tests__/components/auth/AppKitModalBridge.test.ts
@@ -1,0 +1,53 @@
+import { createAppKitModalBridgeStore } from "@/components/auth/AppKitModalBridge";
+
+describe("AppKitModalBridge store", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("bounds a pending modal-open waiter", async () => {
+    const store = createAppKitModalBridgeStore();
+    const waitForOpen = store.waitForOpen();
+    const rejection = expect(waitForOpen).rejects.toThrow(
+      "Timed out waiting for wallet connection services"
+    );
+
+    await jest.advanceTimersByTimeAsync(15_000);
+
+    await rejection;
+  });
+
+  it("rejects current and future waiters after bootstrap failure", async () => {
+    const store = createAppKitModalBridgeStore();
+    const pendingWaiter = store.waitForOpen();
+    const pendingRejection = expect(pendingWaiter).rejects.toThrow(
+      "Wallet connection services failed to initialize"
+    );
+
+    store.failBootstrap();
+
+    await pendingRejection;
+    await expect(store.waitForOpen()).rejects.toThrow(
+      "Wallet connection services failed to initialize"
+    );
+  });
+
+  it("rejects current and future waiters after disposal", async () => {
+    const store = createAppKitModalBridgeStore();
+    const pendingWaiter = store.waitForOpen();
+    const pendingRejection = expect(pendingWaiter).rejects.toThrow(
+      "Wallet connection services became unavailable"
+    );
+
+    store.dispose();
+
+    await pendingRejection;
+    await expect(store.waitForOpen()).rejects.toThrow(
+      "Wallet connection services became unavailable"
+    );
+  });
+});

--- a/__tests__/components/auth/SeizeConnectContext.addAccount.test.tsx
+++ b/__tests__/components/auth/SeizeConnectContext.addAccount.test.tsx
@@ -344,6 +344,7 @@ describe("SeizeConnectProvider add-account flow", () => {
       <AppKitBootstrapContext.Provider
         value={{
           status: "initializing",
+          hasTerminalError: false,
           isCreated: true,
           isReady: false,
           isWaiting: true,

--- a/__tests__/components/auth/SeizeConnectContext.addAccount.test.tsx
+++ b/__tests__/components/auth/SeizeConnectContext.addAccount.test.tsx
@@ -344,6 +344,7 @@ describe("SeizeConnectProvider add-account flow", () => {
       <AppKitBootstrapContext.Provider
         value={{
           status: "initializing",
+          isCreated: true,
           isReady: false,
           isWaiting: true,
           waitForReady,

--- a/__tests__/components/auth/SeizeConnectContext.test.tsx
+++ b/__tests__/components/auth/SeizeConnectContext.test.tsx
@@ -1573,6 +1573,7 @@ describe("Regression Tests: Original Functionality with Secure Implementation", 
       <AppKitBootstrapContext.Provider
         value={{
           status: appKitStatus,
+          hasTerminalError: false,
           isCreated: isAppKitCreated,
           isReady: appKitStatus === "ready",
           isWaiting: appKitStatus === "initializing",
@@ -1642,6 +1643,7 @@ describe("Regression Tests: Original Functionality with Secure Implementation", 
       <AppKitBootstrapContext.Provider
         value={{
           status: "initializing",
+          hasTerminalError: false,
           isCreated: isAppKitCreated,
           isReady: false,
           isWaiting: true,
@@ -1753,6 +1755,7 @@ describe("Regression Tests: Original Functionality with Secure Implementation", 
       <AppKitBootstrapContext.Provider
         value={{
           status: "ready",
+          hasTerminalError: false,
           isCreated: false,
           isReady: true,
           isWaiting: false,

--- a/__tests__/components/auth/SeizeConnectContext.test.tsx
+++ b/__tests__/components/auth/SeizeConnectContext.test.tsx
@@ -1566,13 +1566,16 @@ describe("Regression Tests: Original Functionality with Secure Implementation", 
     const { useAppKitState } = require("@reown/appkit/react");
     const appKitState = { open: false };
     (useAppKitState as jest.Mock).mockImplementation(() => appKitState);
+    let isAppKitCreated = false;
+    let appKitStatus: "initializing" | "ready" = "initializing";
 
     const renderConnectTree = () => (
       <AppKitBootstrapContext.Provider
         value={{
-          status: "initializing",
-          isReady: false,
-          isWaiting: true,
+          status: appKitStatus,
+          isCreated: isAppKitCreated,
+          isReady: appKitStatus === "ready",
+          isWaiting: appKitStatus === "initializing",
           waitForReady,
         }}
       >
@@ -1595,6 +1598,9 @@ describe("Regression Tests: Original Functionality with Secure Implementation", 
     await act(async () => {
       resolveReady();
       await Promise.resolve();
+      isAppKitCreated = true;
+      appKitStatus = "ready";
+      view.rerender(renderConnectTree());
     });
 
     await waitFor(() => {
@@ -1613,6 +1619,161 @@ describe("Regression Tests: Original Functionality with Secure Implementation", 
     await waitFor(() => {
       expect(screen.getByTestId("connect-open")).toHaveTextContent("false");
     });
+  });
+
+  it("keeps AppKit-only hooks deferred without remounting children", async () => {
+    const {
+      useAppKit,
+      useAppKitState,
+      useWalletInfo,
+    } = require("@reown/appkit/react");
+    (useAppKit as jest.Mock).mockImplementation(() => {
+      throw new Error("AppKit has not been created");
+    });
+    (useAppKitState as jest.Mock).mockImplementation(() => {
+      throw new Error("AppKit has not been created");
+    });
+    (useWalletInfo as jest.Mock).mockImplementation(() => {
+      throw new Error("AppKit has not been created");
+    });
+    let isAppKitCreated = false;
+
+    const renderTree = () => (
+      <AppKitBootstrapContext.Provider
+        value={{
+          status: "initializing",
+          isCreated: isAppKitCreated,
+          isReady: false,
+          isWaiting: true,
+          waitForReady: jest.fn(() => new Promise<void>(() => undefined)),
+        }}
+      >
+        <SeizeConnectProvider>
+          <div data-testid="stable-fast-path-child">Fast path</div>
+        </SeizeConnectProvider>
+      </AppKitBootstrapContext.Provider>
+    );
+
+    const view = render(renderTree());
+    const childBeforeAppKit = screen.getByTestId("stable-fast-path-child");
+    expect(useAppKit).not.toHaveBeenCalled();
+    expect(useAppKitState).not.toHaveBeenCalled();
+    expect(useWalletInfo).not.toHaveBeenCalled();
+
+    (useAppKit as jest.Mock).mockReturnValue({ open: mockOpen });
+    (useAppKitState as jest.Mock).mockReturnValue({ open: false });
+    (useWalletInfo as jest.Mock).mockReturnValue({ walletInfo: undefined });
+    isAppKitCreated = true;
+    view.rerender(renderTree());
+
+    await waitFor(() => {
+      expect(useAppKit).toHaveBeenCalledTimes(1);
+      expect(useAppKitState).toHaveBeenCalledTimes(1);
+      expect(useWalletInfo).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByTestId("stable-fast-path-child")).toBe(
+      childBeforeAppKit
+    );
+  });
+
+  it("does not loop when useWalletInfo returns a fresh object", async () => {
+    const { useWalletInfo } = require("@reown/appkit/react");
+    (useWalletInfo as jest.Mock).mockImplementation(() => ({ walletInfo: {} }));
+
+    renderWithProvider(<div data-testid="fresh-wallet-info-child">Test</div>);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("fresh-wallet-info-child")).toBeInTheDocument();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect((useWalletInfo as jest.Mock).mock.calls.length).toBeLessThan(10);
+    expect(console.error).not.toHaveBeenCalledWith(
+      expect.stringContaining("Maximum update depth exceeded")
+    );
+  });
+
+  it("rejects connect when the deferred AppKit bridge hook fails", async () => {
+    mockGetWalletAddress.mockReturnValue(null);
+    const { useAppKit } = require("@reown/appkit/react");
+    (useAppKit as jest.Mock).mockImplementation(() => {
+      throw new Error("bridge failed");
+    });
+    let connectPromise: Promise<void> | undefined;
+
+    const ConnectFailureProbe = () => {
+      const { seizeConnectFresh } = useSeizeConnectContext();
+      return (
+        <button
+          data-testid="bridge-failure-connect"
+          onClick={() => {
+            connectPromise = seizeConnectFresh();
+            void connectPromise.catch(() => undefined);
+          }}
+        >
+          Connect
+        </button>
+      );
+    };
+
+    renderWithProvider(<ConnectFailureProbe />);
+    fireEvent.click(screen.getByTestId("bridge-failure-connect"));
+
+    await waitFor(() => {
+      expect(connectPromise).toBeDefined();
+    });
+    await expect(connectPromise!).rejects.toThrow(
+      "Failed to open wallet connection modal"
+    );
+    expect(mockOpen).not.toHaveBeenCalled();
+  });
+
+  it("rejects and clears a pending AppKit bridge waiter on unmount", async () => {
+    mockGetWalletAddress.mockReturnValue(null);
+    let connectPromise: Promise<void> | undefined;
+
+    const ConnectUnmountProbe = () => {
+      const { seizeConnectFresh } = useSeizeConnectContext();
+      return (
+        <button
+          data-testid="bridge-unmount-connect"
+          onClick={() => {
+            connectPromise = seizeConnectFresh();
+            void connectPromise.catch(() => undefined);
+          }}
+        >
+          Connect
+        </button>
+      );
+    };
+
+    const view = render(
+      <AppKitBootstrapContext.Provider
+        value={{
+          status: "ready",
+          isCreated: false,
+          isReady: true,
+          isWaiting: false,
+          waitForReady: jest.fn(() => Promise.resolve()),
+        }}
+      >
+        <SeizeConnectProvider>
+          <ConnectUnmountProbe />
+        </SeizeConnectProvider>
+      </AppKitBootstrapContext.Provider>
+    );
+
+    fireEvent.click(screen.getByTestId("bridge-unmount-connect"));
+    await act(async () => {
+      await Promise.resolve();
+      view.unmount();
+    });
+
+    await expect(connectPromise!).rejects.toThrow(
+      "Failed to open wallet connection modal"
+    );
   });
 
   it("clears the connect intent fallback if AppKit never reports open", async () => {

--- a/__tests__/components/providers/WagmiSetup.test.tsx
+++ b/__tests__/components/providers/WagmiSetup.test.tsx
@@ -1103,6 +1103,50 @@ describe("WagmiSetup Security Tests", () => {
       );
     });
 
+    it("moves a hung background AppKit initialization to a terminal error", async () => {
+      jest.useFakeTimers();
+      const ready = new Promise<void>(() => {
+        // Intentionally never settles to simulate a hung WalletConnect relay.
+      });
+      mockInitializeAppKit.mockReturnValue({
+        adapter: {
+          wagmiConfig: {
+            chains: [],
+            client: {},
+            connectors: [],
+            _internal: {
+              connectors: {
+                setup: mockConnectorSetup,
+                setState: mockConnectorSetState,
+              },
+            },
+          },
+        },
+        ready,
+      });
+
+      const { container } = render(
+        <WagmiSetup>
+          <AppKitBootstrapProbe />
+        </WagmiSetup>
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+      expect(
+        container.querySelector('[data-testid="appkit-bootstrap-status"]')
+      ).toHaveTextContent("initializing");
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(15_000);
+      });
+      expect(
+        container.querySelector('[data-testid="appkit-bootstrap-status"]')
+      ).toHaveTextContent("error");
+      expect(mockInitializeAppKit).toHaveBeenCalledTimes(1);
+    });
+
     it("rejects connect-intent waiters when AppKit ready hangs past the timeout", async () => {
       jest.useFakeTimers();
       const ready = new Promise<void>(() => {
@@ -1139,6 +1183,7 @@ describe("WagmiSetup Security Tests", () => {
 
       const { container } = render(
         <WagmiSetup>
+          <AppKitBootstrapProbe />
           <WaitForReadyProbe />
         </WagmiSetup>
       );
@@ -1156,6 +1201,10 @@ describe("WagmiSetup Security Tests", () => {
       expect(
         container.querySelector('[data-testid="wait-for-ready-state"]')
       ).toHaveTextContent("rejected");
+      expect(
+        container.querySelector('[data-testid="appkit-bootstrap-status"]')
+      ).toHaveTextContent("error");
+      expect(mockInitializeAppKit).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/__tests__/components/providers/WagmiSetup.test.tsx
+++ b/__tests__/components/providers/WagmiSetup.test.tsx
@@ -284,6 +284,9 @@ describe("WagmiSetup Security Tests", () => {
     return (
       <>
         <div data-testid="appkit-bootstrap-status">{bootstrap.status}</div>
+        <div data-testid="appkit-terminal-error">
+          {String(bootstrap.hasTerminalError)}
+        </div>
         <div data-testid="appkit-created">{String(bootstrap.isCreated)}</div>
       </>
     );
@@ -1093,6 +1096,9 @@ describe("WagmiSetup Security Tests", () => {
           container.querySelector('[data-testid="appkit-bootstrap-status"]')
         ).toHaveTextContent("error");
       });
+      expect(
+        container.querySelector('[data-testid="appkit-terminal-error"]')
+      ).toHaveTextContent("true");
       expect(container.querySelector('[data-testid="children"]')).toBeTruthy();
       expect(mockLogErrorSecurely).toHaveBeenCalledWith(
         "[WagmiSetup] AppKit ready failed after adapter mount",
@@ -1103,7 +1109,7 @@ describe("WagmiSetup Security Tests", () => {
       );
     });
 
-    it("moves a hung background AppKit initialization to a terminal error", async () => {
+    it("bounds a hung background AppKit initialization without uncreating AppKit", async () => {
       jest.useFakeTimers();
       const ready = new Promise<void>(() => {
         // Intentionally never settles to simulate a hung WalletConnect relay.
@@ -1140,6 +1146,149 @@ describe("WagmiSetup Security Tests", () => {
 
       await act(async () => {
         await jest.advanceTimersByTimeAsync(15_000);
+      });
+      expect(
+        container.querySelector('[data-testid="appkit-bootstrap-status"]')
+      ).toHaveTextContent("error");
+      expect(
+        container.querySelector('[data-testid="appkit-created"]')
+      ).toHaveTextContent("true");
+      expect(
+        container.querySelector('[data-testid="appkit-terminal-error"]')
+      ).toHaveTextContent("false");
+      expect(mockInitializeAppKit).toHaveBeenCalledTimes(1);
+    });
+
+    it("recovers future waiters when AppKit becomes ready after the timeout", async () => {
+      jest.useFakeTimers();
+      let resolveReady!: () => void;
+      const ready = new Promise<void>((resolve) => {
+        resolveReady = resolve;
+      });
+      mockInitializeAppKit.mockReturnValue({
+        adapter: {
+          wagmiConfig: {
+            chains: [],
+            client: {},
+            connectors: [],
+            _internal: {
+              connectors: {
+                setup: mockConnectorSetup,
+                setState: mockConnectorSetState,
+              },
+            },
+          },
+        },
+        ready,
+      });
+
+      const WaitForReadyProbe = () => {
+        const bootstrap = useAppKitBootstrap();
+        const [waitState, setWaitState] = React.useState("idle");
+        return (
+          <>
+            <div data-testid="late-ready-wait-state">{waitState}</div>
+            <button
+              data-testid="late-ready-wait"
+              onClick={() => {
+                bootstrap
+                  .waitForReady()
+                  .then(() => setWaitState("resolved"))
+                  .catch(() => setWaitState("rejected"));
+              }}
+            >
+              Wait
+            </button>
+          </>
+        );
+      };
+
+      const { container } = render(
+        <WagmiSetup>
+          <AppKitBootstrapProbe />
+          <WaitForReadyProbe />
+        </WagmiSetup>
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(15_000);
+      });
+      expect(
+        container.querySelector('[data-testid="appkit-bootstrap-status"]')
+      ).toHaveTextContent("error");
+
+      await act(async () => {
+        resolveReady();
+        await ready;
+      });
+      await waitFor(() => {
+        expect(
+          container.querySelector('[data-testid="appkit-bootstrap-status"]')
+        ).toHaveTextContent("ready");
+      });
+      expect(
+        container.querySelector('[data-testid="appkit-terminal-error"]')
+      ).toHaveTextContent("false");
+
+      await act(async () => {
+        container
+          .querySelector<HTMLButtonElement>('[data-testid="late-ready-wait"]')
+          ?.click();
+        await Promise.resolve();
+      });
+      await waitFor(() => {
+        expect(
+          container.querySelector('[data-testid="late-ready-wait-state"]')
+        ).toHaveTextContent("resolved");
+      });
+      expect(mockInitializeAppKit).toHaveBeenCalledTimes(1);
+    });
+
+    it("makes a timed-out bootstrap terminal if AppKit later rejects", async () => {
+      jest.useFakeTimers();
+      let rejectReady!: (error: Error) => void;
+      const ready = new Promise<void>((_resolve, reject) => {
+        rejectReady = reject;
+      });
+      mockInitializeAppKit.mockReturnValue({
+        adapter: {
+          wagmiConfig: {
+            chains: [],
+            client: {},
+            connectors: [],
+            _internal: {
+              connectors: {
+                setup: mockConnectorSetup,
+                setState: mockConnectorSetState,
+              },
+            },
+          },
+        },
+        ready,
+      });
+
+      const { container } = render(
+        <WagmiSetup>
+          <AppKitBootstrapProbe />
+        </WagmiSetup>
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(15_000);
+      });
+      expect(
+        container.querySelector('[data-testid="appkit-terminal-error"]')
+      ).toHaveTextContent("false");
+
+      const readyError = new Error("late ready failure");
+      await act(async () => {
+        rejectReady(readyError);
+        await ready.catch(() => undefined);
+      });
+      await waitFor(() => {
+        expect(
+          container.querySelector('[data-testid="appkit-terminal-error"]')
+        ).toHaveTextContent("true");
       });
       expect(
         container.querySelector('[data-testid="appkit-bootstrap-status"]')

--- a/__tests__/components/providers/WagmiSetup.test.tsx
+++ b/__tests__/components/providers/WagmiSetup.test.tsx
@@ -12,6 +12,13 @@ import { createAppWalletConnector } from "@/wagmiConfig/wagmiAppWalletConnector"
 import { act, render, waitFor } from "@testing-library/react";
 import React from "react";
 
+const resetWagmiAppKitFastPathForTests = (): void => {
+  Reflect.deleteProperty(
+    globalThis,
+    Symbol.for("6529.wagmiAppKitFastPathStore")
+  );
+};
+
 // Mock capacitor-secure-storage-plugin first to prevent import errors
 jest.mock("capacitor-secure-storage-plugin", () => ({
   SecureStoragePlugin: {
@@ -27,11 +34,13 @@ jest.mock("@/components/auth/Auth");
 jest.mock("@/components/app-wallets/AppWalletsContext", () => ({
   useAppWallets: jest.fn(),
 }));
+const mockPasswordRequestDelegates: jest.Mock[] = [];
 jest.mock("@/hooks/useAppWalletPasswordModal", () => ({
-  useAppWalletPasswordModal: () => ({
-    requestPassword: jest.fn(),
-    modal: null,
-  }),
+  useAppWalletPasswordModal: () => {
+    const requestPassword = jest.fn().mockResolvedValue("password");
+    mockPasswordRequestDelegates.push(requestPassword);
+    return { requestPassword, modal: null };
+  },
 }));
 jest.mock("@reown/appkit/react", () => ({
   createAppKit: jest.fn(),
@@ -42,11 +51,9 @@ jest.mock("@capacitor/core", () => ({
   },
 }));
 jest.mock("@/utils/appkit-initialization.utils", () => ({
-  initializeAppKit: jest.fn().mockReturnValue({
-    adapter: {
-      wagmiConfig: { chains: [], client: {} },
-    },
-  }),
+  createAppKitAdapter: jest.fn(),
+  initializeAppKit: jest.fn().mockReturnValue({}),
+  AppKitAdapterConfig: {},
   AppKitInitializationConfig: {},
 }));
 jest.mock("@/components/providers/AppKitAdapterManager", () => ({
@@ -112,6 +119,7 @@ jest.mock("ethers", () => ({
 
 describe("WagmiSetup Security Tests", () => {
   let mockInitializeAppKit: jest.Mock;
+  let mockCreateAppKitAdapter: jest.Mock;
   let mockLogErrorSecurely: jest.Mock;
   let mockSetToast: jest.Mock;
   let mockAdapterCreateMethod: jest.Mock;
@@ -167,6 +175,8 @@ describe("WagmiSetup Security Tests", () => {
   };
 
   beforeEach(() => {
+    resetWagmiAppKitFastPathForTests();
+    mockPasswordRequestDelegates.length = 0;
     jest.clearAllMocks();
     jest.useFakeTimers();
     restoreEthereumState();
@@ -182,6 +192,8 @@ describe("WagmiSetup Security Tests", () => {
 
     mockInitializeAppKit =
       require("@/utils/appkit-initialization.utils").initializeAppKit;
+    mockCreateAppKitAdapter =
+      require("@/utils/appkit-initialization.utils").createAppKitAdapter;
     mockLogErrorSecurely = require("@/utils/error-sanitizer").logErrorSecurely;
     mockSetToast = jest.fn();
     mockAdapterCreateMethod = jest.fn();
@@ -220,21 +232,21 @@ describe("WagmiSetup Security Tests", () => {
     }));
 
     // Default successful mock response
-    mockInitializeAppKit.mockReturnValue({
-      adapter: {
-        wagmiConfig: {
-          chains: [],
-          client: {},
-          connectors: [],
-          _internal: {
-            connectors: {
-              setup: mockConnectorSetup,
-              setState: mockConnectorSetState,
-            },
+    const adapter = {
+      wagmiConfig: {
+        chains: [],
+        client: {},
+        connectors: [],
+        _internal: {
+          connectors: {
+            setup: mockConnectorSetup,
+            setState: mockConnectorSetState,
           },
         },
       },
-    });
+    };
+    mockCreateAppKitAdapter.mockReturnValue(adapter);
+    mockInitializeAppKit.mockReturnValue({ adapter });
   });
 
   const renderAndWaitForMount = async (
@@ -269,7 +281,12 @@ describe("WagmiSetup Security Tests", () => {
 
   const AppKitBootstrapProbe = () => {
     const bootstrap = useAppKitBootstrap();
-    return <div data-testid="appkit-bootstrap-status">{bootstrap.status}</div>;
+    return (
+      <>
+        <div data-testid="appkit-bootstrap-status">{bootstrap.status}</div>
+        <div data-testid="appkit-created">{String(bootstrap.isCreated)}</div>
+      </>
+    );
   };
 
   afterEach(() => {
@@ -297,10 +314,10 @@ describe("WagmiSetup Security Tests", () => {
       );
     });
 
-    it("calls initializeAppKit with empty wallets on mount", async () => {
+    it("creates the Wagmi adapter with empty wallets on mount", async () => {
       await renderAndWaitForMount();
 
-      expect(mockInitializeAppKit).toHaveBeenCalledWith({
+      expect(mockCreateAppKitAdapter).toHaveBeenCalledWith({
         wallets: [],
         adapterManager: expect.any(Object),
         isCapacitor: false,
@@ -701,6 +718,251 @@ describe("WagmiSetup Security Tests", () => {
   });
 
   describe("State Management Security", () => {
+    it("renders the Wagmi provider before starting AppKit", async () => {
+      const { container } = render(
+        <WagmiSetup>
+          <AppKitBootstrapProbe />
+          <div data-testid="children">Test</div>
+        </WagmiSetup>
+      );
+
+      expect(
+        container.querySelector('[data-testid="wagmi-provider"]')
+      ).toBeTruthy();
+      expect(mockCreateAppKitAdapter).toHaveBeenCalledTimes(1);
+      expect(mockInitializeAppKit).not.toHaveBeenCalled();
+      expect(
+        container.querySelector('[data-testid="appkit-created"]')
+      ).toHaveTextContent("false");
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+
+      expect(mockInitializeAppKit).toHaveBeenCalledTimes(1);
+    });
+
+    it("initializes the adapter and AppKit once in Strict Mode", async () => {
+      const tree = (
+        <React.StrictMode>
+          <WagmiSetup>
+            <div data-testid="children">Test</div>
+          </WagmiSetup>
+        </React.StrictMode>
+      );
+      const view = render(tree);
+
+      await waitFor(() => {
+        expect(view.getByTestId("wagmi-provider")).toBeInTheDocument();
+      });
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+
+      view.rerender(tree);
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+
+      expect(mockCreateAppKitAdapter).toHaveBeenCalledTimes(1);
+      expect(mockInitializeAppKit).toHaveBeenCalledTimes(1);
+    });
+
+    it("reuses the adapter and AppKit initialization across a full remount", async () => {
+      const firstView = render(
+        <WagmiSetup>
+          <div data-testid="first-child">First</div>
+        </WagmiSetup>
+      );
+
+      await waitFor(() => {
+        expect(firstView.getByTestId("wagmi-provider")).toBeInTheDocument();
+      });
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+      firstView.unmount();
+
+      const secondView = render(
+        <WagmiSetup>
+          <div data-testid="second-child">Second</div>
+        </WagmiSetup>
+      );
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+
+      expect(secondView.getByTestId("wagmi-provider")).toBeInTheDocument();
+      expect(mockCreateAppKitAdapter).toHaveBeenCalledTimes(1);
+      expect(mockInitializeAppKit).toHaveBeenCalledTimes(1);
+    });
+
+    it("routes retained connector callbacks only to the current password modal", async () => {
+      const appWallet = {
+        address: "0x1234567890123456789012345678901234567890",
+        address_hashed: "hashed-address",
+        name: "Wallet 1",
+        created_at: Date.now(),
+        mnemonic: "",
+        private_key:
+          "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        imported: false,
+      };
+      mockUseAppWallets.mockReturnValue({
+        fetchingAppWallets: false,
+        appWallets: [appWallet],
+        appWalletsSupported: true,
+        createAppWallet: jest.fn(),
+        importAppWallet: jest.fn(),
+        deleteAppWallet: jest.fn(),
+        migrateAppWallet: jest.fn(),
+      });
+
+      const firstView = await renderAndWaitForMount();
+      await waitFor(() => {
+        expect(mockCreateAppWalletConnector).toHaveBeenCalled();
+      });
+      const retainedPasswordRequest = mockCreateAppWalletConnector.mock
+        .calls[0]?.[2] as (() => Promise<string>) | undefined;
+      expect(retainedPasswordRequest).toBeDefined();
+      const firstMountDelegates = [...mockPasswordRequestDelegates];
+
+      firstView.unmount();
+      await expect(retainedPasswordRequest!()).rejects.toThrow(
+        "Internal API failed"
+      );
+      for (const delegate of firstMountDelegates) {
+        expect(delegate).not.toHaveBeenCalled();
+      }
+
+      await renderAndWaitForMount();
+      expect(mockCreateAppWalletConnector).toHaveBeenCalledTimes(1);
+      const currentDelegate = mockPasswordRequestDelegates.at(-1);
+      expect(currentDelegate).toBeDefined();
+      await expect(retainedPasswordRequest!()).resolves.toBe("password");
+
+      expect(currentDelegate).toHaveBeenCalledWith(
+        appWallet.address,
+        appWallet.address_hashed
+      );
+      for (const delegate of firstMountDelegates) {
+        expect(delegate).not.toHaveBeenCalled();
+      }
+      expect(mockCreateAppWalletConnector).toHaveBeenCalledTimes(1);
+    });
+
+    it("routes a retained readiness failure toast to the current provider", async () => {
+      let rejectReady!: (error: Error) => void;
+      const ready = new Promise<void>((_resolve, reject) => {
+        rejectReady = reject;
+      });
+      const adapter = {
+        wagmiConfig: {
+          chains: [],
+          client: {},
+          connectors: [],
+          _internal: {
+            connectors: {
+              setup: mockConnectorSetup,
+              setState: mockConnectorSetState,
+            },
+          },
+        },
+      };
+      const firstToast = jest.fn();
+      const currentToast = jest.fn();
+      mockInitializeAppKit.mockReturnValue({ adapter, ready });
+      (useAuth as jest.Mock).mockReturnValue({ setToast: firstToast });
+
+      const firstView = render(
+        <WagmiSetup>
+          <div>First</div>
+        </WagmiSetup>
+      );
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+      firstView.unmount();
+
+      (useAuth as jest.Mock).mockReturnValue({ setToast: currentToast });
+      render(
+        <WagmiSetup>
+          <div>Second</div>
+        </WagmiSetup>
+      );
+
+      const readyError = new Error("ready failed");
+      await act(async () => {
+        rejectReady(readyError);
+        await ready.catch(() => undefined);
+      });
+
+      await waitFor(() => {
+        expect(currentToast).toHaveBeenCalledWith(
+          expect.objectContaining({ type: "error" })
+        );
+      });
+      expect(firstToast).not.toHaveBeenCalled();
+    });
+
+    it("does not remount children when AppKit is created", async () => {
+      let resolveReady!: () => void;
+      const ready = new Promise<void>((resolve) => {
+        resolveReady = resolve;
+      });
+      const adapter = mockCreateAppKitAdapter.mock.results[0]?.value ?? {
+        wagmiConfig: {
+          chains: [],
+          client: {},
+          connectors: [],
+          _internal: {
+            connectors: {
+              setup: mockConnectorSetup,
+              setState: mockConnectorSetState,
+            },
+          },
+        },
+      };
+      mockInitializeAppKit.mockReturnValue({ adapter, ready });
+      let mountCount = 0;
+      let unmountCount = 0;
+
+      const ChildMountProbe = () => {
+        React.useEffect(() => {
+          mountCount += 1;
+          return () => {
+            unmountCount += 1;
+          };
+        }, []);
+        return <div data-testid="stable-child">Stable</div>;
+      };
+
+      const view = render(
+        <WagmiSetup>
+          <AppKitBootstrapProbe />
+          <ChildMountProbe />
+        </WagmiSetup>
+      );
+      await waitFor(() => {
+        expect(view.getByTestId("stable-child")).toBeInTheDocument();
+      });
+      const childBeforeAppKit = view.getByTestId("stable-child");
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+
+      expect(view.getByTestId("appkit-created")).toHaveTextContent("true");
+      expect(view.getByTestId("stable-child")).toBe(childBeforeAppKit);
+      expect(mountCount).toBe(1);
+      expect(unmountCount).toBe(0);
+
+      await act(async () => {
+        resolveReady();
+        await ready;
+      });
+    });
+
     it("prevents hydration mismatches by using client-side only mounting", async () => {
       // This test verifies the security pattern of preventing SSR hydration mismatches
       // by ensuring the component handles mounting state properly
@@ -1254,8 +1516,7 @@ describe("WagmiSetup Security Tests", () => {
       await renderAndWaitForMount();
 
       expect(mockInitializeAppKit).toHaveBeenCalledWith({
-        wallets: [],
-        adapterManager: expect.any(Object),
+        adapter: expect.any(Object),
         isCapacitor: false,
         chains: expect.any(Array),
       });
@@ -1325,21 +1586,21 @@ describe("WagmiSetup Security Tests", () => {
       };
       const existingConnector = { id: "wallet-connect" };
 
-      mockInitializeAppKit.mockReturnValue({
-        adapter: {
-          wagmiConfig: {
-            chains: [],
-            client: {},
-            connectors: [existingConnector],
-            _internal: {
-              connectors: {
-                setup: mockConnectorSetup,
-                setState: mockConnectorSetState,
-              },
+      const adapter = {
+        wagmiConfig: {
+          chains: [],
+          client: {},
+          connectors: [existingConnector],
+          _internal: {
+            connectors: {
+              setup: mockConnectorSetup,
+              setState: mockConnectorSetState,
             },
           },
         },
-      });
+      };
+      mockCreateAppKitAdapter.mockReturnValue(adapter);
+      mockInitializeAppKit.mockReturnValue({ adapter });
       mockUseAppWallets.mockReturnValue({
         fetchingAppWallets: false,
         appWallets: [validWallet, invalidWallet],
@@ -1397,8 +1658,7 @@ describe("WagmiSetup Security Tests", () => {
       // Component should initialize successfully with valid config
       expect(mockInitializeAppKit).toHaveBeenCalledWith(
         expect.objectContaining({
-          wallets: [],
-          adapterManager: expect.any(Object),
+          adapter: expect.any(Object),
           isCapacitor: false,
         })
       );

--- a/__tests__/utils/appkit-initialization.utils.test.ts
+++ b/__tests__/utils/appkit-initialization.utils.test.ts
@@ -1,4 +1,7 @@
-import { initializeAppKit } from "@/utils/appkit-initialization.utils";
+import {
+  createAppKitAdapter,
+  initializeAppKit,
+} from "@/utils/appkit-initialization.utils";
 import { createAppKit } from "@reown/appkit/react";
 import { mainnet } from "viem/chains";
 import type { AppKitAdapterManager } from "@/components/providers/AppKitAdapterManager";
@@ -26,7 +29,7 @@ jest.mock("@/utils/error-sanitizer", () => ({
   logErrorSecurely: jest.fn(),
 }));
 
-describe("initializeAppKit", () => {
+describe("AppKit initialization", () => {
   const adapter = {
     wagmiConfig: { id: "wagmi-config" },
   } as unknown as WagmiAdapter;
@@ -41,19 +44,30 @@ describe("initializeAppKit", () => {
     };
   });
 
-  it("disables AppKit's default Coinbase connector on Capacitor", () => {
-    initializeAppKit({
+  it("creates the Wagmi adapter independently of AppKit", () => {
+    const result = createAppKitAdapter({
       wallets: [],
       adapterManager: adapterManager as unknown as AppKitAdapterManager,
       isCapacitor: true,
       chains: [mainnet],
     });
 
+    expect(result).toBe(adapter);
     expect(adapterManager.createAdapterWithCache).toHaveBeenCalledWith(
       [],
       true,
       [mainnet]
     );
+    expect(createAppKit).not.toHaveBeenCalled();
+  });
+
+  it("disables AppKit's default Coinbase connector on Capacitor", () => {
+    initializeAppKit({
+      adapter,
+      isCapacitor: true,
+      chains: [mainnet],
+    });
+
     expect(createAppKit).toHaveBeenCalledWith(
       expect.objectContaining({
         enableCoinbase: false,
@@ -63,17 +77,11 @@ describe("initializeAppKit", () => {
 
   it("keeps AppKit's default Coinbase connector enabled outside Capacitor", () => {
     initializeAppKit({
-      wallets: [],
-      adapterManager: adapterManager as unknown as AppKitAdapterManager,
+      adapter,
       isCapacitor: false,
       chains: [mainnet],
     });
 
-    expect(adapterManager.createAdapterWithCache).toHaveBeenCalledWith(
-      [],
-      false,
-      [mainnet]
-    );
     expect(createAppKit).toHaveBeenCalledWith(
       expect.objectContaining({
         enableCoinbase: true,

--- a/components/auth/AppKitModalBridge.tsx
+++ b/components/auth/AppKitModalBridge.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useAppKit, useAppKitState, useWalletInfo } from "@reown/appkit/react";
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useSyncExternalStore,
+} from "react";
+import { logError } from "@/utils/security-logger";
+import { isSafeWalletInfo } from "@/utils/wallet-detection";
+
+type OpenAppKitModal = ReturnType<typeof useAppKit>["open"];
+type AppKitWalletInfo = ReturnType<typeof useWalletInfo>["walletInfo"];
+type AppKitWalletName = NonNullable<AppKitWalletInfo>["name"];
+type AppKitWalletIcon = NonNullable<AppKitWalletInfo>["icon"];
+
+type AppKitModalState = {
+  readonly isOpen: boolean;
+  readonly walletName: AppKitWalletName | undefined;
+  readonly walletIcon: AppKitWalletIcon | undefined;
+  readonly isSafeWallet: boolean;
+};
+
+type AppKitOpenWaiter = {
+  readonly reject: (error: Error) => void;
+  readonly resolve: (open: OpenAppKitModal) => void;
+  readonly timeoutHandle: ReturnType<typeof setTimeout>;
+};
+
+type AppKitModalBridgeStore = {
+  readonly dispose: () => void;
+  readonly failBootstrap: () => void;
+  readonly getSnapshot: () => AppKitModalState;
+  readonly setOpen: (open: OpenAppKitModal | null) => void;
+  readonly setState: (state: AppKitModalState) => void;
+  readonly subscribe: (listener: () => void) => () => void;
+  readonly waitForOpen: () => Promise<OpenAppKitModal>;
+};
+
+const APPKIT_MODAL_BRIDGE_WAIT_TIMEOUT_MS = 15_000;
+const APPKIT_UNAVAILABLE_MESSAGE =
+  "Wallet connection services failed to initialize";
+const EMPTY_APPKIT_MODAL_STATE: AppKitModalState = Object.freeze({
+  isOpen: false,
+  walletName: undefined,
+  walletIcon: undefined,
+  isSafeWallet: false,
+});
+const AppKitModalBridgeStoreContext =
+  createContext<AppKitModalBridgeStore | null>(null);
+
+function getEmptyAppKitModalState(): AppKitModalState {
+  return EMPTY_APPKIT_MODAL_STATE;
+}
+
+export function createAppKitModalBridgeStore(): AppKitModalBridgeStore {
+  let snapshot = EMPTY_APPKIT_MODAL_STATE;
+  let openAppKit: OpenAppKitModal | null = null;
+  let failure: Error | null = null;
+  const listeners = new Set<() => void>();
+  const waiters = new Set<AppKitOpenWaiter>();
+
+  const rejectWaiters = (error: Error): void => {
+    const pendingWaiters = Array.from(waiters);
+    waiters.clear();
+    for (const waiter of pendingWaiters) {
+      clearTimeout(waiter.timeoutHandle);
+      waiter.reject(error);
+    }
+  };
+
+  const fail = (error: Error): void => {
+    failure = error;
+    rejectWaiters(error);
+  };
+
+  return {
+    dispose: () => {
+      fail(new Error("Wallet connection services became unavailable"));
+      listeners.clear();
+    },
+    failBootstrap: () => {
+      fail(new Error(APPKIT_UNAVAILABLE_MESSAGE));
+    },
+    getSnapshot: () => snapshot,
+    setOpen: (nextOpenAppKit) => {
+      openAppKit = nextOpenAppKit;
+      if (!nextOpenAppKit) {
+        return;
+      }
+
+      const pendingWaiters = Array.from(waiters);
+      waiters.clear();
+      for (const waiter of pendingWaiters) {
+        clearTimeout(waiter.timeoutHandle);
+        waiter.resolve(nextOpenAppKit);
+      }
+    },
+    setState: (nextState) => {
+      if (
+        snapshot.isOpen === nextState.isOpen &&
+        snapshot.walletName === nextState.walletName &&
+        snapshot.walletIcon === nextState.walletIcon &&
+        snapshot.isSafeWallet === nextState.isSafeWallet
+      ) {
+        return;
+      }
+
+      snapshot = nextState;
+      for (const listener of listeners) {
+        listener();
+      }
+    },
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    waitForOpen: () => {
+      if (openAppKit) {
+        return Promise.resolve(openAppKit);
+      }
+      if (failure) {
+        return Promise.reject(failure);
+      }
+
+      return new Promise((resolve, reject) => {
+        const waiter: AppKitOpenWaiter = {
+          reject,
+          resolve,
+          timeoutHandle: setTimeout(() => {
+            waiters.delete(waiter);
+            reject(
+              new Error("Timed out waiting for wallet connection services")
+            );
+          }, APPKIT_MODAL_BRIDGE_WAIT_TIMEOUT_MS),
+        };
+        waiters.add(waiter);
+      });
+    },
+  };
+}
+
+export function useAppKitModalBridgeState(
+  store: AppKitModalBridgeStore
+): AppKitModalState {
+  return useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    getEmptyAppKitModalState
+  );
+}
+
+function useAppKitModalBridgeStore(): AppKitModalBridgeStore {
+  const store = useContext(AppKitModalBridgeStoreContext);
+  if (!store) {
+    throw new Error("AppKit modal bridge store is unavailable");
+  }
+  return store;
+}
+
+const AppKitModalHooks: React.FC = () => {
+  const store = useAppKitModalBridgeStore();
+  const { open } = useAppKit();
+  const { walletInfo } = useWalletInfo();
+  const { open: isOpen } = useAppKitState();
+  const walletName = walletInfo?.name;
+  const walletIcon = walletInfo?.icon;
+  const isSafeWallet = isSafeWalletInfo(walletInfo);
+
+  useEffect(() => {
+    store.setOpen(open);
+    return () => {
+      store.setOpen(null);
+    };
+  }, [open, store]);
+
+  useEffect(() => {
+    store.setState({ isOpen, walletName, walletIcon, isSafeWallet });
+  }, [isOpen, isSafeWallet, store, walletIcon, walletName]);
+
+  return null;
+};
+
+class AppKitModalBridgeErrorBoundary extends React.Component<
+  {
+    readonly children: React.ReactNode;
+    readonly store: AppKitModalBridgeStore;
+  },
+  { readonly hasError: boolean }
+> {
+  override state = { hasError: false };
+
+  static getDerivedStateFromError(): { readonly hasError: boolean } {
+    return { hasError: true };
+  }
+
+  override componentDidCatch(error: Error): void {
+    this.props.store.failBootstrap();
+    logError("appkit_modal_bridge", error);
+  }
+
+  override render(): React.ReactNode {
+    return this.state.hasError ? null : this.props.children;
+  }
+}
+
+export const AppKitModalBridge: React.FC<{
+  readonly store: AppKitModalBridgeStore;
+}> = ({ store }) => (
+  <AppKitModalBridgeStoreContext.Provider value={store}>
+    <AppKitModalBridgeErrorBoundary store={store}>
+      <AppKitModalHooks />
+    </AppKitModalBridgeErrorBoundary>
+  </AppKitModalBridgeStoreContext.Provider>
+);

--- a/components/auth/AppKitModalBridge.tsx
+++ b/components/auth/AppKitModalBridge.tsx
@@ -71,8 +71,20 @@ export function createAppKitModalBridgeStore(): AppKitModalBridgeStore {
   };
 
   const fail = (error: Error): void => {
+    if (failure) {
+      return;
+    }
+
     failure = error;
+    openAppKit = null;
+    const stateChanged = snapshot !== EMPTY_APPKIT_MODAL_STATE;
+    snapshot = EMPTY_APPKIT_MODAL_STATE;
     rejectWaiters(error);
+    if (stateChanged) {
+      for (const listener of listeners) {
+        listener();
+      }
+    }
   };
 
   return {
@@ -85,6 +97,10 @@ export function createAppKitModalBridgeStore(): AppKitModalBridgeStore {
     },
     getSnapshot: () => snapshot,
     setOpen: (nextOpenAppKit) => {
+      if (failure) {
+        return;
+      }
+
       openAppKit = nextOpenAppKit;
       if (!nextOpenAppKit) {
         return;
@@ -98,6 +114,10 @@ export function createAppKitModalBridgeStore(): AppKitModalBridgeStore {
       }
     },
     setState: (nextState) => {
+      if (failure) {
+        return;
+      }
+
       if (
         snapshot.isOpen === nextState.isOpen &&
         snapshot.walletName === nextState.walletName &&
@@ -119,11 +139,11 @@ export function createAppKitModalBridgeStore(): AppKitModalBridgeStore {
       };
     },
     waitForOpen: () => {
-      if (openAppKit) {
-        return Promise.resolve(openAppKit);
-      }
       if (failure) {
         return Promise.reject(failure);
+      }
+      if (openAppKit) {
+        return Promise.resolve(openAppKit);
       }
 
       return new Promise((resolve, reject) => {

--- a/components/auth/SeizeConnectProvider.tsx
+++ b/components/auth/SeizeConnectProvider.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import {
-  useAppKit,
-  useAppKitAccount,
-  useAppKitState,
-  useDisconnect,
-  useWalletInfo,
-} from "@reown/appkit/react";
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import { useAppKitAccount, useDisconnect } from "@reown/appkit/react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { getAddress, isAddress } from "viem";
 import { useAccount } from "wagmi";
 import { getNodeEnv, publicEnv } from "@/config/env";
@@ -34,8 +34,12 @@ import {
   logError,
   logSecurityEvent,
 } from "@/utils/security-logger";
-import { isSafeWalletInfo } from "@/utils/wallet-detection";
 import { APP_WALLET_CONNECTOR_TYPE } from "@/wagmiConfig/wagmiAppWalletConnector";
+import {
+  AppKitModalBridge,
+  createAppKitModalBridgeStore,
+  useAppKitModalBridgeState,
+} from "./AppKitModalBridge";
 import { WalletErrorBoundary } from "./error-boundary";
 import { SeizeConnectContext } from "./seizeConnectContextValue";
 import {
@@ -99,12 +103,15 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
 }) => {
   const account = useAppKitAccount();
   const wagmiAccount = useAccount();
-  const { walletInfo } = useWalletInfo();
   const { disconnect } = useDisconnect();
-  const { open } = useAppKit();
-  const state = useAppKitState();
-  const { isReady: isAppKitReady, waitForReady: waitForAppKitReady } =
-    useAppKitBootstrap();
+  const {
+    isCreated: isAppKitCreated,
+    isReady: isAppKitReady,
+    status: appKitBootstrapStatus,
+    waitForReady: waitForAppKitReady,
+  } = useAppKitBootstrap();
+  const appKitModalBridgeStore = useMemo(createAppKitModalBridgeStore, []);
+  const appKitModalState = useAppKitModalBridgeState(appKitModalBridgeStore);
   const [storedConnectedAccounts, setStoredConnectedAccounts] = useState<
     ConnectedWalletAccount[]
   >(() => getConnectedWalletAccounts());
@@ -174,6 +181,19 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
     }
   }, [clearConnectIntentHandoffTimeout]);
 
+  useEffect(() => {
+    if (appKitBootstrapStatus === "error") {
+      appKitModalBridgeStore.failBootstrap();
+    }
+  }, [appKitBootstrapStatus, appKitModalBridgeStore]);
+
+  useEffect(
+    () => () => {
+      appKitModalBridgeStore.dispose();
+    },
+    [appKitModalBridgeStore]
+  );
+
   const scheduleConnectIntentHandoffFallback = useCallback((): void => {
     clearConnectIntentHandoffTimeout();
     connectIntentHandoffTimeoutRef.current = setTimeout(() => {
@@ -204,7 +224,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
     setDisconnected,
     setIsAddingConnectedAccount,
     setIsConnectIntentWaitingForAppKit,
-    stateOpen: state.open,
+    stateOpen: appKitModalState.isOpen,
     storedConnectedAccounts,
     walletState,
   });
@@ -237,7 +257,9 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
           return;
         }
 
-        await open({ view: "Connect" });
+        const openAppKit = await appKitModalBridgeStore.waitForOpen();
+
+        await openAppKit({ view: "Connect" });
 
         logSecurityEvent(
           SecurityEventType.WALLET_MODAL_OPENED,
@@ -257,8 +279,8 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
     [
       clearConnectIntentHandoffTimeout,
       clearConnectIntentWaitingForAppKit,
+      appKitModalBridgeStore,
       isAppKitReady,
-      open,
       scheduleConnectIntentHandoffFallback,
       waitForAppKitReady,
     ]
@@ -521,9 +543,8 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
     [activeAddress, refreshStoredConnectedAccounts, setConnected]
   );
 
-  const canAddConnectedAccount = useMemo(() => {
-    return storedConnectedAccounts.length < MAX_CONNECTED_PROFILES;
-  }, [storedConnectedAccounts]);
+  const canAddConnectedAccount =
+    storedConnectedAccounts.length < MAX_CONNECTED_PROFILES;
 
   const openAddConnectedAccountModal = useCallback(
     (clearAddConnectedAccountGuard: () => void): void => {
@@ -559,7 +580,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
         : null;
     const addFlowOriginAddress = addFlowOriginAddressRef.current;
     const addFlowReturnedToOrigin =
-      !state.open &&
+      !appKitModalState.isOpen &&
       !isConnectIntentWaitingForAppKit &&
       !!liveConnectedWallet &&
       !!addFlowOriginAddress &&
@@ -569,7 +590,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
       isAddingConnectedAccountRef.current &&
       (!isAddingConnectedAccount ||
         addFlowReturnedToOrigin ||
-        (!state.open &&
+        (!appKitModalState.isOpen &&
           !isConnectIntentWaitingForAppKit &&
           !retryConnectTimeoutRef.current &&
           !liveConnectedWallet &&
@@ -645,7 +666,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
     isAddingConnectedAccount,
     isConnectIntentWaitingForAppKit,
     openAddConnectedAccountModal,
-    state.open,
+    appKitModalState.isOpen,
   ]);
 
   const connectedAccounts = useMemo(() => {
@@ -754,10 +775,14 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
   const contextValue = useMemo(
     (): SeizeConnectContextType => ({
       address: activeAddress,
-      walletName: isActiveWalletConnected ? walletInfo?.name : undefined,
-      walletIcon: isActiveWalletConnected ? walletInfo?.icon : undefined,
+      walletName: isActiveWalletConnected
+        ? appKitModalState.walletName
+        : undefined,
+      walletIcon: isActiveWalletConnected
+        ? appKitModalState.walletIcon
+        : undefined,
       isSafeWallet: isActiveWalletConnected
-        ? isSafeWalletInfo(walletInfo)
+        ? appKitModalState.isSafeWallet
         : false,
       seizeConnect,
       seizeConnectFresh,
@@ -767,7 +792,8 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
       seizeAcceptConnection,
       seizeSwitchConnectedAccount,
       seizeAddConnectedAccount,
-      seizeConnectOpen: state.open || isConnectIntentWaitingForAppKit,
+      seizeConnectOpen:
+        appKitModalState.isOpen || isConnectIntentWaitingForAppKit,
       isConnected: isActiveWalletConnected,
       canSignActiveWallet: isActiveWalletConnected,
       hasActiveWalletAddress,
@@ -787,9 +813,9 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
       hasValidWalletAuth,
       isActiveWalletConnected,
       connectedAccounts,
-      walletInfo?.name,
-      walletInfo?.icon,
-      walletInfo?.type,
+      appKitModalState.walletName,
+      appKitModalState.walletIcon,
+      appKitModalState.isSafeWallet,
       seizeConnect,
       seizeConnectFresh,
       seizeDisconnect,
@@ -799,7 +825,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
       seizeSwitchConnectedAccount,
       seizeAddConnectedAccount,
       isConnectIntentWaitingForAppKit,
-      state.open,
+      appKitModalState.isOpen,
       account.isConnected,
       walletState,
       hasInitializationError,
@@ -813,6 +839,9 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
     <WalletErrorBoundary>
       <SeizeConnectContext.Provider value={contextValue}>
         {children}
+        {isAppKitCreated && (
+          <AppKitModalBridge store={appKitModalBridgeStore} />
+        )}
       </SeizeConnectContext.Provider>
     </WalletErrorBoundary>
   );

--- a/components/auth/SeizeConnectProvider.tsx
+++ b/components/auth/SeizeConnectProvider.tsx
@@ -105,6 +105,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
   const wagmiAccount = useAccount();
   const { disconnect } = useDisconnect();
   const {
+    hasTerminalError: hasTerminalBootstrapError,
     isCreated: isAppKitCreated,
     isReady: isAppKitReady,
     status: appKitBootstrapStatus,
@@ -182,10 +183,14 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
   }, [clearConnectIntentHandoffTimeout]);
 
   useEffect(() => {
-    if (appKitBootstrapStatus === "error") {
+    if (appKitBootstrapStatus === "error" && hasTerminalBootstrapError) {
       appKitModalBridgeStore.failBootstrap();
     }
-  }, [appKitBootstrapStatus, appKitModalBridgeStore]);
+  }, [
+    appKitBootstrapStatus,
+    appKitModalBridgeStore,
+    hasTerminalBootstrapError,
+  ]);
 
   useEffect(
     () => () => {

--- a/components/providers/AppKitBootstrapContext.tsx
+++ b/components/providers/AppKitBootstrapContext.tsx
@@ -6,6 +6,7 @@ export type AppKitBootstrapStatus = "initializing" | "ready" | "error";
 
 export type AppKitBootstrapContextValue = {
   readonly status: AppKitBootstrapStatus;
+  readonly isCreated: boolean;
   readonly isReady: boolean;
   readonly isWaiting: boolean;
   readonly waitForReady: () => Promise<void>;
@@ -13,6 +14,7 @@ export type AppKitBootstrapContextValue = {
 
 const readyContextValue = {
   status: "ready",
+  isCreated: true,
   isReady: true,
   isWaiting: false,
   waitForReady: () => Promise.resolve(),

--- a/components/providers/AppKitBootstrapContext.tsx
+++ b/components/providers/AppKitBootstrapContext.tsx
@@ -6,6 +6,7 @@ export type AppKitBootstrapStatus = "initializing" | "ready" | "error";
 
 export type AppKitBootstrapContextValue = {
   readonly status: AppKitBootstrapStatus;
+  readonly hasTerminalError: boolean;
   readonly isCreated: boolean;
   readonly isReady: boolean;
   readonly isWaiting: boolean;
@@ -14,6 +15,7 @@ export type AppKitBootstrapContextValue = {
 
 const readyContextValue = {
   status: "ready",
+  hasTerminalError: false,
   isCreated: true,
   isReady: true,
   isWaiting: false,

--- a/components/providers/WagmiSetup.tsx
+++ b/components/providers/WagmiSetup.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Capacitor } from "@capacitor/core";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
 import { mainnet, sepolia } from "viem/chains";
 import { WagmiProvider } from "wagmi";
 import type { AppWallet } from "@/components/app-wallets/AppWalletsContext";
@@ -17,8 +17,14 @@ import type { AppToastInput } from "@/components/utils/toast/AppToast";
 import { publicEnv } from "@/config/env";
 import { useAppWalletPasswordModal } from "@/hooks/useAppWalletPasswordModal";
 import { AppKitValidationError } from "@/errors/appkit-initialization";
-import type { AppKitInitializationConfig } from "@/utils/appkit-initialization.utils";
-import { initializeAppKit } from "@/utils/appkit-initialization.utils";
+import type {
+  AppKitAdapterConfig,
+  AppKitInitializationConfig,
+} from "@/utils/appkit-initialization.utils";
+import {
+  createAppKitAdapter,
+  initializeAppKit,
+} from "@/utils/appkit-initialization.utils";
 import {
   logErrorSecurely,
   sanitizeErrorForUser,
@@ -39,24 +45,187 @@ type MutableRef<T> = {
   current: T;
 };
 
-type SetupAppKitAdapter = (wallets: AppWallet[]) => Promise<void>;
+type WagmiAppKitFastPathSnapshot = {
+  readonly adapter: WagmiAdapter | null;
+  readonly adapterInitializationStarted: boolean;
+  readonly configurationKey: string | null;
+  readonly initializationPromise: Promise<void> | null;
+  readonly isCreated: boolean;
+  readonly status: AppKitBootstrapStatus;
+};
+
+type WagmiAppKitFastPathStore = {
+  snapshot: WagmiAppKitFastPathSnapshot;
+  readonly listeners: Set<() => void>;
+  readonly processedWallets: MutableRef<Set<string>>;
+  passwordRequestDelegate:
+    | ((address: string, addressHashed: string) => Promise<string>)
+    | null;
+  toastDelegate: ((toast: AppToastInput) => void) | null;
+};
+
+const WAGMI_APPKIT_FAST_PATH_STORE_KEY = Symbol.for(
+  "6529.wagmiAppKitFastPathStore"
+);
+const INTERNAL_API_FAILED_MESSAGE = "Internal API failed";
+
+const EMPTY_FAST_PATH_SNAPSHOT: WagmiAppKitFastPathSnapshot = Object.freeze({
+  adapter: null,
+  adapterInitializationStarted: false,
+  configurationKey: null,
+  initializationPromise: null,
+  isCreated: false,
+  status: "initializing",
+});
+
+function getWagmiAppKitFastPathStore(): WagmiAppKitFastPathStore {
+  const existingStore = Reflect.get(
+    globalThis,
+    WAGMI_APPKIT_FAST_PATH_STORE_KEY
+  ) as WagmiAppKitFastPathStore | undefined;
+  if (existingStore) {
+    return existingStore;
+  }
+
+  const store: WagmiAppKitFastPathStore = {
+    snapshot: EMPTY_FAST_PATH_SNAPSHOT,
+    listeners: new Set(),
+    processedWallets: { current: new Set() },
+    passwordRequestDelegate: null,
+    toastDelegate: null,
+  };
+  Reflect.set(globalThis, WAGMI_APPKIT_FAST_PATH_STORE_KEY, store);
+  return store;
+}
+
+function getWagmiAppKitFastPathSnapshot(): WagmiAppKitFastPathSnapshot {
+  return getWagmiAppKitFastPathStore().snapshot;
+}
+
+function getEmptyWagmiAppKitFastPathSnapshot(): WagmiAppKitFastPathSnapshot {
+  return EMPTY_FAST_PATH_SNAPSHOT;
+}
+
+function subscribeToWagmiAppKitFastPathStore(listener: () => void): () => void {
+  const store = getWagmiAppKitFastPathStore();
+  store.listeners.add(listener);
+  return () => {
+    store.listeners.delete(listener);
+  };
+}
+
+function updateWagmiAppKitFastPathSnapshot(
+  update: Partial<WagmiAppKitFastPathSnapshot>
+): void {
+  const store = getWagmiAppKitFastPathStore();
+  store.snapshot = { ...store.snapshot, ...update };
+  for (const listener of store.listeners) {
+    listener();
+  }
+}
+
+function requestAppWalletPassword(
+  address: string,
+  addressHashed: string
+): Promise<string> {
+  const delegate = getWagmiAppKitFastPathStore().passwordRequestDelegate;
+  if (!delegate) {
+    return Promise.reject(
+      new AppKitValidationError(INTERNAL_API_FAILED_MESSAGE)
+    );
+  }
+
+  return delegate(address, addressHashed);
+}
+
+function showAppKitToast(toast: AppToastInput): void {
+  getWagmiAppKitFastPathStore().toastDelegate?.(toast);
+}
+
+function assertFastPathConfiguration(configurationKey: string): void {
+  const existingConfigurationKey =
+    getWagmiAppKitFastPathSnapshot().configurationKey;
+  if (
+    existingConfigurationKey !== null &&
+    existingConfigurationKey !== configurationKey
+  ) {
+    throw new AppKitValidationError(INTERNAL_API_FAILED_MESSAGE);
+  }
+}
+
+function createWagmiAdapterOnce(
+  configurationKey: string,
+  createAdapter: () => WagmiAdapter
+): WagmiAdapter {
+  assertFastPathConfiguration(configurationKey);
+  const snapshot = getWagmiAppKitFastPathSnapshot();
+  if (snapshot.adapter) {
+    return snapshot.adapter;
+  }
+  if (snapshot.adapterInitializationStarted) {
+    throw new AppKitValidationError(INTERNAL_API_FAILED_MESSAGE);
+  }
+
+  updateWagmiAppKitFastPathSnapshot({
+    adapterInitializationStarted: true,
+    configurationKey,
+  });
+
+  try {
+    const adapter = createAdapter();
+    updateWagmiAppKitFastPathSnapshot({ adapter });
+    return adapter;
+  } catch (error) {
+    updateWagmiAppKitFastPathSnapshot({ status: "error" });
+    throw error;
+  }
+}
+
+async function runAppKitInitialization(
+  initialize: () => Promise<void>
+): Promise<void> {
+  await Promise.resolve();
+  try {
+    await initialize();
+    updateWagmiAppKitFastPathSnapshot({ status: "ready" });
+  } catch (error) {
+    updateWagmiAppKitFastPathSnapshot({ status: "error" });
+    throw error;
+  }
+}
+
+function startAppKitInitializationOnce(
+  configurationKey: string,
+  initialize: () => Promise<void>
+): Promise<void> {
+  try {
+    assertFastPathConfiguration(configurationKey);
+  } catch (error) {
+    return Promise.reject(error);
+  }
+
+  const snapshot = getWagmiAppKitFastPathSnapshot();
+  if (snapshot.initializationPromise) {
+    return snapshot.initializationPromise;
+  }
+
+  const initializationPromise = runAppKitInitialization(initialize);
+
+  updateWagmiAppKitFastPathSnapshot({
+    configurationKey,
+    initializationPromise,
+    status: "initializing",
+  });
+  return initializationPromise;
+}
 
 // Ceiling on how long connect-intent callers wait for AppKit readiness; a hung
 // WalletConnect relay must surface as a connect error, not a stuck busy state.
 const APPKIT_READY_WAIT_TIMEOUT_MS = 15_000;
 
-type InitializeAdapterInput = {
-  readonly currentAdapter: WagmiAdapter | null;
-  readonly isInitializingRef: MutableRef<boolean>;
-  readonly setupAppKitAdapter: SetupAppKitAdapter;
-};
-
 type InjectAppWalletConnectorsInput = {
   readonly currentAdapter: WagmiAdapter | null;
   readonly appWallets: readonly AppWallet[];
-  readonly appWalletPasswordModal: ReturnType<typeof useAppWalletPasswordModal>;
-  readonly processedWallets: MutableRef<Set<string>>;
-  readonly setToast: (toast: AppToastInput) => void;
 };
 
 type AppKitAdapterManagerPublicShape = Pick<
@@ -173,7 +342,7 @@ function canAssignProperty(descriptor: PropertyDescriptor): boolean {
 
 function assertAppKitAdapterManager(value: unknown): AppKitAdapterManager {
   if (!isAppKitAdapterManager(value)) {
-    throw new AppKitValidationError("Internal API failed");
+    throw new AppKitValidationError(INTERNAL_API_FAILED_MESSAGE);
   }
 
   return value;
@@ -198,21 +367,6 @@ function isAppKitAdapterManager(value: unknown): value is AppKitAdapterManager {
   );
 }
 
-function initializeAdapterWhenNeeded({
-  currentAdapter,
-  isInitializingRef,
-  setupAppKitAdapter,
-}: InitializeAdapterInput): void {
-  if (currentAdapter !== null || isInitializingRef.current) {
-    return;
-  }
-
-  installSafeEthereumProxy();
-  // Prevent unhandled promise rejections during eager initialization.
-  // Fail-fast behavior is preserved by leaving `currentAdapter` unset.
-  void setupAppKitAdapter([]).catch(() => undefined);
-}
-
 function markAdapterReadyForLaunchTiming(
   currentAdapter: WagmiAdapter | null
 ): void {
@@ -226,13 +380,12 @@ function markAdapterReadyForLaunchTiming(
 function injectAppWalletConnectors({
   currentAdapter,
   appWallets,
-  appWalletPasswordModal,
-  processedWallets,
-  setToast,
 }: InjectAppWalletConnectorsInput): void {
   if (currentAdapter === null) {
     return;
   }
+
+  const { processedWallets } = getWagmiAppKitFastPathStore();
 
   // Check if wallets have actually changed to prevent unnecessary re-injection
   const currentAddresses = new Set(appWallets.map((w) => w.address));
@@ -254,11 +407,7 @@ function injectAppWalletConnectors({
         const connector = createAppWalletConnector(
           Array.from(currentAdapter.wagmiConfig.chains),
           { appWallet: wallet },
-          () =>
-            appWalletPasswordModal.requestPassword(
-              wallet.address,
-              wallet.address_hashed
-            )
+          () => requestAppWalletPassword(wallet.address, wallet.address_hashed)
         );
         const setupConnector =
           currentAdapter.wagmiConfig._internal.connectors.setup(connector);
@@ -288,7 +437,7 @@ function injectAppWalletConnectors({
   } catch (error) {
     logErrorSecurely("[WagmiSetup] Connector injection failed", error);
     const userMessage = sanitizeErrorForUser(error);
-    setToast({
+    showAppKitToast({
       message: userMessage,
       type: "error",
     });
@@ -307,17 +456,27 @@ export default function WagmiSetup({
   const { appWallets, migrateAppWallet } = useAppWallets();
   const appWalletPasswordModal = useAppWalletPasswordModal(migrateAppWallet);
 
-  const [currentAdapter, setCurrentAdapter] = useState<WagmiAdapter | null>(
-    null
+  const fastPathSnapshot = useSyncExternalStore(
+    subscribeToWagmiAppKitFastPathStore,
+    getWagmiAppKitFastPathSnapshot,
+    getEmptyWagmiAppKitFastPathSnapshot
   );
-  const [appKitBootstrapStatus, setAppKitBootstrapStatus] =
-    useState<AppKitBootstrapStatus>("initializing");
 
-  // Track processed wallets by address for efficient comparison
-  const processedWallets = useRef<Set<string>>(new Set());
-  const isInitializingRef = useRef(false);
-  const isMountedRef = useRef(true);
-  const appKitReadyPromiseRef = useRef<Promise<void> | null>(null);
+  useEffect(() => {
+    const store = getWagmiAppKitFastPathStore();
+    const passwordRequestDelegate = appWalletPasswordModal.requestPassword;
+    store.passwordRequestDelegate = passwordRequestDelegate;
+    store.toastDelegate = setToast;
+
+    return () => {
+      if (store.passwordRequestDelegate === passwordRequestDelegate) {
+        store.passwordRequestDelegate = null;
+      }
+      if (store.toastDelegate === setToast) {
+        store.toastDelegate = null;
+      }
+    };
+  }, [appWalletPasswordModal.requestPassword, setToast]);
 
   // Memoize platform detection to avoid repeated calls
   const isCapacitor = useMemo(() => {
@@ -326,27 +485,104 @@ export default function WagmiSetup({
     return isNative;
   }, []);
 
-  // Use the same adapter manager for both mobile and web
-  // AppKit will automatically handle the appropriate connectors
-  const adapterManager = useMemo(
-    () => new AppKitAdapterManager(appWalletPasswordModal.requestPassword),
-    [appWalletPasswordModal.requestPassword]
+  const chains = useMemo<Chain[]>(
+    () => (enableTestnet ? [mainnet, sepolia] : [mainnet]),
+    [enableTestnet]
   );
 
+  const bootstrapConfigurationKey = `${isCapacitor ? "capacitor" : "web"}:${chains
+    .map((chain) => chain.id)
+    .join(",")}`;
+  const hasFastPathConfigurationMismatch =
+    fastPathSnapshot.configurationKey !== null &&
+    fastPathSnapshot.configurationKey !== bootstrapConfigurationKey;
+  const currentAdapter = hasFastPathConfigurationMismatch
+    ? null
+    : fastPathSnapshot.adapter;
+
   useEffect(() => {
-    isMountedRef.current = true;
-
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, []);
-
-  const waitForAppKitReady = useCallback(async () => {
-    const readyPromise = appKitReadyPromiseRef.current;
-    if (!readyPromise) {
+    if (
+      !hasFastPathConfigurationMismatch ||
+      fastPathSnapshot.status === "error"
+    ) {
       return;
     }
 
+    const error = new AppKitValidationError(INTERNAL_API_FAILED_MESSAGE);
+    updateWagmiAppKitFastPathSnapshot({ status: "error" });
+    logErrorSecurely("[WagmiSetup] AppKit configuration changed", error);
+    showAppKitToast({
+      message: sanitizeErrorForUser(error),
+      type: "error",
+    });
+  }, [fastPathSnapshot.status, hasFastPathConfigurationMismatch]);
+
+  const createWagmiAdapter = useCallback((): WagmiAdapter => {
+    const adapterManager = new AppKitAdapterManager(requestAppWalletPassword);
+
+    const config: AppKitAdapterConfig = {
+      wallets: [],
+      adapterManager: assertAppKitAdapterManager(adapterManager),
+      isCapacitor,
+      chains,
+    };
+
+    return createAppKitAdapter(config);
+  }, [chains, isCapacitor]);
+
+  const startAppKitInitialization = useCallback((): Promise<void> => {
+    if (currentAdapter === null) {
+      return Promise.reject(
+        new AppKitValidationError(INTERNAL_API_FAILED_MESSAGE)
+      );
+    }
+
+    return startAppKitInitializationOnce(
+      bootstrapConfigurationKey,
+      async () => {
+        let result: ReturnType<typeof initializeAppKit>;
+
+        try {
+          const config: AppKitInitializationConfig = {
+            adapter: currentAdapter,
+            isCapacitor,
+            chains,
+          };
+          result = await measureMobileLaunchAsync("wagmi_appkit_init", () =>
+            initializeAppKit(config)
+          );
+          updateWagmiAppKitFastPathSnapshot({ isCreated: true });
+        } catch (error) {
+          logErrorSecurely("[WagmiSetup] AppKit initialization failed", error);
+          showAppKitToast({
+            message: sanitizeErrorForUser(error),
+            type: "error",
+          });
+          throw error;
+        }
+
+        try {
+          await measureMobileLaunchAsync("wagmi_adapter_ready", async () => {
+            await (result.ready ?? Promise.resolve());
+          });
+          markMobileLaunchStep("wagmi_ready");
+        } catch (error) {
+          showAppKitToast({
+            message: sanitizeErrorForUser(error),
+            type: "error",
+          });
+          logErrorSecurely(
+            "[WagmiSetup] AppKit ready failed after adapter mount",
+            error
+          );
+          throw error;
+        }
+      }
+    );
+  }, [bootstrapConfigurationKey, chains, currentAdapter, isCapacitor]);
+
+  const waitForAppKitReady = useCallback(async () => {
+    const readyPromise = startAppKitInitialization();
     let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<never>((_resolve, reject) => {
       timeoutHandle = setTimeout(() => {
@@ -363,116 +599,44 @@ export default function WagmiSetup({
     } finally {
       clearTimeout(timeoutHandle);
     }
-  }, []);
+  }, [startAppKitInitialization]);
 
   const appKitBootstrapValue = useMemo(
     (): AppKitBootstrapContextValue => ({
-      status: appKitBootstrapStatus,
-      isReady: appKitBootstrapStatus === "ready",
-      isWaiting: appKitBootstrapStatus === "initializing",
+      status: fastPathSnapshot.status,
+      isCreated: fastPathSnapshot.isCreated,
+      isReady: fastPathSnapshot.status === "ready",
+      isWaiting: fastPathSnapshot.status === "initializing",
       waitForReady: waitForAppKitReady,
     }),
-    [appKitBootstrapStatus, waitForAppKitReady]
+    [fastPathSnapshot, waitForAppKitReady]
   );
 
-  // Create adapter with essential configuration only
-  const initializeAppKitWithWallets = useCallback(
-    (wallets: AppWallet[]) => {
-      const chains: Chain[] = [mainnet];
-      if (enableTestnet) {
-        chains.push(sepolia);
-      }
-
-      const config: AppKitInitializationConfig = {
-        wallets,
-        adapterManager: assertAppKitAdapterManager(adapterManager),
-        isCapacitor,
-        chains,
-      };
-
-      return initializeAppKit(config);
-    },
-    [adapterManager, isCapacitor, enableTestnet]
-  );
-
-  // Create the wagmi adapter fail-fast, then let AppKit finish readiness work
-  // without blocking the app shell.
-  const setupAppKitAdapter = useCallback(
-    async (wallets: AppWallet[]) => {
-      if (isInitializingRef.current) {
-        throw new AppKitValidationError("Internal API failed");
-      }
-
-      isInitializingRef.current = true;
-      setAppKitBootstrapStatus("initializing");
-      appKitReadyPromiseRef.current = null;
-
-      try {
-        markMobileLaunchStep("wagmi_init_start");
-        const result = await measureMobileLaunchAsync("wagmi_appkit_init", () =>
-          initializeAppKitWithWallets(wallets)
-        );
-        markMobileLaunchStep("wagmi_adapter_created");
-
-        const readyPromise = measureMobileLaunchAsync(
-          "wagmi_adapter_ready",
-          async () => {
-            await (result.ready ?? Promise.resolve());
-          }
-        )
-          .then(() => {
-            markMobileLaunchStep("wagmi_ready");
-            if (isMountedRef.current) {
-              setAppKitBootstrapStatus("ready");
-            }
-            return undefined;
-          })
-          .catch((error) => {
-            if (isMountedRef.current) {
-              setAppKitBootstrapStatus("error");
-              setToast({
-                message: sanitizeErrorForUser(error),
-                type: "error",
-              });
-            }
-            logErrorSecurely(
-              "[WagmiSetup] AppKit ready failed after adapter mount",
-              error
-            );
-            throw error;
-          });
-
-        appKitReadyPromiseRef.current = readyPromise;
-        // Keep the stored promise rejectable for connect-intent callers while
-        // preventing background readiness work from surfacing an unhandled rejection.
-        void readyPromise.catch(() => undefined);
-        setCurrentAdapter(result.adapter);
-      } catch (error) {
-        if (isMountedRef.current) {
-          setAppKitBootstrapStatus("error");
-        }
-        logErrorSecurely("[WagmiSetup] AppKit initialization failed", error);
-        const userMessage = sanitizeErrorForUser(error);
-        setToast({
-          message: userMessage,
-          type: "error",
-        });
-        throw error; // Adapter creation still fails fast because wagmi hooks need a provider.
-      } finally {
-        isInitializingRef.current = false;
-      }
-    },
-    [initializeAppKitWithWallets, setToast]
-  );
-
-  // Initialize adapter eagerly on mount with empty wallets
+  // Create only the Wagmi adapter on mount so hooks can render under a stable
+  // provider before AppKit performs its heavier initialization.
   useEffect(() => {
-    initializeAdapterWhenNeeded({
-      currentAdapter,
-      isInitializingRef,
-      setupAppKitAdapter,
-    });
-  }, [currentAdapter, setupAppKitAdapter]);
+    if (fastPathSnapshot.adapterInitializationStarted) {
+      return;
+    }
+
+    installSafeEthereumProxy();
+    markMobileLaunchStep("wagmi_init_start");
+
+    try {
+      createWagmiAdapterOnce(bootstrapConfigurationKey, createWagmiAdapter);
+      markMobileLaunchStep("wagmi_adapter_created");
+    } catch (error) {
+      logErrorSecurely("[WagmiSetup] AppKit initialization failed", error);
+      showAppKitToast({
+        message: sanitizeErrorForUser(error),
+        type: "error",
+      });
+    }
+  }, [
+    bootstrapConfigurationKey,
+    createWagmiAdapter,
+    fastPathSnapshot.adapterInitializationStarted,
+  ]);
 
   useEffect(() => {
     markAdapterReadyForLaunchTiming(currentAdapter);
@@ -483,11 +647,25 @@ export default function WagmiSetup({
     injectAppWalletConnectors({
       currentAdapter,
       appWallets,
-      appWalletPasswordModal,
-      processedWallets,
-      setToast,
     });
-  }, [currentAdapter, appWallets, appWalletPasswordModal, setToast]);
+  }, [currentAdapter, appWallets]);
+
+  // A new task gives React a paint opportunity after the Wagmi provider and
+  // children commit. User connect intent can start the same singleton sooner
+  // through waitForAppKitReady without creating a second AppKit instance.
+  useEffect(() => {
+    if (currentAdapter === null) {
+      return;
+    }
+
+    const timeoutHandle = setTimeout(() => {
+      void startAppKitInitialization().catch(() => undefined);
+    }, 0);
+
+    return () => {
+      clearTimeout(timeoutHandle);
+    };
+  }, [currentAdapter, startAppKitInitialization]);
 
   // Show loading state until the wagmi adapter exists.
   if (currentAdapter === null) {

--- a/components/providers/WagmiSetup.tsx
+++ b/components/providers/WagmiSetup.tsx
@@ -68,6 +68,11 @@ const WAGMI_APPKIT_FAST_PATH_STORE_KEY = Symbol.for(
   "6529.wagmiAppKitFastPathStore"
 );
 const INTERNAL_API_FAILED_MESSAGE = "Internal API failed";
+// A hung WalletConnect relay must settle the shared bootstrap as an error, not
+// leave every present and future connect intent in a perpetual waiting state.
+const APPKIT_READY_WAIT_TIMEOUT_MS = 15_000;
+const APPKIT_READY_TIMEOUT_MESSAGE =
+  "Timed out waiting for wallet connection services to become ready";
 
 const EMPTY_FAST_PATH_SNAPSHOT: WagmiAppKitFastPathSnapshot = Object.freeze({
   adapter: null,
@@ -185,12 +190,21 @@ async function runAppKitInitialization(
   initialize: () => Promise<void>
 ): Promise<void> {
   await Promise.resolve();
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeoutHandle = setTimeout(() => {
+      reject(new Error(APPKIT_READY_TIMEOUT_MESSAGE));
+    }, APPKIT_READY_WAIT_TIMEOUT_MS);
+  });
+
   try {
-    await initialize();
+    await Promise.race([initialize(), timeoutPromise]);
     updateWagmiAppKitFastPathSnapshot({ status: "ready" });
   } catch (error) {
     updateWagmiAppKitFastPathSnapshot({ status: "error" });
     throw error;
+  } finally {
+    clearTimeout(timeoutHandle);
   }
 }
 
@@ -218,10 +232,6 @@ function startAppKitInitializationOnce(
   });
   return initializationPromise;
 }
-
-// Ceiling on how long connect-intent callers wait for AppKit readiness; a hung
-// WalletConnect relay must surface as a connect error, not a stuck busy state.
-const APPKIT_READY_WAIT_TIMEOUT_MS = 15_000;
 
 type InjectAppWalletConnectorsInput = {
   readonly currentAdapter: WagmiAdapter | null;
@@ -581,25 +591,10 @@ export default function WagmiSetup({
     );
   }, [bootstrapConfigurationKey, chains, currentAdapter, isCapacitor]);
 
-  const waitForAppKitReady = useCallback(async () => {
-    const readyPromise = startAppKitInitialization();
-    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-    const timeoutPromise = new Promise<never>((_resolve, reject) => {
-      timeoutHandle = setTimeout(() => {
-        reject(
-          new Error(
-            "Timed out waiting for wallet connection services to become ready"
-          )
-        );
-      }, APPKIT_READY_WAIT_TIMEOUT_MS);
-    });
-
-    try {
-      await Promise.race([readyPromise, timeoutPromise]);
-    } finally {
-      clearTimeout(timeoutHandle);
-    }
-  }, [startAppKitInitialization]);
+  const waitForAppKitReady = useCallback(
+    () => startAppKitInitialization(),
+    [startAppKitInitialization]
+  );
 
   const appKitBootstrapValue = useMemo(
     (): AppKitBootstrapContextValue => ({
@@ -659,7 +654,7 @@ export default function WagmiSetup({
     }
 
     const timeoutHandle = setTimeout(() => {
-      void startAppKitInitialization().catch(() => undefined);
+      startAppKitInitialization().catch(() => undefined);
     }, 0);
 
     return () => {

--- a/components/providers/WagmiSetup.tsx
+++ b/components/providers/WagmiSetup.tsx
@@ -49,6 +49,7 @@ type WagmiAppKitFastPathSnapshot = {
   readonly adapter: WagmiAdapter | null;
   readonly adapterInitializationStarted: boolean;
   readonly configurationKey: string | null;
+  readonly hasTerminalError: boolean;
   readonly initializationPromise: Promise<void> | null;
   readonly isCreated: boolean;
   readonly status: AppKitBootstrapStatus;
@@ -78,6 +79,7 @@ const EMPTY_FAST_PATH_SNAPSHOT: WagmiAppKitFastPathSnapshot = Object.freeze({
   adapter: null,
   adapterInitializationStarted: false,
   configurationKey: null,
+  hasTerminalError: false,
   initializationPromise: null,
   isCreated: false,
   status: "initializing",
@@ -89,6 +91,17 @@ function getWagmiAppKitFastPathStore(): WagmiAppKitFastPathStore {
     WAGMI_APPKIT_FAST_PATH_STORE_KEY
   ) as WagmiAppKitFastPathStore | undefined;
   if (existingStore) {
+    // Preserve the retained adapter across HMR while safely upgrading stores
+    // created by an earlier module version.
+    if (
+      typeof Reflect.get(existingStore.snapshot, "hasTerminalError") !==
+      "boolean"
+    ) {
+      existingStore.snapshot = {
+        ...existingStore.snapshot,
+        hasTerminalError: existingStore.snapshot.status === "error",
+      };
+    }
     return existingStore;
   }
 
@@ -181,7 +194,10 @@ function createWagmiAdapterOnce(
     updateWagmiAppKitFastPathSnapshot({ adapter });
     return adapter;
   } catch (error) {
-    updateWagmiAppKitFastPathSnapshot({ status: "error" });
+    updateWagmiAppKitFastPathSnapshot({
+      hasTerminalError: true,
+      status: "error",
+    });
     throw error;
   }
 }
@@ -190,18 +206,48 @@ async function runAppKitInitialization(
   initialize: () => Promise<void>
 ): Promise<void> {
   await Promise.resolve();
+  let didTimeout = false;
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<never>((_resolve, reject) => {
     timeoutHandle = setTimeout(() => {
+      didTimeout = true;
       reject(new Error(APPKIT_READY_TIMEOUT_MESSAGE));
     }, APPKIT_READY_WAIT_TIMEOUT_MS);
   });
 
   try {
-    await Promise.race([initialize(), timeoutPromise]);
-    updateWagmiAppKitFastPathSnapshot({ status: "ready" });
+    const sdkInitializationPromise = initialize().then(
+      () => {
+        // The caller still receives the bounded timeout rejection, but a
+        // genuine late SDK readiness signal makes future attempts usable.
+        if (didTimeout) {
+          updateWagmiAppKitFastPathSnapshot({
+            hasTerminalError: false,
+            status: "ready",
+          });
+        }
+        return undefined;
+      },
+      (error: unknown) => {
+        if (didTimeout) {
+          updateWagmiAppKitFastPathSnapshot({
+            hasTerminalError: true,
+            status: "error",
+          });
+        }
+        throw error;
+      }
+    );
+    await Promise.race([sdkInitializationPromise, timeoutPromise]);
+    updateWagmiAppKitFastPathSnapshot({
+      hasTerminalError: false,
+      status: "ready",
+    });
   } catch (error) {
-    updateWagmiAppKitFastPathSnapshot({ status: "error" });
+    updateWagmiAppKitFastPathSnapshot({
+      hasTerminalError: !didTimeout,
+      status: "error",
+    });
     throw error;
   } finally {
     clearTimeout(timeoutHandle);
@@ -219,6 +265,9 @@ function startAppKitInitializationOnce(
   }
 
   const snapshot = getWagmiAppKitFastPathSnapshot();
+  if (snapshot.status === "ready") {
+    return Promise.resolve();
+  }
   if (snapshot.initializationPromise) {
     return snapshot.initializationPromise;
   }
@@ -519,7 +568,10 @@ export default function WagmiSetup({
     }
 
     const error = new AppKitValidationError(INTERNAL_API_FAILED_MESSAGE);
-    updateWagmiAppKitFastPathSnapshot({ status: "error" });
+    updateWagmiAppKitFastPathSnapshot({
+      hasTerminalError: true,
+      status: "error",
+    });
     logErrorSecurely("[WagmiSetup] AppKit configuration changed", error);
     showAppKitToast({
       message: sanitizeErrorForUser(error),
@@ -599,6 +651,7 @@ export default function WagmiSetup({
   const appKitBootstrapValue = useMemo(
     (): AppKitBootstrapContextValue => ({
       status: fastPathSnapshot.status,
+      hasTerminalError: fastPathSnapshot.hasTerminalError,
       isCreated: fastPathSnapshot.isCreated,
       isReady: fastPathSnapshot.status === "ready",
       isWaiting: fastPathSnapshot.status === "initializing",

--- a/utils/appkit-initialization.utils.ts
+++ b/utils/appkit-initialization.utils.ts
@@ -15,9 +15,15 @@ import type { AppKitNetwork } from "@reown/appkit-common";
 import type { Chain } from "viem";
 
 // Configuration interface for AppKit initialization
-export interface AppKitInitializationConfig {
+export interface AppKitAdapterConfig {
   wallets: AppWallet[];
   adapterManager: AppKitAdapterManager;
+  isCapacitor: boolean;
+  chains: Chain[];
+}
+
+export interface AppKitInitializationConfig {
+  adapter: WagmiAdapter;
   isCapacitor: boolean;
   chains: Chain[];
 }
@@ -87,36 +93,42 @@ function createAdapter(
 }
 
 /**
- * Initializes AppKit with wallets using a fail-fast approach with retry logic
- * Extracted from WagmiSetup component for better maintainability and testability
+ * Creates the stable Wagmi adapter before the heavier AppKit bootstrap starts.
+ */
+export function createAppKitAdapter(config: AppKitAdapterConfig): WagmiAdapter {
+  const { wallets, adapterManager, isCapacitor } = config;
+
+  return createAdapter(wallets, adapterManager, isCapacitor, config.chains);
+}
+
+/**
+ * Initializes AppKit around an already-mounted Wagmi adapter.
  */
 export function initializeAppKit(
   config: AppKitInitializationConfig
 ): AppKitInitializationResult {
-  const { wallets, adapterManager, isCapacitor } = config;
-
-  const newAdapter = createAdapter(
-    wallets,
-    adapterManager,
-    isCapacitor,
-    config.chains
-  );
   const appKitConfig = buildAppKitConfig(
-    newAdapter,
+    config.adapter,
     config.chains,
-    isCapacitor
+    config.isCapacitor
   );
   const appKit = createAppKit(appKitConfig);
   const ready = appKit.ready();
   // Prevent unhandled rejections if a caller chooses not to await `ready`.
-  ready.catch((error) => {
-    logErrorSecurely("[AppKitInitialization] AppKit ready() failed", error);
-  });
+  void logAppKitReadyFailure(ready);
 
   return {
-    adapter: newAdapter,
+    adapter: config.adapter,
     ready,
   };
+}
+
+async function logAppKitReadyFailure(ready: Promise<void>): Promise<void> {
+  try {
+    await ready;
+  } catch (error) {
+    logErrorSecurely("[AppKitInitialization] AppKit ready() failed", error);
+  }
 }
 
 /**


### PR DESCRIPTION
## Issue
- The app tree returned `null` inside `WagmiSetup` until adapter creation and full `createAppKit` startup completed. The measured Wave startup research attributed about 1.99 seconds of the critical path to this provider gate.

## Fix
- Create and retain the minimum Wagmi adapter first, render the existing provider tree immediately, and defer full AppKit startup without reporting false readiness.
- Start the same idempotent AppKit promise on early connect intent, while all AppKit-only hooks and modal actions remain behind their real creation/readiness conditions.

## Changes
- Add a configuration-keyed fast-path store that preserves adapter and AppKit identity across Strict Mode, navigation, remount, and HMR-like reloads, while failing closed rather than mixing platform or chain configurations.
- Route password-modal and toast callbacks through stable proxies whose active delegates update on mount and clear safely on unmount, avoiding retained first-mount auth/UI closures.
- Add separate AppKit created and ready state plus a post-children modal bridge. The bridge compares scalar wallet fields and rejects bounded open waiters on bootstrap error, timeout, hook failure, or unmount.
- Preserve wallet reconnect, injected/app-wallet connectors, account and network switching, profile/proxy switching, Coinbase/native behavior, provider order, and existing startup telemetry.
- Add regression coverage for one-time initialization, Strict Mode and HMR-like remounts, fresh-object Reown hook snapshots, retained delegate safety, provider availability before AppKit, readiness-gated actions, failure/unmount handling, connector deduplication, and auth/account isolation.

## Validation
- 16 focused Wagmi/AppKit/auth/security suites: 425 tests passed.
- `6529 run lint:changed`: passed.
- `6529 run typecheck:changed`: passed.
- `6529 run react-doctor:diff`: 99/100; the only advisory is the existing `SeizeConnectProvider` component-size warning.
- `6529 run build`: passed full lint, TypeScript, static generation, and sitemap generation using public production endpoints for read-only build data.
- `6529 run check:changed`: formatting, lint, and typecheck passed; the final global Knip step remains blocked by existing unused ops/script files and exports on `main`, with no finding in this change.
- Production-backed local read-only browser QA with AppKit deliberately held for five seconds: an authenticated shell and profile remained intact before AppKit readiness, post-ready profile switching worked, and an anonymous early connect intent opened the real Reown modal. The temporary delay was restored to zero and the final diff contains no QA code or artifacts.
- Staging-backed authenticated QA was not available because this worktree has no staging API key. The production-backed run above is runtime evidence, not staging evidence.

## Risk
- Level: Medium.
- Why: this changes the shared wallet/auth provider startup boundary, but retains the installed provider order and gates every AppKit-only surface until actual creation/readiness. Failure paths keep the shell alive and reject connect waiters.
- Rollback: revert this PR to restore the previous all-or-nothing `WagmiSetup` gate.

## Review Notes
- Please focus on singleton configuration isolation, delegate lifecycle across remount/HMR, the installed Reown hook safety boundary, connector deduplication, and modal waiter cleanup.
- Existing telemetry names are preserved so `provider_gate_ms`, `wagmi_appkit_init`, and shell timing can compare rollout behavior without new high-volume or identifying signals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the connection modal during startup, remounts, and delayed AppKit readiness.
  * Added stricter handling for wallet-service failures, timeouts, and unavailability to ensure consistent error outcomes and no hanging connection flows.
  * Improved routing for wallet password prompts and toast/error notifications across lifecycle changes.

* **Improvements**
  * Reworked the AppKit/Wagmi initialization flow to reuse adapter initialization more efficiently and stabilize readiness behavior, resulting in faster and more consistent connection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
