### PR TITLE
Send initiators with web deploy alerts

### DIFF
--- a/.github/workflows/build-upload-deploy-prod.yml
+++ b/.github/workflows/build-upload-deploy-prod.yml
@@ -580,7 +580,6 @@ jobs:
           CI_PIPELINES_TARGET_ENV: production
           CI_PIPELINES_STATUS: failure
           CI_PIPELINES_TITLE: "Seize PROD WEB DEPLOY: CI pipeline is broken!!!"
-          CI_PIPELINES_DESCRIPTION: "- ${{ env.COMMIT_MESSAGE }}"
           CI_PIPELINES_ENVIRONMENT: production
           CI_PIPELINES_SERVICE: web
         run: node scripts/notify-ci-wave.mjs
@@ -605,7 +604,6 @@ jobs:
           CI_PIPELINES_TARGET_ENV: production
           CI_PIPELINES_STATUS: success
           CI_PIPELINES_TITLE: "Seize PROD WEB DEPLOY: CI pipeline complete"
-          CI_PIPELINES_DESCRIPTION: "- ${{ env.COMMIT_MESSAGE }}"
           CI_PIPELINES_ENVIRONMENT: production
           CI_PIPELINES_SERVICE: web
           CI_RELEASE_NOTES_PROMPT_PATH: ops/release-notes/release-notes.prompt.md

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -597,7 +597,6 @@ jobs:
           CI_PIPELINES_TARGET_ENV: staging
           CI_PIPELINES_STATUS: failure
           CI_PIPELINES_TITLE: "Seize STAGING WEB DEPLOY: CI pipeline is broken!!!"
-          CI_PIPELINES_DESCRIPTION: "- ${{ env.COMMIT_MESSAGE }}"
           CI_PIPELINES_ENVIRONMENT: staging
           CI_PIPELINES_SERVICE: web
         run: node scripts/notify-ci-wave.mjs
@@ -612,7 +611,6 @@ jobs:
           CI_PIPELINES_TARGET_ENV: staging
           CI_PIPELINES_STATUS: success
           CI_PIPELINES_TITLE: "Seize STAGING WEB DEPLOY: CI pipeline complete"
-          CI_PIPELINES_DESCRIPTION: "- ${{ env.COMMIT_MESSAGE }}"
           CI_PIPELINES_ENVIRONMENT: staging
           CI_PIPELINES_SERVICE: web
         run: node scripts/notify-ci-wave.mjs

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -21,7 +21,9 @@ const {
   GITHUB_RUN_NUMBER,
   GITHUB_SERVER_URL = 'https://github.com',
   GITHUB_SHA,
-  GITHUB_REF_NAME
+  GITHUB_REF_NAME,
+  GITHUB_TRIGGERING_ACTOR,
+  GITHUB_ACTOR
 } = process.env;
 
 function requireValue(name, value) {
@@ -77,6 +79,10 @@ const repository = requireValue('GITHUB_REPOSITORY', GITHUB_REPOSITORY);
 const runId = requireValue('GITHUB_RUN_ID', GITHUB_RUN_ID);
 const status = requireValue('CI_PIPELINES_STATUS', CI_PIPELINES_STATUS);
 const title = requireValue('CI_PIPELINES_TITLE', CI_PIPELINES_TITLE);
+const triggeredByGithubLogin = requireValue(
+  'GITHUB_TRIGGERING_ACTOR or GITHUB_ACTOR',
+  GITHUB_TRIGGERING_ACTOR || GITHUB_ACTOR
+);
 const isReleaseNotesEligible =
   status === 'success' &&
   targetEnvironment === 'prod' &&
@@ -104,6 +110,7 @@ const payload = {
   status,
   title,
   description: CI_PIPELINES_DESCRIPTION || null,
+  triggered_by_github_login: triggeredByGithubLogin,
   run_id: runId,
   run_number: GITHUB_RUN_NUMBER || null,
   run_url: `${GITHUB_SERVER_URL}/${repository}/actions/runs/${runId}`,

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -79,10 +79,7 @@ const repository = requireValue('GITHUB_REPOSITORY', GITHUB_REPOSITORY);
 const runId = requireValue('GITHUB_RUN_ID', GITHUB_RUN_ID);
 const status = requireValue('CI_PIPELINES_STATUS', CI_PIPELINES_STATUS);
 const title = requireValue('CI_PIPELINES_TITLE', CI_PIPELINES_TITLE);
-const triggeredByGithubLogin = requireValue(
-  'GITHUB_TRIGGERING_ACTOR or GITHUB_ACTOR',
-  GITHUB_TRIGGERING_ACTOR || GITHUB_ACTOR
-);
+const triggeredByGithubLogin = GITHUB_TRIGGERING_ACTOR || GITHUB_ACTOR || null;
 const isReleaseNotesEligible =
   status === 'success' &&
   targetEnvironment === 'prod' &&


### PR DESCRIPTION
## Summary

- send the current GitHub triggering actor with every frontend CI Wave alert when available
- keep alert delivery working when GitHub actor metadata is unavailable
- remove commit-message descriptions from production and staging web deploy success/failure notifications
- leave the Device Farm description unchanged

## Root cause

Web deploy alerts prefixed the commit subject with a Markdown list marker. Empty subjects rendered as an empty bullet, while merge commit subjects added implementation plumbing instead of useful deploy context.

## Impact

After [backend PR #1760](https://github.com/6529-Collections/6529seize-backend/pull/1760) is deployed, frontend CI posts will tag the initiating 6529 profile when resolvable and show `Initiated by: unknown` otherwise. Web deploy posts will no longer show empty bullets or merge commit descriptions.

Backend PR #1760 must be deployed before this sender change is used.

## Validation

- frontend `check:changed`
- sender syntax and signed payload execution checks with and without actor metadata