### PR TITLE
Make direct messages faster and lighter on long conversations

### DIFF
--- a/__tests__/components/drops/view/DropsList.test.tsx
+++ b/__tests__/components/drops/view/DropsList.test.tsx
@@ -113,6 +113,7 @@ describe("DropsList", () => {
         onQuoteClick={jest.fn()}
         onDropContentClick={jest.fn()}
         dropViewDropId={null}
+        virtualScrollRootMargin="1200px 0px"
       />
     );
 
@@ -120,6 +121,10 @@ describe("DropsList", () => {
     expect(screen.getAllByTestId("highlight")).toHaveLength(2);
     expect(dropProps).toHaveLength(1);
     expect(lightProps).toHaveLength(1);
+    expect(wrapperProps).toEqual([
+      expect.objectContaining({ rootMargin: "1200px 0px" }),
+      expect.objectContaining({ rootMargin: "1200px 0px" }),
+    ]);
   });
 
   it("hydrates historical light drops after serial scrolling settles", () => {

--- a/__tests__/components/waves/drops/VirtualScrollWrapper.test.tsx
+++ b/__tests__/components/waves/drops/VirtualScrollWrapper.test.tsx
@@ -232,6 +232,23 @@ describe("Height Measurement and Placeholder", () => {
     expect(testChild).toBeInTheDocument();
   });
 
+  test("keeps children mounted when the measured height is zero", () => {
+    const { container } = setup(DropSize.FULL);
+    const div = container.firstChild as HTMLElement;
+    Object.defineProperty(div, "getBoundingClientRect", {
+      value: () => ({ height: 0 }),
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+      intersectionCb([{ isIntersecting: false } as any]);
+    });
+
+    expect(
+      container.querySelector('[data-testid="child"]')
+    ).toBeInTheDocument();
+  });
+
   test("measures height again when leaving viewport for FULL drops", () => {
     const { container } = setup(DropSize.FULL);
     const div = container.firstChild as HTMLElement;

--- a/__tests__/components/waves/drops/VirtualScrollWrapper.test.tsx
+++ b/__tests__/components/waves/drops/VirtualScrollWrapper.test.tsx
@@ -11,12 +11,14 @@ jest.useFakeTimers();
 const observe = jest.fn();
 const unobserve = jest.fn();
 const disconnect = jest.fn();
+const intersectionObserverConstructor = jest.fn();
 let intersectionCb: (entries: any[]) => void = () => {};
 let intersectionObserverOptions: any = null;
 
 beforeAll(() => {
   (global as any).IntersectionObserver = class {
     constructor(cb: any, options: any) {
+      intersectionObserverConstructor();
       intersectionCb = cb;
       intersectionObserverOptions = options;
     }
@@ -30,6 +32,7 @@ afterEach(() => {
   observe.mockClear();
   unobserve.mockClear();
   disconnect.mockClear();
+  intersectionObserverConstructor.mockClear();
   intersectionObserverOptions = null;
   clearWaveDropNearViewport("wave", "drop-1");
   cleanup();
@@ -39,7 +42,7 @@ jest.mock("@/contexts/wave/MyStreamContext", () => ({
   useMyStream: jest.fn(() => ({ fetchAroundSerialNo: jest.fn() })),
 }));
 
-function setup(size: DropSize, dropId?: string) {
+function setup(size: DropSize, dropId?: string, rootMargin?: string) {
   const scrollRef = { current: document.createElement("div") };
   const { container } = render(
     <VirtualScrollWrapper
@@ -48,7 +51,9 @@ function setup(size: DropSize, dropId?: string) {
       dropId={dropId}
       dropSerialNo={1}
       waveId="wave"
-      type={size}>
+      type={size}
+      rootMargin={rootMargin}
+    >
       <div data-testid="child">content</div>
     </VirtualScrollWrapper>
   );
@@ -95,6 +100,26 @@ describe("IntersectionObserver Configuration", () => {
       threshold: 0.0,
       root: expect.any(HTMLDivElement),
     });
+  });
+
+  test("supports a smaller render window", () => {
+    setup(DropSize.FULL, undefined, "1200px 0px");
+    expect(intersectionObserverOptions.rootMargin).toBe("1200px 0px");
+  });
+
+  test("keeps the observer stable when visibility changes", () => {
+    const fetchAroundSerialNo = jest.fn();
+    const module = require("@/contexts/wave/MyStreamContext");
+    (module.useMyStream as jest.Mock).mockReturnValue({ fetchAroundSerialNo });
+
+    setup(DropSize.FULL);
+    expect(intersectionObserverConstructor).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      intersectionCb([{ isIntersecting: false } as any]);
+    });
+
+    expect(intersectionObserverConstructor).toHaveBeenCalledTimes(1);
   });
 
   test("observes container element on mount", () => {
@@ -263,7 +288,8 @@ describe("Custom Delay", () => {
         delay={2000}
         dropSerialNo={1}
         waveId="wave"
-        type={DropSize.FULL}>
+        type={DropSize.FULL}
+      >
         <div data-testid="child">content</div>
       </VirtualScrollWrapper>
     );

--- a/__tests__/components/waves/drops/WaveDropsAll.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropsAll.test.tsx
@@ -526,6 +526,32 @@ describe("WaveDropsAll", () => {
       });
     });
 
+    it("uses a tighter render window only for direct messages", () => {
+      const waveHelpers = require("@/helpers/waves/wave.helpers");
+      const directMessageSpy = jest
+        .spyOn(waveHelpers, "isWaveDirectMessage")
+        .mockImplementation((waveId: string) => waveId === "dm-wave");
+      const mockDrops = [createMockDrop()];
+
+      try {
+        setupMocks({
+          waveMessages: { drops: mockDrops },
+        });
+
+        const renderResult = renderComponent({ waveId: "dm-wave" });
+
+        expect(dropsProps.virtualScrollRootMargin).toBe("1200px 0px");
+
+        renderResult.rerender(
+          <WaveDropsAll {...renderResult.props} waveId="public-wave" />
+        );
+
+        expect(dropsProps.virtualScrollRootMargin).toBeUndefined();
+      } finally {
+        directMessageSpy.mockRestore();
+      }
+    });
+
     it("disables inserted boosted drops when the local preference is hidden", () => {
       localStorage.setItem(
         BOOSTED_DROPS_DISPLAY_PREFERENCE_KEY,

--- a/components/drops/view/DropsList.tsx
+++ b/components/drops/view/DropsList.tsx
@@ -55,6 +55,7 @@ interface DropsListProps {
     | undefined;
   readonly onBoostedDropClick?: ((serialNo: number) => void) | undefined;
   readonly suspendLightDropHydration?: boolean | undefined;
+  readonly virtualScrollRootMargin?: string | undefined;
   readonly winningThreshold?: number | null | undefined;
   readonly winningThresholdMinDurationMs?: number | null | undefined;
   readonly isVotingClosed?: boolean | undefined;
@@ -84,6 +85,7 @@ const DropsList = memo(
     boostedDropsDisplayPreference = DEFAULT_BOOSTED_DROPS_DISPLAY_PREFERENCE,
     onBoostedDropClick,
     suspendLightDropHydration = false,
+    virtualScrollRootMargin,
     winningThreshold,
     winningThresholdMinDurationMs,
     isVotingClosed = false,
@@ -325,6 +327,7 @@ const DropsList = memo(
               waveId={drop.type === DropSize.FULL ? drop.wave.id : drop.waveId}
               type={drop.type}
               suspendLightDropHydration={suspendLightDropHydration}
+              rootMargin={virtualScrollRootMargin}
             >
               {dropContent}
             </VirtualScrollWrapper>
@@ -340,6 +343,7 @@ const DropsList = memo(
       renderBoostCard,
       renderUnreadDivider,
       suspendLightDropHydration,
+      virtualScrollRootMargin,
     ]);
 
     return (

--- a/components/waves/drops/VirtualScrollWrapper.tsx
+++ b/components/waves/drops/VirtualScrollWrapper.tsx
@@ -26,6 +26,7 @@ interface VirtualScrollWrapperProps {
   readonly waveId: string;
   readonly type: DropSize;
   readonly suspendLightDropHydration?: boolean | undefined;
+  readonly rootMargin?: string | undefined;
 
   /**
    * The child components to be rendered or virtualized.
@@ -63,6 +64,7 @@ export default function VirtualScrollWrapper({
   waveId,
   type,
   suspendLightDropHydration = false,
+  rootMargin = "5000px 0px 5000px 0px",
 }: VirtualScrollWrapperProps) {
   const { fetchAroundSerialNo } = useMyStream();
 
@@ -90,7 +92,9 @@ export default function VirtualScrollWrapper({
   const measureHeight = useCallback(() => {
     if (containerRef.current) {
       const rect = containerRef.current.getBoundingClientRect();
-      setMeasuredHeight(rect.height);
+      setMeasuredHeight((currentHeight) =>
+        currentHeight === rect.height ? currentHeight : rect.height
+      );
     }
   }, []);
 
@@ -100,13 +104,13 @@ export default function VirtualScrollWrapper({
    * async changes to settle.
    */
   useEffect(() => {
-    if (type === DropSize.LIGHT) return;
+    if (type === DropSize.LIGHT || !isInView) return;
     const timer = setTimeout(() => {
       measureHeight();
     }, delay);
 
     return () => clearTimeout(timer);
-  }, [delay, measureHeight]);
+  }, [delay, isInView, measureHeight, type]);
 
   /**
    * Intersection Observer to track if the element is in the viewport.
@@ -132,39 +136,37 @@ export default function VirtualScrollWrapper({
           // If leaving viewport, measure height in case content changed
           measureHeight();
         }
-        if (inView !== isInView) {
-          setIsInView(inView);
-        }
+        setIsInView((currentInView) =>
+          currentInView === inView ? currentInView : inView
+        );
         if (inView && type === DropSize.LIGHT && !suspendLightDropHydration) {
           fetchAroundSerialNo(waveId, dropSerialNo);
         }
       },
       {
-        // For a reversed layout, we need a large margin at both top and bottom
-        // This ensures elements are detected well before they enter/leave the viewport
-        // Using a large value for both directions ensures smooth operation in both regular and reversed layouts
-        rootMargin: "5000px 0px 5000px 0px",
+        // Keep enough content mounted around the reversed viewport to avoid
+        // visible placeholder swaps during fast scrolling.
+        rootMargin,
         threshold: 0.0,
         root: scrollContainerRef.current,
       }
     );
 
-    if (containerRef.current) {
-      observer.observe(containerRef.current);
+    const container = containerRef.current;
+    if (container) {
+      observer.observe(container);
     }
 
     // Cleanup observer on unmount
     return () => {
-      if (containerRef.current) {
-        observer.unobserve(containerRef.current);
-      }
+      observer.disconnect();
     };
   }, [
     dropId,
     dropSerialNo,
     fetchAroundSerialNo,
-    isInView,
     measureHeight,
+    rootMargin,
     scrollContainerRef,
     suspendLightDropHydration,
     type,
@@ -202,7 +204,7 @@ export default function VirtualScrollWrapper({
       ) : (
         <div
           style={{
-            height: measuredHeight ?? "auto",
+            height: measuredHeight,
           }}
         />
       )}

--- a/components/waves/drops/VirtualScrollWrapper.tsx
+++ b/components/waves/drops/VirtualScrollWrapper.tsx
@@ -92,6 +92,9 @@ export default function VirtualScrollWrapper({
   const measureHeight = useCallback(() => {
     if (containerRef.current) {
       const rect = containerRef.current.getBoundingClientRect();
+      if (!Number.isFinite(rect.height) || rect.height <= 0) {
+        return;
+      }
       setMeasuredHeight((currentHeight) =>
         currentHeight === rect.height ? currentHeight : rect.height
       );

--- a/components/waves/drops/wave-drops-all/index.tsx
+++ b/components/waves/drops/wave-drops-all/index.tsx
@@ -36,6 +36,7 @@ import { WaveDropsContent } from "./subcomponents/WaveDropsContent";
 const EMPTY_DROPS: Drop[] = [];
 const DEFAULT_VIRTUALIZED_DROPS_PAGE_SIZE = 50;
 const MOBILE_ALL_DROPS_VIRTUALIZED_PAGE_SIZE = 25;
+const DIRECT_MESSAGE_VIRTUAL_SCROLL_ROOT_MARGIN = "1200px 0px";
 
 const getVirtualizedDropsPageSize = (isMobileAllDropsView: boolean): number =>
   isMobileAllDropsView
@@ -102,6 +103,9 @@ const WaveDropsAllInner: React.FC<WaveDropsAllProps> = ({
   const [boostedDropsDisplayPreference] = useBoostedDropsDisplayPreference();
   const shouldRenderInsertedBoostedDrops =
     boostedDropsDisplayPreference !== "hidden";
+  const virtualScrollRootMargin = isWaveDirectMessage(waveId, wave)
+    ? DIRECT_MESSAGE_VIRTUAL_SCROLL_ROOT_MARGIN
+    : undefined;
 
   const scrollBehavior = useScrollBehavior();
   const {
@@ -304,6 +308,7 @@ const WaveDropsAllInner: React.FC<WaveDropsAllProps> = ({
         onScrollToUnread={queueSerialTarget}
         unreadCount={unreadCount}
         suspendLightDropHydration={isScrolling || serialTarget !== null}
+        virtualScrollRootMargin={virtualScrollRootMargin}
         winningThreshold={winningThreshold}
         winningThresholdMinDurationMs={winningThresholdMinDurationMs}
         isVotingClosed={isVotingClosed}

--- a/components/waves/drops/wave-drops-all/subcomponents/WaveDropsContent.tsx
+++ b/components/waves/drops/wave-drops-all/subcomponents/WaveDropsContent.tsx
@@ -52,6 +52,7 @@ interface WaveDropsContentProps {
   readonly onScrollToUnread?: ((serialNo: number) => void) | undefined;
   readonly unreadCount?: number | undefined;
   readonly suspendLightDropHydration?: boolean | undefined;
+  readonly virtualScrollRootMargin?: string | undefined;
   readonly winningThreshold?: number | null | undefined;
   readonly winningThresholdMinDurationMs?: number | null | undefined;
   readonly isVotingClosed?: boolean | undefined;
@@ -86,6 +87,7 @@ export const WaveDropsContent: React.FC<WaveDropsContentProps> = ({
   onScrollToUnread,
   unreadCount,
   suspendLightDropHydration = false,
+  virtualScrollRootMargin,
   winningThreshold,
   winningThresholdMinDurationMs,
   isVotingClosed = false,
@@ -148,6 +150,7 @@ export const WaveDropsContent: React.FC<WaveDropsContentProps> = ({
         onScrollToUnread={onScrollToUnread}
         onDismissUnread={handleDismissUnread}
         suspendLightDropHydration={suspendLightDropHydration}
+        virtualScrollRootMargin={virtualScrollRootMargin}
         winningThreshold={winningThreshold}
         winningThresholdMinDurationMs={winningThresholdMinDurationMs}
         isVotingClosed={isVotingClosed}

--- a/components/waves/drops/wave-drops-all/subcomponents/WaveDropsMessageListSection.tsx
+++ b/components/waves/drops/wave-drops-all/subcomponents/WaveDropsMessageListSection.tsx
@@ -49,6 +49,7 @@ interface WaveDropsMessageListSectionProps {
   readonly onScrollToUnread?: ((serialNo: number) => void) | undefined;
   readonly onDismissUnread: () => void;
   readonly suspendLightDropHydration?: boolean | undefined;
+  readonly virtualScrollRootMargin?: string | undefined;
   readonly winningThreshold?: number | null | undefined;
   readonly winningThresholdMinDurationMs?: number | null | undefined;
   readonly isVotingClosed?: boolean | undefined;
@@ -86,6 +87,7 @@ export const WaveDropsMessageListSection: React.FC<
   onScrollToUnread,
   onDismissUnread,
   suspendLightDropHydration = false,
+  virtualScrollRootMargin,
   winningThreshold,
   winningThresholdMinDurationMs,
   isVotingClosed = false,
@@ -126,6 +128,7 @@ export const WaveDropsMessageListSection: React.FC<
           boostedDropsDisplayPreference={boostedDropsDisplayPreference}
           onBoostedDropClick={onBoostedDropClick}
           suspendLightDropHydration={suspendLightDropHydration}
+          virtualScrollRootMargin={virtualScrollRootMargin}
           winningThreshold={winningThreshold}
           winningThresholdMinDurationMs={winningThresholdMinDurationMs}
           isVotingClosed={isVotingClosed}


### PR DESCRIPTION
## Issue
- Long direct-message histories kept expensive message subtrees mounted across a very large offscreen range, causing DOM, heap, and frame-time growth as older messages loaded.
- The shared intersection observer was also recreated after visibility changes, which could produce repeated observer callbacks and a React maximum-update-depth warning in long-thread profiling.

## Fix
- Keep the existing height-preserving virtualization design, but make its observer lifecycle stable and use a tighter offscreen render window for direct messages.
- Preserve the existing Waves render-window default so this Messages-focused performance change does not alter Waves behavior.

## Changes
- Added a direct-message-only 1,200px render margin while Waves retain the existing 5,000px default.
- Prevented no-op height state updates, cancelled delayed measurements when content is offscreen, disconnected observers cleanly, and kept children mounted until a positive finite placeholder height is available.
- Threaded the optional render margin through the existing drop-list components without changing visual design, copy, routes, APIs, or backend behavior.
- Added focused coverage for observer stability, custom margins, zero-height measurements, propagation, and the direct-message/Waves boundary.

## Validation
- Focused Jest: 82 tests passed across `VirtualScrollWrapper`, `DropsList`, and `WaveDropsAll`.
- `6529 run lint:uncommitted:tight`
- `6529 run typecheck:ci`
- `6529 run react-doctor:diff`: 100/100, no issues.
- Local Chromium visual QA with a synthetic 300-message DM at 1280×720 and 412×915: long thread, composer input, no-selection state, and thread reopen all worked with no maximum-update-depth errors. The local server was stopped afterward.
- Local 300-message profile:
  - Mobile: visible DOM nodes 2,870 → 1,863 (-35%), retained CDP nodes 8,505 → 5,079 (-40%), heap 74.8 MB → 71.7 MB (-4%), p95 frame gap 19.4 ms → 17.1 ms, typing probe 246 ms → 195 ms.
  - Desktop: visible DOM nodes 5,841 → 2,886 (-51%), retained CDP nodes 17,217 → 8,157 (-53%), heap 102.5 MB → 80.5 MB (-21%), average scroll FPS 23.7 → 30.7, p95 frame gap 91.7 ms → 58.4 ms, scripting time 9.05 s → 7.85 s.
  - Desktop typing was noisy in the opposite direction (438 ms → 527 ms), so no desktop typing win is claimed.
- Latest-head GitHub checks passed: installed-app Knip/lint/typechecks/related Jest/production build/Playwright smoke packs, CodeQL, SonarCloud, Snyk, DCO, debt-ratchet, and secret scanning.

## Risk
- Level: Medium
- Why: the observer lifecycle is shared, but its behavior is covered and the smaller render window is direct-message-only. Dynamic media continues to use measured-height placeholders to preserve scroll position, and non-positive measurements cannot collapse a drop.
- Rollback: revert the two signed commits to restore the prior observer behavior and render window.

## Review Notes
- 6529bot's zero-height finding was addressed in the follow-up commit; its latest review reports no new findings. SonarCloud reports zero new issues or hotspots.
- CodeRabbit is green and its latest incremental review completed without findings; its generated summary is currently rate-limited.
- Please focus on reverse-scroll position preservation and dynamic-media placeholder behavior.
- This intentionally avoids a full list-recycler rewrite because serial jumps, unread anchors, incoming-message pinning, boosted cards, and dynamic media make that a substantially broader shared-Waves change. If wrapper/data retention remains material at much larger histories, a true two-way recycler should be a separate frontend follow-up.