### PR TITLE
Make collapsed sidebar menus easier to use

### DIFF
--- a/__tests__/components/layout/sidebar/nav/WebSidebarSubmenu.test.tsx
+++ b/__tests__/components/layout/sidebar/nav/WebSidebarSubmenu.test.tsx
@@ -122,12 +122,15 @@ describe("WebSidebarSubmenu", () => {
     expect(firstLink).toHaveFocus();
   });
 
-  it("moves focus to the next page control when tabbing out", () => {
+  it("moves focus to the next sidebar control when tabbing out", () => {
+    const sidebar = document.createElement("div");
+    sidebar.dataset.sidebarScroll = "true";
     const trigger = document.createElement("button");
     const nextControl = document.createElement("button");
     trigger.textContent = "Open tools";
     nextControl.textContent = "Next control";
-    document.body.prepend(trigger, nextControl);
+    sidebar.append(trigger, nextControl);
+    document.body.prepend(sidebar);
     const onClose = jest.fn();
 
     try {
@@ -149,8 +152,7 @@ describe("WebSidebarSubmenu", () => {
       expect(nextControl).toHaveFocus();
       expect(onClose).toHaveBeenCalledTimes(1);
     } finally {
-      trigger.remove();
-      nextControl.remove();
+      sidebar.remove();
     }
   });
 });

--- a/__tests__/components/layout/sidebar/nav/WebSidebarSubmenu.test.tsx
+++ b/__tests__/components/layout/sidebar/nav/WebSidebarSubmenu.test.tsx
@@ -45,8 +45,11 @@ describe("WebSidebarSubmenu", () => {
 
     expect(screen.getAllByText("Open Data")).toHaveLength(2);
     expect(screen.getByText("Other Tools")).toBeInTheDocument();
-    expect(screen.getByRole("menuitem", { name: "Team" })).toBeInTheDocument();
-    expect(screen.getByRole("menuitem", { name: "API" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("navigation", { name: "Tools sub-navigation" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Team" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "API" })).toBeInTheDocument();
   });
 
   it("closes after navigation", () => {
@@ -60,7 +63,7 @@ describe("WebSidebarSubmenu", () => {
       />
     );
 
-    fireEvent.click(screen.getByRole("menuitem", { name: "API" }));
+    fireEvent.click(screen.getByRole("link", { name: "API" }));
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
@@ -89,7 +92,65 @@ describe("WebSidebarSubmenu", () => {
     );
 
     expect(
-      screen.getByRole("menuitem", { name: "Definitions" })
+      screen.getByRole("link", { name: "Definitions" })
     ).not.toHaveAttribute("aria-current");
+  });
+
+  it("repeats keyboard focus requests while the same flyout stays open", () => {
+    const { rerender } = render(
+      <WebSidebarSubmenu
+        section={section}
+        pathname="/open-data/team"
+        onClose={jest.fn()}
+        focusRequest={1}
+      />
+    );
+
+    const firstLink = screen.getByRole("link", { name: "API" });
+    expect(firstLink).toHaveFocus();
+
+    firstLink.blur();
+    rerender(
+      <WebSidebarSubmenu
+        section={section}
+        pathname="/open-data/team"
+        onClose={jest.fn()}
+        focusRequest={2}
+      />
+    );
+
+    expect(firstLink).toHaveFocus();
+  });
+
+  it("moves focus to the next page control when tabbing out", () => {
+    const trigger = document.createElement("button");
+    const nextControl = document.createElement("button");
+    trigger.textContent = "Open tools";
+    nextControl.textContent = "Next control";
+    document.body.prepend(trigger, nextControl);
+    const onClose = jest.fn();
+
+    try {
+      render(
+        <WebSidebarSubmenu
+          section={section}
+          pathname="/open-data/team"
+          onClose={onClose}
+          triggerElement={trigger}
+        />
+      );
+
+      const links = screen.getAllByRole("link");
+      const lastLink = links.at(-1);
+      expect(lastLink).toBeDefined();
+      lastLink?.focus();
+      fireEvent.keyDown(lastLink as HTMLElement, { key: "Tab" });
+
+      expect(nextControl).toHaveFocus();
+      expect(onClose).toHaveBeenCalled();
+    } finally {
+      trigger.remove();
+      nextControl.remove();
+    }
   });
 });

--- a/__tests__/components/layout/sidebar/nav/WebSidebarSubmenu.test.tsx
+++ b/__tests__/components/layout/sidebar/nav/WebSidebarSubmenu.test.tsx
@@ -97,11 +97,12 @@ describe("WebSidebarSubmenu", () => {
   });
 
   it("repeats keyboard focus requests while the same flyout stays open", () => {
+    const onClose = jest.fn();
     const { rerender } = render(
       <WebSidebarSubmenu
         section={section}
         pathname="/open-data/team"
-        onClose={jest.fn()}
+        onClose={onClose}
         focusRequest={1}
       />
     );
@@ -109,12 +110,13 @@ describe("WebSidebarSubmenu", () => {
     const firstLink = screen.getByRole("link", { name: "API" });
     expect(firstLink).toHaveFocus();
 
-    firstLink.blur();
+    screen.getByRole("link", { name: "Team" }).focus();
+    expect(onClose).not.toHaveBeenCalled();
     rerender(
       <WebSidebarSubmenu
         section={section}
         pathname="/open-data/team"
-        onClose={jest.fn()}
+        onClose={onClose}
         focusRequest={2}
       />
     );

--- a/__tests__/components/layout/sidebar/nav/WebSidebarSubmenu.test.tsx
+++ b/__tests__/components/layout/sidebar/nav/WebSidebarSubmenu.test.tsx
@@ -147,7 +147,7 @@ describe("WebSidebarSubmenu", () => {
       fireEvent.keyDown(lastLink as HTMLElement, { key: "Tab" });
 
       expect(nextControl).toHaveFocus();
-      expect(onClose).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalledTimes(1);
     } finally {
       trigger.remove();
       nextControl.remove();

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -50,7 +50,8 @@ export default function RootLayout({
           <link rel="preconnect" href="https://dnclu2fna0b2b.cloudfront.net" />
         )}
       </head>
-      <body>
+      {/* The touch-first helper may restore data-fine-pointer before hydration. */}
+      <body suppressHydrationWarning>
         <MobileLaunchTimingReporter />
         <AwsRumProvider>
           <Providers>

--- a/components/header/user/HeaderUserMenuDropdown.tsx
+++ b/components/header/user/HeaderUserMenuDropdown.tsx
@@ -143,11 +143,10 @@ export default function HeaderUserMenuDropdown({
       <AnimatePresence mode="wait" initial={false}>
         {isOpen && (
           <motion.div
-            className="tw-fixed tw-bottom-16 tw-left-6 tw-z-[9999] tw-mb-2 tw-mt-1 tw-w-72 tw-rounded-lg tw-bg-iron-800 tw-shadow-xl tw-ring-1 tw-ring-black tw-ring-opacity-5"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 20 }}
-            transition={{ duration: 0.2 }}
+            className="tw-fixed tw-bottom-16 tw-z-[9999] tw-mb-2 tw-mt-1 tw-w-72 tw-rounded-lg tw-bg-iron-800 tw-shadow-xl tw-ring-1 tw-ring-black tw-ring-opacity-5 motion-safe:tw-animate-sidebar-account-menu-in motion-reduce:tw-animate-none"
+            style={{
+              left: "calc(var(--layout-margin, 0px) + 1.5rem)",
+            }}
           >
             <div className="tw-mt-1 tw-w-full tw-overflow-hidden tw-rounded-md tw-bg-iron-800 tw-shadow-2xl">
               <div className="tw-flow-root tw-overflow-y-auto tw-overflow-x-hidden tw-py-2">

--- a/components/layout/sidebar/WebSidebarNav.tsx
+++ b/components/layout/sidebar/WebSidebarNav.tsx
@@ -23,6 +23,7 @@ import React, {
   useEffect,
   useImperativeHandle,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import WebSidebarExpandable from "./nav/WebSidebarExpandable";
@@ -42,6 +43,9 @@ const getBrowserWindow = (): Window | undefined =>
   (globalThis as BrowserGlobal).window;
 
 const getSafePathname = (pathname: string | null): string => pathname ?? "";
+
+const HOVER_OPEN_DELAY_MS = 100;
+const HOVER_CLOSE_DELAY_MS = 200;
 
 const WebSidebarNav = React.forwardRef<
   { closeSubmenu: () => void },
@@ -70,6 +74,13 @@ const WebSidebarNav = React.forwardRef<
   const [submenuTrigger, setSubmenuTrigger] = useState<HTMLElement | null>(
     null
   );
+  const [focusFirstSubmenuItem, setFocusFirstSubmenuItem] = useState(false);
+  const hoverOpenTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+  const hoverCloseTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
 
   const sections = useSidebarSections(
     appWalletsSupported,
@@ -81,11 +92,54 @@ const WebSidebarNav = React.forwardRef<
   const wavesSection = sectionMap.get("waves");
   const aboutSection = sectionMap.get("about");
 
+  const clearHoverOpenTimer = useCallback(() => {
+    if (hoverOpenTimerRef.current !== undefined) {
+      clearTimeout(hoverOpenTimerRef.current);
+      hoverOpenTimerRef.current = undefined;
+    }
+  }, []);
+
+  const clearHoverCloseTimer = useCallback(() => {
+    if (hoverCloseTimerRef.current !== undefined) {
+      clearTimeout(hoverCloseTimerRef.current);
+      hoverCloseTimerRef.current = undefined;
+    }
+  }, []);
+
   const closeSubmenu = useCallback(() => {
+    clearHoverOpenTimer();
+    clearHoverCloseTimer();
     setOpenSubmenuKey(null);
     setSubmenuAnchor(null);
     setSubmenuTrigger(null);
-  }, []);
+    setFocusFirstSubmenuItem(false);
+  }, [clearHoverCloseTimer, clearHoverOpenTimer]);
+
+  const openCollapsedSubmenu = useCallback(
+    (sectionKey: string, trigger: HTMLElement, focusFirstItem = false) => {
+      clearHoverOpenTimer();
+      clearHoverCloseTimer();
+
+      const rect = trigger.getBoundingClientRect();
+      setOpenSubmenuKey(sectionKey);
+      setSubmenuAnchor({
+        left: rect.right + 12,
+        top: rect.top,
+        height: rect.height,
+      });
+      setSubmenuTrigger(trigger);
+      setFocusFirstSubmenuItem(focusFirstItem);
+    },
+    [clearHoverCloseTimer, clearHoverOpenTimer]
+  );
+
+  const scheduleSubmenuClose = useCallback(() => {
+    clearHoverCloseTimer();
+    hoverCloseTimerRef.current = setTimeout(() => {
+      hoverCloseTimerRef.current = undefined;
+      closeSubmenu();
+    }, HOVER_CLOSE_DELAY_MS);
+  }, [clearHoverCloseTimer, closeSubmenu]);
 
   useImperativeHandle(ref, () => ({ closeSubmenu }), [closeSubmenu]);
 
@@ -118,20 +172,10 @@ const WebSidebarNav = React.forwardRef<
 
       if (isCollapsed) {
         const target = event?.currentTarget as HTMLElement | undefined;
-        const nextKey = openSubmenuKey === sectionKey ? null : sectionKey;
-        setOpenSubmenuKey(nextKey);
-
-        if (nextKey && target) {
-          const rect = target.getBoundingClientRect();
-          setSubmenuAnchor({
-            left: rect.right + 12,
-            top: rect.top,
-            height: rect.height,
-          });
-          setSubmenuTrigger(target);
-        } else {
-          setSubmenuAnchor(null);
-          setSubmenuTrigger(null);
+        if (openSubmenuKey === sectionKey) {
+          closeSubmenu();
+        } else if (target) {
+          openCollapsedSubmenu(sectionKey, target, event?.detail === 0);
         }
 
         return;
@@ -155,8 +199,89 @@ const WebSidebarNav = React.forwardRef<
         prev.includes(sectionKey) ? prev : [...prev, sectionKey]
       );
     },
-    [expandedKeys, isCollapsed, openSubmenuKey]
+    [
+      closeSubmenu,
+      expandedKeys,
+      isCollapsed,
+      openCollapsedSubmenu,
+      openSubmenuKey,
+    ]
   );
+
+  const handleSectionPointerEnter = useCallback(
+    (sectionKey: string, event: React.PointerEvent<HTMLButtonElement>) => {
+      if (!isCollapsed || event.pointerType !== "mouse") {
+        return;
+      }
+
+      clearHoverOpenTimer();
+      clearHoverCloseTimer();
+
+      if (openSubmenuKey === sectionKey) {
+        return;
+      }
+
+      const trigger = event.currentTarget;
+      hoverOpenTimerRef.current = setTimeout(() => {
+        hoverOpenTimerRef.current = undefined;
+        openCollapsedSubmenu(sectionKey, trigger);
+      }, HOVER_OPEN_DELAY_MS);
+    },
+    [
+      clearHoverCloseTimer,
+      clearHoverOpenTimer,
+      isCollapsed,
+      openCollapsedSubmenu,
+      openSubmenuKey,
+    ]
+  );
+
+  const handleSectionPointerLeave = useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>) => {
+      if (!isCollapsed || event.pointerType !== "mouse") {
+        return;
+      }
+
+      clearHoverOpenTimer();
+      if (openSubmenuKey !== null) {
+        scheduleSubmenuClose();
+      }
+    },
+    [clearHoverOpenTimer, isCollapsed, openSubmenuKey, scheduleSubmenuClose]
+  );
+
+  const handleSectionKeyDown = useCallback(
+    (sectionKey: string, event: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (!isCollapsed || !["Enter", " ", "ArrowDown"].includes(event.key)) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (openSubmenuKey === sectionKey) {
+        setFocusFirstSubmenuItem(true);
+        return;
+      }
+
+      openCollapsedSubmenu(sectionKey, event.currentTarget, true);
+    },
+    [isCollapsed, openCollapsedSubmenu, openSubmenuKey]
+  );
+
+  useEffect(
+    () => () => {
+      clearHoverOpenTimer();
+      clearHoverCloseTimer();
+    },
+    [clearHoverCloseTimer, clearHoverOpenTimer]
+  );
+
+  useEffect(() => {
+    if (!isCollapsed) {
+      closeSubmenu();
+    }
+  }, [closeSubmenu, isCollapsed]);
 
   useEffect(() => {
     if (isCollapsed && submenuTrigger) {
@@ -219,6 +344,9 @@ const WebSidebarNav = React.forwardRef<
             anchorTop={submenuAnchor.top}
             anchorHeight={submenuAnchor.height}
             triggerElement={submenuTrigger}
+            focusFirstItem={focusFirstSubmenuItem}
+            onPointerEnter={clearHoverCloseTimer}
+            onPointerLeave={scheduleSubmenuClose}
           />
         );
       }
@@ -233,6 +361,9 @@ const WebSidebarNav = React.forwardRef<
       closeSubmenu,
       submenuAnchor,
       submenuTrigger,
+      focusFirstSubmenuItem,
+      clearHoverCloseTimer,
+      scheduleSubmenuClose,
     ]
   );
 
@@ -240,8 +371,17 @@ const WebSidebarNav = React.forwardRef<
     <li className={isCollapsed ? "tw-relative" : undefined} key={section.key}>
       <WebSidebarExpandable
         section={section}
-        expanded={expandedKeys.includes(section.key)}
+        expanded={
+          isCollapsed
+            ? openSubmenuKey === section.key
+            : expandedKeys.includes(section.key)
+        }
         onToggle={(event) => handleSectionToggle(section.key, event)}
+        onPointerEnter={(event) =>
+          handleSectionPointerEnter(section.key, event)
+        }
+        onPointerLeave={handleSectionPointerLeave}
+        onKeyDown={(event) => handleSectionKeyDown(section.key, event)}
         collapsed={isCollapsed}
         pathname={pathname}
         data-section={section.key}

--- a/components/layout/sidebar/WebSidebarNav.tsx
+++ b/components/layout/sidebar/WebSidebarNav.tsx
@@ -74,7 +74,7 @@ const WebSidebarNav = React.forwardRef<
   const [submenuTrigger, setSubmenuTrigger] = useState<HTMLElement | null>(
     null
   );
-  const [focusFirstSubmenuItem, setFocusFirstSubmenuItem] = useState(false);
+  const [submenuFocusRequest, setSubmenuFocusRequest] = useState(0);
   const hoverOpenTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined
   );
@@ -112,7 +112,7 @@ const WebSidebarNav = React.forwardRef<
     setOpenSubmenuKey(null);
     setSubmenuAnchor(null);
     setSubmenuTrigger(null);
-    setFocusFirstSubmenuItem(false);
+    setSubmenuFocusRequest(0);
   }, [clearHoverCloseTimer, clearHoverOpenTimer]);
 
   const openCollapsedSubmenu = useCallback(
@@ -128,7 +128,7 @@ const WebSidebarNav = React.forwardRef<
         height: rect.height,
       });
       setSubmenuTrigger(trigger);
-      setFocusFirstSubmenuItem(focusFirstItem);
+      setSubmenuFocusRequest((previous) => (focusFirstItem ? previous + 1 : 0));
     },
     [clearHoverCloseTimer, clearHoverOpenTimer]
   );
@@ -175,7 +175,7 @@ const WebSidebarNav = React.forwardRef<
         if (openSubmenuKey === sectionKey) {
           closeSubmenu();
         } else if (target) {
-          openCollapsedSubmenu(sectionKey, target, event?.detail === 0);
+          openCollapsedSubmenu(sectionKey, target);
         }
 
         return;
@@ -252,7 +252,7 @@ const WebSidebarNav = React.forwardRef<
 
   const handleSectionKeyDown = useCallback(
     (sectionKey: string, event: React.KeyboardEvent<HTMLButtonElement>) => {
-      if (!isCollapsed || !["Enter", " ", "ArrowDown"].includes(event.key)) {
+      if (!isCollapsed || !["Enter", " "].includes(event.key)) {
         return;
       }
 
@@ -260,7 +260,7 @@ const WebSidebarNav = React.forwardRef<
       event.stopPropagation();
 
       if (openSubmenuKey === sectionKey) {
-        setFocusFirstSubmenuItem(true);
+        setSubmenuFocusRequest((previous) => previous + 1);
         return;
       }
 
@@ -276,12 +276,6 @@ const WebSidebarNav = React.forwardRef<
     },
     [clearHoverCloseTimer, clearHoverOpenTimer]
   );
-
-  useEffect(() => {
-    if (!isCollapsed) {
-      closeSubmenu();
-    }
-  }, [closeSubmenu, isCollapsed]);
 
   useEffect(() => {
     if (isCollapsed && submenuTrigger) {
@@ -344,7 +338,7 @@ const WebSidebarNav = React.forwardRef<
             anchorTop={submenuAnchor.top}
             anchorHeight={submenuAnchor.height}
             triggerElement={submenuTrigger}
-            focusFirstItem={focusFirstSubmenuItem}
+            focusRequest={submenuFocusRequest}
             onPointerEnter={clearHoverCloseTimer}
             onPointerLeave={scheduleSubmenuClose}
           />
@@ -361,7 +355,7 @@ const WebSidebarNav = React.forwardRef<
       closeSubmenu,
       submenuAnchor,
       submenuTrigger,
-      focusFirstSubmenuItem,
+      submenuFocusRequest,
       clearHoverCloseTimer,
       scheduleSubmenuClose,
     ]

--- a/components/layout/sidebar/WebSidebarUser.tsx
+++ b/components/layout/sidebar/WebSidebarUser.tsx
@@ -231,7 +231,11 @@ function WebSidebarUser({
         >
           <div className="tw-relative tw-h-10 tw-w-10 tw-flex-shrink-0">
             <div
-              className={`tw-relative tw-flex tw-h-10 tw-w-10 tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-xl ${connectionIndicator.avatarClassName}`}
+              className={`tw-relative tw-flex tw-h-10 tw-w-10 tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-xl tw-transition-[box-shadow,filter] tw-duration-200 tw-ease-out ${connectionIndicator.avatarClassName} ${
+                isCollapsed
+                  ? "desktop-hover:group-hover/user:tw-shadow-[0_0_0_1px_rgba(255,255,255,0.1),0_0_14px_rgba(255,255,255,0.06)] desktop-hover:group-hover/user:tw-brightness-[1.05]"
+                  : ""
+              }`}
               title={connectionIndicator.title}
             >
               <img

--- a/components/layout/sidebar/nav/WebSidebarExpandable.tsx
+++ b/components/layout/sidebar/nav/WebSidebarExpandable.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import React, { useState, useMemo, useCallback, useEffect } from "react";
+import React, { useState, useMemo, useCallback } from "react";
 import Link from "next/link";
 import { ChevronRightIcon } from "@heroicons/react/24/outline";
 import WebSidebarNavItem from "./WebSidebarNavItem";
 import WebSidebarExpandableGroup from "./WebSidebarExpandableGroup";
 import type { SidebarSection } from "@/components/navigation/navTypes";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import { isSidebarNavItemActive } from "./sidebarActive";
 
 interface WebSidebarExpandableProps {
@@ -42,19 +44,31 @@ function WebSidebarExpandable({
       sub.items.some((item) => isSidebarNavItemActive(item, pathname))
     )?.name ?? null;
 
-  const [expandedSubsection, setExpandedSubsection] = useState<string | null>(
-    () => activeSubsection
-  );
+  const [subsectionSelection, setSubsectionSelection] = useState<{
+    readonly pathname: string | null;
+    readonly activeSubsection: string | null;
+    readonly selectedSubsection: string | null;
+  }>(() => ({
+    pathname,
+    activeSubsection,
+    selectedSubsection: activeSubsection,
+  }));
 
-  useEffect(() => {
-    setExpandedSubsection(activeSubsection);
-  }, [activeSubsection, pathname]);
+  const expandedSubsection =
+    subsectionSelection.pathname === pathname &&
+    subsectionSelection.activeSubsection === activeSubsection
+      ? subsectionSelection.selectedSubsection
+      : activeSubsection;
 
   const handleSubsectionToggle = useCallback(
     (subsectionName: string, isNowExpanded: boolean) => {
-      setExpandedSubsection(isNowExpanded ? subsectionName : null);
+      setSubsectionSelection({
+        pathname,
+        activeSubsection,
+        selectedSubsection: isNowExpanded ? subsectionName : null,
+      });
     },
-    []
+    [activeSubsection, pathname]
   );
 
   const hasActiveItem = useMemo(() => {
@@ -71,6 +85,7 @@ function WebSidebarExpandable({
   }, [section.items, section.subsections, pathname]);
 
   const panelId = `section-${section.key}`;
+  const flyoutId = `sidebar-flyout-${section.key}`;
 
   return (
     <>
@@ -84,8 +99,7 @@ function WebSidebarExpandable({
         active={hasActiveItem}
         collapsed={collapsed}
         ariaExpanded={expanded}
-        ariaControls={panelId}
-        ariaHasPopup={collapsed ? "menu" : undefined}
+        ariaControls={collapsed ? flyoutId : panelId}
         data-section={dataSection}
         rightSlot={
           !collapsed && (
@@ -107,7 +121,10 @@ function WebSidebarExpandable({
           <div className="tw-overflow-hidden">
             <div
               id={panelId}
-              aria-label={`${section.name} items`}
+              role="group"
+              aria-label={t(DEFAULT_LOCALE, "navigation.sidebar.panelLabel", {
+                section: section.name,
+              })}
               className="tw-relative tw-m-0 tw-p-0"
             >
               <div

--- a/components/layout/sidebar/nav/WebSidebarExpandable.tsx
+++ b/components/layout/sidebar/nav/WebSidebarExpandable.tsx
@@ -12,6 +12,15 @@ interface WebSidebarExpandableProps {
   readonly section: SidebarSection;
   readonly expanded: boolean;
   readonly onToggle: (e?: React.MouseEvent) => void;
+  readonly onPointerEnter?:
+    | React.PointerEventHandler<HTMLButtonElement>
+    | undefined;
+  readonly onPointerLeave?:
+    | React.PointerEventHandler<HTMLButtonElement>
+    | undefined;
+  readonly onKeyDown?:
+    | React.KeyboardEventHandler<HTMLButtonElement>
+    | undefined;
   readonly collapsed: boolean;
   readonly pathname: string | null;
   readonly "data-section"?: string | undefined;
@@ -21,6 +30,9 @@ function WebSidebarExpandable({
   section,
   expanded,
   onToggle,
+  onPointerEnter,
+  onPointerLeave,
+  onKeyDown,
   collapsed,
   pathname,
   "data-section": dataSection,
@@ -64,12 +76,16 @@ function WebSidebarExpandable({
     <>
       <WebSidebarNavItem
         onClick={(e) => onToggle(e)}
+        onPointerEnter={onPointerEnter}
+        onPointerLeave={onPointerLeave}
+        onKeyDown={onKeyDown}
         icon={section.icon}
         label={section.name}
         active={hasActiveItem}
         collapsed={collapsed}
         ariaExpanded={expanded}
         ariaControls={panelId}
+        ariaHasPopup={collapsed ? "menu" : undefined}
         data-section={dataSection}
         rightSlot={
           !collapsed && (

--- a/components/layout/sidebar/nav/WebSidebarNavItem.tsx
+++ b/components/layout/sidebar/nav/WebSidebarNavItem.tsx
@@ -9,6 +9,15 @@ type IconComp = React.ComponentType<{ className?: string | undefined }>;
 interface SidebarPrimaryItemProps {
   readonly href?: string | undefined;
   readonly onClick?: ((e?: React.MouseEvent) => void) | undefined;
+  readonly onPointerEnter?:
+    | React.PointerEventHandler<HTMLButtonElement>
+    | undefined;
+  readonly onPointerLeave?:
+    | React.PointerEventHandler<HTMLButtonElement>
+    | undefined;
+  readonly onKeyDown?:
+    | React.KeyboardEventHandler<HTMLButtonElement>
+    | undefined;
   readonly icon?: IconComp | undefined;
   readonly iconSizeClass?: string | undefined;
   readonly label: string;
@@ -17,6 +26,7 @@ interface SidebarPrimaryItemProps {
   readonly collapsed?: boolean | undefined;
   readonly ariaExpanded?: boolean | undefined;
   readonly ariaControls?: string | undefined;
+  readonly ariaHasPopup?: React.AriaAttributes["aria-haspopup"] | undefined;
   readonly rightSlot?: React.ReactNode | undefined;
   readonly hasIndicator?: boolean | undefined;
   readonly "data-section"?: string | undefined;
@@ -25,6 +35,9 @@ interface SidebarPrimaryItemProps {
 function WebSidebarNavItem({
   href,
   onClick,
+  onPointerEnter,
+  onPointerLeave,
+  onKeyDown,
   icon: Icon,
   iconSizeClass,
   label,
@@ -33,6 +46,7 @@ function WebSidebarNavItem({
   collapsed,
   ariaExpanded,
   ariaControls,
+  ariaHasPopup,
   rightSlot,
   hasIndicator,
   "data-section": dataSection,
@@ -79,7 +93,7 @@ function WebSidebarNavItem({
     ...(!hasTouchScreen && {
       "data-tooltip-id": "sidebar-tooltip",
       "data-tooltip-content": label,
-      "data-tooltip-hidden": !collapsed,
+      "data-tooltip-hidden": !collapsed || ariaExpanded === true,
     }),
     ...(dataSection ? { "data-section": dataSection } : {}),
   } as const;
@@ -105,6 +119,9 @@ function WebSidebarNavItem({
     <button
       type="button"
       onClick={(e) => onClick?.(e)}
+      onPointerEnter={onPointerEnter}
+      onPointerLeave={onPointerLeave}
+      onKeyDown={onKeyDown}
       className={`tw-touch-action-manipulation tw-block tw-h-[2.875rem] tw-w-full tw-cursor-pointer tw-rounded-xl tw-border-none tw-bg-transparent tw-px-2 tw-text-left tw-text-base tw-font-medium tw-no-underline tw-transition-colors tw-duration-200 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-iron-500 focus-visible:tw-ring-offset-2 motion-reduce:tw-transition-none ${
         active
           ? "tw-bg-transparent tw-text-white active:tw-text-white desktop-hover:hover:tw-bg-transparent desktop-hover:hover:tw-text-white"
@@ -112,6 +129,7 @@ function WebSidebarNavItem({
       }`}
       aria-expanded={ariaExpanded}
       aria-controls={ariaControls}
+      aria-haspopup={ariaHasPopup}
       {...commonProps}
     >
       {content}

--- a/components/layout/sidebar/nav/WebSidebarSubmenu.tsx
+++ b/components/layout/sidebar/nav/WebSidebarSubmenu.tsx
@@ -8,6 +8,8 @@ import {
   useMemo,
   useRef,
   useState,
+  type FocusEvent,
+  type PointerEvent,
 } from "react";
 import { createPortal } from "react-dom";
 import type {
@@ -20,6 +22,9 @@ interface WebSidebarSubmenuProps {
   readonly section: SidebarSection;
   readonly pathname: string | null;
   readonly onClose: () => void;
+  readonly onPointerEnter?: (() => void) | undefined;
+  readonly onPointerLeave?: (() => void) | undefined;
+  readonly focusFirstItem?: boolean | undefined;
   readonly leftOffset?: number | undefined;
   readonly anchorTop?: number | undefined;
   readonly anchorHeight?: number | undefined;
@@ -30,6 +35,9 @@ function WebSidebarSubmenu({
   section,
   pathname,
   onClose,
+  onPointerEnter,
+  onPointerLeave,
+  focusFirstItem = false,
   leftOffset,
   anchorTop,
   anchorHeight,
@@ -58,9 +66,45 @@ function WebSidebarSubmenu({
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
+      if (event.key === "Escape") {
+        event.preventDefault();
+        triggerElement?.focus();
+        onClose();
+      }
     },
-    [onClose]
+    [onClose, triggerElement]
+  );
+
+  const handlePointerLeave = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (event.pointerType !== "mouse") {
+        return;
+      }
+
+      const activeElement = browserDocument?.activeElement;
+      if (activeElement && containerRef.current?.contains(activeElement)) {
+        return;
+      }
+
+      onPointerLeave?.();
+    },
+    [browserDocument, onPointerLeave]
+  );
+
+  const handleBlur = useCallback(
+    (event: FocusEvent<HTMLDivElement>) => {
+      const nextTarget = event.relatedTarget;
+      if (
+        nextTarget instanceof Node &&
+        (containerRef.current?.contains(nextTarget) ||
+          triggerElement?.contains(nextTarget))
+      ) {
+        return;
+      }
+
+      onClose();
+    },
+    [onClose, triggerElement]
   );
 
   const handleClickOutside = useCallback(
@@ -121,6 +165,16 @@ function WebSidebarSubmenu({
     }
   }, [browserWindow, anchorTop, anchorHeight, section.key, totalItemCount]);
 
+  useEffect(() => {
+    if (!focusFirstItem) {
+      return;
+    }
+
+    containerRef.current
+      ?.querySelector<HTMLElement>("[role='menuitem']")
+      ?.focus();
+  }, [focusFirstItem, section.key]);
+
   if (browserDocument === undefined) {
     return null;
   }
@@ -164,16 +218,20 @@ function WebSidebarSubmenu({
   return createPortal(
     <div
       ref={containerRef}
-      className="tailwind-scope tw-fixed tw-z-[95] tw-flex tw-max-h-[65vh] tw-w-64 tw-flex-col tw-overflow-hidden tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-800 tw-shadow-[0_20px_45px_rgba(7,7,11,0.7)]"
+      id={`section-${section.key}`}
+      className="tailwind-scope tw-fixed tw-z-[95] tw-flex tw-max-h-[65vh] tw-w-64 tw-flex-col tw-overflow-hidden tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-800 tw-shadow-[0_20px_45px_rgba(7,7,11,0.7)] motion-safe:tw-animate-sidebar-flyout-in motion-reduce:tw-animate-none"
       style={{
         left: leftStyle,
         top: topStyle,
       }}
       role="menu"
       aria-label={`${section.name} sub-navigation`}
+      onPointerEnter={onPointerEnter}
+      onPointerLeave={handlePointerLeave}
+      onBlur={handleBlur}
     >
       <div className="tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-iron-700 tw-px-6 tw-pb-2 tw-pt-4">
-        <h3 className="tw-text-base tw-font-semibold tw-text-iron-50">
+        <h3 className="tw-m-0 tw-text-base tw-font-semibold tw-text-iron-50">
           {section.name}
         </h3>
       </div>

--- a/components/layout/sidebar/nav/WebSidebarSubmenu.tsx
+++ b/components/layout/sidebar/nav/WebSidebarSubmenu.tsx
@@ -21,6 +21,9 @@ import { DEFAULT_LOCALE } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
 import { isSidebarNavItemActive } from "./sidebarActive";
 
+const FOCUSABLE_ELEMENT_SELECTOR =
+  "a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])";
+
 interface WebSidebarSubmenuProps {
   readonly section: SidebarSection;
   readonly pathname: string | null;
@@ -108,13 +111,15 @@ function WebSidebarSubmenu({
         return;
       }
 
+      const sidebarFocusScope = triggerElement?.closest(
+        "[data-sidebar-scroll='true']"
+      );
       const focusableElements = Array.from(
-        browserDocument?.querySelectorAll<HTMLElement>(
-          "a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])"
+        sidebarFocusScope?.querySelectorAll<HTMLElement>(
+          FOCUSABLE_ELEMENT_SELECTOR
         ) ?? []
       ).filter(
         (element) =>
-          !container?.contains(element) &&
           !element.closest("[hidden], [inert]") &&
           element.getAttribute("aria-hidden") !== "true"
       );

--- a/components/layout/sidebar/nav/WebSidebarSubmenu.tsx
+++ b/components/layout/sidebar/nav/WebSidebarSubmenu.tsx
@@ -9,6 +9,7 @@ import {
   useRef,
   useState,
   type FocusEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent,
 } from "react";
 import { createPortal } from "react-dom";
@@ -66,15 +67,21 @@ function WebSidebarSubmenu({
     [section.items, section.subsections]
   );
 
-  const handleKeyDown = useCallback(
+  const handleEscapeKeyDown = useCallback(
     (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        triggerElement?.focus();
-        onClose();
+      if (event.key !== "Escape") {
         return;
       }
 
+      event.preventDefault();
+      triggerElement?.focus();
+      onClose();
+    },
+    [onClose, triggerElement]
+  );
+
+  const handleTabKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
       if (event.key !== "Tab") {
         return;
       }
@@ -117,7 +124,12 @@ function WebSidebarSubmenu({
       const nextFocusable =
         triggerIndex >= 0 ? focusableElements.at(triggerIndex + 1) : null;
 
-      (nextFocusable ?? triggerElement)?.focus();
+      if (nextFocusable) {
+        nextFocusable.focus();
+        return;
+      }
+
+      triggerElement?.focus();
       onClose();
     },
     [browserDocument, onClose, triggerElement]
@@ -181,18 +193,18 @@ function WebSidebarSubmenu({
       return;
     }
 
-    browserWindow.addEventListener("keydown", handleKeyDown);
+    browserWindow.addEventListener("keydown", handleEscapeKeyDown);
     browserDocument.addEventListener("mousedown", handleClickOutside);
     browserDocument.addEventListener("touchstart", handleClickOutside, {
       passive: true,
     });
 
     return () => {
-      browserWindow.removeEventListener("keydown", handleKeyDown);
+      browserWindow.removeEventListener("keydown", handleEscapeKeyDown);
       browserDocument.removeEventListener("mousedown", handleClickOutside);
       browserDocument.removeEventListener("touchstart", handleClickOutside);
     };
-  }, [browserWindow, browserDocument, handleKeyDown, handleClickOutside]);
+  }, [browserWindow, browserDocument, handleEscapeKeyDown, handleClickOutside]);
 
   useLayoutEffect(() => {
     if (browserWindow && containerRef.current) {
@@ -274,6 +286,7 @@ function WebSidebarSubmenu({
       })}
       onPointerEnter={onPointerEnter}
       onPointerLeave={handlePointerLeave}
+      onKeyDown={handleTabKeyDown}
       onBlur={handleBlur}
     >
       <div className="tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-iron-700 tw-px-6 tw-pb-2 tw-pt-4">

--- a/components/layout/sidebar/nav/WebSidebarSubmenu.tsx
+++ b/components/layout/sidebar/nav/WebSidebarSubmenu.tsx
@@ -16,6 +16,8 @@ import type {
   SidebarNavItem,
   SidebarSection,
 } from "@/components/navigation/navTypes";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import { isSidebarNavItemActive } from "./sidebarActive";
 
 interface WebSidebarSubmenuProps {
@@ -24,7 +26,7 @@ interface WebSidebarSubmenuProps {
   readonly onClose: () => void;
   readonly onPointerEnter?: (() => void) | undefined;
   readonly onPointerLeave?: (() => void) | undefined;
-  readonly focusFirstItem?: boolean | undefined;
+  readonly focusRequest?: number | undefined;
   readonly leftOffset?: number | undefined;
   readonly anchorTop?: number | undefined;
   readonly anchorHeight?: number | undefined;
@@ -37,7 +39,7 @@ function WebSidebarSubmenu({
   onClose,
   onPointerEnter,
   onPointerLeave,
-  focusFirstItem = false,
+  focusRequest = 0,
   leftOffset,
   anchorTop,
   anchorHeight,
@@ -70,9 +72,55 @@ function WebSidebarSubmenu({
         event.preventDefault();
         triggerElement?.focus();
         onClose();
+        return;
       }
+
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      const container = containerRef.current;
+      const links = Array.from(
+        container?.querySelectorAll<HTMLAnchorElement>("a[href]") ?? []
+      );
+      const activeElement = browserDocument?.activeElement;
+      const isLeavingBackwards =
+        event.shiftKey && activeElement === links.at(0);
+      const isLeavingForwards =
+        !event.shiftKey && activeElement === links.at(-1);
+
+      if (!isLeavingBackwards && !isLeavingForwards) {
+        return;
+      }
+
+      event.preventDefault();
+
+      if (isLeavingBackwards) {
+        triggerElement?.focus();
+        onClose();
+        return;
+      }
+
+      const focusableElements = Array.from(
+        browserDocument?.querySelectorAll<HTMLElement>(
+          "a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])"
+        ) ?? []
+      ).filter(
+        (element) =>
+          !container?.contains(element) &&
+          !element.closest("[hidden], [inert]") &&
+          element.getAttribute("aria-hidden") !== "true"
+      );
+      const triggerIndex = triggerElement
+        ? focusableElements.indexOf(triggerElement)
+        : -1;
+      const nextFocusable =
+        triggerIndex >= 0 ? focusableElements.at(triggerIndex + 1) : null;
+
+      (nextFocusable ?? triggerElement)?.focus();
+      onClose();
     },
-    [onClose, triggerElement]
+    [browserDocument, onClose, triggerElement]
   );
 
   const handlePointerLeave = useCallback(
@@ -135,7 +183,9 @@ function WebSidebarSubmenu({
 
     browserWindow.addEventListener("keydown", handleKeyDown);
     browserDocument.addEventListener("mousedown", handleClickOutside);
-    browserDocument.addEventListener("touchstart", handleClickOutside);
+    browserDocument.addEventListener("touchstart", handleClickOutside, {
+      passive: true,
+    });
 
     return () => {
       browserWindow.removeEventListener("keydown", handleKeyDown);
@@ -166,23 +216,18 @@ function WebSidebarSubmenu({
   }, [browserWindow, anchorTop, anchorHeight, section.key, totalItemCount]);
 
   useEffect(() => {
-    if (!focusFirstItem) {
+    if (focusRequest === 0) {
       return;
     }
 
-    containerRef.current
-      ?.querySelector<HTMLElement>("[role='menuitem']")
-      ?.focus();
-  }, [focusFirstItem, section.key]);
+    containerRef.current?.querySelector<HTMLElement>("a[href]")?.focus();
+  }, [focusRequest, section.key]);
 
   if (browserDocument === undefined) {
     return null;
   }
 
   const portalTarget = browserDocument.body;
-  if (!portalTarget) {
-    return null;
-  }
 
   const leftStyle =
     leftOffset === undefined
@@ -207,7 +252,6 @@ function WebSidebarSubmenu({
             : "tw-font-medium tw-text-iron-300 desktop-hover:hover:tw-bg-iron-700/50 desktop-hover:hover:tw-text-iron-50"
         }`}
         aria-current={active ? "page" : undefined}
-        role="menuitem"
         onClick={onClose}
       >
         <span className="tw-truncate">{item.name}</span>
@@ -218,14 +262,16 @@ function WebSidebarSubmenu({
   return createPortal(
     <div
       ref={containerRef}
-      id={`section-${section.key}`}
+      id={`sidebar-flyout-${section.key}`}
       className="tailwind-scope tw-fixed tw-z-[95] tw-flex tw-max-h-[65vh] tw-w-64 tw-flex-col tw-overflow-hidden tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-800 tw-shadow-[0_20px_45px_rgba(7,7,11,0.7)] motion-safe:tw-animate-sidebar-flyout-in motion-reduce:tw-animate-none"
       style={{
         left: leftStyle,
         top: topStyle,
       }}
-      role="menu"
-      aria-label={`${section.name} sub-navigation`}
+      role="navigation"
+      aria-label={t(DEFAULT_LOCALE, "navigation.sidebar.submenuLabel", {
+        section: section.name,
+      })}
       onPointerEnter={onPointerEnter}
       onPointerLeave={handlePointerLeave}
       onBlur={handleBlur}
@@ -247,7 +293,7 @@ function WebSidebarSubmenu({
                 section.items.length > 0 ? "tw-mt-3" : "tw-mt-3 first:tw-mt-0"
               }
             >
-              <div className="tw-px-3 tw-pb-1 tw-text-xs tw-font-semibold tw-uppercase tw-tracking-[0.14em] tw-text-iron-500">
+              <div className="tw-px-3 tw-pb-1 tw-text-xs tw-font-semibold tw-uppercase tw-tracking-[0.14em] tw-text-iron-400">
                 {subsection.name}
               </div>
 

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -286,6 +286,8 @@ const NAVIGATION_MESSAGES = objectMessages("navigation", {
   "primary.join6529": "Join 6529",
   "primary.about": "About",
   "primary.home": "Home",
+  "sidebar.submenuLabel": "{section} sub-navigation",
+  "sidebar.panelLabel": "{section} items",
   "account.notifications": "Notifications",
   "section.main": "Main",
   "section.utility": "Utility",

--- a/ops/docs/navigation/feature-sidebar-navigation.md
+++ b/ops/docs/navigation/feature-sidebar-navigation.md
@@ -11,6 +11,10 @@ On web layouts, route switching is sidebar-first.
 - Touch small-screen web: header menu button opens the same sidebar as overlay.
 - In collapsed rail mode, flyout submenus keep the same subsection labels and
   nested route grouping shown in the expanded rail.
+- In collapsed rail mode, a mouse hover opens `NFTs` and `About` after a short
+  intent delay; tap or click remains available for touch and pointer users.
+- Collapsed flyouts enter with a short opacity and horizontal-position reveal;
+  reduced-motion preferences show them immediately without animation.
 - The 6529 logo links to `/`; there is no labeled `Home` product row.
 - Primary menu concepts are `NFTs`, `Waves`, `DMs`, `Join 6529`, and `About`.
 - `NFTs` and `About` are expandable groups; `Waves`, `DMs`, and `Join 6529`
@@ -23,6 +27,8 @@ On web layouts, route switching is sidebar-first.
   `Notifications` row with its own unread dot.
 - Connected account avatar in the sidebar account area can show an unread dot
   when another connected account has unread notifications.
+- In the collapsed rail, the connected account avatar gets a visible hover
+  highlight; the account menu still opens by click or keyboard activation.
 
 ## Location in the Site
 
@@ -60,7 +66,8 @@ On web layouts, route switching is sidebar-first.
    or disconnected `Share`.
 4. Open `NFTs` or `About` for nested routes; use the `Waves` row for direct
    `/waves` navigation and the `Join 6529` row for `/join-6529`.
-5. In collapsed mode, group rows open anchored flyout submenus that preserve
+5. In collapsed mode, hover a group row with a mouse or activate it by tap,
+   click, or keyboard to open an anchored flyout submenu. The flyout preserves
    subsection labels such as `Network & Reputation`, `Delegation & Wallets`, or
    `Data & Developer Tools`.
 6. Select a destination and watch active state update.
@@ -118,9 +125,16 @@ On web layouts, route switching is sidebar-first.
   connected accounts (not the active one).
 - Active grouped routes auto-expand their section on route load/change.
 - In collapsed mode, selecting the same group toggles flyout open/closed.
+- Mouse hover uses a short intent delay before opening and a close grace period
+  so crossing from the group icon into the flyout does not dismiss it.
+- Only one collapsed flyout is open at a time. Moving from one group to another
+  replaces the open flyout.
 - Collapsed flyouts keep subsection headers as labels; only the nested rows
   inside each subsection navigate.
-- Flyouts close on outside click, `Escape`, or when rail exits collapsed mode.
+- Flyouts close after the mouse leaves both the trigger and flyout, on outside
+  click, with `Escape`, or when the rail exits collapsed mode. Keyboard opening
+  moves focus into the links, and `Escape` restores focus to the group trigger.
+- The collapsed-row tooltip stays hidden while its flyout is open.
 - Flyouts reposition on sidebar scroll and window resize.
 - `Notifications` row appears only when wallet connection is active.
 - `Profile` row appears only when wallet connection is active.
@@ -129,6 +143,8 @@ On web layouts, route switching is sidebar-first.
 - Connected user row opens the account menu on a single activate; a quick
   second activate cycles to the next connected account when at least two are
   available.
+- The web account dropdown stays horizontally anchored to the connected user
+  row when the centered desktop layout adds wide-screen margins.
 - Disconnected `Share` row is hidden in Capacitor/native context and
   mobile-device web.
 - Connected desktop-web `Share` moves into the user menu and stays hidden until

--- a/ops/docs/navigation/feature-wallet-account-controls.md
+++ b/ops/docs/navigation/feature-wallet-account-controls.md
@@ -36,11 +36,15 @@ expose different controls.
   - single activate opens the account dropdown
   - quick double activate cycles to the next connected account when at least
     two accounts are available
+  - collapsed-rail hover visibly highlights the avatar without opening the
+    dropdown
   - avatar can show a small unread dot when another connected account has
     unread notifications.
 
 ### Web Account Dropdown
 
+- The dropdown enters with a short opacity and vertical-position reveal;
+  reduced-motion preferences show it immediately without animation.
 - Identity rows:
   - base identity row is always present
   - received proxy rows appear when available
@@ -135,6 +139,8 @@ expose different controls.
 - `Profile` shortcuts in web/app navigation appear only when an address is
   present.
 - Web dropdown always includes the base identity row.
+- Web dropdown positioning follows the sidebar account row when wide desktop
+  layouts add centered outer margins.
 - Connected-account controls appear only when at least one connected account is
   available.
 - Add-account controls appear only while fewer than five connected profiles are

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -66,6 +66,7 @@
         "The web sidebar Waves row opens /waves directly; Discover Waves remains secondary inside the Waves experience and searchable, while Network, Delegation, Tools, Open Data, and reference material live under About.",
         "Drop Forge appears as a standalone sidebar row after About only when the connected wallet can access /drop-forge.",
         "The sidebar can be collapsed or expanded depending on viewport and layout state.",
+        "In the collapsed web rail, NFTs and About open on intentional mouse hover while tap, click, and keyboard activation remain available; the flyout stays open while crossing into it and closes after leaving both surfaces or pressing Escape.",
         "Search, Share, Connect Wallet, Notifications, and Profile are utility or account controls rather than product menu items."
       ],
       "canonical_path": "/waves",
@@ -677,6 +678,7 @@
       "facts": [
         "Wallet authentication lets a user connect, sign in, and act as a 6529 profile.",
         "Profile switching and account controls live in the wallet/account area of the app header.",
+        "On desktop web, the collapsed sidebar account avatar highlights on hover but opens its account dropdown only when activated; the dropdown stays aligned with the sidebar on centered wide-screen layouts.",
         "If wallet connection is not working, retry from the header wallet controls and confirm the wallet modal is completed before using write actions.",
         "Some write actions, settings, and subscriptions require a connected profile."
       ],

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -66,6 +66,7 @@
         "The web sidebar Waves row opens /waves directly; Discover Waves remains secondary inside the Waves experience and searchable, while Network, Delegation, Tools, Open Data, and reference material live under About.",
         "Drop Forge appears as a standalone sidebar row after About only when the connected wallet can access /drop-forge.",
         "The sidebar can be collapsed or expanded depending on viewport and layout state.",
+        "In the collapsed web rail, NFTs and About open on intentional mouse hover while tap, click, and keyboard activation remain available; the flyout stays open while crossing into it and closes after leaving both surfaces or pressing Escape.",
         "Search, Share, Connect Wallet, Notifications, and Profile are utility or account controls rather than product menu items."
       ],
       "canonical_path": "/waves",
@@ -677,6 +678,7 @@
       "facts": [
         "Wallet authentication lets a user connect, sign in, and act as a 6529 profile.",
         "Profile switching and account controls live in the wallet/account area of the app header.",
+        "On desktop web, the collapsed sidebar account avatar highlights on hover but opens its account dropdown only when activated; the dropdown stays aligned with the sidebar on centered wide-screen layouts.",
         "If wallet connection is not working, retry from the header wallet controls and confirm the wallet modal is completed before using write actions.",
         "Some write actions, settings, and subscriptions require a connected profile."
       ],

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -107,6 +107,26 @@ const tailwindConfig: Config = {
             opacity: "1",
           },
         },
+        "sidebar-flyout-in": {
+          "0%": {
+            opacity: "0",
+            transform: "translate3d(-4px, 0, 0)",
+          },
+          "100%": {
+            opacity: "1",
+            transform: "translate3d(0, 0, 0)",
+          },
+        },
+        "sidebar-account-menu-in": {
+          "0%": {
+            opacity: "0",
+            transform: "translate3d(0, 4px, 0)",
+          },
+          "100%": {
+            opacity: "1",
+            transform: "translate3d(0, 0, 0)",
+          },
+        },
         slideUp: {
           "0%": {
             opacity: "0",
@@ -214,6 +234,10 @@ const tailwindConfig: Config = {
         "gradient-x": "gradient-x 3s ease infinite",
         "spin-slow": "spin 15s linear infinite",
         fadeIn: "fadeIn 0.3s ease-out forwards",
+        "sidebar-flyout-in":
+          "sidebar-flyout-in 160ms cubic-bezier(0.22, 1, 0.36, 1) both",
+        "sidebar-account-menu-in":
+          "sidebar-account-menu-in 160ms cubic-bezier(0.22, 1, 0.36, 1) both",
         slideUp: "slideUp 0.3s ease-out forwards",
         slideDown: "slideDown 0.3s ease-out forwards",
         shake: "shake 0.3s ease-in-out",


### PR DESCRIPTION
## Issue
- In the collapsed sidebar, the NFTs and About groups required a click before their links were visible, adding friction for mouse users.
- The tooltip could overlap an open flyout, pointer movement across the gap could feel fragile, and keyboard focus needed an explicit path into the menu.
- Follow-up polish also identified weak profile-avatar hover feedback, wide-screen account-menu drift, and an expected `data-fine-pointer` hydration warning in development.

## Fix
- Add pointer-intent hover opening with a short close grace period while preserving tap, click, touch, and expanded-sidebar behavior.
- Keep flyout state, positioning, focus, and dismissal behavior centralized in the existing sidebar navigation.
- Use short opacity/translate-only CSS entry motion with reduced-motion support.
- Suppress only the intentional root-body hydration attribute difference caused by restoring persisted fine-pointer evidence before hydration.

## Changes
- Open collapsed NFTs and About flyouts after a 100 ms mouse-intent delay and close them after a 200 ms grace period once both trigger and flyout are left.
- Keep one flyout open at a time, hide its duplicate tooltip, close on outside click or Escape, focus the first link for keyboard opening, and restore logical focus on Escape and Tab exit.
- Preserve click/tap activation and expanded accordion behavior.
- Use unique controlled-region IDs, native navigation/link semantics, localized accessible labels, and higher-contrast subsection headings.
- Add a subtle collapsed profile-avatar hover state and anchor the account dropdown to the sidebar on wide centered layouts.
- Add lightweight 160 ms compositor-only flyout entry motion; reduced-motion users see the surfaces immediately.
- Update navigation/account documentation and the generated Help Bot index.

## Validation
- `./bin/6529 run help-index:sync`
- `./bin/6529 run test --testPathPatterns=__tests__/components/layout/sidebar/nav/WebSidebarSubmenu.test.tsx --runInBand`
- `./bin/6529 run lint:uncommitted:tight`
- `./bin/6529 run typecheck`
- `./bin/6529 run check:changed`
- `./bin/6529 run react-doctor:diff` — 99/100; the remaining two diagnostics are non-blocking existing structure warnings.
- `git diff --check`
- Live desktop QA on the collapsed NFTs/About flyouts, hover bridge, keyboard entry/Escape behavior, subtle motion, and wide-screen account-menu alignment.
- Stable fresh reload confirmed zero hydration errors after the root-body fix.

## Risk
- Level: Medium
- Why: The change is localized to sidebar interaction state, but spans mouse, keyboard, and touch-compatible activation paths.
- Rollback: Revert the signed feature and review-fix commits.

## Review Notes
- Please focus on pointer-intent timing, trigger-to-flyout traversal, focus restoration, and preservation of tap/click behavior.
- Entry animations use only opacity and `translate3d`; there is no blur, scale, spring, height, or layout animation.
- The body-level hydration suppression is the one-level escape hatch for the pre-hydration `data-fine-pointer` attribute on `<body>`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hover- and keyboard-driven flyout navigation for the collapsed sidebar.
  * Improved submenu focus management, keyboard navigation, dismissal, and accessibility labeling.
  * Added visual hover feedback for the collapsed sidebar account avatar.
  * Added smoother sidebar flyout and account menu animations, with reduced-motion support.
  * Improved account dropdown positioning on wide desktop layouts.

* **Documentation**
  * Updated navigation and account-control documentation and help content with the new interaction behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->