### PR TITLE
fix: Hardened the WebKit extension telemetry filter so mixed exception events remain reportable.

### DIFF
--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -65,6 +65,8 @@ describe("instrumentation-client", () => {
     "auto.browser.browserapierrors.setTimeout";
   const browserUnhandledRejectionMechanismType =
     "auto.browser.global_handlers.onunhandledrejection";
+  const webkitExtensionMessagingTabNotFoundMessage =
+    "Invalid call to runtime.sendMessage(). Tab not found.";
   const rainbowKitNotFoundMessage = "not found rainbowkit";
   const nativeJsonStringifyFrame = {
     filename: "[native code]",
@@ -145,6 +147,28 @@ describe("instrumentation-client", () => {
       ],
     },
   });
+
+  const createWebKitExtensionMessagingTabNotFoundEvent = (
+    valueOverrides: Record<string, unknown> = {},
+    eventOverrides: Record<string, unknown> = {}
+  ) => {
+    const event = createUnhandledRejectionEvent(
+      webkitExtensionMessagingTabNotFoundMessage
+    );
+
+    return {
+      ...event,
+      ...eventOverrides,
+      exception: {
+        values: [
+          {
+            ...event.exception.values[0],
+            ...valueOverrides,
+          },
+        ],
+      },
+    };
+  };
 
   const createAppleWebKitSortedTrackListEvent = (
     frames: Array<Record<string, unknown>> = [
@@ -1353,6 +1377,98 @@ describe("instrumentation-client", () => {
     const result = beforeSend(noiseFilterFixtures.threeV);
 
     expect(result).toBeNull();
+  });
+
+  it("drops the exact frame-less WebKit extension tab-not-found rejection", () => {
+    const beforeSend = loadBeforeSend();
+
+    const result = beforeSend(
+      createWebKitExtensionMessagingTabNotFoundEvent()
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it.each([
+    [
+      "an altered message",
+      { value: "Invalid call to runtime.sendMessage(). No tab found." },
+      {},
+    ],
+    ["a different exception type", { type: "TypeError" }, {}],
+    [
+      "a different mechanism",
+      {
+        mechanism: {
+          type: "auto.browser.global_handlers.onerror",
+          handled: false,
+        },
+      },
+      {},
+    ],
+    [
+      "a handled mechanism",
+      {
+        mechanism: {
+          type: browserUnhandledRejectionMechanismType,
+          handled: true,
+        },
+      },
+      {},
+    ],
+    [
+      "an app-owned frame",
+      {
+        stacktrace: {
+          frames: [
+            {
+              filename:
+                "webpack-internal:///(app-pages-browser)/./services/messaging/sendMessage.ts",
+              function: "sendMessage",
+              in_app: true,
+            },
+          ],
+        },
+      },
+      {},
+    ],
+    [
+      "an app-owned serialized stack",
+      {},
+      {
+        extra: {
+          __serialized__: {
+            message: webkitExtensionMessagingTabNotFoundMessage,
+            stack:
+              "Error: Invalid call to runtime.sendMessage(). Tab not found.\n    at sendMessage (app:///services/messaging/sendMessage.ts:10:1)",
+          },
+        },
+      },
+    ],
+  ])("keeps the WebKit tab-not-found near miss with %s", (_, value, event) => {
+    const beforeSend = loadBeforeSend();
+
+    const result = beforeSend(
+      createWebKitExtensionMessagingTabNotFoundEvent(value, event)
+    );
+
+    expect(result).not.toBeNull();
+  });
+
+  it("keeps WebKit tab-not-found rejections with app-owned original stacks", () => {
+    const beforeSend = loadBeforeSend();
+    const error = new Error(webkitExtensionMessagingTabNotFoundMessage);
+    error.stack = [
+      `Error: ${webkitExtensionMessagingTabNotFoundMessage}`,
+      "    at sendMessage (webpack-internal:///(app-pages-browser)/./services/messaging/sendMessage.ts:10:1)",
+    ].join("\n");
+
+    const result = beforeSend(
+      createWebKitExtensionMessagingTabNotFoundEvent(),
+      { originalException: error }
+    );
+
+    expect(result).not.toBeNull();
   });
 
   it("drops the raw DK Coinbase request-relay websocket event", () => {

--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -1389,6 +1389,37 @@ describe("instrumentation-client", () => {
     expect(result).toBeNull();
   });
 
+  it("keeps mixed WebKit and app-owned exceptions", () => {
+    const beforeSend = loadBeforeSend();
+    const baseEvent = createWebKitExtensionMessagingTabNotFoundEvent();
+    const event = {
+      ...baseEvent,
+      exception: {
+        values: [
+          ...baseEvent.exception.values,
+          {
+            type: "TypeError",
+            value: "App-owned failure",
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "webpack-internal:///(app-pages-browser)/./services/messaging/sendMessage.ts",
+                  function: "sendMessage",
+                  in_app: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result).not.toBeNull();
+  });
+
   it.each([
     [
       "an altered message",

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -6419,6 +6419,36 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(false);
   });
 
+  it("does not filter mixed WebKit and app-owned exceptions", () => {
+    // Arrange
+    const event = createWebKitExtensionMessagingTabNotFoundEvent();
+    event.exception = {
+      values: [
+        ...(event.exception?.values ?? []),
+        {
+          type: "TypeError",
+          value: "App-owned failure",
+          stacktrace: {
+            frames: [
+              {
+                filename:
+                  "webpack-internal:///(app-pages-browser)/./services/messaging/sendMessage.ts",
+                function: "sendMessage",
+                in_app: true,
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    // Act
+    const result = shouldFilterBrowserExtensionSendMessageError(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
   it("does not filter WebKit tab-not-found errors with app-owned frames", () => {
     // Arrange
     const event = createWebKitExtensionMessagingTabNotFoundEvent({

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -7,6 +7,7 @@ import {
   shouldFilterAnonymousUnsafeEvalCspError,
   shouldFilterAppleWebKitSortedTrackListTypeError,
   shouldFilterBrowserExtensionMessagingConnectionError,
+  shouldFilterBrowserExtensionSendMessageError,
   shouldFilterCoinbaseWalletLinkWebSocket1006,
   shouldFilterDisconnectedWalletProviderRejection,
   shouldFilterGifPickerTenorCategoriesError,
@@ -138,6 +139,8 @@ describe("sentry-client-filters", () => {
     "No matching key. session topic doesn't exist: f17f5eaa1c3041fe37871f9eb24f4de53e1b11e494ec3def4b510d09acf42e32";
   const extensionMessagingConnectionFailureMessage =
     "Could not establish connection. Receiving end does not exist.";
+  const webkitExtensionMessagingTabNotFoundMessage =
+    "Invalid call to runtime.sendMessage(). Tab not found.";
 
   const buildSpan = (
     overrides: TestSentryTransactionSpanOverrides = {}
@@ -725,6 +728,33 @@ describe("sentry-client-filters", () => {
     ],
     ...overrides,
   });
+
+  const createWebKitExtensionMessagingTabNotFoundEvent = (
+    valueOverrides: Record<string, unknown> = {},
+    eventOverrides: TestSentryClientEventOverrides = {}
+  ): TestSentryClientEvent => {
+    const value = {
+      type: "Error",
+      value: webkitExtensionMessagingTabNotFoundMessage,
+      mechanism: {
+        type: "auto.browser.global_handlers.onunhandledrejection",
+        handled: false,
+      },
+    };
+
+    return {
+      transaction: "/",
+      ...eventOverrides,
+      exception: {
+        values: [
+          {
+            ...value,
+            ...valueOverrides,
+          },
+        ],
+      },
+    };
+  };
 
   const createAppleWebKitSortedTrackListEvent = ({
     type = "TypeError",
@@ -6360,6 +6390,94 @@ describe("sentry-client-filters", () => {
 
     // Act
     const result = shouldFilterBrowserExtensionMessagingConnectionError(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("filters the exact frame-less WebKit extension tab-not-found rejection", () => {
+    // Arrange
+    const event = createWebKitExtensionMessagingTabNotFoundEvent();
+
+    // Act
+    const result = shouldFilterBrowserExtensionSendMessageError(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("does not filter nearby WebKit extension messaging errors", () => {
+    // Arrange
+    const event = createWebKitExtensionMessagingTabNotFoundEvent({
+      value: "Invalid call to runtime.sendMessage(). No tab found.",
+    });
+
+    // Act
+    const result = shouldFilterBrowserExtensionSendMessageError(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter WebKit tab-not-found errors with app-owned frames", () => {
+    // Arrange
+    const event = createWebKitExtensionMessagingTabNotFoundEvent({
+      stacktrace: {
+        frames: [
+          {
+            filename:
+              "webpack-internal:///(app-pages-browser)/./services/messaging/sendMessage.ts",
+            function: "sendMessage",
+            in_app: true,
+          },
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterBrowserExtensionSendMessageError(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter WebKit tab-not-found errors with app-owned original stacks", () => {
+    // Arrange
+    const event = createWebKitExtensionMessagingTabNotFoundEvent();
+    const error = new Error(webkitExtensionMessagingTabNotFoundMessage);
+    error.stack = [
+      `Error: ${webkitExtensionMessagingTabNotFoundMessage}`,
+      "    at sendMessage (webpack-internal:///(app-pages-browser)/./services/messaging/sendMessage.ts:10:1)",
+    ].join("\n");
+
+    // Act
+    const result = shouldFilterBrowserExtensionSendMessageError(event, {
+      originalException: error,
+    });
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter WebKit tab-not-found errors with app-owned serialized stacks", () => {
+    // Arrange
+    const event = createWebKitExtensionMessagingTabNotFoundEvent(
+      {},
+      {
+        extra: {
+          __serialized__: {
+            message: webkitExtensionMessagingTabNotFoundMessage,
+            stack: [
+              `Error: ${webkitExtensionMessagingTabNotFoundMessage}`,
+              "    at sendMessage (app:///services/messaging/sendMessage.ts:10:1)",
+            ].join("\n"),
+          },
+        },
+      }
+    );
+
+    // Act
+    const result = shouldFilterBrowserExtensionSendMessageError(event);
 
     // Assert
     expect(result).toBe(false);

--- a/utils/sentry-client-filters/constants.ts
+++ b/utils/sentry-client-filters/constants.ts
@@ -231,6 +231,8 @@ export const extensionMessagingContentScriptPaths = new Set([
 export const injectedScriptBundlePathToken = "injectedscript.bundle.js";
 export const injectedScriptSendMessageError =
   "Cannot read properties of undefined (reading 'sendMessage')";
+export const webkitExtensionMessagingTabNotFoundMessage =
+  "Invalid call to runtime.sendMessage(). Tab not found.";
 export const sentryBrowserHelperPathToken = "/helpers.ts";
 export const sentryBrowserPackagePathTokens = [
   "@sentry/browser",

--- a/utils/sentry-client-filters/extension-messaging.ts
+++ b/utils/sentry-client-filters/extension-messaging.ts
@@ -7,6 +7,7 @@ import {
   injectedScriptSendMessageError,
   sentryBrowserHelperPathToken,
   sentryBrowserPackagePathTokens,
+  webkitExtensionMessagingTabNotFoundMessage,
 } from "./constants";
 import type {
   SentryClientEvent,
@@ -113,9 +114,13 @@ export function shouldFilterBrowserExtensionSendMessageError(
   hint?: SentryEventHint
 ): boolean {
   const value = event.exception?.values?.[0];
+  const normalizedMessage = normalizeErrorPrefix(value?.value ?? "");
+  const isWebKitExtensionTabNotFoundError =
+    normalizedMessage === webkitExtensionMessagingTabNotFoundMessage;
   if (
     value?.type !== "Error" ||
-    normalizeErrorPrefix(value.value ?? "") !== injectedScriptSendMessageError
+    (normalizedMessage !== injectedScriptSendMessageError &&
+      !isWebKitExtensionTabNotFoundError)
   ) {
     return false;
   }
@@ -126,6 +131,10 @@ export function shouldFilterBrowserExtensionSendMessageError(
     hasAppOwnedSourceEvidence(event, value, hint)
   ) {
     return false;
+  }
+
+  if (isWebKitExtensionTabNotFoundError) {
+    return true;
   }
 
   return hasOnlyInjectedSendMessageFrames(value.stacktrace?.frames);

--- a/utils/sentry-client-filters/extension-messaging.ts
+++ b/utils/sentry-client-filters/extension-messaging.ts
@@ -134,7 +134,7 @@ export function shouldFilterBrowserExtensionSendMessageError(
   }
 
   if (isWebKitExtensionTabNotFoundError) {
-    return true;
+    return event.exception?.values?.length === 1;
   }
 
   return hasOnlyInjectedSendMessageFrames(value.stacktrace?.frames);


### PR DESCRIPTION
<!-- sentry-fix-job:17 issue:7616500234 -->
## Issue

- Sentry: [6529-FRONTEND-EV](https://seize-ff.sentry.io/issues/7616500234/)
- First seen: 2026-07-17T04:01:49.598Z
- Latest occurrence: 2026-07-17T04:01:49.000Z
- Automatic triage confidence: 98%

A narrow repository-owned telemetry filter is useful. This is an exact WebKit WebExtension messaging failure captured by Sentry's global rejection handler, not an application failure.

## Fix

[WebKit’s runtime messaging implementation](https://github.com/WebKit/WebKit/blob/b008d85bb026f03ac31665a9f99536906c88bf77/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm#L130-L146) produces the exact tab-not-found rejection. The existing repair matched the first exception value but did not require it to be the event’s only exception, which could suppress a mixed event containing an application failure.

## Changes

- Required exactly one exception value before filtering the frame-less WebKit signature.
- Added focused utility coverage preserving a mixed WebKit and app-owned exception event.
- Added beforeSend integration coverage proving the mixed event remains reportable.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Focused Jest suites passed: 2 suites, 356 tests.
- lint:diff passed for the uncommitted repair.
- lint:changed passed for the published branch changes.
- typecheck:changed passed for 25 changed TypeScript files.
- git diff --check passed.

## Risk

- Assessed risk: low
- Changed files: 4
- Changed lines: 308
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

The originating extension cannot be identified from the frame-less event. The repair remains uncommitted and unpushed for the trusted publisher, so remote CI has not evaluated these latest local edits.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
