### PR TITLE
fix: Repaired the draft PR by adding focused fail-open coverage for the narrow Twitter iOS telemetry filter.

### DIFF
--- a/__tests__/fixtures/sentry-noise-filter-hardening.json
+++ b/__tests__/fixtures/sentry-noise-filter-hardening.json
@@ -79,7 +79,7 @@
     "request": {
       "url": "https://6529.io/waves/00000000-0000-4000-8000-000000000002",
       "headers": {
-        "User-Agent": "Twitter/12.3 (iPhone; iOS 16.7.14)"
+        "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_7_16 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/20H392 Twitter for iPhone/12.9"
       }
     },
     "exception": {

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -21,6 +21,7 @@ import {
   shouldFilterTalismanExtensionOnboardingError,
   shouldFilterThirdPartyTelemetryNetworkError,
   shouldFilterThirdPartyTelemetrySpan,
+  shouldFilterTwitterCurrentInsetReferenceError,
   shouldFilterTwitterConfigReferenceError,
   shouldFilterWalletConnectStaleSessionTopic,
   tagSampledLowValueNetworkError,
@@ -77,6 +78,8 @@ describe("sentry-client-filters", () => {
     "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 RabbyMobile/0.6.78 RabbyMobileAndroid/0.6.78 Mobile Safari/537.36";
   const rainbowKitNotFoundMessage = "not found rainbowkit";
   const originalNavigatorUserAgent = globalThis.navigator.userAgent;
+  const twitterForIphoneUserAgent =
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 16_7_16 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/20H392 Twitter for iPhone/12.9";
   const reactDomInsertBeforeMessage =
     __testing.REACT_DOM_INSERT_BEFORE_NOT_FOUND_ERROR_MESSAGE;
   const gifPickerTenorUndefinedTagsMessage =
@@ -203,6 +206,37 @@ describe("sentry-client-filters", () => {
     tags: {
       browser: "Twitter 11.62",
       "browser.name": "Twitter",
+    },
+    ...overrides,
+  });
+
+  const createTwitterCurrentInsetEvent = (
+    overrides: TestSentryClientEventOverrides = {}
+  ): TestSentryClientEvent => ({
+    request: {
+      headers: {
+        "User-Agent": twitterForIphoneUserAgent,
+      },
+    },
+    exception: {
+      values: [
+        {
+          type: "ReferenceError",
+          value: "Can't find variable: currentInset",
+          mechanism: {
+            type: "auto.browser.global_handlers.onerror",
+            handled: false,
+          },
+          stacktrace: {
+            frames: [
+              {
+                filename:
+                  "app:///waves/00000000-0000-4000-8000-000000000002",
+              },
+            ],
+          },
+        },
+      ],
     },
     ...overrides,
   });
@@ -3738,6 +3772,30 @@ describe("sentry-client-filters", () => {
     expect(getLowValueNetworkErrorTargetUrl(event)).toBeNull();
     expect(getNetworkErrorMessageTargetUrl(event)).toBe("/notifications");
     expect(getLowValueNetworkErrorDecision(event, 0)).toBe("not_applicable");
+  });
+
+  it("filters Twitter currentInset errors from the production iPhone user agent", () => {
+    // Arrange
+    const event = createTwitterCurrentInsetEvent();
+
+    // Act
+    const result = shouldFilterTwitterCurrentInsetReferenceError(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("filters Twitter currentInset errors from the runtime iPhone user agent", () => {
+    // Arrange
+    const event = createTwitterCurrentInsetEvent({ request: undefined });
+
+    // Act
+    const result = withRuntimeUserAgent(twitterForIphoneUserAgent, () =>
+      shouldFilterTwitterCurrentInsetReferenceError(event)
+    );
+
+    // Assert
+    expect(result).toBe(true);
   });
 
   it("filters Twitter CONFIG reference errors with injected wave document frames", () => {

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -33,6 +33,11 @@ import {
 type TestSentryClientEvent = SentryClientEvent;
 type TestSentryClientEventOverrides = Partial<TestSentryClientEvent>;
 type TestSentryTransactionSpanOverrides = Partial<SentryTransactionSpan>;
+type TwitterCurrentInsetEventOptions = {
+  request?: TestSentryClientEvent["request"];
+  mechanismType?: string;
+  handled?: boolean;
+};
 type AppleWebKitSortedTrackListOverrides = {
   type?: string | undefined;
   value?: string | undefined;
@@ -210,22 +215,24 @@ describe("sentry-client-filters", () => {
     ...overrides,
   });
 
-  const createTwitterCurrentInsetEvent = (
-    overrides: TestSentryClientEventOverrides = {}
-  ): TestSentryClientEvent => ({
-    request: {
+  const createTwitterCurrentInsetEvent = ({
+    request = {
       headers: {
         "User-Agent": twitterForIphoneUserAgent,
       },
     },
+    mechanismType = "auto.browser.global_handlers.onerror",
+    handled = false,
+  }: TwitterCurrentInsetEventOptions = {}): TestSentryClientEvent => ({
+    request,
     exception: {
       values: [
         {
           type: "ReferenceError",
           value: "Can't find variable: currentInset",
           mechanism: {
-            type: "auto.browser.global_handlers.onerror",
-            handled: false,
+            type: mechanismType,
+            handled,
           },
           stacktrace: {
             frames: [
@@ -238,7 +245,6 @@ describe("sentry-client-filters", () => {
         },
       ],
     },
-    ...overrides,
   });
 
   const createInjectedWalletCollisionEvent = (
@@ -3787,7 +3793,7 @@ describe("sentry-client-filters", () => {
 
   it("filters Twitter currentInset errors from the runtime iPhone user agent", () => {
     // Arrange
-    const event = createTwitterCurrentInsetEvent({ request: undefined });
+    const event = createTwitterCurrentInsetEvent({ request: {} });
 
     // Act
     const result = withRuntimeUserAgent(twitterForIphoneUserAgent, () =>
@@ -3796,6 +3802,38 @@ describe("sentry-client-filters", () => {
 
     // Assert
     expect(result).toBe(true);
+  });
+
+  it("does not filter currentInset errors from non-Twitter iPhone Safari", () => {
+    // Arrange
+    const event = createTwitterCurrentInsetEvent({
+      request: {
+        headers: {
+          "User-Agent":
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 16_7_16 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1",
+        },
+      },
+    });
+
+    // Act
+    const result = shouldFilterTwitterCurrentInsetReferenceError(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it.each([
+    ["a different capture mechanism", { mechanismType: "generic" }],
+    ["a handled error", { handled: true }],
+  ])("does not filter Twitter currentInset errors from %s", (_label, options) => {
+    // Arrange
+    const event = createTwitterCurrentInsetEvent(options);
+
+    // Act
+    const result = shouldFilterTwitterCurrentInsetReferenceError(event);
+
+    // Assert
+    expect(result).toBe(false);
   });
 
   it("filters Twitter CONFIG reference errors with injected wave document frames", () => {

--- a/utils/sentry-client-filters/errors.ts
+++ b/utils/sentry-client-filters/errors.ts
@@ -65,7 +65,8 @@ const sentryBrowserPathTokens = ["@sentry/browser", "@sentry+browser"];
 const anonymousUnsafeEvalRawChunkPathPattern =
   /^app:\/\/\/_next\/static\/chunks\/[a-z0-9._~-]+\.js$/i;
 const anonymousUnsafeEvalRawWrapperLineNumbers = new Set([3, 7]);
-const twitterUserAgentPattern = /(?:^|[\s;(])twitter(?:android)?\//i;
+const twitterUserAgentPattern =
+  /(?:^|[\s;(])twitter(?:android| for iphone)?\//i;
 
 function shouldFilterFilenameExceptions(
   frames: SentryStackFrame[] | undefined


### PR DESCRIPTION
<!-- sentry-fix-job:19 issue:7366647316 -->
## Issue

- Sentry: [6529-FRONTEND-9N](https://seize-ff.sentry.io/issues/7366647316/)
- First seen: 2026-03-26T19:54:25.360Z
- Latest occurrence: 2026-07-16T22:45:15.000Z
- Automatic triage confidence: 98%

Create a narrow telemetry-filter fix. Twitter/X’s iOS in-app browser injects the failing code, and the existing filter misses production because its user-agent matcher does not recognize `Twitter for iPhone/<version>`.

## Fix

The implementation correctly recognizes `Twitter for iPhone/<version>`, but its new tests covered only filtering paths and did not directly protect non-Twitter or mechanism near-misses from future over-filtering.

## Changes

- Added a negative regression test preserving the same `currentInset` error from plain iPhone Safari.
- Added negative cases for a different capture mechanism and for handled errors.
- Changed the runtime-user-agent test to use an explicitly headerless request object, avoiding shallow-merge assumptions.
- Confirmed the hardening fixture is consumed per event; the separate legacy Twitter fixture does not impose a global user-agent format.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Focused Sentry suites passed: 2 suites, 346 tests.
- `./bin/6529 run lint:changed` passed.
- `./bin/6529 run typecheck:changed` passed for 24 changed TypeScript files.
- `git diff --check` passed.
- Final Sonar-sensitive diff scan found no new quality concerns.

## Risk

- Assessed risk: low
- Changed files: 3
- Changed lines: 101
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

Twitter/X’s injected script remains unavailable, so its internal reason for leaving `currentInset` undefined cannot be verified. Post-deployment occurrence monitoring remains with the trusted publisher; no commit, push, deployment, merge, PR-state change, or Sentry mutation was performed.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
