### PR TITLE
fix: Registered the v2 telemetry contract and dated migration plan. The existing provenance repair remains int

### DIFF
--- a/__tests__/utils/cyclicJsonTimerDiagnostics.test.ts
+++ b/__tests__/utils/cyclicJsonTimerDiagnostics.test.ts
@@ -4,6 +4,10 @@ import {
   installCyclicJsonTimerDiagnostics,
   isIosWkWebViewUserAgent,
 } from "@/utils/monitoring/cyclicJsonTimerDiagnostics";
+import {
+  getProductionAssetPrefix,
+  PRODUCTION_ASSET_HOSTNAME,
+} from "@/config/assetPrefix";
 import type { Event } from "@sentry/nextjs";
 
 const CYCLIC_JSON_MESSAGE =
@@ -11,9 +15,7 @@ const CYCLIC_JSON_MESSAGE =
 const WKWEBVIEW_USER_AGENT =
   "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148";
 const MOBILE_SAFARI_USER_AGENT = `${WKWEBVIEW_USER_AGENT} Version/18.7 Safari/604.1`;
-const PRODUCTION_ASSET_HOSTNAME = "dnclu2fna0b2b.cloudfront.net";
-const PRODUCTION_ASSET_PREFIX =
-  `https://${PRODUCTION_ASSET_HOSTNAME}/web_build/test-release`;
+const PRODUCTION_ASSET_PREFIX = getProductionAssetPrefix("test-release");
 
 type ScheduledTimer = {
   handler: ((...args: unknown[]) => unknown) | string;
@@ -235,9 +237,7 @@ describe("cyclic JSON timer diagnostics", () => {
     const { target, getOriginalReceiver } = createTimerHarness();
     const detachedSetTimeout = target.setTimeout;
 
-    expect(detachedSetTimeout.name).toBe(
-      "cyclicJsonTimerDiagnosticSetTimeout"
-    );
+    expect(detachedSetTimeout.name).toBe("cyclicJsonTimerDiagnosticSetTimeout");
     detachedSetTimeout(jest.fn(), 5);
 
     expect(getOriginalReceiver()).toBe(target);
@@ -301,10 +301,10 @@ describe("cyclic JSON timer diagnostics", () => {
     expect(serializedDiagnostics).not.toContain("secret-extension-id");
   });
 
-  it("recognizes production CDN chunks and removes a minified capture-site frame", () => {
+  it("recognizes production CDN chunks and removes the capture-site frame", () => {
     const diagnostics = captureDiagnostics([
       "Error: cyclic-json-timer-schedule",
-      `u@${PRODUCTION_ASSET_PREFIX}/_next/static/chunks/diagnostics.js:21:99680`,
+      `cyclicJsonTimerDiagnosticSetTimeout@${PRODUCTION_ASSET_PREFIX}/_next/static/chunks/diagnostics.js:21:99680`,
       "injectedCallback@https://wallet.example/inpage.js:790:281",
       `scheduleRefresh@${PRODUCTION_ASSET_PREFIX}/_next/static/chunks/app/waves.js:51:8567`,
     ]);
@@ -332,6 +332,40 @@ describe("cyclic JSON timer diagnostics", () => {
         },
       ],
     });
+  });
+
+  it("keeps the first scheduling frame when the wrapper frame is absent", () => {
+    const diagnostics = captureDiagnostics([
+      `u@${PRODUCTION_ASSET_PREFIX}/_next/static/chunks/app/waves.js:51:8567`,
+      "injectedCallback@https://wallet.example/inpage.js:790:281",
+    ]);
+
+    expect(diagnostics.scheduleOrigin).toBe("mixed");
+    expect(diagnostics.schedulingFrames).toEqual([
+      {
+        file: "/_next/static/chunks/app/waves.js",
+        function: "u",
+        line: 51,
+        column: 8567,
+        origin: "first_party",
+      },
+      {
+        file: "external/inpage.js",
+        function: "injectedCallback",
+        line: 790,
+        column: 281,
+        origin: "third_party",
+      },
+    ]);
+  });
+
+  it("reports unknown provenance when the wrapper is the only frame", () => {
+    const diagnostics = captureDiagnostics([
+      `cyclicJsonTimerDiagnosticSetTimeout@${PRODUCTION_ASSET_PREFIX}/_next/static/chunks/diagnostics.js:21:99680`,
+    ]);
+
+    expect(diagnostics.scheduleOrigin).toBe("unknown");
+    expect(diagnostics.schedulingFrames).toEqual([]);
   });
 
   it.each([
@@ -369,7 +403,7 @@ describe("cyclic JSON timer diagnostics", () => {
   ])("does not classify $name as a production app asset", (testCase) => {
     const diagnostics = captureDiagnostics([
       "Error: cyclic-json-timer-schedule",
-      `u@${PRODUCTION_ASSET_PREFIX}/_next/static/chunks/diagnostics.js:1:2`,
+      `cyclicJsonTimerDiagnosticSetTimeout@${PRODUCTION_ASSET_PREFIX}/_next/static/chunks/diagnostics.js:1:2`,
       `candidate@${testCase.location}`,
     ]);
 

--- a/__tests__/utils/cyclicJsonTimerDiagnostics.test.ts
+++ b/__tests__/utils/cyclicJsonTimerDiagnostics.test.ts
@@ -11,6 +11,9 @@ const CYCLIC_JSON_MESSAGE =
 const WKWEBVIEW_USER_AGENT =
   "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148";
 const MOBILE_SAFARI_USER_AGENT = `${WKWEBVIEW_USER_AGENT} Version/18.7 Safari/604.1`;
+const PRODUCTION_ASSET_HOSTNAME = "dnclu2fna0b2b.cloudfront.net";
+const PRODUCTION_ASSET_PREFIX =
+  `https://${PRODUCTION_ASSET_HOSTNAME}/web_build/test-release`;
 
 type ScheduledTimer = {
   handler: ((...args: unknown[]) => unknown) | string;
@@ -87,6 +90,37 @@ function createTimerHarness(options?: {
     target,
     getScheduled: () => scheduled,
     getOriginalReceiver: () => originalReceiver,
+  };
+}
+
+function captureDiagnostics(stackLines: string[]) {
+  const { target, getScheduled } = createTimerHarness({
+    stackFactory: () => stackLines.join("\n"),
+  });
+  const expectedError = new TypeError(CYCLIC_JSON_MESSAGE);
+  target.setTimeout(() => {
+    throw expectedError;
+  }, 0);
+
+  const scheduled = getScheduled();
+  try {
+    (scheduled?.handler as (...args: unknown[]) => unknown)();
+  } catch (error) {
+    expect(error).toBe(expectedError);
+  }
+
+  const event = createCyclicJsonEvent();
+  enrichCyclicJsonTimerEvent(event, { originalException: expectedError });
+  return event.extra?.["cyclicJsonTimerDiagnostics"] as {
+    schemaVersion: string;
+    scheduleOrigin: string;
+    schedulingFrames: Array<{
+      file: string;
+      function: string;
+      line: number;
+      column: number;
+      origin: string;
+    }>;
   };
 }
 
@@ -232,11 +266,11 @@ describe("cyclic JSON timer diagnostics", () => {
     enrichCyclicJsonTimerEvent(event, { originalException: expectedError });
 
     expect(event.tags).toMatchObject({
-      [CYCLIC_JSON_TIMER_DIAGNOSTICS_TAG]: "v1",
+      [CYCLIC_JSON_TIMER_DIAGNOSTICS_TAG]: "v2",
       cyclic_json_timer_schedule_origin: "mixed",
     });
     expect(event.extra?.["cyclicJsonTimerDiagnostics"]).toEqual({
-      schemaVersion: "v1",
+      schemaVersion: "v2",
       timerSampleRate: 1 / 16,
       callbackName: "failingTimerCallback",
       webViewFamily: "ios-wkwebview",
@@ -265,6 +299,90 @@ describe("cyclic JSON timer diagnostics", () => {
     expect(serializedDiagnostics).not.toContain("0xprivate");
     expect(serializedDiagnostics).not.toContain("private");
     expect(serializedDiagnostics).not.toContain("secret-extension-id");
+  });
+
+  it("recognizes production CDN chunks and removes a minified capture-site frame", () => {
+    const diagnostics = captureDiagnostics([
+      "Error: cyclic-json-timer-schedule",
+      `u@${PRODUCTION_ASSET_PREFIX}/_next/static/chunks/diagnostics.js:21:99680`,
+      "injectedCallback@https://wallet.example/inpage.js:790:281",
+      `scheduleRefresh@${PRODUCTION_ASSET_PREFIX}/_next/static/chunks/app/waves.js:51:8567`,
+    ]);
+
+    expect(diagnostics).toEqual({
+      schemaVersion: "v2",
+      timerSampleRate: 1 / 16,
+      callbackName: "anonymous",
+      webViewFamily: "ios-wkwebview",
+      scheduleOrigin: "mixed",
+      schedulingFrames: [
+        {
+          file: "external/inpage.js",
+          function: "injectedCallback",
+          line: 790,
+          column: 281,
+          origin: "third_party",
+        },
+        {
+          file: "/_next/static/chunks/app/waves.js",
+          function: "scheduleRefresh",
+          line: 51,
+          column: 8567,
+          origin: "first_party",
+        },
+      ],
+    });
+  });
+
+  it.each([
+    {
+      name: "a lookalike hostname",
+      location: `https://${PRODUCTION_ASSET_HOSTNAME}.example.com/web_build/test-release/_next/static/chunks/app.js:3:4`,
+      expectedFile: "external/app.js",
+      expectedOrigin: "third_party",
+    },
+    {
+      name: "an unrelated path on the app asset CDN",
+      location: `https://${PRODUCTION_ASSET_HOSTNAME}/_next/static/chunks/app.js:3:4`,
+      expectedFile: "external/app.js",
+      expectedOrigin: "third_party",
+    },
+    {
+      name: "the separate media CDN",
+      location:
+        "https://d3lqz0a4bldqgf.cloudfront.net/web_build/test-release/_next/static/chunks/app.js:3:4",
+      expectedFile: "external/app.js",
+      expectedOrigin: "third_party",
+    },
+    {
+      name: "a non-HTTP script",
+      location: "data:text/javascript,fixture:3:4",
+      expectedFile: "non-http-script",
+      expectedOrigin: "unknown",
+    },
+    {
+      name: "a generic external script",
+      location: "https://scripts.example/vendor.js:3:4",
+      expectedFile: "external/vendor.js",
+      expectedOrigin: "third_party",
+    },
+  ])("does not classify $name as a production app asset", (testCase) => {
+    const diagnostics = captureDiagnostics([
+      "Error: cyclic-json-timer-schedule",
+      `u@${PRODUCTION_ASSET_PREFIX}/_next/static/chunks/diagnostics.js:1:2`,
+      `candidate@${testCase.location}`,
+    ]);
+
+    expect(diagnostics.scheduleOrigin).toBe(testCase.expectedOrigin);
+    expect(diagnostics.schedulingFrames).toEqual([
+      {
+        file: testCase.expectedFile,
+        function: "candidate",
+        line: 3,
+        column: 4,
+        origin: testCase.expectedOrigin,
+      },
+    ]);
   });
 
   it("does not tag unrelated errors or create a second event", () => {

--- a/config/assetPrefix.ts
+++ b/config/assetPrefix.ts
@@ -1,0 +1,5 @@
+export const PRODUCTION_ASSET_HOSTNAME = "dnclu2fna0b2b.cloudfront.net";
+
+export function getProductionAssetPrefix(version: string): string {
+  return `https://${PRODUCTION_ASSET_HOSTNAME}/web_build/${version}`;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,7 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 
 import { NextConfig } from "next";
+import { getProductionAssetPrefix } from "@/config/assetPrefix";
 import { computeVersionFromEnvOrGit, logOnceConfig } from "@/config/version";
 import {
   loadAssetsFlagAtRuntime,
@@ -33,7 +34,7 @@ function getAssetPrefix(assetsFromS3: boolean, version: string): string {
   if (!assetsFromS3) {
     return "";
   }
-  return `https://dnclu2fna0b2b.cloudfront.net/web_build/${version}`;
+  return getProductionAssetPrefix(version);
 }
 
 const standaloneOutput = { output: "standalone" as const };

--- a/ops/telemetry/registry.json
+++ b/ops/telemetry/registry.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastReviewed": "2026-07-15",
+  "lastReviewed": "2026-07-17",
   "operationalOwner": "frontend-platform",
   "providers": [
     {
@@ -402,6 +402,20 @@
       "lifecycle": "temporary",
       "replacement": "Remove after the server-seeded feed path is evaluated and a review records the decision",
       "reviewBy": "2026-10-15"
+    },
+    {
+      "name": "cyclic_json_timer_diagnostics",
+      "kind": "error-family",
+      "question": "Which code origin schedules exact cyclic JSON timer failures in iOS WKWebViews?",
+      "owner": "sentry",
+      "producer": "utils/monitoring/cyclicJsonTimerDiagnostics.ts",
+      "destinations": ["sentry:owner"],
+      "sampling": "eligible function timers in iOS WKWebViews are sampled independently at 1/16; only exact unhandled cyclic-JSON timer errors receive sampled provenance",
+      "privacy": "timer arguments are removed from every matching event; sampled extras contain bounded sanitized function names, script basenames, line and column numbers, origin enums, WebView family, and sample rate only",
+      "externalUsage": "v1 is live; Sentry dashboard, saved-search, and alert usage could not be verified because read-only endpoints returned 403",
+      "lifecycle": "temporary",
+      "replacement": "By the review date, verify or migrate every v1-keyed Sentry consumer to v2; remove the timer diagnostics after corrected provenance identifies the caller",
+      "reviewBy": "2026-08-17"
     },
     {
       "name": "reaction.*",

--- a/utils/monitoring/cyclicJsonTimerDiagnostics.ts
+++ b/utils/monitoring/cyclicJsonTimerDiagnostics.ts
@@ -1,4 +1,5 @@
 import type { Event, EventHint } from "@sentry/nextjs";
+import { PRODUCTION_ASSET_HOSTNAME } from "@/config/assetPrefix";
 
 const CYCLIC_JSON_TIMER_DIAGNOSTICS_VERSION = "v2";
 export const CYCLIC_JSON_TIMER_DIAGNOSTICS_TAG =
@@ -13,9 +14,7 @@ const DEFAULT_TIMER_SAMPLE_RATE = 1 / 16;
 const MAX_SCHEDULING_FRAMES = 8;
 const INTERNAL_TIMER_FUNCTION = "cyclicJsonTimerDiagnosticSetTimeout";
 const INTERNAL_STACK_FUNCTIONS = new Set([INTERNAL_TIMER_FUNCTION]);
-const PRODUCTION_ASSET_HOSTNAME = "dnclu2fna0b2b.cloudfront.net";
-const PRODUCTION_ASSET_PATH_PATTERN =
-  /^\/web_build\/[^/]+\/_next\/static\//;
+const PRODUCTION_ASSET_PATH_PATTERN = /^\/web_build\/[^/]+\/_next\/static\//;
 const SAFE_NAME_PATTERN = /[^\w$<>. -]/g;
 // Privacy wins over callback-name fidelity: long minified names can be
 // redacted because they are indistinguishable from identifier-shaped secrets.
@@ -293,15 +292,10 @@ function createDiagnostics(
   sampleRate: number,
   stack: string | undefined
 ): CyclicJsonTimerDiagnostics {
-  const parsedFrames = (stack ?? "")
+  const schedulingFrames = (stack ?? "")
     .split("\n")
     .map((line) => parseStackLine(line, firstPartyHostname))
-    .filter((frame): frame is CyclicJsonTimerSchedulingFrame => frame !== null);
-  // Error.stack starts at this diagnostic wrapper. Drop that capture-site frame
-  // by position because production minification can rename the function. Keep
-  // the name filter for engines that emit an additional internal frame.
-  const schedulingFrames = parsedFrames
-    .slice(1)
+    .filter((frame): frame is CyclicJsonTimerSchedulingFrame => frame !== null)
     .filter((frame) => !INTERNAL_STACK_FUNCTIONS.has(frame.function))
     .slice(0, MAX_SCHEDULING_FRAMES);
 
@@ -362,73 +356,75 @@ export function installCyclicJsonTimerDiagnostics(
   const stackFactory = options.stackFactory;
   const firstPartyHostname = target.location?.hostname ?? "6529.io";
 
-  const diagnosticSetTimeout: TimerSetTimeout = function cyclicJsonTimerDiagnosticSetTimeout(
-    this: TimerTarget,
-    handler,
-    timeout,
-    ...args
-  ) {
-    if (typeof handler !== "function") {
-      return originalSetTimeout.apply(target, [handler, timeout, ...args]);
-    }
-
-    let shouldSample = false;
-    try {
-      shouldSample = random() < sampleRate;
-    } catch {
-      // A diagnostics failure must preserve the original timer path.
-    }
-    if (!shouldSample) {
-      return originalSetTimeout.apply(target, [handler, timeout, ...args]);
-    }
-
-    let diagnostics: CyclicJsonTimerDiagnostics;
-    try {
-      const schedulingStack = stackFactory
-        ? stackFactory()
-        : new Error("cyclic-json-timer-schedule").stack;
-      diagnostics = createDiagnostics(
-        handler,
-        userAgent,
-        firstPartyHostname,
-        sampleRate,
-        schedulingStack
-      );
-    } catch {
-      return originalSetTimeout.apply(target, [handler, timeout, ...args]);
-    }
-
-    const diagnosticCallback: TimerCallback = function (
-      this: unknown,
-      ...callbackArgs
-    ) {
-      try {
-        return handler.apply(this, callbackArgs);
-      } catch (error) {
-        // This intentionally covers synchronous callback throws only. Promise
-        // rejections use a different Sentry mechanism and cannot be associated
-        // with the timer Error object here.
-        if (isExactCyclicJsonTypeError(error)) {
-          diagnosticsByError.set(error, diagnostics);
-        }
-        throw error;
+  // JavaScriptCore stack traces use the source-level function name. A static
+  // method keeps its public property key through production minification, so
+  // internal-frame cleanup can use an exact name instead of frame position.
+  class DiagnosticTimer {
+    static cyclicJsonTimerDiagnosticSetTimeout(
+      this: void,
+      handler: TimerHandler,
+      timeout?: number,
+      ...args: unknown[]
+    ): number {
+      if (typeof handler !== "function") {
+        return originalSetTimeout.apply(target, [handler, timeout, ...args]);
       }
-    };
 
-    return originalSetTimeout.apply(target, [
-      diagnosticCallback,
-      timeout,
-      ...args,
-    ]);
-  };
+      let shouldSample = false;
+      try {
+        shouldSample = random() < sampleRate;
+      } catch {
+        // A diagnostics failure must preserve the original timer path.
+      }
+      if (!shouldSample) {
+        return originalSetTimeout.apply(target, [handler, timeout, ...args]);
+      }
+
+      let diagnostics: CyclicJsonTimerDiagnostics;
+      try {
+        const schedulingStack = stackFactory
+          ? stackFactory()
+          : new Error("cyclic-json-timer-schedule").stack;
+        diagnostics = createDiagnostics(
+          handler,
+          userAgent,
+          firstPartyHostname,
+          sampleRate,
+          schedulingStack
+        );
+      } catch {
+        return originalSetTimeout.apply(target, [handler, timeout, ...args]);
+      }
+
+      const diagnosticCallback: TimerCallback = function (
+        this: unknown,
+        ...callbackArgs
+      ) {
+        try {
+          return handler.apply(this, callbackArgs);
+        } catch (error) {
+          // This intentionally covers synchronous callback throws only. Promise
+          // rejections use a different Sentry mechanism and cannot be associated
+          // with the timer Error object here.
+          if (isExactCyclicJsonTypeError(error)) {
+            diagnosticsByError.set(error, diagnostics);
+          }
+          throw error;
+        }
+      };
+
+      return originalSetTimeout.apply(target, [
+        diagnosticCallback,
+        timeout,
+        ...args,
+      ]);
+    }
+  }
+
+  const diagnosticSetTimeout: TimerSetTimeout =
+    DiagnosticTimer.cyclicJsonTimerDiagnosticSetTimeout;
 
   try {
-    // Preserve a recognizable name where the runtime allows it so duplicate
-    // internal frames can still be removed after the capture-site frame.
-    Object.defineProperty(diagnosticSetTimeout, "name", {
-      configurable: true,
-      value: INTERNAL_TIMER_FUNCTION,
-    });
     target.setTimeout = diagnosticSetTimeout;
     installedTargets.add(target);
     return true;

--- a/utils/monitoring/cyclicJsonTimerDiagnostics.ts
+++ b/utils/monitoring/cyclicJsonTimerDiagnostics.ts
@@ -1,6 +1,6 @@
 import type { Event, EventHint } from "@sentry/nextjs";
 
-const CYCLIC_JSON_TIMER_DIAGNOSTICS_VERSION = "v1";
+const CYCLIC_JSON_TIMER_DIAGNOSTICS_VERSION = "v2";
 export const CYCLIC_JSON_TIMER_DIAGNOSTICS_TAG =
   "cyclic_json_timer_diagnostics";
 
@@ -13,6 +13,9 @@ const DEFAULT_TIMER_SAMPLE_RATE = 1 / 16;
 const MAX_SCHEDULING_FRAMES = 8;
 const INTERNAL_TIMER_FUNCTION = "cyclicJsonTimerDiagnosticSetTimeout";
 const INTERNAL_STACK_FUNCTIONS = new Set([INTERNAL_TIMER_FUNCTION]);
+const PRODUCTION_ASSET_HOSTNAME = "dnclu2fna0b2b.cloudfront.net";
+const PRODUCTION_ASSET_PATH_PATTERN =
+  /^\/web_build\/[^/]+\/_next\/static\//;
 const SAFE_NAME_PATTERN = /[^\w$<>. -]/g;
 // Privacy wins over callback-name fidelity: long minified names can be
 // redacted because they are indistinguishable from identifier-shaped secrets.
@@ -135,6 +138,15 @@ function getStaticAssetPath(pathname: string): string | null {
   return pathname.slice(staticIndex).slice(0, 512);
 }
 
+function isProductionNextAssetUrl(url: URL): boolean {
+  return (
+    url.protocol === "https:" &&
+    url.hostname === PRODUCTION_ASSET_HOSTNAME &&
+    url.port === "" &&
+    PRODUCTION_ASSET_PATH_PATTERN.test(url.pathname)
+  );
+}
+
 function getSanitizedFile(
   rawLocation: string,
   firstPartyHostname: string
@@ -159,7 +171,8 @@ function getSanitizedFile(
       isHttp &&
       (parsed.hostname === firstPartyHostname ||
         parsed.hostname === "6529.io" ||
-        parsed.hostname.endsWith(".6529.io"));
+        parsed.hostname.endsWith(".6529.io") ||
+        isProductionNextAssetUrl(parsed));
 
     if (isFirstParty) {
       return {
@@ -280,10 +293,15 @@ function createDiagnostics(
   sampleRate: number,
   stack: string | undefined
 ): CyclicJsonTimerDiagnostics {
-  const schedulingFrames = (stack ?? "")
+  const parsedFrames = (stack ?? "")
     .split("\n")
     .map((line) => parseStackLine(line, firstPartyHostname))
-    .filter((frame): frame is CyclicJsonTimerSchedulingFrame => frame !== null)
+    .filter((frame): frame is CyclicJsonTimerSchedulingFrame => frame !== null);
+  // Error.stack starts at this diagnostic wrapper. Drop that capture-site frame
+  // by position because production minification can rename the function. Keep
+  // the name filter for engines that emit an additional internal frame.
+  const schedulingFrames = parsedFrames
+    .slice(1)
     .filter((frame) => !INTERNAL_STACK_FUNCTIONS.has(frame.function))
     .slice(0, MAX_SCHEDULING_FRAMES);
 
@@ -405,8 +423,8 @@ export function installCyclicJsonTimerDiagnostics(
   };
 
   try {
-    // Preserve the diagnostic frame name through production minification so
-    // stack cleanup does not rely on a fixed frame position.
+    // Preserve a recognizable name where the runtime allows it so duplicate
+    // internal frames can still be removed after the capture-site frame.
     Object.defineProperty(diagnosticSetTimeout, "name", {
       configurable: true,
       value: INTERNAL_TIMER_FUNCTION,


### PR DESCRIPTION
<!-- sentry-fix-job:21 issue:7615674739 -->
## Issue

- Sentry: [6529-FRONTEND-ET](https://seize-ff.sentry.io/issues/7615674739/)
- First seen: 2026-07-16T17:46:31.692Z
- Latest occurrence: 2026-07-16T18:13:52.000Z
- Automatic triage confidence: 93%

A repository fix is useful, but it should repair the origin diagnostics rather than suppress this error. Exact release coordinates show app-owned production bundle frames were labeled third-party and the diagnostic wrapper’s minified frame was retained, making the current third-party tag untrustworthy.

## Fix

The diagnostic tag and extra schema changed from v1 to v2 without registering the custom Sentry error family. External consumer usage could not be verified because the relevant read-only Sentry endpoints returned 403.

## Changes

- Registered cyclic_json_timer_diagnostics with its owner, producer, destination, sampling, privacy, external usage, and lifecycle.
- Documented the v1-to-v2 consumer migration requirement with a 2026-08-17 review date.
- Updated the telemetry registry review date.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Focused Jest: 2 suites and 97 tests passed.
- Diff lint passed.
- Changed-file typecheck passed for 24 TypeScript files.
- React Doctor passed at 100/100.
- Registry assertions and git diff --check passed.
- Repository Prettier was infrastructure-blocked by a missing shared Tailwind file; a plugin-free check using repository formatting options passed for all changed files.

## Risk

- Assessed risk: medium
- Changed files: 5
- Changed lines: 324
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

The underlying cyclic JSON.stringify caller remains unknown. Live Sentry dashboards, saved searches, and alerts require an account with sufficient read permissions to audit. The previously reported Turbopack build-root infrastructure blocker was not rerun because this round only added the registry contract.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
