### PR TITLE
fix: No additional repair was needed. The existing draft-PR change is correct, focused, and the worktree remai

### DIFF
--- a/__tests__/components/notifications/NotificationsContext.test.tsx
+++ b/__tests__/components/notifications/NotificationsContext.test.tsx
@@ -693,6 +693,32 @@ describe("push registration behavior", () => {
     );
   });
 
+  it("records Firebase request backoff as a transient native registration error", async () => {
+    const sentry = require("@sentry/nextjs");
+    const errorMessage =
+      "The operation couldn’t be completed. Too many server requests.";
+    const nativeError = { error: errorMessage };
+    const { registrationErrorCallback } = await setupRegistrationCallback();
+
+    act(() => {
+      registrationErrorCallback(nativeError);
+    });
+
+    expect(sentry.captureException).not.toHaveBeenCalled();
+    expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: "warning",
+        message: "Push registration transient error.",
+        data: expect.objectContaining({
+          component: "NotificationsProvider",
+          operation: "pushRegistrationError",
+          retryable: true,
+          error_message: errorMessage,
+        }),
+      })
+    );
+  });
+
   it.each([
     "The request timed out.",
     "A server with the specified hostname could not be found.",
@@ -729,6 +755,7 @@ describe("push registration behavior", () => {
     "Network request failed: unauthorized.",
     "The request timed out because the device token is invalid.",
     "A server with the specified hostname could not be found because the push configuration is invalid.",
+    "Too many server requests because the push configuration is invalid.",
   ])(
     "captures permanent native registration near-miss %s",
     async (errorMessage) => {

--- a/components/notifications/NotificationsContext.tsx
+++ b/components/notifications/NotificationsContext.tsx
@@ -92,6 +92,7 @@ const TRANSIENT_ERROR_PATTERNS = [
   "network request failed",
   "network error",
   "server with the specified hostname could not be found",
+  "too many server requests",
   "timed out",
   "timeout",
 ];


### PR DESCRIPTION
<!-- sentry-fix-job:14 issue:7583958635 -->
## Issue

- Sentry: [6529-FRONTEND-DY](https://seize-ff.sentry.io/issues/7583958635/)
- First seen: 2026-06-30T08:23:30.280Z
- Latest occurrence: 2026-07-15T19:00:09.000Z
- Automatic triage confidence: 98%

A narrow repository telemetry fix is useful. The handled native push-registration failure exactly matches Firebase Installations’ request-backoff error, but the frontend’s transient classifier does not recognize its distinctive “too many server requests” wording and therefore captures it as an application error.

## Fix

Firebase Installations emits “Too many server requests.” while request backoff is active ([Firebase source](https://github.com/firebase/firebase-ios-sdk/blob/65b6a7153d9c9f5b404123f7b78a12c73d012f92/FirebaseInstallations/Source/Library/Errors/FIRInstallationsErrorUtil.m#L104-L114)), and Capacitor forwards the native localized description through `registrationError` ([Capacitor source](https://github.com/ionic-team/capacitor-plugins/blob/927f549a995118acd8e5735835300c4c3cbf3de7/push-notifications/ios/Sources/PushNotificationsPlugin/PushNotificationsPlugin.swift#L202-L209)). The existing PR narrowly classifies that phrase as transient.

## Changes

- No additional repair edits; retained the existing narrow classifier change and its positive and permanent-near-miss regression coverage.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- PASS: focused NotificationsContext Jest suite in-band — 35/35 tests.
- PASS: `./bin/6529 run lint:changed`.
- PASS: `./bin/6529 run typecheck:changed`.
- PASS/no-op: `./bin/6529 run react-doctor:diff` exited successfully and reported no new repair-round source diff.
- PASS: `git diff --check` for the worktree and the complete PR diff.
- PASS: all current GitHub PR checks reported success; CodeRabbit intentionally skipped review because the PR remains draft.

## Risk

- Assessed risk: low
- Changed files: 2
- Changed lines: 28
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

The bridge payload omits the original native NSError domain and code, so Firebase ownership remains based on the exact pinned vendor string and verified Capacitor forwarding behavior. No correctness uncertainty remains from the advisory feedback.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary push notification registration errors.
  * These errors are now treated as retryable, reducing unnecessary error reporting while registration recovers.
  * Added coverage for additional Firebase push registration error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->