### PR TITLE
chore: add Wave abort diagnostics

### DIFF
--- a/__tests__/contexts/wave/hooks/useWaveAbortController.test.ts
+++ b/__tests__/contexts/wave/hooks/useWaveAbortController.test.ts
@@ -1,36 +1,131 @@
-import { renderHook, act } from '@testing-library/react';
-import { useWaveAbortController } from '@/contexts/wave/hooks/useWaveAbortController';
+import * as Sentry from "@sentry/nextjs";
+import { act, renderHook } from "@testing-library/react";
+import { useWaveAbortController } from "@/contexts/wave/hooks/useWaveAbortController";
 
-describe('useWaveAbortController', () => {
-  it('creates, cancels and cleans up controllers', () => {
-    const { result, unmount } = renderHook(() => useWaveAbortController());
+jest.mock("@sentry/nextjs", () => ({
+  addBreadcrumb: jest.fn(),
+}));
 
-    const controller = result.current.createController('w1');
-    const abortSpy = jest.spyOn(controller, 'abort');
+describe("useWaveAbortController", () => {
+  const addBreadcrumbMock = jest.mocked(Sentry.addBreadcrumb);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates, cancels, and cleans up controllers", () => {
+    const { result } = renderHook(() => useWaveAbortController("feed"));
+
+    const controller = result.current.createController("w1");
+    const abortSpy = jest.spyOn(controller, "abort");
 
     act(() => {
-      result.current.cancelFetch('w1');
+      result.current.cancelFetch("w1", "wave_deactivated");
     });
     expect(abortSpy).toHaveBeenCalledTimes(1);
 
     act(() => {
-      result.current.cleanupController('w1', controller);
+      result.current.cleanupController("w1", controller);
     });
 
     act(() => {
-      result.current.cancelFetch('w1');
+      result.current.cancelFetch("w1", "wave_deactivated");
     });
     expect(abortSpy).toHaveBeenCalledTimes(1);
+  });
 
-    const controller2 = result.current.createController('w2');
-    const abortSpy2 = jest.spyOn(controller2, 'abort');
+  it("records the feed request kind and cancellation trigger", () => {
+    const { result } = renderHook(() => useWaveAbortController("feed"));
+
+    result.current.createController("private-wave-id-newest-sync");
+
     act(() => {
-      result.current.cancelAllFetches();
+      result.current.cancelFetch(
+        "private-wave-id-newest-sync",
+        "wave_deactivated"
+      );
     });
-    expect(abortSpy2).toHaveBeenCalled();
 
-    const abortSpy3 = jest.spyOn(controller2, 'abort');
-    unmount();
-    expect(abortSpy3).toHaveBeenCalled();
+    expect(addBreadcrumbMock).toHaveBeenCalledWith({
+      category: "wave.request",
+      level: "info",
+      message: "wave_request_aborted",
+      data: {
+        request_kind: "background_sync",
+        trigger: "wave_deactivated",
+      },
+    });
+    expect(JSON.stringify(addBreadcrumbMock.mock.calls)).not.toContain(
+      "private-wave-id"
+    );
+  });
+
+  it("records replacement, pagination, and unmount triggers", () => {
+    const feedHook = renderHook(() => useWaveAbortController("feed"));
+
+    const replacedController =
+      feedHook.result.current.createController("w1-initial-backfill");
+    const replacedAbortSpy = jest.spyOn(replacedController, "abort");
+    feedHook.result.current.createController("w1-initial-backfill");
+
+    expect(replacedAbortSpy).toHaveBeenCalledTimes(1);
+    expect(addBreadcrumbMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          request_kind: "native_initial_backfill",
+          trigger: "request_replaced",
+        },
+      })
+    );
+
+    const paginationHook = renderHook(() =>
+      useWaveAbortController("pagination")
+    );
+    paginationHook.result.current.createController("w2-around");
+    act(() => {
+      paginationHook.result.current.cancelFetch(
+        "w2-around",
+        "pagination_cancelled"
+      );
+    });
+    expect(addBreadcrumbMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          request_kind: "pagination_around",
+          trigger: "pagination_cancelled",
+        },
+      })
+    );
+
+    const unmountController = feedHook.result.current.createController("w3");
+    const unmountAbortSpy = jest.spyOn(unmountController, "abort");
+    act(() => {
+      feedHook.unmount();
+    });
+    expect(unmountAbortSpy).toHaveBeenCalledTimes(1);
+    expect(addBreadcrumbMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          request_kind: "initial_visible",
+          trigger: "hook_unmounted",
+        },
+      })
+    );
+  });
+
+  it("still aborts when breadcrumb recording fails", () => {
+    addBreadcrumbMock.mockImplementationOnce(() => {
+      throw new Error("Sentry unavailable");
+    });
+    const { result } = renderHook(() => useWaveAbortController("feed"));
+    const controller = result.current.createController("w1-newest-sync");
+    const abortSpy = jest.spyOn(controller, "abort");
+
+    expect(() => {
+      act(() => {
+        result.current.cancelFetch("w1-newest-sync", "wave_deactivated");
+      });
+    }).not.toThrow();
+    expect(abortSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/contexts/wave/hooks/useWaveDataFetching.test.ts
+++ b/__tests__/contexts/wave/hooks/useWaveDataFetching.test.ts
@@ -706,9 +706,15 @@ describe("useWaveDataFetching", () => {
       result.current.cancelWaveDataFetch("wave1");
     });
 
-    expect(cancelFetch).toHaveBeenCalledWith("wave1");
-    expect(cancelFetch).toHaveBeenCalledWith("wave1-initial-backfill");
-    expect(cancelFetch).toHaveBeenCalledWith("wave1-newest-sync");
+    expect(cancelFetch).toHaveBeenCalledWith("wave1", "wave_deactivated");
+    expect(cancelFetch).toHaveBeenCalledWith(
+      "wave1-initial-backfill",
+      "wave_deactivated"
+    );
+    expect(cancelFetch).toHaveBeenCalledWith(
+      "wave1-newest-sync",
+      "wave_deactivated"
+    );
   });
 
   it("does not schedule native initial backfill for targeted serial restores", async () => {

--- a/contexts/wave/hooks/useWaveAbortController.ts
+++ b/contexts/wave/hooks/useWaveAbortController.ts
@@ -1,32 +1,92 @@
 "use client";
 
-import { useCallback, useRef, useEffect } from "react";
+import * as Sentry from "@sentry/nextjs";
+import { useCallback, useEffect, useRef } from "react";
 
-export function useWaveAbortController() {
+type WaveAbortOwner = "feed" | "pagination";
+
+export type WaveAbortTrigger =
+  | "hook_unmounted"
+  | "pagination_cancelled"
+  | "request_replaced"
+  | "wave_deactivated";
+
+type WaveAbortRequestKind =
+  | "background_sync"
+  | "initial_visible"
+  | "native_initial_backfill"
+  | "pagination_around"
+  | "pagination_next_page";
+
+const getWaveAbortRequestKind = (
+  owner: WaveAbortOwner,
+  abortKey: string
+): WaveAbortRequestKind => {
+  if (abortKey.endsWith("-newest-sync")) {
+    return "background_sync";
+  }
+  if (abortKey.endsWith("-initial-backfill")) {
+    return "native_initial_backfill";
+  }
+  if (abortKey.endsWith("-around")) {
+    return "pagination_around";
+  }
+
+  return owner === "pagination" ? "pagination_next_page" : "initial_visible";
+};
+
+const addWaveAbortBreadcrumb = (
+  owner: WaveAbortOwner,
+  abortKey: string,
+  trigger: WaveAbortTrigger
+): void => {
+  try {
+    Sentry.addBreadcrumb({
+      category: "wave.request",
+      level: "info",
+      message: "wave_request_aborted",
+      data: {
+        request_kind: getWaveAbortRequestKind(owner, abortKey),
+        trigger,
+      },
+    });
+  } catch {
+    // Diagnostic telemetry must never interfere with request cancellation.
+  }
+};
+
+export function useWaveAbortController(owner: WaveAbortOwner) {
   // Track abort controllers for cancellation
   const abortControllers = useRef<Record<string, AbortController>>({});
 
   /**
    * Cancels an ongoing fetch for a specific wave
    */
-  const cancelFetch = useCallback((waveId: string) => {
-    if (abortControllers.current[waveId]) {
-      abortControllers.current[waveId].abort();
-      delete abortControllers.current[waveId];
-    }
-  }, []);
+  const cancelFetch = useCallback(
+    (abortKey: string, trigger: WaveAbortTrigger) => {
+      const controller = abortControllers.current[abortKey];
+      if (!controller) {
+        return;
+      }
+
+      addWaveAbortBreadcrumb(owner, abortKey, trigger);
+      controller.abort();
+      delete abortControllers.current[abortKey];
+    },
+    [owner]
+  );
 
   /**
    * Sets up and returns an AbortController for the request
    */
   const createController = useCallback(
-    (waveId: string): AbortController => {
-      // Cancel any existing request for this wave
-      cancelFetch(waveId);
+    (abortKey: string): AbortController => {
+      // Cancel any existing request for this request slot.
+      cancelFetch(abortKey, "request_replaced");
 
       // Create a new abort controller
       const controller = new AbortController();
-      abortControllers.current[waveId] = controller;
+      abortControllers.current[abortKey] = controller;
 
       return controller;
     },
@@ -50,8 +110,8 @@ export function useWaveAbortController() {
    * Cancels all ongoing fetches
    */
   const cancelAllFetches = useCallback(() => {
-    Object.keys(abortControllers.current).forEach((waveId) => {
-      cancelFetch(waveId);
+    Object.keys(abortControllers.current).forEach((abortKey) => {
+      cancelFetch(abortKey, "hook_unmounted");
     });
   }, [cancelFetch]);
 

--- a/contexts/wave/hooks/useWaveDataFetching.ts
+++ b/contexts/wave/hooks/useWaveDataFetching.ts
@@ -17,7 +17,10 @@ import {
   fetchWaveMessages,
   formatWaveMessages,
 } from "../utils/wave-messages-utils";
-import { useWaveAbortController } from "./useWaveAbortController";
+import {
+  type WaveAbortTrigger,
+  useWaveAbortController,
+} from "./useWaveAbortController";
 import {
   createWaveFeedAbortError,
   createWaveFeedUnavailableError,
@@ -268,7 +271,7 @@ function useNativeInitialBackfill({
   updateData,
   updateEligibility,
 }: {
-  readonly cancelFetch: (waveId: string) => void;
+  readonly cancelFetch: (waveId: string, trigger: WaveAbortTrigger) => void;
   readonly cleanupController: (
     waveId: string,
     controller: AbortController
@@ -328,7 +331,7 @@ function useNativeInitialBackfill({
       }
 
       clearInitialBackfillTimeout(waveId);
-      cancelFetch(`${waveId}-initial-backfill`);
+      cancelFetch(`${waveId}-initial-backfill`, "request_replaced");
 
       initialBackfillTimeoutsRef.current[waveId] = setTimeout(() => {
         delete initialBackfillTimeoutsRef.current[waveId];
@@ -566,7 +569,7 @@ export function useWaveDataFetching({
   const { getLoadingState, setLoadingState, setPromise, clearLoadingState } =
     useWaveLoadingState();
   const { cancelFetch, createController, cleanupController } =
-    useWaveAbortController();
+    useWaveAbortController("feed");
   const { updateEligibility } = useWaveEligibility();
   const initialWaveDropsLimit = getWaveDropsInitialLimit(isCapacitor);
   const trackedCacheSuccessWaveIdsRef = useRef<Set<string>>(new Set());
@@ -776,9 +779,9 @@ export function useWaveDataFetching({
   const cancelWaveDataFetch = useCallback(
     (waveId: string) => {
       clearInitialBackfillTimeout(waveId);
-      cancelFetch(waveId);
-      cancelFetch(`${waveId}-initial-backfill`);
-      cancelFetch(getNewestSyncAbortKey(waveId));
+      cancelFetch(waveId, "wave_deactivated");
+      cancelFetch(`${waveId}-initial-backfill`, "wave_deactivated");
+      cancelFetch(getNewestSyncAbortKey(waveId), "wave_deactivated");
     },
     [cancelFetch, clearInitialBackfillTimeout]
   );

--- a/contexts/wave/hooks/useWavePagination.ts
+++ b/contexts/wave/hooks/useWavePagination.ts
@@ -51,7 +51,7 @@ export function useWavePagination({
     cancelFetch: cancelAbort,
     createController,
     cleanupController,
-  } = useWaveAbortController();
+  } = useWaveAbortController("pagination");
 
   // Track pagination loading state
   const paginationStates = useRef<Record<string, PaginationState>>({});
@@ -333,7 +333,7 @@ export function useWavePagination({
   const cancelPaginationFetch = useCallback(
     (waveId: string) => {
       // Cancel the abort controller
-      cancelAbort(waveId);
+      cancelAbort(waveId, "pagination_cancelled");
 
       // Clear pagination state
       if (paginationStates.current[waveId]) {


### PR DESCRIPTION
## Issue
- Sentry issue `6529-FRONTEND-V` still receives frame-less WebKit `AbortError` events after the targeted Twitter preview playback fix.
- The latest occurrence coincided with background Wave feed cancellation, but the event did not show which request slot or cancellation trigger produced the rejection.

## Fix
- Record a lightweight Sentry breadcrumb at the shared Wave request cancellation boundary.
- Capture only bounded diagnostic values for the request kind and cancellation trigger so the next event can distinguish replacement, deactivation, pagination cancellation, and hook cleanup without exposing Wave IDs.

## Changes
- Classify feed and pagination request slots as background sync, initial load, native backfill, next-page pagination, or around-serial pagination.
- Pass explicit cancellation triggers through the existing callers.
- Keep breadcrumb recording fail-open so monitoring cannot interfere with request cancellation.
- Add focused coverage for source/trigger classification, identifier exclusion, replacement and unmount paths, and Sentry failure behavior.

## Validation
- `git diff --check`
- Manual review of the scoped diff and every shared abort-controller call site.
- Not run locally in this pass: unit tests, lint, typecheck, and React Doctor. PR CI remains required.

## Risk
- Level: Low
- Why: Observability-only breadcrumb data; no request behavior, abort reason, error filtering, or user-facing behavior changes.
- Rollback: Revert the single commit to remove the breadcrumb and explicit trigger metadata.

## Review Notes
- Confirm the enum values are sufficient for future Sentry triage.
- Confirm no raw Wave/request identifier can enter the breadcrumb payload.