### PR TITLE
fix: Repaired the retry telemetry while preserving the narrow iOS helper-error boundary. Local changes are rea

### DIFF
--- a/__tests__/components/notifications/NotificationsContext.test.tsx
+++ b/__tests__/components/notifications/NotificationsContext.test.tsx
@@ -125,6 +125,9 @@ describe("NotificationsContext initialization", () => {
   beforeEach(() => {
     mockIsActive = true;
     const { PushNotifications } = require("@capacitor/push-notifications");
+    const {
+      getStableDeviceId,
+    } = require("@/components/notifications/stable-device-id");
     const sentry = require("@sentry/nextjs");
     jest.clearAllMocks();
     mockSeizeConnectContext.address = "0xaaa";
@@ -139,7 +142,13 @@ describe("NotificationsContext initialization", () => {
     ];
     PushNotifications.removeAllListeners.mockClear();
     PushNotifications.addListener.mockClear();
+    PushNotifications.requestPermissions.mockReset();
+    PushNotifications.requestPermissions.mockResolvedValue({
+      receive: "granted",
+    });
     PushNotifications.register.mockClear();
+    getStableDeviceId.mockReset();
+    getStableDeviceId.mockResolvedValue("test-device-id");
     sentry.captureException.mockClear();
     sentry.addBreadcrumb.mockClear();
   });
@@ -208,6 +217,147 @@ describe("NotificationsContext initialization", () => {
     });
 
     expect(PushNotifications.register).not.toHaveBeenCalled();
+  });
+
+  it("records a recovered iOS push permission helper error as a warning breadcrumb", async () => {
+    const { PushNotifications } = require("@capacitor/push-notifications");
+    const sentry = require("@sentry/nextjs");
+    const helperApplicationError = new Error(
+      "Couldn’t communicate with a helper application."
+    );
+
+    PushNotifications.requestPermissions
+      .mockRejectedValueOnce(helperApplicationError)
+      .mockResolvedValueOnce({ receive: "denied" });
+
+    renderHook(() => useNotificationsContext(), { wrapper });
+
+    await waitFor(() => {
+      expect(sentry.addBreadcrumb).toHaveBeenCalledWith({
+        category: "notifications",
+        level: "warning",
+        message: "Push permission request recovered after native error.",
+        data: {
+          component: "NotificationsProvider",
+          operation: "requestPermissions",
+          retryable: true,
+          recovered: true,
+          error_name: "Error",
+          error_message: "Couldn’t communicate with a helper application.",
+        },
+      });
+    });
+
+    expect(PushNotifications.requestPermissions).toHaveBeenCalledTimes(2);
+    expect(sentry.addBreadcrumb).toHaveBeenCalledTimes(1);
+    expect(sentry.captureException).not.toHaveBeenCalled();
+    expect(PushNotifications.register).not.toHaveBeenCalled();
+  });
+
+  it("captures a persistent iOS push permission helper error", async () => {
+    const { PushNotifications } = require("@capacitor/push-notifications");
+    const sentry = require("@sentry/nextjs");
+    const initialError = new Error(
+      "Couldn’t communicate with a helper application."
+    );
+    const retryError = new Error(
+      "Couldn’t communicate with a helper application."
+    );
+
+    PushNotifications.requestPermissions
+      .mockRejectedValueOnce(initialError)
+      .mockRejectedValue(retryError);
+
+    renderHook(() => useNotificationsContext(), { wrapper });
+
+    await waitFor(() => {
+      expect(sentry.captureException).toHaveBeenCalledWith(
+        retryError,
+        expect.objectContaining({
+          tags: {
+            component: "NotificationsProvider",
+            operation: "initializeNotifications",
+          },
+        })
+      );
+    });
+
+    expect(PushNotifications.requestPermissions).toHaveBeenCalledTimes(2);
+    expect(sentry.addBreadcrumb).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Push permission request recovered after native error.",
+      })
+    );
+  });
+
+  it("captures the helper-application error from another initialization step", async () => {
+    const { PushNotifications } = require("@capacitor/push-notifications");
+    const {
+      getStableDeviceId,
+    } = require("@/components/notifications/stable-device-id");
+    const sentry = require("@sentry/nextjs");
+    const secureStorageError = new Error(
+      "Couldn’t communicate with a helper application."
+    );
+
+    getStableDeviceId.mockRejectedValue(secureStorageError);
+
+    renderHook(() => useNotificationsContext(), { wrapper });
+
+    await waitFor(() => {
+      expect(sentry.captureException).toHaveBeenCalledWith(
+        secureStorageError,
+        expect.objectContaining({
+          tags: {
+            component: "NotificationsProvider",
+            operation: "initializeNotifications",
+          },
+        })
+      );
+    });
+
+    expect(PushNotifications.requestPermissions).not.toHaveBeenCalled();
+    expect(sentry.addBreadcrumb).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Push permission request recovered after native error.",
+      })
+    );
+  });
+
+  it.each([
+    "Couldn't communicate with a helper application.",
+    "Couldn’t communicate with a helper application. Retry later.",
+  ])("captures push permission helper-error near-miss %s", async (errorMessage) => {
+    const { PushNotifications } = require("@capacitor/push-notifications");
+    const sentry = require("@sentry/nextjs");
+    const nearMiss = new Error(errorMessage);
+
+    PushNotifications.requestPermissions.mockRejectedValueOnce(nearMiss);
+
+    renderHook(() => useNotificationsContext(), { wrapper });
+
+    await waitFor(() => {
+      expect(sentry.captureException).toHaveBeenCalledWith(
+        nearMiss,
+        expect.objectContaining({
+          tags: {
+            component: "NotificationsProvider",
+            operation: "initializeNotifications",
+          },
+          extra: expect.objectContaining({
+            error_name: "Error",
+            error_message: errorMessage,
+          }),
+        })
+      );
+    });
+
+    expect(sentry.addBreadcrumb).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Push permission request recovered after native error.",
+      })
+    );
+    expect(PushNotifications.requestPermissions).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/__tests__/components/notifications/NotificationsContext.test.tsx
+++ b/__tests__/components/notifications/NotificationsContext.test.tsx
@@ -219,7 +219,7 @@ describe("NotificationsContext initialization", () => {
     expect(PushNotifications.register).not.toHaveBeenCalled();
   });
 
-  it("records a recovered iOS push permission helper error as a warning breadcrumb", async () => {
+  it("records a denied permission response after retrying the exact iOS helper error", async () => {
     const { PushNotifications } = require("@capacitor/push-notifications");
     const sentry = require("@sentry/nextjs");
     const helperApplicationError = new Error(
@@ -236,12 +236,14 @@ describe("NotificationsContext initialization", () => {
       expect(sentry.addBreadcrumb).toHaveBeenCalledWith({
         category: "notifications",
         level: "warning",
-        message: "Push permission request recovered after native error.",
+        message:
+          "Push permission request completed after native error retry.",
         data: {
           component: "NotificationsProvider",
           operation: "requestPermissions",
           retryable: true,
-          recovered: true,
+          retry_succeeded: true,
+          permission_status: "denied",
           error_name: "Error",
           error_message: "Couldn’t communicate with a helper application.",
         },
@@ -252,6 +254,40 @@ describe("NotificationsContext initialization", () => {
     expect(sentry.addBreadcrumb).toHaveBeenCalledTimes(1);
     expect(sentry.captureException).not.toHaveBeenCalled();
     expect(PushNotifications.register).not.toHaveBeenCalled();
+  });
+
+  it("continues registration when the exact iOS helper error retry grants permission", async () => {
+    const { PushNotifications } = require("@capacitor/push-notifications");
+    const sentry = require("@sentry/nextjs");
+    const helperApplicationError = new Error(
+      "Couldn’t communicate with a helper application."
+    );
+
+    PushNotifications.requestPermissions
+      .mockRejectedValueOnce(helperApplicationError)
+      .mockResolvedValueOnce({ receive: "granted" });
+
+    renderHook(() => useNotificationsContext(), { wrapper });
+
+    await waitFor(
+      () => {
+        expect(PushNotifications.register).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 2000 }
+    );
+
+    expect(PushNotifications.requestPermissions).toHaveBeenCalledTimes(2);
+    expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message:
+          "Push permission request completed after native error retry.",
+        data: expect.objectContaining({
+          retry_succeeded: true,
+          permission_status: "granted",
+        }),
+      })
+    );
+    expect(sentry.captureException).not.toHaveBeenCalled();
   });
 
   it("captures a persistent iOS push permission helper error", async () => {
@@ -285,7 +321,8 @@ describe("NotificationsContext initialization", () => {
     expect(PushNotifications.requestPermissions).toHaveBeenCalledTimes(2);
     expect(sentry.addBreadcrumb).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        message: "Push permission request recovered after native error.",
+        message:
+          "Push permission request completed after native error retry.",
       })
     );
   });
@@ -319,7 +356,8 @@ describe("NotificationsContext initialization", () => {
     expect(PushNotifications.requestPermissions).not.toHaveBeenCalled();
     expect(sentry.addBreadcrumb).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        message: "Push permission request recovered after native error.",
+        message:
+          "Push permission request completed after native error retry.",
       })
     );
   });
@@ -354,7 +392,8 @@ describe("NotificationsContext initialization", () => {
 
     expect(sentry.addBreadcrumb).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        message: "Push permission request recovered after native error.",
+        message:
+          "Push permission request completed after native error retry.",
       })
     );
     expect(PushNotifications.requestPermissions).toHaveBeenCalledTimes(1);

--- a/components/notifications/NotificationsContext.tsx
+++ b/components/notifications/NotificationsContext.tsx
@@ -3,6 +3,7 @@
 import { Device, type DeviceInfo } from "@capacitor/device";
 import {
   PushNotifications,
+  type PermissionStatus,
   type PushNotificationSchema,
 } from "@capacitor/push-notifications";
 import * as Sentry from "@sentry/nextjs";
@@ -76,6 +77,8 @@ const PUSH_REGISTRATION_BASE_DELAY_MS = 500;
 const PUSH_REGISTRATION_MAX_DELAY_MS = 4000;
 const PUSH_REGISTRATION_JITTER_FACTOR = 0.2;
 const PUSH_REGISTRATION_MAX_RETRY_AFTER_MS = 10000;
+const IOS_PUSH_PERMISSION_HELPER_APPLICATION_ERROR_MESSAGE =
+  "Couldn’t communicate with a helper application.";
 
 const DELEGATE_ERROR_PATTERNS = [
   "capacitorDidRegisterForRemoteNotifications",
@@ -410,6 +413,39 @@ const toCaptureExceptionInput = (
     return error;
   }
   return new Error(toErrorMessage(error, fallbackMessage));
+};
+
+const isIosPushPermissionHelperApplicationError = (error: unknown): boolean =>
+  toErrorMessage(error) ===
+  IOS_PUSH_PERMISSION_HELPER_APPLICATION_ERROR_MESSAGE;
+
+const requestPushNotificationPermissions = async (
+  isIos: boolean
+): Promise<PermissionStatus> => {
+  try {
+    return await PushNotifications.requestPermissions();
+  } catch (error: unknown) {
+    if (!isIos || !isIosPushPermissionHelperApplicationError(error)) {
+      throw error;
+    }
+
+    const permissionStatus = await PushNotifications.requestPermissions();
+    const errorExtra = createErrorTelemetryExtra(error);
+    console.warn("iOS push permission request recovered after retry", errorExtra);
+    Sentry.addBreadcrumb({
+      category: "notifications",
+      level: "warning",
+      message: "Push permission request recovered after native error.",
+      data: {
+        component: "NotificationsProvider",
+        operation: "requestPermissions",
+        retryable: true,
+        recovered: true,
+        ...errorExtra,
+      },
+    });
+    return permissionStatus;
+  }
 };
 
 const getUsableProfileId = (profile?: ApiIdentity): string | null => {
@@ -1181,7 +1217,7 @@ export const NotificationsProvider: React.FC<{ children: React.ReactNode }> = ({
           }
         );
 
-        const permStatus = await PushNotifications.requestPermissions();
+        const permStatus = await requestPushNotificationPermissions(isIos);
 
         if (permStatus.receive === "granted") {
           if (isIos) {

--- a/components/notifications/NotificationsContext.tsx
+++ b/components/notifications/NotificationsContext.tsx
@@ -77,6 +77,8 @@ const PUSH_REGISTRATION_BASE_DELAY_MS = 500;
 const PUSH_REGISTRATION_MAX_DELAY_MS = 4000;
 const PUSH_REGISTRATION_JITTER_FACTOR = 0.2;
 const PUSH_REGISTRATION_MAX_RETRY_AFTER_MS = 10000;
+// Capacitor omits the native domain/code, so keep this limited to the exact
+// production signature instead of suppressing similar helper failures.
 const IOS_PUSH_PERMISSION_HELPER_APPLICATION_ERROR_MESSAGE =
   "Couldn’t communicate with a helper application.";
 
@@ -431,18 +433,23 @@ const requestPushNotificationPermissions = async (
 
     const permissionStatus = await PushNotifications.requestPermissions();
     const errorExtra = createErrorTelemetryExtra(error);
-    console.warn("iOS push permission request recovered after retry", errorExtra);
+    const retryData = {
+      component: "NotificationsProvider",
+      operation: "requestPermissions",
+      retryable: true,
+      retry_succeeded: true,
+      permission_status: permissionStatus.receive,
+      ...errorExtra,
+    };
+    console.warn(
+      "iOS push permission request completed after native error retry",
+      retryData
+    );
     Sentry.addBreadcrumb({
       category: "notifications",
       level: "warning",
-      message: "Push permission request recovered after native error.",
-      data: {
-        component: "NotificationsProvider",
-        operation: "requestPermissions",
-        retryable: true,
-        recovered: true,
-        ...errorExtra,
-      },
+      message: "Push permission request completed after native error retry.",
+      data: retryData,
     });
     return permissionStatus;
   }


### PR DESCRIPTION
<!-- sentry-fix-job:22 issue:7498345179 -->
## Issue

- Sentry: [6529-FRONTEND-C6](https://seize-ff.sentry.io/issues/7498345179/)
- First seen: 2026-05-21T21:43:57.789Z
- Latest occurrence: 2026-07-16T16:34:47.000Z
- Automatic triage confidence: 94%

A low-risk draft telemetry fix is useful. Both occurrences are handled native iOS/Capacitor push-initialization failures with the same Apple XPC interruption signature, not Waves failures. Downgrade only this exact signature to a warning breadcrumb while preserving all nearby initialization errors.

## Fix

A resolved permission retry was labeled as generic recovery even when the returned permission status was denied, conflating API recovery with authorization outcome.

## Changes

- Replaced ambiguous recovery telemetry with `retry_succeeded` and the returned `permission_status`.
- Documented why the filter remains limited to the exact observed production signature.
- Added coverage proving a granted retry continues to push registration while denied, persistent-failure, wrong-step, and near-miss behavior remains protected.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- NotificationsContext Jest suite passed: 39/39.
- `./bin/6529 run lint:diff` passed.
- `./bin/6529 run lint:changed` passed.
- `./bin/6529 run typecheck:changed` passed for 24 changed TypeScript files.
- React Doctor completed at 99/100; its two warnings are unchanged provider-size and sequential-await advisories.
- `git diff --check` passed; only the component and its focused test are modified.

## Risk

- Assessed risk: low
- Changed files: 2
- Changed lines: 234
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

Sentry and Capacitor still do not expose the native NSError domain/code, and no physical iOS reproduction was performed. The exact matcher intentionally leaves unobserved localized, apostrophe, and suffix variants reportable.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS push notification permission initialization by retrying once after a specific helper-application error.
  * Added clearer error handling and monitoring for failed permission requests.
  * Prevented unnecessary retries for similar but unrelated errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->