### PR TITLE
fix: No repair was needed. Revision 12 matches the draft’s exact extension signature and occurred on the deplo

### DIFF
--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -1585,6 +1585,37 @@ describe("instrumentation-client", () => {
     expect(result).toBeNull();
   });
 
+  it("keeps mixed-exception events with a Poper Blocker rejection first", () => {
+    const beforeSend = loadBeforeSend();
+    const poperBlockerEvent = createPoperBlockerOrphanFetchRejectionEvent();
+    const event = {
+      ...poperBlockerEvent,
+      exception: {
+        values: [
+          ...poperBlockerEvent.exception.values,
+          {
+            type: "Error",
+            value: "Application request validation failed.",
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "webpack-internal:///(app-pages-browser)/./services/api/common-api.ts",
+                  function: "executeApiRequest",
+                  in_app: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result).not.toBeNull();
+  });
+
   it("keeps first-party unread-DM network failures without the extension signature", () => {
     const beforeSend = loadBeforeSend();
     const event = {

--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -65,6 +65,164 @@ describe("instrumentation-client", () => {
     "auto.browser.browserapierrors.setTimeout";
   const browserUnhandledRejectionMechanismType =
     "auto.browser.global_handlers.onunhandledrejection";
+  const poperBlockerNetworkErrorMessage =
+    "Network request failed. Please check your connection and try again. (/api/dm-drops/unread)";
+  const poperBlockerInjectedFetchFrames = [
+    {
+      filename: "app:///injectScriptAdjust.js",
+      abs_path: "app:///injectScriptAdjust.js",
+      function: "window.fetch",
+      lineno: 1,
+      colno: 4520,
+      in_app: true,
+    },
+    {
+      filename: "app:///injectScriptAdjust.js",
+      abs_path: "app:///injectScriptAdjust.js",
+      function: "VihJ",
+      lineno: 1,
+      colno: 3159,
+      in_app: true,
+    },
+  ];
+  const poperBlockerProcessedFrames = [
+    {
+      filename:
+        "node_modules/.pnpm/aws-rum-web@1.25.0/node_modules/aws-rum-web/dist/es/dispatch/FetchHttpHandler.js",
+      function: "e.prototype.handle",
+      in_app: false,
+    },
+    ...poperBlockerInjectedFetchFrames,
+  ];
+  const poperBlockerLatestRawFrames = [
+    {
+      filename: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      abs_path: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      function: "a",
+      lineno: 11,
+      colno: 9819,
+      in_app: true,
+    },
+    {
+      filename: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      abs_path: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      function: "Object.next",
+      lineno: 11,
+      colno: 10983,
+      in_app: true,
+    },
+    {
+      filename: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      abs_path: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      function: "e.<anonymous>",
+      lineno: 11,
+      colno: 11456,
+      in_app: true,
+    },
+    {
+      filename: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      abs_path: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      function: "e.handle",
+      lineno: 11,
+      colno: 6396,
+      in_app: true,
+    },
+    {
+      filename: "app:///_next/static/chunks/0_6tmws~mg4aj.js",
+      abs_path: "app:///_next/static/chunks/0_6tmws~mg4aj.js",
+      lineno: 10,
+      colno: 1824,
+      in_app: true,
+    },
+    ...poperBlockerInjectedFetchFrames,
+  ];
+  const poperBlockerRecommendedRawFrames = [
+    {
+      filename: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      abs_path: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      function: "a",
+      lineno: 11,
+      colno: 1231,
+      in_app: true,
+    },
+    {
+      filename: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      abs_path: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      function: "Object.next",
+      lineno: 11,
+      colno: 2395,
+      in_app: true,
+    },
+    {
+      filename: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      abs_path: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      function: "ts.<anonymous>",
+      lineno: 11,
+      colno: 2889,
+      in_app: true,
+    },
+    {
+      filename: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      abs_path: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      function: "e.handle",
+      lineno: 11,
+      colno: 11269,
+      in_app: true,
+    },
+    {
+      filename: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      abs_path: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      function: "tW",
+      lineno: 11,
+      colno: 9763,
+      in_app: true,
+    },
+    {
+      filename: "<anonymous>",
+      abs_path: "<anonymous>",
+      function: "new Promise",
+      in_app: true,
+    },
+    {
+      filename: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      abs_path: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      lineno: 11,
+      colno: 10014,
+      in_app: true,
+    },
+    {
+      filename: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      abs_path: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      function: "Object.next",
+      lineno: 11,
+      colno: 10983,
+      in_app: true,
+    },
+    {
+      filename: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      abs_path: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      function: "e.<anonymous>",
+      lineno: 11,
+      colno: 11456,
+      in_app: true,
+    },
+    {
+      filename: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      abs_path: "app:///_next/static/chunks/0f73v56w55r2u.js",
+      function: "e.handle",
+      lineno: 11,
+      colno: 6396,
+      in_app: true,
+    },
+    {
+      filename: "app:///_next/static/chunks/0l0_44jw8k0xa.js",
+      abs_path: "app:///_next/static/chunks/0l0_44jw8k0xa.js",
+      lineno: 10,
+      colno: 1824,
+      in_app: true,
+    },
+    ...poperBlockerInjectedFetchFrames,
+  ];
   const rainbowKitNotFoundMessage = "not found rainbowkit";
   const nativeJsonStringifyFrame = {
     filename: "[native code]",
@@ -140,6 +298,28 @@ describe("instrumentation-client", () => {
           mechanism: {
             type: browserUnhandledRejectionMechanismType,
             handled: false,
+          },
+        },
+      ],
+    },
+  });
+
+  const createPoperBlockerOrphanFetchRejectionEvent = (
+    value = poperBlockerNetworkErrorMessage,
+    frames: Array<Record<string, unknown>> = poperBlockerProcessedFrames
+  ) => ({
+    level: "warning",
+    exception: {
+      values: [
+        {
+          type: "TypeError",
+          value,
+          mechanism: {
+            type: browserUnhandledRejectionMechanismType,
+            handled: false,
+          },
+          stacktrace: {
+            frames,
           },
         },
       ],
@@ -1370,6 +1550,72 @@ describe("instrumentation-client", () => {
 
     expect(result).not.toBeNull();
     expect(result?.tags?.["network_noise_sampled"]).toBe("true");
+  });
+
+  it("drops the normalized Poper Blocker orphan fetch rejection", () => {
+    const beforeSend = loadBeforeSend();
+    const event = createPoperBlockerOrphanFetchRejectionEvent();
+
+    const result = beforeSend(event);
+
+    expect(result).toBeNull();
+  });
+
+  it("drops the latest raw Poper Blocker orphan fetch rejection", () => {
+    const beforeSend = loadBeforeSend();
+    const event = createPoperBlockerOrphanFetchRejectionEvent(
+      poperBlockerNetworkErrorMessage,
+      poperBlockerLatestRawFrames
+    );
+
+    const result = beforeSend(event);
+
+    expect(result).toBeNull();
+  });
+
+  it("drops the recommended raw Poper Blocker orphan fetch rejection", () => {
+    const beforeSend = loadBeforeSend();
+    const event = createPoperBlockerOrphanFetchRejectionEvent(
+      "Failed to fetch",
+      poperBlockerRecommendedRawFrames
+    );
+
+    const result = beforeSend(event);
+
+    expect(result).toBeNull();
+  });
+
+  it("keeps first-party unread-DM network failures without the extension signature", () => {
+    const beforeSend = loadBeforeSend();
+    const event = {
+      level: "warning",
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: poperBlockerNetworkErrorMessage,
+            mechanism: {
+              type: browserUnhandledRejectionMechanismType,
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "webpack-internal:///(app-pages-browser)/./services/api/common-api.ts",
+                  function: "executeApiRequest",
+                  in_app: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result).not.toBeNull();
   });
 
   it("keeps app-owned Twitter currentInset errors", () => {

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -734,6 +734,7 @@ describe("sentry-client-filters", () => {
     value = poperBlockerNetworkErrorMessage,
     mechanismType = "auto.browser.global_handlers.onunhandledrejection",
     handled = false,
+    includeHandled = true,
     frames = [
       {
         filename:
@@ -763,6 +764,7 @@ describe("sentry-client-filters", () => {
     value?: string | undefined;
     mechanismType?: string | undefined;
     handled?: boolean | undefined;
+    includeHandled?: boolean | undefined;
     frames?: SentryStackFrame[] | undefined;
   } = {}): TestSentryClientEvent => ({
     transaction: "/waves/:wave",
@@ -773,7 +775,7 @@ describe("sentry-client-filters", () => {
           value,
           mechanism: {
             type: mechanismType,
-            handled,
+            ...(includeHandled ? { handled } : {}),
           },
           stacktrace: { frames },
         },
@@ -6516,10 +6518,40 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(false);
   });
 
+  it("keeps Poper Blocker-shaped rejections with an extra injected frame", () => {
+    const event = createPoperBlockerOrphanFetchRejectionEvent({
+      frames: [
+        {
+          filename: "app:///injectScriptAdjust.js",
+          function: "window.fetch",
+          lineno: 1,
+          colno: 4520,
+        },
+        {
+          filename: "app:///injectScriptAdjust.js",
+          function: "VihJ",
+          lineno: 1,
+          colno: 3159,
+        },
+        {
+          filename: "app:///injectScriptAdjust.js",
+          function: "window.fetch",
+          lineno: 1,
+          colno: 4520,
+        },
+      ],
+    });
+
+    const result = shouldFilterPoperBlockerOrphanFetchRejection(event);
+
+    expect(result).toBe(false);
+  });
+
   it.each([
     ["unrelated error", { value: "Application request validation failed." }],
     ["non-TypeError", { type: "Error" }],
     ["handled rejection", { handled: true }],
+    ["missing handled flag", { includeHandled: false }],
     ["different mechanism", { mechanismType: "generic" }],
   ])("keeps a Poper Blocker frame pair for an %s", (_caseName, overrides) => {
     const event = createPoperBlockerOrphanFetchRejectionEvent(overrides);
@@ -6552,6 +6584,36 @@ describe("sentry-client-filters", () => {
         },
       ],
     });
+
+    const result = shouldFilterPoperBlockerOrphanFetchRejection(event);
+
+    expect(result).toBe(false);
+  });
+
+  it("keeps mixed-exception events with a Poper Blocker rejection first", () => {
+    const poperBlockerEvent = createPoperBlockerOrphanFetchRejectionEvent();
+    const event: TestSentryClientEvent = {
+      ...poperBlockerEvent,
+      exception: {
+        values: [
+          ...(poperBlockerEvent.exception?.values ?? []),
+          {
+            type: "Error",
+            value: "Application request validation failed.",
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "webpack-internal:///(app-pages-browser)/./services/api/common-api.ts",
+                  function: "executeApiRequest",
+                  in_app: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
 
     const result = shouldFilterPoperBlockerOrphanFetchRejection(event);
 

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -15,6 +15,7 @@ import {
   shouldFilterReactDomInsertBeforeNotFoundError,
   shouldFilterReactDomRemoveChildNotFoundError,
   shouldFilterInjectedWasmCspUnsafeEval,
+  shouldFilterPoperBlockerOrphanFetchRejection,
   shouldFilterRabbyMobileRainbowKitNotFoundError,
   shouldFilterRabbyMobileUserRejectedRequest,
   shouldFilterSentryRouteParameterizationError,
@@ -138,6 +139,8 @@ describe("sentry-client-filters", () => {
     "No matching key. session topic doesn't exist: f17f5eaa1c3041fe37871f9eb24f4de53e1b11e494ec3def4b510d09acf42e32";
   const extensionMessagingConnectionFailureMessage =
     "Could not establish connection. Receiving end does not exist.";
+  const poperBlockerNetworkErrorMessage =
+    "Network request failed. Please check your connection and try again. (/api/dm-drops/unread)";
 
   const buildSpan = (
     overrides: TestSentryTransactionSpanOverrides = {}
@@ -724,6 +727,58 @@ describe("sentry-client-filters", () => {
       },
     ],
     ...overrides,
+  });
+
+  const createPoperBlockerOrphanFetchRejectionEvent = ({
+    type = "TypeError",
+    value = poperBlockerNetworkErrorMessage,
+    mechanismType = "auto.browser.global_handlers.onunhandledrejection",
+    handled = false,
+    frames = [
+      {
+        filename:
+          "node_modules/.pnpm/aws-rum-web@1.25.0/node_modules/aws-rum-web/dist/es/dispatch/FetchHttpHandler.js",
+        function: "e.prototype.handle",
+        in_app: false,
+      },
+      {
+        filename: "app:///injectScriptAdjust.js",
+        abs_path: "app:///injectScriptAdjust.js",
+        function: "window.fetch",
+        lineno: 1,
+        colno: 4520,
+        in_app: true,
+      },
+      {
+        filename: "app:///injectScriptAdjust.js",
+        abs_path: "app:///injectScriptAdjust.js",
+        function: "VihJ",
+        lineno: 1,
+        colno: 3159,
+        in_app: true,
+      },
+    ],
+  }: {
+    type?: string | undefined;
+    value?: string | undefined;
+    mechanismType?: string | undefined;
+    handled?: boolean | undefined;
+    frames?: SentryStackFrame[] | undefined;
+  } = {}): TestSentryClientEvent => ({
+    transaction: "/waves/:wave",
+    exception: {
+      values: [
+        {
+          type,
+          value,
+          mechanism: {
+            type: mechanismType,
+            handled,
+          },
+          stacktrace: { frames },
+        },
+      ],
+    },
   });
 
   const createAppleWebKitSortedTrackListEvent = ({
@@ -6362,6 +6417,144 @@ describe("sentry-client-filters", () => {
     const result = shouldFilterBrowserExtensionMessagingConnectionError(event);
 
     // Assert
+    expect(result).toBe(false);
+  });
+
+  it("filters the observed Poper Blocker rejection with the short AWS RUM stack", () => {
+    const event = createPoperBlockerOrphanFetchRejectionEvent();
+
+    const result = shouldFilterPoperBlockerOrphanFetchRejection(event);
+
+    expect(result).toBe(true);
+  });
+
+  it("filters the observed Poper Blocker rejection with the expanded AWS RUM stack", () => {
+    const event = createPoperBlockerOrphanFetchRejectionEvent({
+      frames: [
+        {
+          filename:
+            "node_modules/.pnpm/aws-rum-web@1.25.0/node_modules/aws-rum-web/dist/es/dispatch/DataPlaneClient.js",
+          function: "ts.<anonymous>",
+          in_app: false,
+        },
+        {
+          filename:
+            "node_modules/.pnpm/aws-rum-web@1.25.0/node_modules/aws-rum-web/dist/es/dispatch/RetryHttpHandler.js",
+          function: "e.prototype.handle",
+          in_app: false,
+        },
+        {
+          filename: "<anonymous>",
+          function: "new Promise",
+          in_app: true,
+        },
+        {
+          filename: "app:///injectScriptAdjust.js",
+          function: "window.fetch",
+          lineno: 1,
+          colno: 4520,
+          in_app: true,
+        },
+        {
+          filename: "app:///injectScriptAdjust.js",
+          function: "VihJ",
+          lineno: 1,
+          colno: 3159,
+          in_app: true,
+        },
+      ],
+    });
+
+    const result = shouldFilterPoperBlockerOrphanFetchRejection(event);
+
+    expect(result).toBe(true);
+  });
+
+  it.each([
+    ["similar filename", { filename: "app:///injectScriptAdjustment.js" }],
+    ["changed function", { function: "window.fetchWrapper" }],
+    ["changed line", { lineno: 2 }],
+    ["changed column", { colno: 4519 }],
+  ])("keeps Poper Blocker near-misses with a %s", (_caseName, frameChange) => {
+    const event = createPoperBlockerOrphanFetchRejectionEvent({
+      frames: [
+        {
+          filename: "app:///injectScriptAdjust.js",
+          function: "window.fetch",
+          lineno: 1,
+          colno: 4520,
+          ...frameChange,
+        },
+        {
+          filename: "app:///injectScriptAdjust.js",
+          function: "VihJ",
+          lineno: 1,
+          colno: 3159,
+        },
+      ],
+    });
+
+    const result = shouldFilterPoperBlockerOrphanFetchRejection(event);
+
+    expect(result).toBe(false);
+  });
+
+  it("keeps Poper Blocker-shaped rejections with a missing signature frame", () => {
+    const event = createPoperBlockerOrphanFetchRejectionEvent({
+      frames: [
+        {
+          filename: "app:///injectScriptAdjust.js",
+          function: "window.fetch",
+          lineno: 1,
+          colno: 4520,
+        },
+      ],
+    });
+
+    const result = shouldFilterPoperBlockerOrphanFetchRejection(event);
+
+    expect(result).toBe(false);
+  });
+
+  it.each([
+    ["unrelated error", { value: "Application request validation failed." }],
+    ["non-TypeError", { type: "Error" }],
+    ["handled rejection", { handled: true }],
+    ["different mechanism", { mechanismType: "generic" }],
+  ])("keeps a Poper Blocker frame pair for an %s", (_caseName, overrides) => {
+    const event = createPoperBlockerOrphanFetchRejectionEvent(overrides);
+
+    const result = shouldFilterPoperBlockerOrphanFetchRejection(event);
+
+    expect(result).toBe(false);
+  });
+
+  it("keeps Poper Blocker-shaped rejections with app-owned source evidence", () => {
+    const event = createPoperBlockerOrphanFetchRejectionEvent({
+      frames: [
+        {
+          filename: "app:///injectScriptAdjust.js",
+          function: "window.fetch",
+          lineno: 1,
+          colno: 4520,
+        },
+        {
+          filename: "app:///injectScriptAdjust.js",
+          function: "VihJ",
+          lineno: 1,
+          colno: 3159,
+        },
+        {
+          filename:
+            "webpack-internal:///(app-pages-browser)/./services/api/common-api.ts",
+          function: "executeApiRequest",
+          in_app: true,
+        },
+      ],
+    });
+
+    const result = shouldFilterPoperBlockerOrphanFetchRejection(event);
+
     expect(result).toBe(false);
   });
 

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -26,6 +26,7 @@ import {
   shouldFilterByFilenameExceptions,
   shouldFilterBrowserExtensionMessagingConnectionError,
   shouldFilterBrowserExtensionSendMessageError,
+  shouldFilterPoperBlockerOrphanFetchRejection,
   shouldFilterCoinbaseWalletLinkWebSocket1006,
   shouldFilterDisconnectedWalletProviderRejection,
   shouldFilterInjectedProviderProxyStartsWithError,
@@ -160,6 +161,10 @@ function shouldFilterEvent(
   }
 
   if (shouldFilterBrowserExtensionSendMessageError(event, hint)) {
+    return true;
+  }
+
+  if (shouldFilterPoperBlockerOrphanFetchRejection(event, hint)) {
     return true;
   }
 

--- a/utils/sentry-client-filters.ts
+++ b/utils/sentry-client-filters.ts
@@ -32,6 +32,9 @@ export {
   shouldFilterBrowserExtensionSendMessageError,
 } from "./sentry-client-filters/extension-messaging";
 export {
+  shouldFilterPoperBlockerOrphanFetchRejection,
+} from "./sentry-client-filters/extension-fetch";
+export {
   shouldFilterCoinbaseWalletLinkWebSocket1006,
   shouldFilterDisconnectedWalletProviderRejection,
   shouldFilterInjectedProviderProxyStartsWithError,

--- a/utils/sentry-client-filters/extension-fetch.ts
+++ b/utils/sentry-client-filters/extension-fetch.ts
@@ -56,7 +56,12 @@ export function shouldFilterPoperBlockerOrphanFetchRejection(
   event: SentryClientEvent,
   hint?: SentryEventHint
 ): boolean {
-  const value = event.exception?.values?.[0];
+  const values = event.exception?.values;
+  if (!Array.isArray(values) || values.length !== 1) {
+    return false;
+  }
+
+  const [value] = values;
   if (
     value?.type !== "TypeError" ||
     !isNetworkErrorMessage(value.value ?? "") ||

--- a/utils/sentry-client-filters/extension-fetch.ts
+++ b/utils/sentry-client-filters/extension-fetch.ts
@@ -1,0 +1,71 @@
+import { browserUnhandledRejectionMechanism } from "./constants";
+import type {
+  SentryClientEvent,
+  SentryEventHint,
+  SentryStackFrame,
+} from "./types";
+import { hasAppOwnedSourceEvidence } from "./app-frame-utils";
+import { getFramePaths, isNetworkErrorMessage } from "./value-utils";
+
+const poperBlockerInjectedFetchPath = "app:///injectScriptAdjust.js";
+const poperBlockerInjectedFetchFrameSignatures = [
+  { functionName: "window.fetch", lineNumber: 1, columnNumber: 4520 },
+  { functionName: "VihJ", lineNumber: 1, columnNumber: 3159 },
+] as const;
+
+function isPoperBlockerInjectedFetchPath(path: string): boolean {
+  return path === poperBlockerInjectedFetchPath;
+}
+
+function isExactPoperBlockerInjectedFetchFrame(
+  frame: SentryStackFrame,
+  signature: (typeof poperBlockerInjectedFetchFrameSignatures)[number]
+): boolean {
+  const framePaths = getFramePaths(frame);
+  return (
+    frame.function === signature.functionName &&
+    frame.lineno === signature.lineNumber &&
+    frame.colno === signature.columnNumber &&
+    framePaths.length > 0 &&
+    framePaths.every(isPoperBlockerInjectedFetchPath)
+  );
+}
+
+function hasExactPoperBlockerInjectedFetchFramePair(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  if (!Array.isArray(frames)) {
+    return false;
+  }
+
+  const injectedFetchFrames = frames.filter((frame) =>
+    getFramePaths(frame).some(isPoperBlockerInjectedFetchPath)
+  );
+  return (
+    injectedFetchFrames.length ===
+      poperBlockerInjectedFetchFrameSignatures.length &&
+    poperBlockerInjectedFetchFrameSignatures.every((signature) =>
+      injectedFetchFrames.some((frame) =>
+        isExactPoperBlockerInjectedFetchFrame(frame, signature)
+      )
+    )
+  );
+}
+
+export function shouldFilterPoperBlockerOrphanFetchRejection(
+  event: SentryClientEvent,
+  hint?: SentryEventHint
+): boolean {
+  const value = event.exception?.values?.[0];
+  if (
+    value?.type !== "TypeError" ||
+    !isNetworkErrorMessage(value.value ?? "") ||
+    value.mechanism?.type !== browserUnhandledRejectionMechanism ||
+    value.mechanism.handled !== false ||
+    hasAppOwnedSourceEvidence(event, value, hint)
+  ) {
+    return false;
+  }
+
+  return hasExactPoperBlockerInjectedFetchFramePair(value.stacktrace?.frames);
+}


### PR DESCRIPTION
<!-- sentry-fix-job:12 issue:7084719263 -->
## Issue

- Sentry: [6529-FRONTEND-2Y](https://seize-ff.sentry.io/issues/7084719263/)
- First seen: 2025-12-03T17:37:20.920Z
- Latest occurrence: 2026-07-17T10:38:32.000Z
- Automatic triage confidence: 98%

A narrow telemetry filter is useful. The earlier `/g/collect` fix is already merged; the current production cohort instead has an exact browser-extension signature from Poper Blocker's `injectScriptAdjust.js`. The extension wraps `window.fetch` and creates an orphan rejection when a request fails, causing Sentry to report handled application or AWS RUM failures as unhandled warnings.

## Fix

An injected browser-extension script wraps window.fetch and starts an async observer without rejection handling, creating an orphan unhandled rejection. The [pinned script source](https://github.com/Sibam-Paul/Volkov/blob/decabe70b56bdbe6ab3540a9d8aaa28c4928ff70/chromium/Default/Extensions/bkkbcggnhapdmkeljlodobbkopceiche/7.9.5_0/injectScriptAdjust.js) corroborates this behavior. The latest event has one TypeError, the required unhandled-rejection mechanism, both exact injected frames, and no application-owned source frame.

## Changes

- Not reported.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Focused Jest suites passed: 2 suites, 361 tests.
- ./bin/6529 run lint:changed passed.
- ./bin/6529 run typecheck:changed passed for 25 changed TypeScript files.
- Base-diff whitespace check passed; the worktree is clean and local and remote draft heads match.
- Current draft-head GitHub Actions, CodeQL, SonarCloud, Snyk, DCO, debt-ratchet, and secret-scan checks pass.

## Risk

- Assessed risk: low
- Changed files: 5
- Changed lines: 616
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

The draft is not deployed, so production suppression can only be confirmed after rollout. A future extension version may change frame coordinates; such variants intentionally fail open and remain visible.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
