### PR TITLE
Reduce Wave telemetry volume and bound client monitoring data

### DIFF
--- a/__tests__/components/monitoring/AwsRumProvider.test.tsx
+++ b/__tests__/components/monitoring/AwsRumProvider.test.tsx
@@ -13,11 +13,21 @@ jest.mock("next/navigation", () => ({
 }));
 
 jest.mock("aws-rum-web", () => {
+  type MockPluginContext = {
+    record: (eventType: string, eventData: object) => void;
+    recordPageView: (pageId: string) => void;
+  };
+  type MockPluginConfig = {
+    readonly eventPluginsToLoad?: Array<{
+      load?: (context: MockPluginContext) => void;
+    }>;
+  };
   const createPlugin = (
     pluginId: string
   ): new (config?: unknown) => {
     readonly config: unknown;
     getPluginId: () => string;
+    load: (context: MockPluginContext) => void;
   } =>
     class {
       readonly config: unknown;
@@ -29,14 +39,35 @@ jest.mock("aws-rum-web", () => {
       getPluginId(): string {
         return pluginId;
       }
+
+      load(context: MockPluginContext): void {
+        void context;
+      }
     };
 
   return {
-    AwsRum: jest.fn(() => ({
-      disable: jest.fn(),
-      recordEvent: jest.fn(),
-      recordPageView: jest.fn(),
-    })),
+    AwsRum: jest.fn(
+      (
+        _applicationId: string,
+        _applicationVersion: string,
+        _region: string,
+        config: MockPluginConfig
+      ) => {
+        const instance = {
+          disable: jest.fn(),
+          recordEvent: jest.fn(),
+          recordPageView: jest.fn(),
+        };
+        const pluginContext: MockPluginContext = {
+          record: instance.recordEvent,
+          recordPageView: instance.recordPageView,
+        };
+        config.eventPluginsToLoad?.forEach((plugin) => {
+          plugin.load?.(pluginContext);
+        });
+        return instance;
+      }
+    ),
     FetchPlugin: createPlugin("fetch"),
     JsErrorPlugin: createPlugin("js-error"),
     NavigationPlugin: createPlugin("navigation"),
@@ -181,6 +212,7 @@ describe("AwsRumProvider", () => {
     expect(getMockAwsRumInstance().recordPageView).toHaveBeenCalledWith(
       "/[user]"
     );
+    expect(getMockAwsRumInstance().recordPageView).toHaveBeenCalledTimes(1);
     expect(
       JSON.stringify(getMockAwsRumInstance().recordPageView.mock.calls)
     ).not.toContain("private-profile-handle");

--- a/__tests__/components/monitoring/AwsRumProvider.test.tsx
+++ b/__tests__/components/monitoring/AwsRumProvider.test.tsx
@@ -12,23 +12,46 @@ jest.mock("next/navigation", () => ({
   usePathname: () => mockPathname,
 }));
 
-jest.mock("aws-rum-web", () => ({
-  AwsRum: jest.fn(() => ({
-    disable: jest.fn(),
-    recordEvent: jest.fn(),
-    recordPageView: jest.fn(),
-  })),
-}));
+jest.mock("aws-rum-web", () => {
+  const createPlugin = (
+    pluginId: string
+  ): new (config?: unknown) => {
+    readonly config: unknown;
+    getPluginId: () => string;
+  } =>
+    class {
+      readonly config: unknown;
+
+      constructor(config?: unknown) {
+        this.config = config;
+      }
+
+      getPluginId(): string {
+        return pluginId;
+      }
+    };
+
+  return {
+    AwsRum: jest.fn(() => ({
+      disable: jest.fn(),
+      recordEvent: jest.fn(),
+      recordPageView: jest.fn(),
+    })),
+    FetchPlugin: createPlugin("fetch"),
+    JsErrorPlugin: createPlugin("js-error"),
+    NavigationPlugin: createPlugin("navigation"),
+    ResourcePlugin: createPlugin("resource"),
+    WebVitalsPlugin: createPlugin("web-vitals"),
+    XhrPlugin: createPlugin("xhr"),
+  };
+});
 
 const mockAwsRum = AwsRum as jest.Mock;
 const originalPublicEnv = { ...publicEnv };
 
-type AwsRumHttpTelemetry = [
-  "http",
-  {
-    urlsToExclude: RegExp[];
-  },
-];
+type AwsRumHttpPluginConfig = {
+  readonly urlsToExclude: RegExp[];
+};
 
 type MockAwsRumInstance = {
   readonly disable: jest.Mock;
@@ -77,18 +100,22 @@ describe("AwsRumProvider", () => {
         sessionSampleRate: 0.5,
         releaseId: "test-version",
         disableAutoPageView: true,
-        telemetries: [
-          "performance",
-          "errors",
-          [
-            "http",
-            {
-              urlsToExclude: expect.arrayContaining([expect.any(RegExp)]),
-            },
-          ],
-        ],
+        telemetries: [],
       })
     );
+    expect(
+      getAwsRumConfig().eventPluginsToLoad?.map((plugin) =>
+        plugin.getPluginId()
+      )
+    ).toEqual([
+      "6529-aws-rum-privacy",
+      "navigation",
+      "resource",
+      "web-vitals",
+      "js-error",
+      "xhr",
+      "fetch",
+    ]);
     expect(window.awsRum).toBe(mockAwsRum.mock.results[0]?.value);
     expect(getMockAwsRumInstance().recordPageView).toHaveBeenCalledWith(
       "/waves/[wave]"
@@ -137,6 +164,28 @@ describe("AwsRumProvider", () => {
     expect(payload).not.toContain(OTHER_WAVE_ID);
   });
 
+  it("normalizes a root profile before automatic telemetry plugins load", async () => {
+    mockPathname = "/private-profile-handle";
+
+    render(
+      <AwsRumProvider>
+        <div>Child content</div>
+      </AwsRumProvider>
+    );
+
+    await waitFor(() => expect(mockAwsRum).toHaveBeenCalledTimes(1));
+
+    expect(getAwsRumConfig().eventPluginsToLoad?.[0]?.getPluginId()).toBe(
+      "6529-aws-rum-privacy"
+    );
+    expect(getMockAwsRumInstance().recordPageView).toHaveBeenCalledWith(
+      "/[user]"
+    );
+    expect(
+      JSON.stringify(getMockAwsRumInstance().recordPageView.mock.calls)
+    ).not.toContain("private-profile-handle");
+  });
+
   it("excludes third-party analytics noise without excluding app-owned APIs", async () => {
     render(
       <AwsRumProvider>
@@ -150,32 +199,30 @@ describe("AwsRumProvider", () => {
     const isExcluded = (url: string): boolean =>
       urlsToExclude.some((urlPattern) => urlPattern.test(url));
 
-    expect(
-      isExcluded("https://www.google-analytics.com/g/collect?v=2")
-    ).toBe(true);
+    expect(isExcluded("https://www.google-analytics.com/g/collect?v=2")).toBe(
+      true
+    );
     expect(
       isExcluded("https://region7.google-analytics.com/g/collect?v=2")
     ).toBe(true);
-    expect(isExcluded("https://analytics.google.com/g/collect?v=2")).toBe(
-      true
-    );
+    expect(isExcluded("https://analytics.google.com/g/collect?v=2")).toBe(true);
     expect(isExcluded("https://www.google.com/g/collect?v=2")).toBe(true);
     expect(isExcluded("https://cca-lite.coinbase.com/amp?event=load")).toBe(
       true
     );
-    expect(
-      isExcluded("https://cca-lite.coinbase.com/metrics?event=load")
-    ).toBe(true);
+    expect(isExcluded("https://cca-lite.coinbase.com/metrics?event=load")).toBe(
+      true
+    );
     expect(isExcluded("https://api-js.mixpanel.com/track/?ip=1")).toBe(true);
     expect(isExcluded("https://api-js.mixpanel.com/engage/?verbose=1")).toBe(
       true
     );
-    expect(isExcluded("https://rpc.walletconnect.org/v1/?chainId=eip155:1")).toBe(
-      true
-    );
-    expect(isExcluded("https://rpc.walletconnect.com/v1/?chainId=eip155:1")).toBe(
-      true
-    );
+    expect(
+      isExcluded("https://rpc.walletconnect.org/v1/?chainId=eip155:1")
+    ).toBe(true);
+    expect(
+      isExcluded("https://rpc.walletconnect.com/v1/?chainId=eip155:1")
+    ).toBe(true);
     expect(isExcluded("https://rpc.walletconnect.com/v1/sessions/abc")).toBe(
       true
     );
@@ -183,16 +230,16 @@ describe("AwsRumProvider", () => {
       isExcluded("https://identity.walletconnect.org/v1/profile?projectId=test")
     ).toBe(true);
     expect(isExcluded("https://sts.amazonaws.com/")).toBe(true);
-    expect(isExcluded("https://cognito-identity.us-east-1.amazonaws.com/")).toBe(
-      true
-    );
+    expect(
+      isExcluded("https://cognito-identity.us-east-1.amazonaws.com/")
+    ).toBe(true);
     expect(
       isExcluded("https://dataplane.rum.us-east-1.amazonaws.com/appmonitors")
     ).toBe(true);
 
-    expect(
-      isExcluded("https://api.6529.io/api/auth/session-refresh")
-    ).toBe(false);
+    expect(isExcluded("https://api.6529.io/api/auth/session-refresh")).toBe(
+      false
+    );
     expect(
       isExcluded("https://api.6529.io/api/v2/waves/123/drops?limit=50")
     ).toBe(false);
@@ -327,19 +374,38 @@ describe("AwsRumProvider", () => {
 });
 
 const getHttpUrlsToExclude = (): RegExp[] => {
+  const plugins = getAwsRumConfig().eventPluginsToLoad ?? [];
+  const xhrConfig = plugins.find((plugin) => plugin.getPluginId() === "xhr")
+    ?.config as AwsRumHttpPluginConfig | undefined;
+  const fetchConfig = plugins.find((plugin) => plugin.getPluginId() === "fetch")
+    ?.config as AwsRumHttpPluginConfig | undefined;
+
+  expect(xhrConfig).toBeDefined();
+  expect(fetchConfig?.urlsToExclude).toEqual(xhrConfig?.urlsToExclude);
+
+  return xhrConfig?.urlsToExclude ?? [];
+};
+
+const getAwsRumConfig = (): {
+  readonly eventPluginsToLoad?: Array<{
+    readonly config?: unknown;
+    getPluginId: () => string;
+  }>;
+} => {
   const config = mockAwsRum.mock.calls[0]?.[3] as
     | {
-        telemetries?: Array<string | AwsRumHttpTelemetry>;
+        readonly eventPluginsToLoad?: Array<{
+          readonly config?: unknown;
+          getPluginId: () => string;
+        }>;
       }
     | undefined;
-  const httpTelemetry = config?.telemetries?.find(
-    (telemetry): telemetry is AwsRumHttpTelemetry =>
-      Array.isArray(telemetry) && telemetry[0] === "http"
-  );
 
-  expect(httpTelemetry).toBeDefined();
+  if (!config) {
+    throw new Error("AWS RUM config was not provided");
+  }
 
-  return httpTelemetry?.[1].urlsToExclude ?? [];
+  return config;
 };
 
 const getMockAwsRumInstance = (): MockAwsRumInstance => {

--- a/__tests__/ops/telemetryRegistry.test.ts
+++ b/__tests__/ops/telemetryRegistry.test.ts
@@ -129,12 +129,26 @@ describe("frontend telemetry registry", () => {
     }
   });
 
-  it("matches every product-impact dual write without duplicating ownership roles", () => {
+  it("matches product-impact delivery without duplicating provider roles", () => {
+    const sentryOmittedSignals = new Set([
+      "Wave Feed Load Started",
+      "Wave Feed Load Cancelled",
+    ]);
+
     for (const signalName of PRODUCT_IMPACT_EVENT_NAMES) {
-      const providers = getSignal(signalName)
-        .destinations.map((destination) => destination.split(":")[0])
+      const signal = getSignal(signalName);
+      const providers = signal.destinations
+        .map((destination) => destination.split(":")[0])
         .sort();
-      expect(providers).toEqual(["mixpanel", "sentry"]);
+      expect(providers).toEqual(
+        sentryOmittedSignals.has(signalName)
+          ? ["mixpanel"]
+          : ["mixpanel", "sentry"]
+      );
+
+      if (sentryOmittedSignals.has(signalName)) {
+        expect(signal.sampling).toContain("omitted from Sentry");
+      }
     }
   });
 

--- a/__tests__/services/analytics/productImpactTelemetry.test.ts
+++ b/__tests__/services/analytics/productImpactTelemetry.test.ts
@@ -32,8 +32,15 @@ async function loadProductImpactTelemetry(): Promise<{
 }
 
 describe("productImpactTelemetry", () => {
+  let randomSpy: jest.SpyInstance<number, []>;
+
   beforeEach(() => {
     globalThis.history.pushState({}, "", "/");
+    randomSpy = jest.spyOn(Math, "random").mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it("tracks wave feed route families without raw wave or drop ids", async () => {
@@ -69,6 +76,7 @@ describe("productImpactTelemetry", () => {
       expect.objectContaining({
         duration_ms: 1200,
         route_family: "/waves/:waveId",
+        sentry_sample_rate: 0.05,
       })
     );
     expect(trackAnalyticsEventMock).toHaveBeenCalledWith(
@@ -102,35 +110,103 @@ describe("productImpactTelemetry", () => {
     );
   });
 
-  it("keeps destinations isolated when one provider throws", async () => {
+  it("samples only initial Wave successes and suppresses routine Sentry info", async () => {
+    const { telemetry, sentry } = await loadProductImpactTelemetry();
+    randomSpy.mockReset();
+    randomSpy.mockReturnValueOnce(0.049).mockReturnValueOnce(0.05);
+
+    telemetry.trackWaveFeedLoadSucceeded({
+      dropCount: 3,
+      durationMs: 1200,
+      hadCachedDrops: false,
+      isNative: false,
+      loadSource: "server_initial",
+    });
+    telemetry.trackWaveFeedLoadSucceeded({
+      dropCount: 3,
+      durationMs: 1200,
+      hadCachedDrops: false,
+      isNative: false,
+      loadSource: "initial_visible",
+    });
+    telemetry.trackWaveFeedLoadSucceeded({
+      dropCount: 3,
+      durationMs: 1200,
+      hadCachedDrops: true,
+      isNative: false,
+      loadSource: "background_sync",
+    });
+    telemetry.trackWaveFeedLoadStarted({
+      hadCachedDrops: false,
+      isNative: false,
+      loadSource: "server_initial",
+    });
+    telemetry.trackWaveFeedLoadCancelled({
+      error: new DOMException("Aborted", "AbortError"),
+      hadCachedDrops: true,
+      isNative: false,
+      loadSource: "background_sync",
+      remainedUnavailable: false,
+    });
+
+    expect(sentry.logger.info).toHaveBeenCalledTimes(1);
+    expect(sentry.logger.info).toHaveBeenCalledWith(
+      "wave_feed_load_succeeded",
+      expect.objectContaining({
+        load_source: "server_initial",
+        sentry_sample_rate: 0.05,
+      })
+    );
+    expect(randomSpy).toHaveBeenCalledTimes(2);
+    expect(trackAnalyticsEventMock).toHaveBeenCalledTimes(5);
+  });
+
+  it("keeps destinations and sampling isolated when monitoring throws", async () => {
     const { telemetry, sentry } = await loadProductImpactTelemetry();
     trackAnalyticsEventMock.mockImplementationOnce(() => {
       throw new Error("Mixpanel unavailable");
     });
 
     expect(() =>
-      telemetry.trackWaveFeedLoadStarted({
+      telemetry.trackWaveFeedLoadFailed({
+        error: new Error("Unavailable"),
+        hadCachedDrops: false,
+        isNative: false,
+        loadSource: "initial_visible",
+        remainedUnavailable: true,
+      })
+    ).not.toThrow();
+    expect(sentry.logger.warn).toHaveBeenCalledWith(
+      "wave_feed_load_failed",
+      expect.any(Object)
+    );
+
+    sentry.logger.warn.mockImplementationOnce(() => {
+      throw new Error("Sentry unavailable");
+    });
+    expect(() =>
+      telemetry.trackWaveFeedLoadFailed({
+        error: new Error("Unavailable"),
+        hadCachedDrops: true,
+        isNative: false,
+        loadSource: "background_sync",
+        remainedUnavailable: false,
+      })
+    ).not.toThrow();
+    expect(trackAnalyticsEventMock).toHaveBeenCalledTimes(2);
+
+    randomSpy.mockImplementationOnce(() => {
+      throw new Error("Sampler unavailable");
+    });
+    expect(() =>
+      telemetry.trackWaveFeedLoadSucceeded({
+        dropCount: 1,
         hadCachedDrops: false,
         isNative: false,
         loadSource: "initial_visible",
       })
     ).not.toThrow();
-    expect(sentry.logger.info).toHaveBeenCalledWith(
-      "wave_feed_load_started",
-      expect.any(Object)
-    );
-
-    sentry.logger.info.mockImplementationOnce(() => {
-      throw new Error("Sentry unavailable");
-    });
-    expect(() =>
-      telemetry.trackWaveFeedLoadStarted({
-        hadCachedDrops: true,
-        isNative: false,
-        loadSource: "cache",
-      })
-    ).not.toThrow();
-    expect(trackAnalyticsEventMock).toHaveBeenCalledTimes(2);
+    expect(trackAnalyticsEventMock).toHaveBeenCalledTimes(3);
   });
 
   it("tracks auth refresh route families without raw profile handles", async () => {
@@ -191,8 +267,9 @@ describe("productImpactTelemetry", () => {
     expect(sentry.logger.warn).toHaveBeenCalledTimes(3);
   });
 
-  it("classifies wave feed HTTP failures into status and error buckets", async () => {
-    const { telemetry } = await loadProductImpactTelemetry();
+  it("classifies and always retains wave feed HTTP failures", async () => {
+    const { telemetry, sentry } = await loadProductImpactTelemetry();
+    randomSpy.mockReturnValue(1);
     const serviceError = Object.assign(new Error("Service unavailable"), {
       status: 503,
     });
@@ -210,6 +287,13 @@ describe("productImpactTelemetry", () => {
       "Wave Feed Load Failed",
       expect.objectContaining({
         error_kind: "server",
+        product_failure: true,
+        status_bucket: "5xx",
+      })
+    );
+    expect(sentry.logger.warn).toHaveBeenCalledWith(
+      "wave_feed_load_failed",
+      expect.objectContaining({
         product_failure: true,
         status_bucket: "5xx",
       })
@@ -237,8 +321,8 @@ describe("productImpactTelemetry", () => {
     );
   });
 
-  it("tracks wave feed cancellations as expected aborts", async () => {
-    const { telemetry } = await loadProductImpactTelemetry();
+  it("keeps cancellations as non-failures without routine Sentry logs", async () => {
+    const { telemetry, sentry } = await loadProductImpactTelemetry();
     const abortError = new DOMException(
       "The operation was aborted",
       "AbortError"
@@ -263,6 +347,8 @@ describe("productImpactTelemetry", () => {
         status_bucket: "aborted",
       })
     );
+    expect(sentry.logger.info).not.toHaveBeenCalled();
+    expect(sentry.logger.warn).not.toHaveBeenCalled();
   });
 
   it("tracks auth refresh success and cancellation as reportable outcomes", async () => {

--- a/__tests__/services/analytics/productImpactTelemetry.test.ts
+++ b/__tests__/services/analytics/productImpactTelemetry.test.ts
@@ -32,11 +32,16 @@ async function loadProductImpactTelemetry(): Promise<{
 }
 
 describe("productImpactTelemetry", () => {
-  let randomSpy: jest.SpyInstance<number, []>;
+  let getRandomValuesSpy: jest.SpyInstance;
 
   beforeEach(() => {
     globalThis.history.pushState({}, "", "/");
-    randomSpy = jest.spyOn(Math, "random").mockReturnValue(0);
+    getRandomValuesSpy = jest
+      .spyOn(globalThis.crypto, "getRandomValues")
+      .mockImplementation((values) => {
+        (values as Uint32Array)[0] = 0;
+        return values;
+      });
   });
 
   afterEach(() => {
@@ -112,8 +117,16 @@ describe("productImpactTelemetry", () => {
 
   it("samples only initial Wave successes and suppresses routine Sentry info", async () => {
     const { telemetry, sentry } = await loadProductImpactTelemetry();
-    randomSpy.mockReset();
-    randomSpy.mockReturnValueOnce(0.049).mockReturnValueOnce(0.05);
+    getRandomValuesSpy.mockReset();
+    getRandomValuesSpy
+      .mockImplementationOnce((values) => {
+        (values as Uint32Array)[0] = 214_748_364;
+        return values;
+      })
+      .mockImplementationOnce((values) => {
+        (values as Uint32Array)[0] = 214_748_365;
+        return values;
+      });
 
     telemetry.trackWaveFeedLoadSucceeded({
       dropCount: 3,
@@ -157,7 +170,7 @@ describe("productImpactTelemetry", () => {
         sentry_sample_rate: 0.05,
       })
     );
-    expect(randomSpy).toHaveBeenCalledTimes(2);
+    expect(getRandomValuesSpy).toHaveBeenCalledTimes(2);
     expect(trackAnalyticsEventMock).toHaveBeenCalledTimes(5);
   });
 
@@ -195,7 +208,7 @@ describe("productImpactTelemetry", () => {
     ).not.toThrow();
     expect(trackAnalyticsEventMock).toHaveBeenCalledTimes(2);
 
-    randomSpy.mockImplementationOnce(() => {
+    getRandomValuesSpy.mockImplementationOnce(() => {
       throw new Error("Sampler unavailable");
     });
     expect(() =>
@@ -269,7 +282,9 @@ describe("productImpactTelemetry", () => {
 
   it("classifies and always retains wave feed HTTP failures", async () => {
     const { telemetry, sentry } = await loadProductImpactTelemetry();
-    randomSpy.mockReturnValue(1);
+    getRandomValuesSpy.mockImplementation(() => {
+      throw new Error("Sampler should not run for failures");
+    });
     const serviceError = Object.assign(new Error("Service unavailable"), {
       status: 503,
     });

--- a/__tests__/utils/monitoring/awsRumPageId.test.ts
+++ b/__tests__/utils/monitoring/awsRumPageId.test.ts
@@ -12,12 +12,21 @@ describe("getAwsRumPageId", () => {
     [`/waves/${WAVE_ID}`, "/waves/[wave]"],
     [`/messages/${WAVE_ID}`, "/messages/[wave]"],
     [`/tools/app-wallets/${WALLET}`, "/tools/app-wallets/[app-wallet-address]"],
+    ["/alice", "/[user]"],
+    ["/alice/rep", "/[user]/rep"],
     [`/${WALLET}`, "/[user]"],
     [`/${WALLET}/collected`, "/[user]/collected"],
     [`/${WALLET}/private-cms-page`, "/[user]/[...cmsPath]"],
   ])("normalizes %s to the stable page ID %s", (route, expectedPageId) => {
     expect(getAwsRumPageId(route)).toBe(expectedPageId);
   });
+
+  it.each(["/author", "/notifications", "/rep", "/waves"])(
+    "keeps the known static root %s literal",
+    (route) => {
+      expect(getAwsRumPageId(route)).toBe(route);
+    }
+  );
 
   it("strips query strings and hashes before creating the page ID", () => {
     expect(
@@ -42,12 +51,14 @@ describe("getAwsRumPageId", () => {
       getAwsRumPageId(`/waves/${WAVE_ID}?drop=${OTHER_WAVE_ID}`),
       getAwsRumPageId(`/${WALLET}/collected#${WAVE_ID}`),
       getAwsRumPageId(`/tools/app-wallets/${WALLET}`),
+      getAwsRumPageId("/alice"),
     ];
     const payload = JSON.stringify(pageIds);
 
     expect(payload).not.toContain(WAVE_ID);
     expect(payload).not.toContain(OTHER_WAVE_ID);
     expect(payload).not.toContain(WALLET);
+    expect(payload).not.toContain("alice");
     expect(payload).not.toContain("?");
     expect(payload).not.toContain("#");
   });

--- a/__tests__/utils/monitoring/awsRumPageId.test.ts
+++ b/__tests__/utils/monitoring/awsRumPageId.test.ts
@@ -13,7 +13,7 @@ describe("getAwsRumPageId", () => {
     [`/messages/${WAVE_ID}`, "/messages/[wave]"],
     [`/tools/app-wallets/${WALLET}`, "/tools/app-wallets/[app-wallet-address]"],
     ["/alice", "/[user]"],
-    ["/alice/rep", "/[user]/rep"],
+    ["/alice/rep", "/[user]/[...cmsPath]"],
     [`/${WALLET}`, "/[user]"],
     [`/${WALLET}/collected`, "/[user]/collected"],
     [`/${WALLET}/private-cms-page`, "/[user]/[...cmsPath]"],

--- a/__tests__/utils/monitoring/awsRumPrivacy.test.ts
+++ b/__tests__/utils/monitoring/awsRumPrivacy.test.ts
@@ -1,0 +1,99 @@
+import type { PluginContext } from "aws-rum-web";
+import {
+  createAwsRumPrivacyPlugin,
+  sanitizeAwsRumEvent,
+  sanitizeAwsRumUrl,
+} from "@/utils/monitoring/awsRumPrivacy";
+
+const AUTHOR_UUID = "12345678-1234-4abc-8def-1234567890ab";
+const SESSION_TOPIC = "a".repeat(64);
+const MEDIA_URL = `https://media.example.cloudfront.net/renditions/drops/author_${AUTHOR_UUID}/file-id/hls/file.m3u8?quality=auto`;
+
+describe("AWS RUM privacy boundary", () => {
+  it("replaces only author UUID path segments with a bounded placeholder", () => {
+    expect(sanitizeAwsRumUrl(MEDIA_URL)).toBe(
+      "https://media.example.cloudfront.net/renditions/drops/author_id/file-id/hls/file.m3u8?quality=auto"
+    );
+    expect(
+      sanitizeAwsRumUrl(
+        "https://media.example.cloudfront.net/renditions/drops/author_public/file.m3u8"
+      )
+    ).toBe(
+      "https://media.example.cloudfront.net/renditions/drops/author_public/file.m3u8"
+    );
+  });
+
+  it("sanitizes HTTP and resource URLs without mutating the source event", () => {
+    const httpEvent = {
+      version: "1.0.0",
+      request: { method: "GET", url: MEDIA_URL },
+      response: { status: 404 },
+    };
+    const resourceEvent = {
+      version: "1.0.0",
+      targetUrl: MEDIA_URL,
+      initiatorType: "video",
+      duration: 100,
+      fileType: "video",
+    };
+
+    const sanitizedHttp = sanitizeAwsRumEvent(
+      "com.amazon.rum.http_event",
+      httpEvent
+    );
+    const sanitizedResource = sanitizeAwsRumEvent(
+      "com.amazon.rum.performance_resource_event",
+      resourceEvent
+    );
+    const payload = JSON.stringify({ sanitizedHttp, sanitizedResource });
+
+    expect(payload).toContain("author_id");
+    expect(payload).not.toContain(AUTHOR_UUID);
+    expect(httpEvent.request.url).toBe(MEDIA_URL);
+    expect(resourceEvent.targetUrl).toBe(MEDIA_URL);
+  });
+
+  it("redacts only the exact WalletConnect stale-topic message shape", () => {
+    const message = `No matching key. session topic doesn't exist: ${SESSION_TOPIC}`;
+    const sanitized = sanitizeAwsRumEvent("com.amazon.rum.js_error_event", {
+      version: "1.0.0",
+      type: "Error",
+      message,
+      stack: `Error: ${message}\n at isValidSessionTopic (walletconnect.js:1:1)`,
+    });
+    const payload = JSON.stringify(sanitized);
+
+    expect(payload).toContain("[redacted-topic]");
+    expect(payload).not.toContain(SESSION_TOPIC);
+    expect(
+      sanitizeAwsRumEvent("com.amazon.rum.js_error_event", {
+        message: "A different wallet error",
+      })
+    ).toEqual({ message: "A different wallet error" });
+  });
+
+  it("establishes the safe page before forwarding sanitized plugin events", () => {
+    const record = jest.fn();
+    const recordPageView = jest.fn();
+    const context = {
+      record,
+      recordPageView,
+    } as unknown as PluginContext;
+    const plugin = createAwsRumPrivacyPlugin("/[user]");
+
+    plugin.load(context);
+    context.record("com.amazon.rum.http_event", {
+      request: { method: "GET", url: MEDIA_URL },
+    });
+
+    expect(recordPageView).toHaveBeenCalledWith("/[user]");
+    expect(record).toHaveBeenCalledWith(
+      "com.amazon.rum.http_event",
+      expect.objectContaining({
+        request: expect.objectContaining({
+          url: expect.stringContaining("/author_id/"),
+        }),
+      })
+    );
+  });
+});

--- a/__tests__/utils/monitoring/dropReactionMonitoring.test.ts
+++ b/__tests__/utils/monitoring/dropReactionMonitoring.test.ts
@@ -1064,7 +1064,7 @@ describe("dropReactionMonitoring", () => {
         data: expect.objectContaining({
           endpoint_family: "drop_reaction",
           has_profile_context: true,
-          route_family: "/[user]/rep",
+          route_family: "/[user]/[...cmsPath]",
         }),
       })
     );
@@ -1073,7 +1073,7 @@ describe("dropReactionMonitoring", () => {
         endpoint_family: "drop_reaction",
         intended_reaction_present: true,
         optimistic_matches_intended: true,
-        route_family: "/[user]/rep",
+        route_family: "/[user]/[...cmsPath]",
       })
     );
 

--- a/__tests__/utils/monitoring/dropReactionMonitoring.test.ts
+++ b/__tests__/utils/monitoring/dropReactionMonitoring.test.ts
@@ -12,6 +12,8 @@ import {
 } from "@/utils/monitoring/dropReactionMonitoring";
 import { WebSocketStatus } from "@/services/websocket/WebSocketTypes";
 
+const mockSetExtras = jest.fn();
+
 jest.mock("@sentry/nextjs", () => ({
   __esModule: true,
   addBreadcrumb: jest.fn(),
@@ -20,7 +22,7 @@ jest.mock("@sentry/nextjs", () => ({
       setLevel: jest.fn(),
       setFingerprint: jest.fn(),
       setTag: jest.fn(),
-      setExtras: jest.fn(),
+      setExtras: mockSetExtras,
     };
     callback(scope);
   }),
@@ -35,6 +37,7 @@ describe("dropReactionMonitoring", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    globalThis.history.pushState({}, "", "/");
     __resetDropReactionMonitoringForTests();
     dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(1_000);
   });
@@ -91,7 +94,7 @@ describe("dropReactionMonitoring", () => {
       expect.objectContaining({
         message: "reaction.request_succeeded",
         data: expect.objectContaining({
-          latency_ms: 150,
+          latency_bucket: "under_250ms",
         }),
       })
     );
@@ -157,7 +160,9 @@ describe("dropReactionMonitoring", () => {
       })
     );
     expect(withScopeMock).toHaveBeenCalled();
-    expect(captureExceptionMock).toHaveBeenCalledWith(error);
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Drop reaction request failed" })
+    );
     expect(addBreadcrumbMock).toHaveBeenCalledWith(
       expect.objectContaining({
         message: "reaction.rollback_applied",
@@ -205,7 +210,6 @@ describe("dropReactionMonitoring", () => {
         data: expect.objectContaining({
           status_code: 403,
           error_kind: "auth",
-          error_message: "Proxy doesn't have permission to add reactions",
           captured: false,
         }),
       })
@@ -250,7 +254,6 @@ describe("dropReactionMonitoring", () => {
         data: expect.objectContaining({
           status_code: 403,
           error_kind: "auth",
-          error_message: "Chatting and reacting is not enabled in this wave",
           captured: false,
         }),
       })
@@ -298,48 +301,48 @@ describe("dropReactionMonitoring", () => {
     recordReactionRequestFailed(mutation, error);
 
     expect(withScopeMock).toHaveBeenCalled();
-    expect(captureExceptionMock).toHaveBeenCalledWith(error);
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Drop reaction request failed" })
+    );
   });
 
-  it.each(
-    [
-      {
-        caseName: "the same denial returned as 401",
-        endpoint: "drops/drop-proxy/reaction",
-        message: "Proxy doesn't have permission to add reactions",
-        method: "POST",
-        status: 401,
-      },
-      {
-        caseName: "an unexpected 403 auth message",
-        endpoint: "drops/drop-proxy/reaction",
-        message: "Forbidden",
-        method: "POST",
-        status: 403,
-      },
-      {
-        caseName: "the denial from a different endpoint",
-        endpoint: "drops/another-drop/reaction",
-        message: "Proxy doesn't have permission to add reactions",
-        method: "POST",
-        status: 403,
-      },
-      {
-        caseName: "the denial on a remove request",
-        endpoint: "drops/drop-proxy/reaction",
-        message: "Proxy doesn't have permission to add reactions",
-        method: "DELETE",
-        status: 403,
-      },
-      {
-        caseName: "the same message returned as a server error",
-        endpoint: "drops/drop-proxy/reaction",
-        message: "Proxy doesn't have permission to add reactions",
-        method: "POST",
-        status: 500,
-      },
-    ] as const
-  )("captures $caseName", ({ endpoint, message, method, status }) => {
+  it.each([
+    {
+      caseName: "the same denial returned as 401",
+      endpoint: "drops/drop-proxy/reaction",
+      message: "Proxy doesn't have permission to add reactions",
+      method: "POST",
+      status: 401,
+    },
+    {
+      caseName: "an unexpected 403 auth message",
+      endpoint: "drops/drop-proxy/reaction",
+      message: "Forbidden",
+      method: "POST",
+      status: 403,
+    },
+    {
+      caseName: "the denial from a different endpoint",
+      endpoint: "drops/another-drop/reaction",
+      message: "Proxy doesn't have permission to add reactions",
+      method: "POST",
+      status: 403,
+    },
+    {
+      caseName: "the denial on a remove request",
+      endpoint: "drops/drop-proxy/reaction",
+      message: "Proxy doesn't have permission to add reactions",
+      method: "DELETE",
+      status: 403,
+    },
+    {
+      caseName: "the same message returned as a server error",
+      endpoint: "drops/drop-proxy/reaction",
+      message: "Proxy doesn't have permission to add reactions",
+      method: "POST",
+      status: 500,
+    },
+  ] as const)("captures $caseName", ({ endpoint, message, method, status }) => {
     const mutation = beginReactionMutation({
       dropId: "drop-proxy",
       waveId: "wave-1",
@@ -364,7 +367,9 @@ describe("dropReactionMonitoring", () => {
     recordReactionRequestFailed(mutation, error);
 
     expect(withScopeMock).toHaveBeenCalled();
-    expect(captureExceptionMock).toHaveBeenCalledWith(error);
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Drop reaction request failed" })
+    );
   });
 
   it("records rate-limit warning metadata without capturing an exception", () => {
@@ -408,7 +413,7 @@ describe("dropReactionMonitoring", () => {
         data: expect.objectContaining({
           status_code: 429,
           error_kind: "rate-limit",
-          retry_after_ms: 2000,
+          retry_after_bucket: "1s_5s",
         }),
       })
     );
@@ -454,7 +459,6 @@ describe("dropReactionMonitoring", () => {
         data: expect.objectContaining({
           status_code: 404,
           error_kind: "endpoint-contract",
-          error_message: "Drop drop-stale not found",
         }),
       })
     );
@@ -464,7 +468,6 @@ describe("dropReactionMonitoring", () => {
         data: expect.objectContaining({
           status_code: 404,
           error_kind: "endpoint-contract",
-          error_message: "Drop drop-stale not found",
           captured: false,
         }),
       })
@@ -520,7 +523,9 @@ describe("dropReactionMonitoring", () => {
     recordReactionRequestFailed(mutation, error);
 
     expect(withScopeMock).toHaveBeenCalled();
-    expect(captureExceptionMock).toHaveBeenCalledWith(error);
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Drop reaction request failed" })
+    );
   });
 
   it("breadcrumbs an older success as superseded without capturing an issue", () => {
@@ -561,7 +566,6 @@ describe("dropReactionMonitoring", () => {
         message: "reaction.response_superseded",
         data: expect.objectContaining({
           superseded: true,
-          superseded_by_mutation_id: expect.any(String),
         }),
       })
     );
@@ -612,7 +616,6 @@ describe("dropReactionMonitoring", () => {
         message: "reaction.response_superseded",
         data: expect.objectContaining({
           superseded: true,
-          superseded_by_mutation_id: newerMutation.mutationId,
         }),
       })
     );
@@ -719,9 +722,10 @@ describe("dropReactionMonitoring", () => {
       expect.objectContaining({
         message: "reaction.realtime_superseded",
         data: expect.objectContaining({
-          expected_reaction: ":smile:",
-          server_reaction: ":wave:",
-          superseded_by_mutation_id: newerMutation.mutationId,
+          expected_reaction_present: true,
+          server_reaction_present: true,
+          server_matches_expected: false,
+          superseded: true,
         }),
       })
     );
@@ -771,7 +775,7 @@ describe("dropReactionMonitoring", () => {
       expect.objectContaining({
         message: "reaction.optimistic_reverted",
         data: expect.objectContaining({
-          time_since_mutation_ms: 217_657,
+          time_since_mutation_bucket: "over_15s",
         }),
       })
     );
@@ -1032,6 +1036,130 @@ describe("dropReactionMonitoring", () => {
     expect(latestMutation.dropMutationSeq).toBe(3);
   });
 
+  it("keeps Sentry payloads bounded and free of reaction identifiers", () => {
+    globalThis.history.pushState({}, "", "/private-handle/rep");
+    const mutation = beginReactionMutation({
+      dropId: "private-drop-id",
+      waveId: "private-wave-id",
+      source: "picker",
+      action: "replace",
+      previousReaction: ":private-old-reaction:",
+      intendedReaction: ":private-new-reaction:",
+      optimisticReaction: ":private-new-reaction:",
+      profileId: "private-profile-id",
+      websocketStatus: WebSocketStatus.CONNECTED,
+    });
+
+    recordReactionRequestSent(mutation, {
+      endpoint: "drops/private-drop-id/reaction",
+      method: "POST",
+    });
+    recordReactionRequestFailed(
+      mutation,
+      new Error("private-drop-id failed for private-profile-id")
+    );
+
+    expect(addBreadcrumbMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          endpoint_family: "drop_reaction",
+          has_profile_context: true,
+          route_family: "/[user]/rep",
+        }),
+      })
+    );
+    expect(mockSetExtras).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint_family: "drop_reaction",
+        intended_reaction_present: true,
+        optimistic_matches_intended: true,
+        route_family: "/[user]/rep",
+      })
+    );
+
+    const sentryPayload = JSON.stringify({
+      breadcrumbs: addBreadcrumbMock.mock.calls,
+      exceptions: captureExceptionMock.mock.calls,
+      extras: mockSetExtras.mock.calls,
+    });
+    for (const privateValue of [
+      "private-drop-id",
+      "private-wave-id",
+      "private-profile-id",
+      ":private-old-reaction:",
+      ":private-new-reaction:",
+      "/private-handle/rep",
+      "drops/private-drop-id/reaction",
+    ]) {
+      expect(sentryPayload).not.toContain(privateValue);
+    }
+
+    const sentryData = [
+      ...addBreadcrumbMock.mock.calls.map(
+        (call) =>
+          (call[0] as { readonly data?: Record<string, unknown> }).data ?? {}
+      ),
+      ...mockSetExtras.mock.calls.map(
+        (call) => call[0] as Record<string, unknown>
+      ),
+    ];
+    for (const removedKey of [
+      "mutation_id",
+      "drop_id",
+      "wave_id",
+      "profile_id",
+      "previous_reaction",
+      "intended_reaction",
+      "optimistic_reaction",
+      "pathname",
+      "endpoint",
+      "error_message",
+    ]) {
+      for (const data of sentryData) {
+        expect(data).not.toHaveProperty(removedKey);
+      }
+    }
+  });
+
+  it("keeps reaction behavior non-blocking when Sentry throws", () => {
+    addBreadcrumbMock.mockImplementationOnce(() => {
+      throw new Error("Breadcrumb transport unavailable");
+    });
+
+    expect(() =>
+      beginReactionMutation({
+        dropId: "drop-non-blocking",
+        waveId: "wave-1",
+        source: "quick-react",
+        action: "add",
+        previousReaction: null,
+        intendedReaction: ":smile:",
+        optimisticReaction: ":smile:",
+        profileId: "profile-1",
+        websocketStatus: WebSocketStatus.CONNECTED,
+      })
+    ).not.toThrow();
+
+    const mutation = beginReactionMutation({
+      dropId: "drop-capture-non-blocking",
+      waveId: "wave-1",
+      source: "quick-react",
+      action: "add",
+      previousReaction: null,
+      intendedReaction: ":smile:",
+      optimisticReaction: ":smile:",
+      profileId: "profile-1",
+      websocketStatus: WebSocketStatus.CONNECTED,
+    });
+    withScopeMock.mockImplementationOnce(() => {
+      throw new Error("Sentry scope unavailable");
+    });
+
+    expect(() =>
+      recordReactionRequestFailed(mutation, new TypeError("Failed to fetch"))
+    ).not.toThrow();
+  });
+
   it("does not let a stale failure consume the latest failure capture", () => {
     const firstMutation = beginReactionMutation({
       dropId: "drop-8",
@@ -1073,6 +1201,8 @@ describe("dropReactionMonitoring", () => {
     recordReactionRequestFailed(secondMutation, networkError);
 
     expect(captureExceptionMock).toHaveBeenCalledTimes(1);
-    expect(captureExceptionMock).toHaveBeenCalledWith(networkError);
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Drop reaction request failed" })
+    );
   });
 });

--- a/__tests__/utils/monitoring/mobileLaunchTiming.test.ts
+++ b/__tests__/utils/monitoring/mobileLaunchTiming.test.ts
@@ -554,6 +554,9 @@ describe("mobileLaunchTiming", () => {
       )
     ).toBe("/api/waves/:wallet/drops/:id");
     expect(sanitizers.sanitizeRouteFamily("/alice?jwt=secret")).toBe("/[user]");
+    expect(sanitizers.sanitizeRouteFamily("/alice/rep?jwt=secret")).toBe(
+      "/[user]/rep"
+    );
     expect(sanitizers.sanitizeRouteFamily("/messages/wave-123")).toBe(
       "/messages/[wave]"
     );

--- a/__tests__/utils/monitoring/mobileLaunchTiming.test.ts
+++ b/__tests__/utils/monitoring/mobileLaunchTiming.test.ts
@@ -555,7 +555,7 @@ describe("mobileLaunchTiming", () => {
     ).toBe("/api/waves/:wallet/drops/:id");
     expect(sanitizers.sanitizeRouteFamily("/alice?jwt=secret")).toBe("/[user]");
     expect(sanitizers.sanitizeRouteFamily("/alice/rep?jwt=secret")).toBe(
-      "/[user]/rep"
+      "/[user]/[...cmsPath]"
     );
     expect(sanitizers.sanitizeRouteFamily("/messages/wave-123")).toBe(
       "/messages/[wave]"

--- a/components/monitoring/AwsRumProvider.tsx
+++ b/components/monitoring/AwsRumProvider.tsx
@@ -121,11 +121,7 @@ export default function AwsRumProvider({
         awsRumRef.current = awsRum;
         // Optional: Store the instance globally for manual tracking if needed
         window.awsRum = awsRum;
-        lastRecordedPageIdRef.current = recordAwsRumPageView(
-          awsRum,
-          latestPathnameRef.current,
-          lastRecordedPageIdRef.current
-        );
+        lastRecordedPageIdRef.current = initialPageId;
       } catch (error) {
         // Silently handle errors to prevent breaking the application
         console.warn("AWS RUM: Failed to initialize", error);

--- a/components/monitoring/AwsRumProvider.tsx
+++ b/components/monitoring/AwsRumProvider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { publicEnv } from "@/config/env";
+import { createAwsRumPrivacyPlugin } from "@/utils/monitoring/awsRumPrivacy";
 import { getAwsRumPageId } from "@/utils/monitoring/mobileLaunchTimingSanitizers";
 import type { AwsRum as AwsRumInstance, AwsRumConfig } from "aws-rum-web";
 import { usePathname } from "next/navigation";
@@ -67,23 +68,35 @@ export default function AwsRumProvider({
           return;
         }
 
-        const { AwsRum } = await import("aws-rum-web");
+        const {
+          AwsRum,
+          FetchPlugin,
+          JsErrorPlugin,
+          NavigationPlugin,
+          ResourcePlugin,
+          WebVitalsPlugin,
+          XhrPlugin,
+        } = await import("aws-rum-web");
 
         if (cancelled) {
           return;
         }
 
+        const initialPageId = getAwsRumPageId(latestPathnameRef.current);
+        const httpPluginConfig = {
+          urlsToExclude: [...AWS_RUM_HTTP_URLS_TO_EXCLUDE],
+        };
         const config: AwsRumConfig = {
           sessionSampleRate: SAMPLE_RATE,
-          telemetries: [
-            "performance",
-            "errors",
-            [
-              "http",
-              {
-                urlsToExclude: [...AWS_RUM_HTTP_URLS_TO_EXCLUDE],
-              },
-            ],
+          telemetries: [],
+          eventPluginsToLoad: [
+            createAwsRumPrivacyPlugin(initialPageId),
+            new NavigationPlugin(),
+            new ResourcePlugin(),
+            new WebVitalsPlugin(),
+            new JsErrorPlugin(),
+            new XhrPlugin(httpPluginConfig),
+            new FetchPlugin(httpPluginConfig),
           ],
           allowCookies: true,
           enableXRay: false,

--- a/ops/telemetry/README.md
+++ b/ops/telemetry/README.md
@@ -56,10 +56,10 @@ SDK's automatic page-view plugin uses raw browser paths. A first-loaded privacy
 plugin establishes the normalized initial page before the SDK's performance,
 error, and HTTP plugins start; client navigation remains manually normalized.
 Query strings, hashes, profile/wallet values, UUIDs, and dynamic route
-parameters are excluded. Root profile handles collapse to `/[user]`, including
-their `/rep` tab family, while known static roots remain literal. Unknown
-subroutes collapse to a bounded top-level family, and consecutive equal
-families are deduplicated.
+parameters are excluded. Root profile handles collapse to `/[user]`, profile
+CMS paths such as `/[user]/rep` collapse to `/[user]/[...cmsPath]`, and known
+static roots remain literal. Unknown subroutes collapse to a bounded top-level
+family, and consecutive equal families are deduplicated.
 
 The same first-loaded AWS RUM boundary replaces exact CloudFront
 `author_<uuid>` path segments with `author_id` in HTTP/resource telemetry and

--- a/ops/telemetry/README.md
+++ b/ops/telemetry/README.md
@@ -21,15 +21,24 @@ questions. The registry must say which question each destination owns. A
 temporary or compatibility destination needs a replacement/removal plan and a
 dated review.
 
-## This audit
+## Current policy
 
-No runtime destination was removed. The repo Mixpanel runbook names the auth
-and Wave feed events, but live dashboard use could not be verified. The
-registry therefore documents owner versus compatibility/diagnostic roles while
-the runtime preserves every existing dual write. The runtime exports only the
-stable event-name list; destination ownership has one source of truth here.
-Wave feed success now adds exact `duration_ms` only to Sentry; Mixpanel keeps
-the existing bounded duration bucket and product outcome.
+The repo Mixpanel runbook names the auth and Wave feed events, but live
+dashboard use could not be verified. Mixpanel therefore keeps every existing
+Wave event unsampled for consented production sessions. Routine Sentry Wave
+logs use a narrower policy: starts and normal cancellations are omitted, as are
+cache, background-sync, and native-backfill successes. Only `server_initial`
+and `initial_visible` successes are eligible for a 5% per-event sample, with
+the sample rate and exact `duration_ms` attached. Warnings, failures, and
+product-unavailable outcomes remain always eligible for Sentry delivery.
+Cancellation remains a non-failure classification.
+
+Using the observed release volume of about 55,700 routine Wave start, success,
+and cancellation records versus 31 warnings, even the conservative assumption
+that every routine record is sample-eligible bounds routine Sentry volume at
+2,785 records while retaining all warnings: about a 95% reduction. The actual
+reduction should be larger because most routine categories are omitted rather
+than sampled.
 
 Page-view provider overlap is intentional for now: manually normalized AWS RUM
 page views answer browser performance questions, Mixpanel answers product
@@ -43,12 +52,20 @@ property names while removing handles and route identifiers; dashboards
 grouping by literal paths or raw fallback logical pages may need migration.
 
 AWS RUM page views are recorded manually by the provider because the pinned
-SDK's automatic page-view plugin uses raw browser paths. The provider keeps the
-SDK's performance, error, and HTTP telemetry enabled, but supplies allowlisted
-App Router families for the initial page and client-side navigation. Query
-strings, hashes, profile/wallet values, UUIDs, and dynamic route parameters are
-excluded. Unknown subroutes collapse to a bounded top-level family, and
-consecutive equal families are deduplicated.
+SDK's automatic page-view plugin uses raw browser paths. A first-loaded privacy
+plugin establishes the normalized initial page before the SDK's performance,
+error, and HTTP plugins start; client navigation remains manually normalized.
+Query strings, hashes, profile/wallet values, UUIDs, and dynamic route
+parameters are excluded. Root profile handles collapse to `/[user]`, including
+their `/rep` tab family, while known static roots remain literal. Unknown
+subroutes collapse to a bounded top-level family, and consecutive equal
+families are deduplicated.
+
+The same first-loaded AWS RUM boundary replaces exact CloudFront
+`author_<uuid>` path segments with `author_id` in HTTP/resource telemetry and
+redacts only the known WalletConnect stale-session-topic hash shape in JS error
+messages and stacks. It does not change product requests, response status,
+error classification, or external AWS configuration.
 
 The AWS RUM compatibility event `drop_popup_ready` and the legacy AWS RUM-owned
 events `ab_card_impression`, `ab_card_link_out`, and `ab_card_live_open` keep
@@ -110,8 +127,9 @@ per-item log was added.
 
 1. Verify live Mixpanel, AWS RUM, Google, and Sentry dashboard/alert usage, then
    retire compatibility destinations that have no owner.
-2. Migrate legacy reaction and push-notification diagnostic extras away from
-   raw code-level identifiers/error text. They are registered as temporary and
-   were deliberately not expanded into this narrow runtime change.
+2. Migrate legacy push-notification diagnostic extras away from raw profile and
+   error values. Drop-reaction telemetry was migrated to bounded route and
+   endpoint families, booleans, counts, enums, status/error categories, and
+   duration buckets on 2026-07-17.
 3. Review temporary route-data spans after enough production traffic exists;
    keep only measurements tied to a continuing performance decision.

--- a/ops/telemetry/registry.json
+++ b/ops/telemetry/registry.json
@@ -257,7 +257,7 @@
       "producer": "utils/monitoring/mobileLaunchTiming.ts",
       "destinations": ["sentry:owner"],
       "sampling": "5% normal; 100% focused non-desktop Waves, Messages, and Notifications routes; slow/timeout/error always",
-      "privacy": "route/endpoint families including /[user]/rep, bounded device/app cohorts, buckets, numeric durations, and auth cohort only",
+      "privacy": "route/endpoint families including /[user]/[...cmsPath] for profile CMS paths such as /[user]/rep, bounded device/app cohorts, buckets, numeric durations, and auth cohort only",
       "externalUsage": "unverified",
       "lifecycle": "keep",
       "replacement": null,

--- a/ops/telemetry/registry.json
+++ b/ops/telemetry/registry.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastReviewed": "2026-07-15",
+  "lastReviewed": "2026-07-17",
   "operationalOwner": "frontend-platform",
   "providers": [
     {
@@ -14,7 +14,7 @@
       "automatic": ["performance", "errors", "http"],
       "sampling": "AWS_RUM_SAMPLE_RATE per browser session; default 0.2",
       "release": "public VERSION as releaseId",
-      "notes": "X-Ray, interaction telemetry, and raw automatic page views are disabled; the provider manually records allowlisted App Router page families with query, hash, and dynamic identifiers removed"
+      "notes": "X-Ray, interaction telemetry, and raw automatic page views are disabled; a first-loaded privacy plugin establishes the normalized initial page before automatic telemetry plugins, manually recorded navigation uses allowlisted App Router families, author UUID media segments are bounded, and the exact WalletConnect stale-topic message shape is redacted"
     },
     {
       "id": "sentry",
@@ -183,15 +183,15 @@
       "name": "Wave Feed Load Started",
       "kind": "event-log",
       "question": "How many Wave feed load attempts start?",
-      "owner": "sentry",
+      "owner": "mixpanel-compatibility",
       "producer": "services/analytics/productImpactTelemetry.ts",
-      "destinations": ["sentry:owner", "mixpanel:compatibility"],
-      "sampling": "Sentry log transport plus consented production Mixpanel sessions",
+      "destinations": ["mixpanel:compatibility"],
+      "sampling": "consented production Mixpanel sessions; omitted from Sentry",
       "privacy": "route family, load source, cached/native booleans, and buckets only",
       "externalUsage": "repo Mixpanel runbook; live dashboard unverified",
       "lifecycle": "temporary",
-      "replacement": "Remove the Mixpanel destination after dashboard usage is verified absent or migrated",
-      "reviewBy": "2026-10-13"
+      "replacement": "Remove after dashboard usage is verified absent or migrate to an owned product denominator",
+      "reviewBy": "2026-10-17"
     },
     {
       "name": "Wave Feed Load Succeeded",
@@ -200,26 +200,26 @@
       "owner": "sentry-performance; mixpanel-product-outcome",
       "producer": "services/analytics/productImpactTelemetry.ts",
       "destinations": ["sentry:owner", "mixpanel:owner"],
-      "sampling": "Sentry log transport plus consented production Mixpanel sessions",
+      "sampling": "consented production Mixpanel sessions; Sentry samples 5% of server_initial and initial_visible successes and omits cache, background-sync, and native-backfill successes",
       "privacy": "Sentry receives numeric duration; Mixpanel receives duration/drop-count buckets and booleans; both use route families",
       "externalUsage": "repo Mixpanel runbook; live dashboard unverified",
       "lifecycle": "keep",
       "replacement": null,
-      "reviewBy": "2026-10-13"
+      "reviewBy": "2026-10-17"
     },
     {
       "name": "Wave Feed Load Cancelled",
       "kind": "event-log",
       "question": "How much load volume is normal navigation cancellation?",
-      "owner": "sentry",
+      "owner": "mixpanel-compatibility",
       "producer": "services/analytics/productImpactTelemetry.ts",
-      "destinations": ["sentry:owner", "mixpanel:compatibility"],
-      "sampling": "Sentry log transport plus consented production Mixpanel sessions",
+      "destinations": ["mixpanel:compatibility"],
+      "sampling": "consented production Mixpanel sessions; omitted from Sentry because cancellation is a normal non-failure",
       "privacy": "route family, load source, cached/native booleans, status, and duration bucket only",
       "externalUsage": "repo Mixpanel runbook; live dashboard unverified",
       "lifecycle": "temporary",
-      "replacement": "Remove the Mixpanel destination after dashboard usage is verified absent or migrated",
-      "reviewBy": "2026-10-13"
+      "replacement": "Remove after dashboard usage is verified absent or migrate to an owned cancellation-rate signal",
+      "reviewBy": "2026-10-17"
     },
     {
       "name": "Wave Feed Load Failed",
@@ -228,12 +228,12 @@
       "owner": "sentry-diagnostic; mixpanel-product-outcome",
       "producer": "services/analytics/productImpactTelemetry.ts",
       "destinations": ["mixpanel:owner", "sentry:owner"],
-      "sampling": "Sentry log transport plus consented production Mixpanel sessions",
+      "sampling": "all Sentry warnings plus consented production Mixpanel sessions; no custom failure sampler",
       "privacy": "route family, error/status buckets, load source, and booleans only",
       "externalUsage": "repo Mixpanel runbook; live dashboard unverified",
       "lifecycle": "keep",
       "replacement": null,
-      "reviewBy": "2026-10-13"
+      "reviewBy": "2026-10-17"
     },
     {
       "name": "auth_session_refresh",
@@ -257,7 +257,7 @@
       "producer": "utils/monitoring/mobileLaunchTiming.ts",
       "destinations": ["sentry:owner"],
       "sampling": "5% normal; 100% focused non-desktop Waves, Messages, and Notifications routes; slow/timeout/error always",
-      "privacy": "route/endpoint families, bounded device/app cohorts, buckets, numeric durations, and auth cohort only",
+      "privacy": "route/endpoint families including /[user]/rep, bounded device/app cohorts, buckets, numeric durations, and auth cohort only",
       "externalUsage": "unverified",
       "lifecycle": "keep",
       "replacement": null,
@@ -411,11 +411,11 @@
       "producer": "utils/monitoring/dropReactionMonitoring.ts",
       "destinations": ["sentry:owner"],
       "sampling": "breadcrumbs attach to captured Sentry events; error capture has a 60-second dedupe window",
-      "privacy": "legacy code-level identifiers remain under review; do not copy this attribute shape to new signals",
+      "privacy": "bounded route and endpoint families, source/action/status/error enums, booleans, mutation sequence, and duration buckets only; raw mutation/drop/wave/profile identifiers, reaction values, paths, endpoints, and error messages were removed 2026-07-17",
       "externalUsage": "unverified",
-      "lifecycle": "temporary",
-      "replacement": "Follow-up migration to route families and bounded state attributes",
-      "reviewBy": "2026-08-13"
+      "lifecycle": "keep",
+      "replacement": null,
+      "reviewBy": "2026-10-17"
     },
     {
       "name": "notifications.* error diagnostics",

--- a/services/analytics/productImpactTelemetry.ts
+++ b/services/analytics/productImpactTelemetry.ts
@@ -28,6 +28,15 @@ type ProductImpactStatusBucket =
   | "unknown";
 
 type ProductImpactSeverity = "info" | "warning";
+type ProductImpactSentryDelivery =
+  | "always"
+  | "never"
+  | "sample_initial_success";
+
+type ProductImpactLogOptions = {
+  readonly sentryDelivery?: ProductImpactSentryDelivery;
+  readonly sentryOnlyProperties?: ProductImpactProperties;
+};
 
 export const PRODUCT_IMPACT_EVENT_NAMES = [
   "Auth Session Refresh Product Impact",
@@ -90,6 +99,7 @@ interface AuthRefreshImpactTelemetry extends AuthRefreshTelemetryBase {
 }
 
 const TELEMETRY_VERSION = 1;
+const WAVE_FEED_INITIAL_SUCCESS_SENTRY_SAMPLE_RATE = 0.05;
 const DEFAULT_AUTH_REFRESH_IMPACT_DEDUPE_SCOPE = "default";
 const authRefreshImpactDedupeKeysByScope = new Map<string, Set<string>>();
 
@@ -367,7 +377,7 @@ function logProductImpactEvent(
   eventName: ProductImpactEventName,
   properties: ProductImpactProperties,
   severity: ProductImpactSeverity,
-  sentryOnlyProperties: ProductImpactProperties = {}
+  options: ProductImpactLogOptions = {}
 ): void {
   const payload = buildBaseProperties(properties);
 
@@ -378,9 +388,20 @@ function logProductImpactEvent(
   }
 
   try {
+    const sentryDelivery = options.sentryDelivery ?? "always";
+    if (sentryDelivery === "never") {
+      return;
+    }
+    if (
+      sentryDelivery === "sample_initial_success" &&
+      Math.random() >= WAVE_FEED_INITIAL_SUCCESS_SENTRY_SAMPLE_RATE
+    ) {
+      return;
+    }
+
     const sentryPayload = {
       ...payload,
-      ...sentryOnlyProperties,
+      ...options.sentryOnlyProperties,
     };
     const sentryLogName = eventName.toLowerCase().replaceAll(" ", "_");
     if (severity === "warning") {
@@ -447,6 +468,10 @@ function getWaveBaseProperties(
   };
 }
 
+function isInitialWaveFeedLoadSource(loadSource: WaveFeedLoadSource): boolean {
+  return loadSource === "initial_visible" || loadSource === "server_initial";
+}
+
 export function trackWaveFeedLoadStarted(
   telemetry: WaveFeedTelemetryBase
 ): void {
@@ -456,7 +481,8 @@ export function trackWaveFeedLoadStarted(
       ...getWaveBaseProperties(telemetry),
       product_failure: false,
     },
-    "info"
+    "info",
+    { sentryDelivery: "never" }
   );
 }
 
@@ -474,7 +500,13 @@ export function trackWaveFeedLoadSucceeded(
     },
     "info",
     {
-      duration_ms: getRawDurationMs(telemetry.durationMs),
+      sentryDelivery: isInitialWaveFeedLoadSource(telemetry.loadSource)
+        ? "sample_initial_success"
+        : "never",
+      sentryOnlyProperties: {
+        duration_ms: getRawDurationMs(telemetry.durationMs),
+        sentry_sample_rate: WAVE_FEED_INITIAL_SUCCESS_SENTRY_SAMPLE_RATE,
+      },
     }
   );
 }
@@ -490,7 +522,8 @@ export function trackWaveFeedLoadCancelled(
       product_failure: false,
       status_bucket: "aborted",
     },
-    "info"
+    "info",
+    { sentryDelivery: "never" }
   );
 }
 

--- a/services/analytics/productImpactTelemetry.ts
+++ b/services/analytics/productImpactTelemetry.ts
@@ -100,6 +100,13 @@ interface AuthRefreshImpactTelemetry extends AuthRefreshTelemetryBase {
 
 const TELEMETRY_VERSION = 1;
 const WAVE_FEED_INITIAL_SUCCESS_SENTRY_SAMPLE_RATE = 0.05;
+const UINT32_SAMPLE_SPACE = 2 ** 32;
+
+function getTelemetrySampleValue(): number {
+  const sample = new Uint32Array(1);
+  globalThis.crypto.getRandomValues(sample);
+  return (sample[0] ?? 0) / UINT32_SAMPLE_SPACE;
+}
 const DEFAULT_AUTH_REFRESH_IMPACT_DEDUPE_SCOPE = "default";
 const authRefreshImpactDedupeKeysByScope = new Map<string, Set<string>>();
 
@@ -394,7 +401,7 @@ function logProductImpactEvent(
     }
     if (
       sentryDelivery === "sample_initial_success" &&
-      Math.random() >= WAVE_FEED_INITIAL_SUCCESS_SENTRY_SAMPLE_RATE
+      getTelemetrySampleValue() >= WAVE_FEED_INITIAL_SUCCESS_SENTRY_SAMPLE_RATE
     ) {
       return;
     }

--- a/utils/monitoring/awsRumPrivacy.ts
+++ b/utils/monitoring/awsRumPrivacy.ts
@@ -1,0 +1,150 @@
+import type { Plugin, PluginContext } from "aws-rum-web";
+
+const AWS_RUM_HTTP_EVENT_TYPE = "com.amazon.rum.http_event";
+const AWS_RUM_JS_ERROR_EVENT_TYPE = "com.amazon.rum.js_error_event";
+const AWS_RUM_RESOURCE_EVENT_TYPE = "com.amazon.rum.performance_resource_event";
+const AWS_RUM_PRIVACY_PLUGIN_ID = "6529-aws-rum-privacy";
+const AUTHOR_UUID_SEGMENT =
+  /^author_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const WALLETCONNECT_STALE_TOPIC =
+  /No matching key\. session topic doesn't exist: [0-9a-f]{32,128}/gi;
+const WALLETCONNECT_STALE_TOPIC_REPLACEMENT =
+  "No matching key. session topic doesn't exist: [redacted-topic]";
+
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sanitizeAuthorUuidSegment(segment: string): string {
+  let decodedSegment = segment;
+  try {
+    decodedSegment = decodeURIComponent(segment);
+  } catch {
+    // Keep the original segment for a narrow literal match.
+  }
+
+  return AUTHOR_UUID_SEGMENT.test(decodedSegment) ? "author_id" : segment;
+}
+
+export function sanitizeAwsRumUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value, "https://rum.local");
+  } catch {
+    return value;
+  }
+
+  const segments = url.pathname.split("/");
+  const sanitizedSegments = segments.map(sanitizeAuthorUuidSegment);
+  if (
+    segments.every((segment, index) => segment === sanitizedSegments[index])
+  ) {
+    return value;
+  }
+
+  url.pathname = sanitizedSegments.join("/");
+  return /^https?:\/\//i.test(value)
+    ? url.toString()
+    : `${url.pathname}${url.search}${url.hash}`;
+}
+
+function sanitizeWalletConnectTopic(value: string): string {
+  return value.replace(
+    WALLETCONNECT_STALE_TOPIC,
+    WALLETCONNECT_STALE_TOPIC_REPLACEMENT
+  );
+}
+
+function sanitizeHttpEvent(eventData: object): object {
+  if (!isRecord(eventData) || !isRecord(eventData["request"])) {
+    return eventData;
+  }
+
+  const request = eventData["request"];
+  const url = request["url"];
+  if (typeof url !== "string") {
+    return eventData;
+  }
+
+  const sanitizedUrl = sanitizeAwsRumUrl(url);
+  return sanitizedUrl === url
+    ? eventData
+    : {
+        ...eventData,
+        request: {
+          ...request,
+          url: sanitizedUrl,
+        },
+      };
+}
+
+function sanitizeResourceEvent(eventData: object): object {
+  if (!isRecord(eventData) || typeof eventData["targetUrl"] !== "string") {
+    return eventData;
+  }
+
+  const targetUrl = eventData["targetUrl"];
+  const sanitizedUrl = sanitizeAwsRumUrl(targetUrl);
+  return sanitizedUrl === targetUrl
+    ? eventData
+    : { ...eventData, targetUrl: sanitizedUrl };
+}
+
+function sanitizeJsErrorEvent(eventData: object): object {
+  if (!isRecord(eventData)) {
+    return eventData;
+  }
+
+  const message = eventData["message"];
+  const stack = eventData["stack"];
+  const sanitizedMessage =
+    typeof message === "string" ? sanitizeWalletConnectTopic(message) : message;
+  const sanitizedStack =
+    typeof stack === "string" ? sanitizeWalletConnectTopic(stack) : stack;
+
+  if (sanitizedMessage === message && sanitizedStack === stack) {
+    return eventData;
+  }
+
+  return {
+    ...eventData,
+    ...(typeof sanitizedMessage === "string"
+      ? { message: sanitizedMessage }
+      : {}),
+    ...(typeof sanitizedStack === "string" ? { stack: sanitizedStack } : {}),
+  };
+}
+
+export function sanitizeAwsRumEvent(
+  eventType: string,
+  eventData: object
+): object {
+  if (eventType === AWS_RUM_HTTP_EVENT_TYPE) {
+    return sanitizeHttpEvent(eventData);
+  }
+  if (eventType === AWS_RUM_RESOURCE_EVENT_TYPE) {
+    return sanitizeResourceEvent(eventData);
+  }
+  if (eventType === AWS_RUM_JS_ERROR_EVENT_TYPE) {
+    return sanitizeJsErrorEvent(eventData);
+  }
+
+  return eventData;
+}
+
+export function createAwsRumPrivacyPlugin(initialPageId: string): Plugin {
+  return {
+    getPluginId: () => AWS_RUM_PRIVACY_PLUGIN_ID,
+    load: (context: PluginContext) => {
+      const record = context.record;
+      context.record = (eventType: string, eventData: object) => {
+        record(eventType, sanitizeAwsRumEvent(eventType, eventData));
+      };
+      context.recordPageView(initialPageId);
+    },
+    enable: () => undefined,
+    disable: () => undefined,
+  };
+}

--- a/utils/monitoring/dropReactionErrorClassification.ts
+++ b/utils/monitoring/dropReactionErrorClassification.ts
@@ -34,13 +34,6 @@ export function toErrorMessage(error: unknown): string {
   return String(error);
 }
 
-export function toCaptureExceptionInput(error: unknown): Error {
-  if (error instanceof Error) {
-    return error;
-  }
-  return new Error(toErrorMessage(error));
-}
-
 function isNetworkError(error: unknown): boolean {
   if (error instanceof TypeError) {
     return true;

--- a/utils/monitoring/dropReactionMonitoring.ts
+++ b/utils/monitoring/dropReactionMonitoring.ts
@@ -3,13 +3,13 @@
 import type { ApiDrop } from "@/generated/models/ApiDrop";
 import { extractRetryAfterMs } from "@/helpers/reactions/reactionRateLimit";
 import { WebSocketStatus } from "@/services/websocket/WebSocketTypes";
+import { getAwsRumPageId } from "@/utils/monitoring/mobileLaunchTimingSanitizers";
 import * as Sentry from "@sentry/nextjs";
 import {
   classifyReactionError,
   isExpectedProxyReactionPermissionDeniedError,
   isExpectedStaleDropNotFoundError,
   isExpectedWaveReactionDisabledError,
-  toCaptureExceptionInput,
   toErrorMessage,
 } from "./dropReactionErrorClassification";
 
@@ -24,24 +24,30 @@ const WEBSOCKET_STATUSES = new Set<string>(Object.values(WebSocketStatus));
 
 export type ReactionSource = "quick-react" | "picker" | "chip";
 type ReactionAction = "add" | "remove" | "replace";
+type ReactionRequestMethod = "POST" | "DELETE";
+type ReactionDurationBucket =
+  | "under_250ms"
+  | "250ms_1s"
+  | "1s_5s"
+  | "5s_15s"
+  | "over_15s";
 interface ReactionMutationContext {
   readonly mutationId: string;
   readonly dropMutationSeq: number;
   readonly dropId: string;
-  readonly waveId: string;
   readonly source: ReactionSource;
   readonly action: ReactionAction;
   readonly previousReaction: string | null;
   readonly intendedReaction: string | null;
   readonly optimisticReaction: string | null;
-  readonly profileId: string | null;
+  readonly hasProfileContext: boolean;
   readonly startedAt: number;
-  readonly pathname: string | null;
+  readonly routeFamily: string;
   readonly visibilityState: string | null;
   readonly online: boolean | null;
   readonly websocketStatus: WebSocketStatus | null;
   endpoint?: string | null;
-  method?: string | null;
+  method?: ReactionRequestMethod | null;
   requestSentAt: number | null;
   apiSucceededAt: number | null;
   apiFailedAt: number | null;
@@ -115,11 +121,12 @@ function createMutationId(): string {
   return `reaction-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
-function getCurrentPathname(): string | null {
+function getCurrentRouteFamily(): string {
   if (typeof window === "undefined") {
-    return null;
+    return "unknown";
   }
-  return window.location.pathname || null;
+
+  return getAwsRumPageId(window.location.pathname);
 }
 
 function getVisibilityState(): string | null {
@@ -150,36 +157,84 @@ function toWebsocketStatus(
   return null;
 }
 
+function getReactionDurationBucket(durationMs: number): ReactionDurationBucket {
+  if (durationMs < 250) {
+    return "under_250ms";
+  }
+  if (durationMs < 1_000) {
+    return "250ms_1s";
+  }
+  if (durationMs < 5_000) {
+    return "1s_5s";
+  }
+  if (durationMs < 15_000) {
+    return "5s_15s";
+  }
+
+  return "over_15s";
+}
+
+function getRetryAfterBucket(
+  retryAfterMs: number | null
+): ReactionDurationBucket | undefined {
+  return retryAfterMs === null
+    ? undefined
+    : getReactionDurationBucket(retryAfterMs);
+}
+
+function getEndpointFamily(
+  context: ReactionMutationContext
+): "drop_reaction" | "other" | undefined {
+  if (!context.endpoint) {
+    return undefined;
+  }
+
+  return context.endpoint === `drops/${context.dropId}/reaction`
+    ? "drop_reaction"
+    : "other";
+}
+
+function getReactionStateData(
+  context: ReactionMutationContext
+): Record<string, unknown> {
+  return {
+    mutation_sequence: context.dropMutationSeq,
+    source: context.source,
+    action: context.action,
+    previous_reaction_present: context.previousReaction !== null,
+    intended_reaction_present: context.intendedReaction !== null,
+    optimistic_reaction_present: context.optimisticReaction !== null,
+    optimistic_matches_intended:
+      context.optimisticReaction === context.intendedReaction,
+    has_profile_context: context.hasProfileContext,
+    route_family: context.routeFamily,
+    visibility_state: context.visibilityState ?? undefined,
+    online: context.online ?? undefined,
+    websocket_status: context.websocketStatus ?? undefined,
+    endpoint_family: getEndpointFamily(context),
+    method: context.method ?? undefined,
+  };
+}
+
 function addReactionBreadcrumb(
   message: string,
   context: ReactionMutationContext,
   data: Record<string, unknown> = {},
   level: "info" | "warning" | "error" = "info"
 ): void {
-  Sentry.addBreadcrumb({
-    category: "reactions",
-    level,
-    message,
-    data: {
-      mutation_id: context.mutationId,
-      drop_mutation_seq: context.dropMutationSeq,
-      drop_id: context.dropId,
-      wave_id: context.waveId,
-      source: context.source,
-      action: context.action,
-      previous_reaction: context.previousReaction,
-      intended_reaction: context.intendedReaction,
-      optimistic_reaction: context.optimisticReaction,
-      profile_id: context.profileId ?? undefined,
-      pathname: context.pathname ?? undefined,
-      visibility_state: context.visibilityState ?? undefined,
-      online: context.online ?? undefined,
-      websocket_status: context.websocketStatus ?? undefined,
-      endpoint: context.endpoint ?? undefined,
-      method: context.method ?? undefined,
-      ...data,
-    },
-  });
+  try {
+    Sentry.addBreadcrumb({
+      category: "reactions",
+      level,
+      message,
+      data: {
+        ...getReactionStateData(context),
+        ...data,
+      },
+    });
+  } catch {
+    // Reaction behavior must not depend on Sentry availability.
+  }
 }
 
 function captureReactionEvent({
@@ -195,15 +250,19 @@ function captureReactionEvent({
   tags: Record<string, string>;
   extra: Record<string, unknown>;
 }): void {
-  Sentry.withScope((scope) => {
-    scope.setLevel(level);
-    scope.setFingerprint(fingerprint);
-    Object.entries(tags).forEach(([key, value]) => {
-      scope.setTag(key, value);
+  try {
+    Sentry.withScope((scope) => {
+      scope.setLevel(level);
+      scope.setFingerprint(fingerprint);
+      Object.entries(tags).forEach(([key, value]) => {
+        scope.setTag(key, value);
+      });
+      scope.setExtras(extra);
+      Sentry.captureException(error);
     });
-    scope.setExtras(extra);
-    Sentry.captureException(error);
-  });
+  } catch {
+    // Reaction behavior must not depend on Sentry availability.
+  }
 }
 
 function recordSupersededResponse(
@@ -224,8 +283,9 @@ function recordSupersededResponse(
     context,
     {
       superseded: true,
-      superseded_by_mutation_id: latestMutationId,
-      time_since_mutation_ms: now - context.startedAt,
+      time_since_mutation_bucket: getReactionDurationBucket(
+        now - context.startedAt
+      ),
     },
     "warning"
   );
@@ -281,15 +341,15 @@ export function beginReactionMutation(params: {
     mutationId: createMutationId(),
     dropMutationSeq: nextSeq,
     dropId: params.dropId,
-    waveId: params.waveId,
     source: params.source,
     action: params.action,
     previousReaction: toNullableReaction(params.previousReaction),
     intendedReaction: toNullableReaction(params.intendedReaction),
     optimisticReaction: toNullableReaction(params.optimisticReaction),
-    profileId: params.profileId ?? null,
+    hasProfileContext:
+      params.profileId !== null && params.profileId !== undefined,
     startedAt: now,
-    pathname: getCurrentPathname(),
+    routeFamily: getCurrentRouteFamily(),
     visibilityState: getVisibilityState(),
     online: getOnlineStatus(),
     websocketStatus: toWebsocketStatus(params.websocketStatus),
@@ -318,7 +378,7 @@ export function recordReactionRequestSent(
   context: ReactionMutationContext,
   params: {
     endpoint: string;
-    method: "POST" | "DELETE";
+    method: ReactionRequestMethod;
   }
 ): void {
   context.endpoint = params.endpoint;
@@ -344,7 +404,9 @@ export function recordReactionRequestSucceeded(
   const result = recordSupersededResponse(context, now);
 
   addReactionBreadcrumb("reaction.request_succeeded", context, {
-    latency_ms: now - (context.requestSentAt ?? context.startedAt),
+    latency_bucket: getReactionDurationBucket(
+      now - (context.requestSentAt ?? context.startedAt)
+    ),
   });
 
   if (result.isLatestMutation && context.realtimeReconciledAt !== null) {
@@ -374,10 +436,9 @@ export function recordReactionRequestFailed(
     context,
     {
       status_code: statusCode ?? undefined,
-      latency_ms: latencyMs,
+      latency_bucket: getReactionDurationBucket(latencyMs),
       error_kind: errorKind,
-      error_message: errorMessage,
-      retry_after_ms: retryAfterMs ?? undefined,
+      retry_after_bucket: getRetryAfterBucket(retryAfterMs),
     },
     "warning"
   );
@@ -404,9 +465,8 @@ export function recordReactionRequestFailed(
       context,
       {
         status_code: statusCode ?? undefined,
-        latency_ms: latencyMs,
+        latency_bucket: getReactionDurationBucket(latencyMs),
         error_kind: errorKind,
-        error_message: errorMessage,
         captured: false,
       },
       "warning"
@@ -429,9 +489,8 @@ export function recordReactionRequestFailed(
       context,
       {
         status_code: statusCode ?? undefined,
-        latency_ms: latencyMs,
+        latency_bucket: getReactionDurationBucket(latencyMs),
         error_kind: errorKind,
-        error_message: errorMessage,
         captured: false,
       },
       "warning"
@@ -453,9 +512,8 @@ export function recordReactionRequestFailed(
       context,
       {
         status_code: statusCode ?? undefined,
-        latency_ms: latencyMs,
+        latency_bucket: getReactionDurationBucket(latencyMs),
         error_kind: errorKind,
-        error_message: errorMessage,
         captured: false,
       },
       "warning"
@@ -480,7 +538,7 @@ export function recordReactionRequestFailed(
   }
 
   captureReactionEvent({
-    error: toCaptureExceptionInput(error),
+    error: new Error("Drop reaction request failed"),
     level: errorKind === "server" ? "error" : "warning",
     fingerprint: [REACTION_FEATURE, errorKind],
     tags: {
@@ -491,25 +549,11 @@ export function recordReactionRequestFailed(
       error_kind: errorKind,
     },
     extra: {
-      mutation_id: context.mutationId,
-      drop_mutation_seq: context.dropMutationSeq,
-      drop_id: context.dropId,
-      wave_id: context.waveId,
-      previous_reaction: context.previousReaction,
-      intended_reaction: context.intendedReaction,
-      optimistic_reaction: context.optimisticReaction,
-      profile_id: context.profileId ?? undefined,
-      pathname: context.pathname ?? undefined,
-      visibility_state: context.visibilityState ?? undefined,
-      online: context.online ?? undefined,
-      websocket_status: context.websocketStatus ?? undefined,
-      endpoint: context.endpoint ?? undefined,
-      method: context.method ?? undefined,
+      ...getReactionStateData(context),
       status_code: statusCode ?? undefined,
-      latency_ms: latencyMs,
+      latency_bucket: getReactionDurationBucket(latencyMs),
       error_kind: errorKind,
-      error_message: errorMessage,
-      retry_after_ms: retryAfterMs ?? undefined,
+      retry_after_bucket: getRetryAfterBucket(retryAfterMs),
     },
   });
 
@@ -568,8 +612,11 @@ export function recordReactionRealtimeReconciliation(params: {
     context.realtimeReconciledAt = now;
     addReactionBreadcrumb("reaction.realtime_reconciled", context, {
       reconciled_from: "ws_refetch",
-      server_reaction: serverReaction ?? undefined,
-      time_since_mutation_ms: timeSinceMutationMs,
+      expected_reaction_present: expectedReaction !== null,
+      server_reaction_present: serverReaction !== null,
+      server_matches_expected: true,
+      time_since_mutation_bucket:
+        getReactionDurationBucket(timeSinceMutationMs),
       websocket_status: websocketStatus,
     });
     if (context.apiSucceededAt !== null) {
@@ -587,10 +634,12 @@ export function recordReactionRealtimeReconciliation(params: {
       context,
       {
         reconciled_from: "ws_refetch",
-        expected_reaction: expectedReaction ?? undefined,
-        server_reaction: serverReaction ?? undefined,
-        superseded_by_mutation_id: context.mutationId,
-        time_since_mutation_ms: timeSinceMutationMs,
+        expected_reaction_present: expectedReaction !== null,
+        server_reaction_present: serverReaction !== null,
+        server_matches_expected: false,
+        superseded: true,
+        time_since_mutation_bucket:
+          getReactionDurationBucket(timeSinceMutationMs),
         websocket_status: websocketStatus,
       },
       "warning"
@@ -615,8 +664,11 @@ export function recordReactionRealtimeReconciliation(params: {
     context,
     {
       reconciled_from: "ws_refetch",
-      server_reaction: serverReaction ?? undefined,
-      time_since_mutation_ms: timeSinceMutationMs,
+      expected_reaction_present: expectedReaction !== null,
+      server_reaction_present: serverReaction !== null,
+      server_matches_expected: false,
+      time_since_mutation_bucket:
+        getReactionDurationBucket(timeSinceMutationMs),
       websocket_status: websocketStatus,
     },
     "warning"
@@ -653,26 +705,17 @@ export function recordReactionRealtimeReconciliation(params: {
       action: context.action,
     },
     extra: {
-      mutation_id: context.mutationId,
-      drop_mutation_seq: context.dropMutationSeq,
-      drop_id: context.dropId,
-      wave_id: context.waveId,
-      previous_reaction: context.previousReaction,
-      intended_reaction: context.intendedReaction,
-      optimistic_reaction: context.optimisticReaction,
-      server_reaction: serverReaction ?? undefined,
-      profile_id: context.profileId ?? undefined,
-      pathname: context.pathname ?? undefined,
-      visibility_state: context.visibilityState ?? undefined,
-      online: context.online ?? undefined,
+      ...getReactionStateData(context),
+      expected_reaction_present: expectedReaction !== null,
+      server_reaction_present: serverReaction !== null,
+      server_matches_expected: false,
       websocket_status:
         toWebsocketStatus(params.websocketStatus) ??
         context.websocketStatus ??
         undefined,
-      endpoint: context.endpoint ?? undefined,
-      method: context.method ?? undefined,
       reconciled_from: "ws_refetch",
-      time_since_mutation_ms: timeSinceMutationMs,
+      time_since_mutation_bucket:
+        getReactionDurationBucket(timeSinceMutationMs),
       anomaly_kind: ANOMALY_OPTIMISTIC_REVERTED,
     },
   });

--- a/utils/monitoring/mobileLaunchTimingSanitizers.ts
+++ b/utils/monitoring/mobileLaunchTimingSanitizers.ts
@@ -114,6 +114,7 @@ const STATIC_TOP_LEVEL_ROUTE_SEGMENTS = new Set([
   "om",
   "open-data",
   "open-mobile",
+  "rep",
   "rememes",
   "restricted",
   "sentry-example-page",
@@ -132,6 +133,7 @@ const USER_ROUTE_TAB_SEGMENTS = new Set([
   "groups",
   "identity",
   "proxy",
+  "rep",
   "subscriptions",
   "waves",
   "xtdh",
@@ -155,7 +157,6 @@ const STATIC_MEME_LAB_SEGMENTS = new Set(["collection"]);
 const STATIC_NEXTGEN_SEGMENTS = new Set(["collection", "manager", "token"]);
 
 const AWS_RUM_NON_PAGE_ROUTE_SEGMENTS = new Set(["api"]);
-const AWS_RUM_ADDITIONAL_PAGE_ROUTE_SEGMENTS = new Set(["rep"]);
 const AWS_RUM_PROFILE_CMS_PAGE_ID = "/[user]/[...cmsPath]";
 const AWS_RUM_UNKNOWN_PAGE_ID = "/unknown";
 
@@ -306,8 +307,7 @@ export function getAwsRumPageId(route: string): string {
   }
 
   const isKnownStaticPageRoot =
-    STATIC_TOP_LEVEL_ROUTE_SEGMENTS.has(firstSegment) ||
-    AWS_RUM_ADDITIONAL_PAGE_ROUTE_SEGMENTS.has(firstSegment);
+    STATIC_TOP_LEVEL_ROUTE_SEGMENTS.has(firstSegment);
 
   return isKnownStaticPageRoot
     ? `/${firstSegment}`

--- a/utils/monitoring/mobileLaunchTimingSanitizers.ts
+++ b/utils/monitoring/mobileLaunchTimingSanitizers.ts
@@ -133,7 +133,6 @@ const USER_ROUTE_TAB_SEGMENTS = new Set([
   "groups",
   "identity",
   "proxy",
-  "rep",
   "subscriptions",
   "waves",
   "xtdh",
@@ -375,7 +374,7 @@ function getUserRouteTemplate(segments: readonly string[]): string | undefined {
     return `/[user]/${segments[1]}`;
   }
 
-  return undefined;
+  return AWS_RUM_PROFILE_CMS_PAGE_ID;
 }
 
 function matchesRouteFamilyPattern(


### PR DESCRIPTION
## Issue

- Routine Wave feed start, success, and cancellation logs dominate Sentry ingestion while actionable warnings are rare.
- Client telemetry could expose root profile handles, profile CMS paths, drop-reaction identifiers/free-form values, a CloudFront media author UUID segment, and a known WalletConnect stale-session topic hash.

## Fix

- Keep all existing Mixpanel Wave events, retain every Sentry warning/failure, and sample only 5% of `server_initial` and `initial_visible` Wave successes in Sentry.
- Establish normalized AWS RUM page state before automatic telemetry plugins and apply narrow, event-specific privacy transforms.
- Replace drop-reaction identifiers and free-form values with bounded route/endpoint families, booleans, enums, counts, status categories, and duration buckets.

## Changes

- Omit routine Wave starts, cancellations, cache successes, background-sync successes, and native-backfill successes from Sentry; preserve cancellation as a non-failure.
- Normalize root profiles to `/[user]` and profile CMS subpaths such as `/alice/rep` to `/[user]/[...cmsPath]`, while keeping known static roots such as `/rep` literal.
- Bound exact CloudFront `author_<uuid>` path segments in AWS RUM HTTP/resource events and redact only the known WalletConnect stale-session-topic hash shape in JS errors.
- Keep telemetry failures non-blocking and preserve existing AWS RUM performance, error, HTTP, page-view, sampling, and exclusion behavior.
- Update the telemetry registry/policy and add focused sampling, failure-retention, normalization, sanitization, non-blocking, and provider-order regression coverage.
- From the supplied 55.7k routine Wave records versus 31 warnings, the retained routine expectation is at most about 2,785 records plus all warnings, or at least about a 95% routine-volume reduction. The actual reduction should be larger because most routine categories are omitted before sampling.

## Validation

- Current refreshed head focused Jest: 11 suites, 154 tests passed, including telemetry privacy/volume coverage and the incoming Wave abort/composer regression suites.
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 exec react-doctor . --project 6529seize --verbose --offline --diff=origin/main` — 100/100, no findings.
- `./bin/6529 exec prettier --check <15 PR files>`
- `git diff --check origin/main...HEAD`
- `./bin/6529 run check:changed` reached the known repository Knip baseline locally; task-created unused exports were removed. Exact-head App PR CI passed Knip.
- Latest-head App PR CI passed changed-source lint/typecheck, Playwright helper typecheck, related Jest, production build, small Playwright smoke, and critical route-shell Playwright.
- Latest-head DCO, Snyk, push secret scan, debt ratchet, plan/security checks, CodeQL, SonarCloud, CodeRabbit, and repository review-bot checks passed.

## Risk

- Level: Medium
- Why: the change affects client telemetry plugin initialization and monitoring payload contracts, but not product requests, auth, UI, or backend behavior.
- The AWS RUM URL transform is intentionally limited to the production-observed CloudFront author UUID shape. A broader application-URL taxonomy would need separate evidence and review to avoid collapsing true HTTP fault diagnostics.
- Rollback: revert these commits to restore the previous logging volume and payload behavior; no external provider configuration or migration is required.

## Review Notes

- Verify the AWS RUM plugin order: privacy boundary first, followed by the existing navigation/resource/web-vitals/JS-error/XHR/fetch plugins with `telemetries: []` to avoid duplicate built-ins.
- Confirm all real Wave failures and HTTP faults remain visible while normal cancellations stay classified as non-failures.
- No server-side Sentry instrumentation is enabled by this PR.