### PR TITLE
Make mobile DM reactions respond immediately

### DIFF
--- a/tests/social/direct-message-sandbox.spec.ts
+++ b/tests/social/direct-message-sandbox.spec.ts
@@ -212,7 +212,7 @@ async function centerOf(target: Locator) {
 }
 
 function reactionChip(drop: Locator) {
-  return drop.locator("button").filter({ hasText: /^\D*1$/ });
+  return drop.getByRole("button", { name: /^👍\s*1$/ });
 }
 
 async function getReactionMutationMethods(baseURL: string | undefined) {

--- a/tests/social/direct-message-sandbox.spec.ts
+++ b/tests/social/direct-message-sandbox.spec.ts
@@ -1,3 +1,6 @@
+import type { Locator, Page } from "@playwright/test";
+
+import { DEFAULT_LONG_PRESS_DURATION_MS } from "../../hooks/useLongPressInteraction";
 import {
   expect,
   expectNoHorizontalOverflow,
@@ -5,15 +8,19 @@ import {
   waitForRouteReady,
 } from "../testHelpers";
 import {
+  dismissNextDevTools,
   expectNoUnsafeSandboxMutations,
   fetchSandboxRequests,
   LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
   useLocalSandboxMutationGuard,
 } from "../support/localSandbox";
+import { isCapacitorSimulationProject } from "../support/surfaceSimulation";
 
 const SANDBOX_DM_WAVE_ID = "00000000-0000-4000-8000-000000000532";
+const SANDBOX_DROP_ID = "00000000-0000-4000-8000-000000000530";
 const SANDBOX_DM_RECIPIENT_WALLET =
   "0x0000000000000000000000000000000000000532";
+const REACTION_PATH = `/api/drops/${SANDBOX_DROP_ID}/reaction`;
 
 test.describe("Direct message local sandbox @auth @medium @local-only", () => {
   useLocalSandboxMutationGuard(
@@ -66,7 +73,154 @@ test.describe("Direct message local sandbox @auth @medium @local-only", () => {
     });
     await expectNoUnsafeSandboxMutations(baseURL);
   });
+
+  test("shows a mobile direct-message reaction immediately and after reload", async ({
+    baseURL,
+    browserName,
+    page,
+  }, testInfo) => {
+    test.skip(
+      !isCapacitorSimulationProject(testInfo.project.name) ||
+        browserName !== "chromium",
+      "This regression requires a Chromium Capacitor simulation for trusted CDP touch input."
+    );
+
+    await seedQuickReaction(page);
+    await gotoSandboxDirectMessage(page);
+
+    const drop = page.locator('[data-serial-no="1"]').first();
+    await openMobileDropMenu(page, drop);
+
+    const quickReactButton = page
+      .getByRole("button", { name: "Click to react" })
+      .first();
+    await expect(quickReactButton).toBeVisible({
+      timeout: LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
+    });
+    await quickReactButton.evaluate((button: HTMLButtonElement) =>
+      button.click()
+    );
+
+    const optimisticReactionChip = reactionChip(drop);
+    await expect(optimisticReactionChip).toBeVisible({
+      timeout: LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
+    });
+    await expect(optimisticReactionChip).toHaveClass(/tw-border-primary-500/);
+    await expect
+      .poll(async () => getReactionMutationMethods(baseURL))
+      .toEqual(["POST"]);
+
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expectSandboxDirectMessageReady(page);
+
+    const persistedDrop = page.locator('[data-serial-no="1"]').first();
+    const persistedReactionChip = reactionChip(persistedDrop);
+    await expect(persistedReactionChip).toBeVisible({
+      timeout: LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
+    });
+    await expect(persistedReactionChip).toHaveClass(/tw-border-primary-500/);
+    await persistedReactionChip.click();
+
+    await expect(persistedReactionChip).toHaveCount(0, {
+      timeout: LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
+    });
+    await expect
+      .poll(async () => getReactionMutationMethods(baseURL))
+      .toEqual(["POST", "DELETE"]);
+
+    const requests = await fetchSandboxRequests(baseURL);
+    const allowedRequests = requests.filter(
+      (request) =>
+        request.kind === "allowed-sandbox-mutation" &&
+        request.path === REACTION_PATH
+    );
+    expect(allowedRequests).toEqual([
+      {
+        method: "POST",
+        path: REACTION_PATH,
+        kind: "allowed-sandbox-mutation",
+        body: { reaction: ":+1:" },
+      },
+      {
+        method: "DELETE",
+        path: REACTION_PATH,
+        kind: "allowed-sandbox-mutation",
+      },
+    ]);
+    await expectNoHorizontalOverflow(page);
+    await expectNoUnsafeSandboxMutations(baseURL);
+  });
 });
+
+async function gotoSandboxDirectMessage(page: Page) {
+  await page.goto(`/messages/${SANDBOX_DM_WAVE_ID}`, {
+    waitUntil: "domcontentloaded",
+  });
+  await expectSandboxDirectMessageReady(page);
+}
+
+async function expectSandboxDirectMessageReady(page: Page) {
+  await waitForRouteReady(page);
+  await expect(page).toHaveURL(new RegExp(`/messages/${SANDBOX_DM_WAVE_ID}$`));
+  await expect(page.getByText("Sandbox Direct Message").first()).toBeVisible({
+    timeout: LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
+  });
+  await dismissNextDevTools(page);
+  await expectNoHorizontalOverflow(page);
+}
+
+async function seedQuickReaction(page: Page) {
+  await page.addInitScript(() => {
+    globalThis.localStorage.setItem(
+      "emoji-mart.frequently",
+      JSON.stringify({ "+1": 10 })
+    );
+  });
+}
+
+async function openMobileDropMenu(page: Page, drop: Locator) {
+  const point = await centerOf(drop);
+  const cdp = await page.context().newCDPSession(page);
+
+  try {
+    await cdp.send("Input.dispatchTouchEvent", {
+      type: "touchStart",
+      touchPoints: [point],
+    });
+    await page.waitForTimeout(DEFAULT_LONG_PRESS_DURATION_MS + 600);
+    await cdp.send("Input.dispatchTouchEvent", {
+      type: "touchEnd",
+      touchPoints: [],
+    });
+  } finally {
+    await cdp.detach();
+  }
+}
+
+async function centerOf(target: Locator) {
+  const box = await target.boundingBox();
+  if (!box) {
+    throw new Error(
+      "Expected the mobile reaction target to have a layout box."
+    );
+  }
+
+  return {
+    x: box.x + box.width / 2,
+    y: box.y + box.height / 2,
+  };
+}
+
+function reactionChip(drop: Locator) {
+  return drop.locator("button").filter({ hasText: /^\D*1$/ });
+}
+
+async function getReactionMutationMethods(baseURL: string | undefined) {
+  const requests = await fetchSandboxRequests(baseURL);
+  return requests
+    .filter((request) => request.path === REACTION_PATH)
+    .map((request) => request.method);
+}
 
 function escapeRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/tests/social/direct-message-sandbox.spec.ts
+++ b/tests/social/direct-message-sandbox.spec.ts
@@ -1,6 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
 
-import { DEFAULT_LONG_PRESS_DURATION_MS } from "../../hooks/useLongPressInteraction";
 import {
   expect,
   expectNoHorizontalOverflow,
@@ -79,7 +78,7 @@ test.describe("Direct message local sandbox @auth @medium @local-only", () => {
     browserName,
     page,
   }, testInfo) => {
-    test.skip(
+    testInfo.skip(
       !isCapacitorSimulationProject(testInfo.project.name) ||
         browserName !== "chromium",
       "This regression requires a Chromium Capacitor simulation for trusted CDP touch input."
@@ -89,11 +88,11 @@ test.describe("Direct message local sandbox @auth @medium @local-only", () => {
     await gotoSandboxDirectMessage(page);
 
     const drop = page.locator('[data-serial-no="1"]').first();
-    await openMobileDropMenu(page, drop);
-
     const quickReactButton = page
       .getByRole("button", { name: "Click to react" })
       .first();
+    await openMobileDropMenu(page, drop, quickReactButton);
+
     await expect(quickReactButton).toBeVisible({
       timeout: LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
     });
@@ -178,7 +177,11 @@ async function seedQuickReaction(page: Page) {
   });
 }
 
-async function openMobileDropMenu(page: Page, drop: Locator) {
+async function openMobileDropMenu(
+  page: Page,
+  drop: Locator,
+  quickReactButton: Locator
+) {
   const point = await centerOf(drop);
   const cdp = await page.context().newCDPSession(page);
 
@@ -187,12 +190,17 @@ async function openMobileDropMenu(page: Page, drop: Locator) {
       type: "touchStart",
       touchPoints: [point],
     });
-    await page.waitForTimeout(DEFAULT_LONG_PRESS_DURATION_MS + 600);
-    await cdp.send("Input.dispatchTouchEvent", {
-      type: "touchEnd",
-      touchPoints: [],
+    await quickReactButton.waitFor({
+      state: "visible",
+      timeout: LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
     });
   } finally {
+    await cdp
+      .send("Input.dispatchTouchEvent", {
+        type: "touchEnd",
+        touchPoints: [],
+      })
+      .catch(() => undefined);
     await cdp.detach();
   }
 }

--- a/tests/support/composerSandboxServer.cjs
+++ b/tests/support/composerSandboxServer.cjs
@@ -523,6 +523,13 @@ function currentLocalDrop() {
     : localDrop;
 }
 
+function currentDirectMessageDrop() {
+  return {
+    ...currentLocalDrop(),
+    content: "Synthetic local-only direct message body for Playwright.",
+  };
+}
+
 const createdWaveMin = {
   ...localWaveMin,
   id: SANDBOX_CREATED_WAVE_ID,
@@ -642,7 +649,7 @@ const dmWaveOverview = {
     id: "local-dm-description-drop",
     content: "Synthetic local-only direct message for Playwright.",
   },
-  total_drops_count: 0,
+  total_drops_count: 1,
   is_private: true,
   is_dm_wave: true,
 };
@@ -685,6 +692,10 @@ const dmWave = {
   chat: {
     ...localWave.chat,
     scope: { group: { is_direct_message: true } },
+  },
+  metrics: {
+    ...localWave.metrics,
+    drops_count: dmWaveOverview.total_drops_count,
   },
 };
 
@@ -1715,9 +1726,7 @@ function loggedRequestBody(pathname, body) {
         : null,
       part_count: Array.isArray(body.parts) ? body.parts.length : 0,
       part_contents: Array.isArray(body.parts)
-        ? body.parts.map((part) =>
-            isPlainObject(part) ? part.content : null
-          )
+        ? body.parts.map((part) => (isPlainObject(part) ? part.content : null))
         : [],
       part_keys: isPlainObject(firstPart) ? sortedKeys(firstPart) : [],
       media_count: Array.isArray(firstPart?.media) ? firstPart.media.length : 0,
@@ -1835,7 +1844,7 @@ const mockApiExactReadRoutes = new Map([
   [`/api/waves/${SANDBOX_DM_WAVE_ID}`, () => dmWave],
   [
     `/api/v2/waves/${SANDBOX_DM_WAVE_ID}/drops`,
-    () => ({ wave: dmWaveOverview, drops: [] }),
+    () => ({ wave: dmWaveOverview, drops: [currentDirectMessageDrop()] }),
   ],
   [`/api/waves/${SANDBOX_NOTIFICATION_WAVE_ID}`, () => notificationWave],
   [


### PR DESCRIPTION
## Issue

Emoji reactions in native-mobile direct messages were reported as not appearing after selection. The existing authenticated DM sandbox did not render a message, so it could not verify the mobile action-sheet-to-renderer path.

## Fix

Current main already handles the production flow correctly. This PR keeps the production implementation unchanged and adds focused local-only regression coverage that proves a DM reaction appears optimistically, survives reload, and toggles off.

## Notable changes

- Serve one deterministic plain-text message in the local direct-message fixture.
- Open the mobile drop action sheet with trusted CDP touch dispatch.
- Synchronize the held touch on the visible action-sheet control rather than a fixed delay.
- Assert the reaction chip by its accessible name immediately and after reload.
- Assert the exact bounded POST and DELETE reaction mutations and reject unsafe writes.
- Keep desktop/non-native behavior unchanged.

## Validation

- Final-head Capacitor matrix repeat: Android 3/3 passed; iOS 3/3 skipped because trusted CDP touch input is Chromium-only.
- Focused Jest suites: 4 suites, 81 tests passed.
- Desktop DM sandbox: 1 passed, mobile-only case skipped.
- Existing desktop reaction sandbox: 2 passed.
- Playwright typecheck: passed.
- Changed-file lint and typecheck: passed on the final head.
- Scoped ESLint and Prettier checks: passed.
- React Doctor: no changed production source files; skipped cleanly.
- Local `check:changed`: format, lint, and typecheck phases passed; the local full Knip scan reported unrelated baseline findings outside this two-file diff. The clean App PR CI Knip and installed-app checks passed.
- SonarCloud quality gate: passed with 0 new issues and 0 security hotspots.
- CodeRabbit: no actionable comments.
- 6529bot security, i18n, WCAG, responsiveness, general, and follow-up reviews: no blocking findings.

## Visual evidence

A local-only phone-width screenshot was captured after reload. It showed the selected 👍 reaction chip with count 1 under the DM body and no horizontal overflow. The artifact remains ignored and is not committed.

Staging was opened at phone width, but it is gated by Team Login in this session, so no staging reaction mutation was performed.

## Risk

Low. The change is limited to the local Playwright fixture and regression test. It does not change production rendering, APIs, persistence, realtime handling, accessibility, or user-facing copy.

## Review notes

Evidence tier is browser simulation, not packaged native runtime. The action-sheet open is trusted touch; the transient reaction button is activated after a visibility assertion with a DOM click because both Playwright actionability and CDP tapping were unstable while the animated sheet detached.

Real-iPhone and iOS Simulator proof remain blocked because the sibling mobile repo is not on its required workflow branch, has unrelated local changes, and lacks the workflow document required by the repo mobile-device guidance. No production, staging, or deployment action was performed.