### PR TITLE
Keep chat input actions visible while typing on desktop

### DIFF
--- a/__tests__/components/waves/CreateDropContent.identity.test.tsx
+++ b/__tests__/components/waves/CreateDropContent.identity.test.tsx
@@ -310,6 +310,11 @@ describe("CreateDropContent identity picker flow", () => {
     mockSetToast.mockClear();
     mockRequestAuth.mockClear();
     resizeObserverCallback = null;
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1024,
+      writable: true,
+    });
     (global as any).ResizeObserver = jest
       .fn()
       .mockImplementation((callback: ResizeObserverCallback) => {
@@ -696,7 +701,7 @@ describe("CreateDropContent identity picker flow", () => {
     }
   });
 
-  it("collapses wide composer options when content is typed", async () => {
+  it("keeps wide composer options visible when content is typed", async () => {
     const rectSpy = mockComposerWidth(501);
 
     try {
@@ -713,7 +718,7 @@ describe("CreateDropContent identity picker flow", () => {
       await waitFor(() => {
         expect(screen.getByTestId("actions")).toHaveAttribute(
           "data-show-options",
-          "false"
+          "true"
         );
         expect(screen.getByTestId("actions")).toHaveAttribute(
           "data-animate-options",
@@ -726,7 +731,7 @@ describe("CreateDropContent identity picker flow", () => {
     }
   });
 
-  it("reopens wide composer options and collapses them on the next content change", async () => {
+  it("keeps wide composer options visible across repeated content changes", async () => {
     const rectSpy = mockComposerWidth(501);
 
     try {
@@ -737,7 +742,7 @@ describe("CreateDropContent identity picker flow", () => {
       await waitFor(() => {
         expect(screen.getByTestId("actions")).toHaveAttribute(
           "data-show-options",
-          "false"
+          "true"
         );
       });
 
@@ -757,7 +762,7 @@ describe("CreateDropContent identity picker flow", () => {
       await waitFor(() => {
         expect(screen.getByTestId("actions")).toHaveAttribute(
           "data-show-options",
-          "false"
+          "true"
         );
       });
     } finally {
@@ -776,7 +781,7 @@ describe("CreateDropContent identity picker flow", () => {
       await waitFor(() => {
         expect(screen.getByTestId("actions")).toHaveAttribute(
           "data-show-options",
-          "false"
+          "true"
         );
       });
 
@@ -811,7 +816,7 @@ describe("CreateDropContent identity picker flow", () => {
       await waitFor(() => {
         expect(screen.getByTestId("actions")).toHaveAttribute(
           "data-show-options",
-          "false"
+          "true"
         );
       });
 
@@ -832,6 +837,55 @@ describe("CreateDropContent identity picker flow", () => {
           "false"
         );
       });
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
+  it("switches cleanly at the mobile viewport breakpoint", async () => {
+    const rectSpy = mockComposerWidth(501);
+
+    try {
+      Object.defineProperty(window, "innerWidth", {
+        configurable: true,
+        value: 750,
+        writable: true,
+      });
+      renderSubject();
+
+      expect(screen.getByTestId("actions")).toHaveAttribute(
+        "data-show-options",
+        "false"
+      );
+
+      await userEvent.click(screen.getByText("type content"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("actions")).toHaveAttribute(
+          "data-show-options",
+          "false"
+        );
+      });
+
+      act(() => {
+        window.innerWidth = 751;
+        window.dispatchEvent(new Event("resize"));
+      });
+
+      expect(screen.getByTestId("actions")).toHaveAttribute(
+        "data-show-options",
+        "true"
+      );
+
+      act(() => {
+        window.innerWidth = 750;
+        window.dispatchEvent(new Event("resize"));
+      });
+
+      expect(screen.getByTestId("actions")).toHaveAttribute(
+        "data-show-options",
+        "false"
+      );
     } finally {
       rectSpy.mockRestore();
     }
@@ -879,7 +933,7 @@ describe("CreateDropContent identity picker flow", () => {
       await waitFor(() => {
         expect(screen.getByTestId("actions")).toHaveAttribute(
           "data-show-options",
-          "false"
+          "true"
         );
       });
 

--- a/__tests__/components/waves/CreateDropContent.identity.test.tsx
+++ b/__tests__/components/waves/CreateDropContent.identity.test.tsx
@@ -858,6 +858,13 @@ describe("CreateDropContent identity picker flow", () => {
         "false"
       );
 
+      await userEvent.click(screen.getByText("open options"));
+
+      expect(screen.getByTestId("actions")).toHaveAttribute(
+        "data-show-options",
+        "true"
+      );
+
       await userEvent.click(screen.getByText("type content"));
 
       await waitFor(() => {

--- a/__tests__/components/waves/CreateDropContent.identity.test.tsx
+++ b/__tests__/components/waves/CreateDropContent.identity.test.tsx
@@ -731,7 +731,7 @@ describe("CreateDropContent identity picker flow", () => {
     }
   });
 
-  it("keeps wide composer options visible across repeated content changes", async () => {
+  it("ignores the collapsed options state in a wide desktop composer", async () => {
     const rectSpy = mockComposerWidth(501);
 
     try {
@@ -872,20 +872,24 @@ describe("CreateDropContent identity picker flow", () => {
         window.dispatchEvent(new Event("resize"));
       });
 
-      expect(screen.getByTestId("actions")).toHaveAttribute(
-        "data-show-options",
-        "true"
-      );
+      await waitFor(() => {
+        expect(screen.getByTestId("actions")).toHaveAttribute(
+          "data-show-options",
+          "true"
+        );
+      });
 
       act(() => {
         window.innerWidth = 750;
         window.dispatchEvent(new Event("resize"));
       });
 
-      expect(screen.getByTestId("actions")).toHaveAttribute(
-        "data-show-options",
-        "false"
-      );
+      await waitFor(() => {
+        expect(screen.getByTestId("actions")).toHaveAttribute(
+          "data-show-options",
+          "false"
+        );
+      });
     } finally {
       rectSpy.mockRestore();
     }

--- a/__tests__/components/waves/CreateDropContent.utils.test.ts
+++ b/__tests__/components/waves/CreateDropContent.utils.test.ts
@@ -142,7 +142,7 @@ describe("CreateDropContent utilities", () => {
           ],
         } as any,
         files: [currentFile],
-        isWideContainer: true,
+        keepOptionsVisible: true,
         waveId: "wave-1",
         setToast,
         setFiles,

--- a/components/waves/CreateDropContent.tsx
+++ b/components/waves/CreateDropContent.tsx
@@ -487,7 +487,7 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
     drop,
     editingPartIndex,
     finalizeAndAddDropPartDraft,
-    isWideContainer,
+    keepOptionsVisible: keepDesktopOptionsVisible,
     refreshState,
     setDrop,
     setEditingPartIndex,
@@ -595,7 +595,7 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
   const { handleFileChange, removeFile } = useCreateDropFileHandlers({
     drop,
     files,
-    isWideContainer,
+    keepOptionsVisible: keepDesktopOptionsVisible,
     waveId: wave.id,
     externalAttachmentDrop,
     onExternalAttachmentDropConsumed,
@@ -611,13 +611,13 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
     (next: boolean) => {
       shouldAnimateOptionsRef.current = true;
       setShowOptionsState({ scopeKey: wave.id, value: next });
-      if (isWideContainer) {
+      if (keepDesktopOptionsVisible) {
         closeOnNextInputRef.current = false;
         return;
       }
       closeOnNextInputRef.current = next;
     },
-    [isWideContainer, wave.id]
+    [keepDesktopOptionsVisible, wave.id]
   );
 
   const handleEditorStateChange = useCallback(
@@ -625,7 +625,7 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
       setEditorState(newEditorState);
       shouldCollapseOptionsAfterMarkdownSyncRef.current = true;
 
-      if (isWideContainer) {
+      if (keepDesktopOptionsVisible) {
         return;
       }
 
@@ -633,12 +633,12 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
         collapseOptions();
       }
     },
-    [collapseOptions, isWideContainer]
+    [collapseOptions, keepDesktopOptionsVisible]
   );
 
   const handleEditorBlur = useCallback(
     (event: React.FocusEvent<HTMLDivElement>) => {
-      if (isWideContainer) {
+      if (keepDesktopOptionsVisible) {
         return;
       }
       const nextTarget = event.relatedTarget as Node | null;
@@ -649,7 +649,7 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
       setShowOptionsState({ scopeKey: wave.id, value: false });
       closeOnNextInputRef.current = false;
     },
-    [isWideContainer, wave.id]
+    [keepDesktopOptionsVisible, wave.id]
   );
 
   useEffect(() => {

--- a/components/waves/CreateDropContent.tsx
+++ b/components/waves/CreateDropContent.tsx
@@ -151,8 +151,11 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
     shouldCollapseOptionsAfterMarkdownSyncRef.current = false;
   }
   const dropModeSessionScopeKey = `${wave.id}:drop-mode:${dropModeSessionEpoch}`;
+  const keepDesktopOptionsVisible = !isMobile && isWideContainer;
+  // Keep the scoped collapse state live so resizing back to a narrow layout
+  // restores the chevron immediately.
   const showOptions =
-    (!isMobile && isWideContainer) ||
+    keepDesktopOptionsVisible ||
     (showOptionsState?.scopeKey === wave.id && showOptionsState.value);
 
   useLayoutEffect(() => {

--- a/components/waves/CreateDropContent.tsx
+++ b/components/waves/CreateDropContent.tsx
@@ -3,6 +3,7 @@
 import { SAFE_MARKDOWN_TRANSFORMERS } from "@/components/drops/create/lexical/transformers/markdownTransformers";
 import { ApiDropType } from "@/generated/models/ApiDropType";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
+import useIsMobileScreen from "@/hooks/isMobileScreen";
 import { useEditingDrop } from "@/contexts/EditingDropContext";
 import type { EditorState } from "lexical";
 import React, {
@@ -113,6 +114,7 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
   const { isSafeWallet, address } = useSeizeConnectContext();
   const { send } = useWebSocket();
   const { isApp } = useDeviceInfo();
+  const isMobile = useIsMobileScreen();
   const locale = useBrowserLocale();
   const { actionsContainerRef, isWideContainer, setActionsContainerRef } =
     useCreateDropContainerWidth();
@@ -150,9 +152,8 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
   }
   const dropModeSessionScopeKey = `${wave.id}:drop-mode:${dropModeSessionEpoch}`;
   const showOptions =
-    showOptionsState?.scopeKey === wave.id
-      ? showOptionsState.value
-      : isWideContainer;
+    (!isMobile && isWideContainer) ||
+    (showOptionsState?.scopeKey === wave.id && showOptionsState.value);
 
   useLayoutEffect(() => {
     if (prevIsDropModeRef.current && !isDropMode) {

--- a/components/waves/create-drop-content/content-helpers.ts
+++ b/components/waves/create-drop-content/content-helpers.ts
@@ -540,7 +540,7 @@ export const handleComposerFileChange = ({
   newFiles,
   drop,
   files,
-  isWideContainer,
+  keepOptionsVisible,
   waveId,
   setToast,
   setFiles,
@@ -551,7 +551,7 @@ export const handleComposerFileChange = ({
   readonly newFiles: File[];
   readonly drop: CreateDropConfig | null;
   readonly files: File[];
-  readonly isWideContainer: boolean;
+  readonly keepOptionsVisible: boolean;
   readonly waveId: string;
   readonly setToast: (toast: AppToastInput) => void;
   readonly setFiles: React.Dispatch<React.SetStateAction<File[]>>;
@@ -622,7 +622,7 @@ export const handleComposerFileChange = ({
     });
   }
 
-  if (!isWideContainer) {
+  if (!keepOptionsVisible) {
     shouldAnimateOptionsRef.current = true;
     setShowOptionsState({ scopeKey: waveId, value: false });
     closeOnNextInputRef.current = false;

--- a/components/waves/create-drop-content/useCreateDropFileHandlers.ts
+++ b/components/waves/create-drop-content/useCreateDropFileHandlers.ts
@@ -10,7 +10,7 @@ import type { MutableCurrentRef, ScopedValueState } from "./types";
 export const useCreateDropFileHandlers = ({
   drop,
   files,
-  isWideContainer,
+  keepOptionsVisible,
   waveId,
   externalAttachmentDrop,
   onExternalAttachmentDropConsumed,
@@ -23,7 +23,7 @@ export const useCreateDropFileHandlers = ({
 }: {
   readonly drop: CreateDropConfig | null;
   readonly files: File[];
-  readonly isWideContainer: boolean;
+  readonly keepOptionsVisible: boolean;
   readonly waveId: string;
   readonly externalAttachmentDrop:
     | {
@@ -49,7 +49,7 @@ export const useCreateDropFileHandlers = ({
       newFiles,
       drop,
       files,
-      isWideContainer,
+      keepOptionsVisible,
       waveId,
       setToast,
       setFiles,

--- a/components/waves/create-drop-content/useStormPartActions.ts
+++ b/components/waves/create-drop-content/useStormPartActions.ts
@@ -17,7 +17,7 @@ interface UseStormPartActionsParams {
   readonly finalizeAndAddDropPartDraft: (
     replacePartIndex?: number | null
   ) => CreateDropConfig;
-  readonly isWideContainer: boolean;
+  readonly keepOptionsVisible: boolean;
   readonly refreshState: () => void;
   readonly setDrop: Dispatch<SetStateAction<CreateDropConfig | null>>;
   readonly setEditingPartIndex: Dispatch<SetStateAction<number | null>>;
@@ -35,7 +35,7 @@ export const useStormPartActions = ({
   drop,
   editingPartIndex,
   finalizeAndAddDropPartDraft,
-  isWideContainer,
+  keepOptionsVisible,
   refreshState,
   setDrop,
   setEditingPartIndex,
@@ -161,13 +161,13 @@ export const useStormPartActions = ({
   const breakIntoStorm = useCallback(() => {
     finalizeAndAddDropPart();
     setIsStormMode(true);
-    if (!isWideContainer) {
+    if (!keepOptionsVisible) {
       collapseOptions();
     }
   }, [
     collapseOptions,
     finalizeAndAddDropPart,
-    isWideContainer,
+    keepOptionsVisible,
     setIsStormMode,
   ]);
 


### PR DESCRIPTION
## Issue

On desktop, focusing or typing in the wave chat composer collapsed the upload, GIF, poll, and storm actions into a chevron even when the composer had enough horizontal space. This added an unnecessary click and made useful actions disappear while writing.

## Fix

Treat a wide, non-mobile composer as authoritative: its action row stays visible regardless of the narrow-screen collapse state. Mobile and narrow layouts keep the existing chevron behavior.

## Notable changes

- Reuse the existing mobile breakpoint rather than introducing another responsive threshold.
- Preserve the existing container-width guard so constrained desktop layouts remain safe.
- Add regression coverage for typing on desktop and for repeated 750 → 751 → 750 viewport transitions.

## Validation

- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- Focused CreateDropContent suite: 30 passed
- Isolated desktop/mobile composer sandbox: 18 passed
- React Doctor diff review: 99/100; only existing component-size/state-count warnings
- Manual responsive QA covered empty, focused, typing, long text, 390px mobile, and repeated 750/751 resizing with no horizontal overflow or layout jump

`./bin/6529 run check:changed` completed formatting, lint, and typecheck successfully, then stopped at the repository-wide Knip scan because current `main` already reports unrelated unused ops scripts and exports.

## Risk

Low. The change is limited to deriving action-row visibility from the existing mobile and container-width signals; submission, uploads, drafts, and action handlers are unchanged.

## Review notes

Please focus on the responsive invariant: wide non-mobile composers always show actions, while mobile or constrained composers continue to honor the existing expand/collapse state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved composer action-option visibility across mobile and desktop layouts.
  * Ensured options update correctly when resizing or switching between responsive breakpoints.
  * Preserved consistent option behavior when changing wave content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->