### PR TITLE
Make mobile DM reactions respond immediately

### DIFF
--- a/__tests__/components/waves/drops/WaveDropActionsQuickReact.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropActionsQuickReact.test.tsx
@@ -1,0 +1,73 @@
+import WaveDropActionsQuickReact from "@/components/waves/drops/WaveDropActionsQuickReact";
+import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
+import { useDropReaction } from "@/hooks/drops/useDropReaction";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+jest.mock("@/hooks/drops/useDropReaction", () => ({
+  useDropReaction: jest.fn(),
+}));
+
+jest.mock("@/contexts/EmojiContext", () => ({
+  useEmoji: () => ({
+    emojiMap: [],
+    findNativeEmoji: jest.fn(),
+    loadEmojiData: jest.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+jest.mock("@/helpers/reactions/reactionHistory", () => ({
+  getReactionSnapshot: () => "snapshot",
+  getReactionSnapshotServer: () => "snapshot",
+  getTopReactions: () => [":+1:"],
+  subscribeToReactionStore: () => () => undefined,
+}));
+
+const mockedUseDropReaction = jest.mocked(useDropReaction);
+const drop = { id: "drop-1" } as ExtendedDrop;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+it("reports an enabled mobile quick reaction without waiting for the request", () => {
+  const react = jest.fn(() => new Promise<void>(() => undefined));
+  const onReactionStarted = jest.fn();
+  mockedUseDropReaction.mockReturnValue({ canReact: true, react });
+
+  render(
+    <WaveDropActionsQuickReact
+      drop={drop}
+      isMobile
+      onReactionStarted={onReactionStarted}
+    />
+  );
+
+  fireEvent.click(screen.getByRole("button", { name: "Click to react" }));
+
+  expect(react).toHaveBeenCalledWith(":+1:");
+  expect(onReactionStarted).toHaveBeenCalledTimes(1);
+  expect(react.mock.invocationCallOrder[0]).toBeLessThan(
+    onReactionStarted.mock.invocationCallOrder[0]!
+  );
+});
+
+it("does nothing when mobile quick reactions are disabled", () => {
+  const react = jest.fn();
+  const onReactionStarted = jest.fn();
+  mockedUseDropReaction.mockReturnValue({ canReact: false, react });
+
+  render(
+    <WaveDropActionsQuickReact
+      drop={drop}
+      isMobile
+      onReactionStarted={onReactionStarted}
+    />
+  );
+
+  const button = screen.getByRole("button", { name: "Click to react" });
+  expect(button).toBeDisabled();
+  fireEvent.click(button);
+
+  expect(react).not.toHaveBeenCalled();
+  expect(onReactionStarted).not.toHaveBeenCalled();
+});

--- a/__tests__/hooks/useDropReaction.test.ts
+++ b/__tests__/hooks/useDropReaction.test.ts
@@ -416,7 +416,7 @@ describe("useDropReaction", () => {
     expect(commonApi.commonApiDelete).not.toHaveBeenCalled();
   });
 
-  it("shows structured API error messages for quick react failures", async () => {
+  it("resolves after surfacing a structured quick react failure", async () => {
     (commonApi.commonApiPost as jest.Mock).mockRejectedValueOnce(
       createStructuredReactionError({
         body: JSON.stringify({ error: "Reaction not allowed" }),
@@ -430,7 +430,7 @@ describe("useDropReaction", () => {
     );
 
     await act(async () => {
-      await result.current.react(":smile:");
+      await expect(result.current.react(":smile:")).resolves.toBeUndefined();
     });
 
     expect(commonApi.commonApiPost).toHaveBeenCalledWith({

--- a/__tests__/hooks/useDropReaction.test.ts
+++ b/__tests__/hooks/useDropReaction.test.ts
@@ -716,6 +716,50 @@ describe("useDropReaction", () => {
     expect(rollbackMock).not.toHaveBeenCalled();
   });
 
+  it("applies the optimistic reaction without waiting for request success", async () => {
+    const request = createDeferred<ApiDrop>();
+    (commonApi.commonApiPost as jest.Mock).mockReturnValueOnce(request.promise);
+
+    const { result } = renderHook(() =>
+      useDropReaction(mockDrop, { source: "quick-react" })
+    );
+
+    let reaction!: Promise<void>;
+    act(() => {
+      reaction = result.current.react(":smile:");
+    });
+
+    expect(
+      dropReactionMonitoring.recordReactionOptimisticApplied
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      (dropReactionMonitoring.recordReactionOptimisticApplied as jest.Mock).mock
+        .invocationCallOrder[0]
+    ).toBeLessThan(
+      (commonApi.commonApiPost as jest.Mock).mock.invocationCallOrder[0]!
+    );
+    const optimisticUpdate = applyOptimisticDropUpdateMock.mock.calls[0]![0];
+    const optimisticDrop = {
+      ...mockDrop,
+      context_profile_context: { ...mockDrop.context_profile_context },
+      reactions: [...mockDrop.reactions],
+    };
+    optimisticUpdate.update(optimisticDrop);
+    expect(optimisticDrop.context_profile_context?.reaction).toBe(":smile:");
+    expect(optimisticDrop.reactions).toEqual([
+      expect.objectContaining({
+        reaction: ":smile:",
+        count: 1,
+        profiles: [expect.objectContaining({ id: "identity-1" })],
+      }),
+    ]);
+
+    await act(async () => {
+      request.resolve({} as ApiDrop);
+      await reaction;
+    });
+  });
+
   it("falls back for unsafe structured quick react failures", async () => {
     (commonApi.commonApiPost as jest.Mock).mockRejectedValueOnce(
       createStructuredReactionError({

--- a/components/waves/drops/WaveDropActionsQuickReact.tsx
+++ b/components/waves/drops/WaveDropActionsQuickReact.tsx
@@ -25,12 +25,21 @@ const DEFAULT_QUICK_REACTION_ID = "+1";
 const WaveDropActionsQuickReact: React.FC<{
   readonly drop: ExtendedDrop;
   readonly isMobile?: boolean;
-  readonly onReacted?: () => void;
-}> = ({ drop, isMobile = false, onReacted }) => {
-  const { react, canReact } = useDropReaction(drop, {
-    source: "quick-react",
-    onSuccess: onReacted,
-  });
+  readonly onReactionStarted?: () => void;
+}> = ({ drop, isMobile = false, onReactionStarted }) => {
+  const { react, canReact } = useDropReaction(drop, { source: "quick-react" });
+
+  const handleReaction = useCallback(
+    (reactionCode: string) => {
+      if (!canReact) {
+        return;
+      }
+
+      void react(reactionCode);
+      onReactionStarted?.();
+    },
+    [canReact, onReactionStarted, react]
+  );
 
   // Subscribe to localStorage changes (hydration-safe)
   useSyncExternalStore(
@@ -47,7 +56,7 @@ const WaveDropActionsQuickReact: React.FC<{
       reactionCode={code}
       dropId={drop.id}
       canReact={canReact}
-      onReact={react}
+      onReact={handleReaction}
       isMobile={isMobile}
     />
   ));

--- a/components/waves/drops/WaveDropMobileMenu.tsx
+++ b/components/waves/drops/WaveDropMobileMenu.tsx
@@ -162,7 +162,7 @@ function WaveDropMobileMenuAuthenticatedActions({
       <WaveDropActionsQuickReact
         drop={extendedDrop}
         isMobile
-        onReacted={closeMenu}
+        onReactionStarted={closeMenu}
       />
       <WaveDropActionsAddReaction
         drop={extendedDrop}

--- a/tests/social/direct-message-sandbox.spec.ts
+++ b/tests/social/direct-message-sandbox.spec.ts
@@ -92,6 +92,7 @@ test.describe("Direct message local sandbox @auth @medium @local-only", () => {
       .getByRole("button", { name: "Click to react" })
       .first();
     await openMobileDropMenu(page, drop, quickReactButton);
+    const delayedReaction = await delayReactionResponse(page);
 
     await expect(quickReactButton).toBeVisible({
       timeout: LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
@@ -101,6 +102,12 @@ test.describe("Direct message local sandbox @auth @medium @local-only", () => {
     );
 
     const optimisticReactionChip = reactionChip(drop);
+    try {
+      await delayedReaction.requestStarted;
+      await expect(quickReactButton).toHaveCount(0);
+    } finally {
+      delayedReaction.release();
+    }
     await expect(optimisticReactionChip).toBeVisible({
       timeout: LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
     });
@@ -149,7 +156,89 @@ test.describe("Direct message local sandbox @auth @medium @local-only", () => {
     await expectNoHorizontalOverflow(page);
     await expectNoUnsafeSandboxMutations(baseURL);
   });
+
+  test("closes the mobile reaction menu before a failed response rolls back", async ({
+    baseURL,
+    browserName,
+    page,
+  }, testInfo) => {
+    testInfo.skip(
+      !isCapacitorSimulationProject(testInfo.project.name) ||
+        browserName !== "chromium",
+      "This regression requires a Chromium Capacitor simulation for trusted CDP touch input."
+    );
+
+    await seedQuickReaction(page);
+    await gotoSandboxDirectMessage(page);
+
+    const drop = page.locator('[data-serial-no="1"]').first();
+    const quickReactButton = page
+      .getByRole("button", { name: "Click to react" })
+      .first();
+    await openMobileDropMenu(page, drop, quickReactButton);
+    const delayedReaction = await delayReactionResponse(page, {
+      failureMessage: "Sandbox reaction rejected",
+    });
+
+    await quickReactButton.evaluate((button: HTMLButtonElement) =>
+      button.click()
+    );
+
+    const optimisticReactionChip = reactionChip(drop);
+    try {
+      await delayedReaction.requestStarted;
+      await expect(quickReactButton).toHaveCount(0);
+    } finally {
+      delayedReaction.release();
+    }
+
+    await expect(optimisticReactionChip).toHaveCount(0, {
+      timeout: LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
+    });
+    await expect(page.getByText("Sandbox reaction rejected")).toBeVisible({
+      timeout: LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
+    });
+    expect(await getReactionMutationMethods(baseURL)).toEqual([]);
+    await expectNoUnsafeSandboxMutations(baseURL);
+  });
 });
+
+async function delayReactionResponse(
+  page: Page,
+  options?: { readonly failureMessage?: string }
+) {
+  let release!: () => void;
+  const responseGate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let markRequestStarted!: () => void;
+  const requestStarted = new Promise<void>((resolve) => {
+    markRequestStarted = resolve;
+  });
+
+  await page.route(`**${REACTION_PATH}`, async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.fallback();
+      return;
+    }
+
+    markRequestStarted();
+    await responseGate;
+
+    if (options?.failureMessage) {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: options.failureMessage }),
+      });
+      return;
+    }
+
+    await route.fallback();
+  });
+
+  return { release, requestStarted };
+}
 
 async function gotoSandboxDirectMessage(page: Page) {
   await page.goto(`/messages/${SANDBOX_DM_WAVE_ID}`, {
@@ -197,7 +286,7 @@ async function openMobileDropMenu(
   } finally {
     await cdp
       .send("Input.dispatchTouchEvent", {
-        type: "touchEnd",
+        type: "touchCancel",
         touchPoints: [],
       })
       .catch(() => undefined);

--- a/tests/social/direct-message-sandbox.spec.ts
+++ b/tests/social/direct-message-sandbox.spec.ts
@@ -284,6 +284,7 @@ async function openMobileDropMenu(
       timeout: LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
     });
   } finally {
+    // Cancel the held gesture so its release cannot retarget the opened sheet.
     await cdp
       .send("Input.dispatchTouchEvent", {
         type: "touchCancel",


### PR DESCRIPTION
## Issue

PR #3345 added mobile DM reaction coverage, but the quick-reaction action sheet still waited for the POST or DELETE request to succeed before closing. On a slow connection, tapping one of the three quick reactions therefore looked unresponsive even though the optimistic reaction had already started.

## Fix

Close the mobile quick-reaction action sheet synchronously after the enabled reaction action is invoked, instead of wiring dismissal to server success. Persistence, realtime reconciliation, rapid-mutation ownership, rollback, and the existing failure toast continue in the background.

## Notable changes

- Rename the quick-reaction callback to `onReactionStarted` so its timing is explicit.
- Guard disabled quick reactions before invoking either the reaction or dismissal callback.
- Keep the shared reaction hook, desktop quick reactions, and full emoji-picker success flow unchanged.
- Delay the sandbox reaction response to prove the mobile sheet closes before the request completes.
- Cover success persistence, failure rollback/toast, optimistic reaction data, callback ordering, and disabled behavior.
- Use CDP touch cancellation after the held long press so the synthetic release cannot activate an action-sheet item under the original touch point.

## Validation

- Confirmed the regression before the production change: the delayed-response mobile test found the quick-reaction button still present while the POST was pending.
- Focused Jest: 5 suites, 57 tests passed (reaction hook, quick reactions, mobile menu, desktop actions, and full picker).
- Capacitor Android simulation: 2 delayed mobile DM reaction tests passed (success/persistence/toggle and failure rollback/toast).
- `lint:uncommitted:tight`: passed.
- `lint:changed`: passed.
- `typecheck:changed`: passed for 2 changed TypeScript files.
- React Doctor: 100/100, no issues in 4 changed source files.
- `check:changed`: formatting, lint, and changed-file typecheck passed; its repo-wide Knip phase reported existing unrelated baseline entries outside this PR.
- Visual QA at phone dimensions confirmed the action sheet dismissed and the selected 👍 reaction chip rendered without horizontal overflow.
- The installed 6529 Staging app was opened on a connected iPhone. That already-installed build does not contain this unmerged fix, so no staging reaction mutation was used as fix evidence.

## Risk

Low. The production change is scoped to quick-reaction callback timing. The existing async mutation, optimistic state, rollback, error reporting, realtime reconciliation, and picker completion callback are unchanged.

## Review notes

The committed native-mobile evidence uses the repository's Chromium Capacitor simulation and a bounded local mock API. Physical staging was opened only to verify the requested staging-backed app surface; the unmerged branch was not deployed or injected into it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick reactions now appear immediately with optimistic updates.
  * Mobile reaction menus close as soon as a reaction starts.

* **Bug Fixes**
  * Failed reactions no longer leave behind incorrect reaction state.
  * Quick-reaction controls are disabled when reactions are unavailable.
  * Improved mobile gesture handling to prevent accidental menu retargeting.

* **Tests**
  * Added coverage for quick reactions, optimistic updates, failed requests, and mobile menu behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->