### PR TITLE
Fix cramped notifications on small phone screens

### DIFF
--- a/components/brain/notifications/drop-reacted/NotificationDropReactedGroup.tsx
+++ b/components/brain/notifications/drop-reacted/NotificationDropReactedGroup.tsx
@@ -326,7 +326,11 @@ function NotificationDropReactedGroupComponent({
           <NotificationTimestamp createdAt={createdAt} />
         </NotificationHeader>
       ) : (
-        <div className="tw-flex tw-items-center tw-gap-x-2">
+        <div className="tw-flex tw-items-start tw-gap-x-3">
+          <div
+            aria-hidden="true"
+            className="tw-h-7 tw-w-7 tw-flex-shrink-0"
+          />
           <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-wrap tw-items-center tw-gap-x-2 tw-gap-y-2">
             <div className="tw-flex tw-min-w-[min(100%,16rem)] tw-flex-1 tw-flex-wrap tw-items-center tw-gap-x-1">
               <span className="tw-mr-1 tw-text-sm tw-font-normal tw-text-iron-400">

--- a/components/brain/notifications/drop-reacted/NotificationDropReactedGroup.tsx
+++ b/components/brain/notifications/drop-reacted/NotificationDropReactedGroup.tsx
@@ -326,11 +326,7 @@ function NotificationDropReactedGroupComponent({
           <NotificationTimestamp createdAt={createdAt} />
         </NotificationHeader>
       ) : (
-        <div className="tw-flex tw-items-start tw-gap-x-3">
-          <div
-            aria-hidden="true"
-            className="tw-h-7 tw-w-7 tw-flex-shrink-0"
-          />
+        <div className="tw-flex tw-items-center tw-gap-x-2">
           <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-wrap tw-items-center tw-gap-x-2 tw-gap-y-2">
             <div className="tw-flex tw-min-w-[min(100%,16rem)] tw-flex-1 tw-flex-wrap tw-items-center tw-gap-x-1">
               <span className="tw-mr-1 tw-text-sm tw-font-normal tw-text-iron-400">
@@ -387,7 +383,11 @@ function NotificationDropReactedGroupComponent({
               <NotificationTimestamp createdAt={createdAt} />
             </div>
             {fullReactors.length > 0 && (
-              <div className="tw-max-w-full tw-flex-none">
+              <div className="tw-flex tw-max-w-full tw-flex-none tw-items-start tw-gap-x-3">
+                <div
+                  aria-hidden="true"
+                  className="tw-h-7 tw-w-7 tw-flex-shrink-0"
+                />
                 <NotificationsFollowAllBtn
                   profiles={fullReactors}
                   size={UserFollowBtnSize.SMALL}

--- a/components/brain/notifications/drop-reacted/NotificationDropReactedGroup.tsx
+++ b/components/brain/notifications/drop-reacted/NotificationDropReactedGroup.tsx
@@ -327,8 +327,8 @@ function NotificationDropReactedGroupComponent({
         </NotificationHeader>
       ) : (
         <div className="tw-flex tw-items-center tw-gap-x-2">
-          <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-items-start tw-gap-y-2 min-[390px]:tw-flex-row min-[390px]:tw-items-center min-[390px]:tw-justify-between min-[390px]:tw-gap-x-2">
-            <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-x-1">
+          <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-wrap tw-items-center tw-gap-x-2 tw-gap-y-2">
+            <div className="tw-flex tw-min-w-[min(100%,16rem)] tw-flex-1 tw-flex-wrap tw-items-center tw-gap-x-1">
               <span className="tw-mr-1 tw-text-sm tw-font-normal tw-text-iron-400">
                 New reactions
               </span>
@@ -383,7 +383,7 @@ function NotificationDropReactedGroupComponent({
               <NotificationTimestamp createdAt={createdAt} />
             </div>
             {fullReactors.length > 0 && (
-              <div className="tw-flex-shrink-0">
+              <div className="tw-max-w-full tw-flex-none">
                 <NotificationsFollowAllBtn
                   profiles={fullReactors}
                   size={UserFollowBtnSize.SMALL}

--- a/components/brain/notifications/subcomponents/NotificationHeader.tsx
+++ b/components/brain/notifications/subcomponents/NotificationHeader.tsx
@@ -39,8 +39,8 @@ export default function NotificationHeader({
           <div className="tw-h-full tw-w-full tw-flex-shrink-0 tw-rounded-md tw-bg-iron-800 tw-ring-1 tw-ring-iron-700" />
         )}
       </div>
-      <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-items-start tw-gap-y-2 min-[390px]:tw-flex-row min-[390px]:tw-items-center min-[390px]:tw-justify-between min-[390px]:tw-gap-x-2">
-        <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-x-1">
+      <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-wrap tw-items-center tw-gap-x-2 tw-gap-y-2">
+        <div className="tw-flex tw-min-w-[min(100%,16rem)] tw-flex-1 tw-flex-wrap tw-items-center tw-gap-x-1">
           <UserProfileTooltipWrapper user={author.handle ?? ""}>
             <Link
               href={`/${author.handle}`}
@@ -51,7 +51,7 @@ export default function NotificationHeader({
           </UserProfileTooltipWrapper>
           {children}
         </div>
-        {actions && <div className="tw-flex-shrink-0">{actions}</div>}
+        {actions && <div className="tw-max-w-full tw-flex-none">{actions}</div>}
       </div>
     </div>
   );

--- a/components/brain/notifications/wave-created/NotificationWaveCreated.tsx
+++ b/components/brain/notifications/wave-created/NotificationWaveCreated.tsx
@@ -64,7 +64,7 @@ export default function NotificationWaveCreated({
       <NotificationHeader
         author={notification.related_identity}
         actions={
-          <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-end tw-gap-2">
+          <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
             {waveAction}
             <NotificationsFollowBtn
               profile={notification.related_identity}

--- a/ops/docs/notifications/feature-notifications-feed.md
+++ b/ops/docs/notifications/feature-notifications-feed.md
@@ -66,6 +66,8 @@ with cause filters, grouped reactions, and inline drop previews.
   `New reactions` row with grouped avatars and reaction badges.
 - Grouped reactions rows include batch follow action:
   `Follow All` or `Following All`.
+- Header actions stay beside notification text when both remain readable and
+  wrap below it when the available width is too narrow.
 - Priority alerts show `sent a priority alert 🚨` as:
   - header-only rows (no related drop), or
   - header plus first related drop preview.

--- a/ops/docs/notifications/feature-notifications-feed.md
+++ b/ops/docs/notifications/feature-notifications-feed.md
@@ -68,8 +68,8 @@ with cause filters, grouped reactions, and inline drop previews.
   `Follow All` or `Following All`.
 - Header actions stay beside notification text when both remain readable and
   wrap below it when the available width is too narrow.
-- Multi-actor reaction summaries reserve the same leading avatar column as
-  actor notifications so labels and actions keep a consistent scan line.
+- Multi-actor reaction summaries keep their heading at the row edge while the
+  batch action follows the same scan line as actor-notification actions.
 - Priority alerts show `sent a priority alert 🚨` as:
   - header-only rows (no related drop), or
   - header plus first related drop preview.

--- a/ops/docs/notifications/feature-notifications-feed.md
+++ b/ops/docs/notifications/feature-notifications-feed.md
@@ -68,6 +68,8 @@ with cause filters, grouped reactions, and inline drop previews.
   `Follow All` or `Following All`.
 - Header actions stay beside notification text when both remain readable and
   wrap below it when the available width is too narrow.
+- Multi-actor reaction summaries reserve the same leading avatar column as
+  actor notifications so labels and actions keep a consistent scan line.
 - Priority alerts show `sent a priority alert 🚨` as:
   - header-only rows (no related drop), or
   - header plus first related drop preview.


### PR DESCRIPTION
## Issue
- Notification headers switch to a side-by-side layout at 390px even when their actions cannot fit.
- On small phones, multi-button rows such as wave invites squeeze the actor, description, wave name, and timestamp into a narrow strip and can push controls beyond the viewport.
- The grouped-reaction action begins at the row edge while other notification actions begin after the avatar column, creating an inconsistent action rail.

## Fix
- Let notification content and actions wrap according to their actual combined width.
- Preserve a readable content width whenever space permits, then move actions below the text when they no longer fit.
- Keep the multi-actor heading at the row edge while reserving the standard avatar-and-gutter width inside its batch-action block.

## Changes
- Apply the intrinsic wrapping layout to the shared notification header used across notification types.
- Apply the same behavior to grouped reaction headers with Follow All.
- Keep New reactions aligned with the row/avatar edge while placing Follow All on the same action scan line as Follow and wave actions.
- Let wave invite buttons wrap and align naturally on the narrowest phones.
- Document the responsive notification-header behavior and grouped-row alignment.

## Validation
- Changed-file ESLint: passed with zero warnings.
- Changed-file TypeScript check: passed.
- React Doctor diff scan: 100/100, no findings.
- Documentation link validation: passed across 280 Markdown files.
- Existing notification sandbox on desktop Chromium: 3/3 passed.
- Live browser QA on the local notification sandbox at 320px, 360px, 390px, 430px, 768px, and 1280px: no page overflow, readable invite text, usable single/multi-action layouts, and clean tablet/desktop transition.
- At every 320-430px viewport, New reactions stays on the row/avatar edge while Follow, Follow All, and the first wave action share the same x-coordinate exactly 40px inward; action gaps remain exactly 8px.
- Confirmed the mobile category strip keeps a visible scroll affordance and the right chevron brings the hidden Invites tab fully into view.
- The full desktop-oriented notification spec was also forced onto the mobile Playwright project; its three reply-composer cases time out in the existing hover-only reply helper before completing. The affected responsive notification flow was verified directly in the live mobile browser instead.

## Risk
- Level: Low
- Why: Tailwind-only layout changes in the shared notification header and grouped-reactions variant; notification copy and action behavior are unchanged.
- Rollback: revert the notification layout commits.

## Review Notes
- Please focus on the stable action rail, the left-anchored grouped heading, and wrapping for one action, multiple actions, and long labels around narrow-width transitions.
- The layout uses intrinsic flex wrapping rather than notification-type breakpoints, so action width determines whether actions remain beside the text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated notification layouts so reaction details and header content wrap cleanly on narrower screens.
  - Refined spacing and alignment for reaction summaries and batch actions.
  - Adjusted action container styling to better maintain consistent sizing and alignment without overflow.
- **Documentation**
  - Clarified responsive “row and action behavior,” including when header actions stay on the same line versus wrap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
