### PR TITLE
Filter expected AWS RUM abort failures

### DIFF
--- a/__tests__/components/monitoring/AwsRumProvider.test.tsx
+++ b/__tests__/components/monitoring/AwsRumProvider.test.tsx
@@ -2,21 +2,24 @@ import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import { publicEnv } from "@/config/env";
 import AwsRumProvider from "@/components/monitoring/AwsRumProvider";
-import { AwsRum } from "aws-rum-web";
+import { AwsRum, FetchPlugin, XhrPlugin } from "aws-rum-web";
 
 const WAVE_ID = `${"a".repeat(8)}-${"b".repeat(4)}-4${"c".repeat(3)}-a${"d".repeat(3)}-${"e".repeat(12)}`;
 const OTHER_WAVE_ID = `${"f".repeat(8)}-${"1".repeat(4)}-4${"2".repeat(3)}-a${"3".repeat(3)}-${"4".repeat(12)}`;
+const TEST_AUTHOR_ID = `${"1".repeat(8)}-${"2".repeat(4)}-4${"3".repeat(3)}-8${"4".repeat(3)}-${"5".repeat(12)}`;
+const MEDIA_URL = `https://media.example.cloudfront.net/renditions/drops/author_${TEST_AUTHOR_ID}/file.m3u8`;
 let mockPathname = `/waves/${WAVE_ID}`;
+
+type MockPluginContext = {
+  record: (eventType: string, eventData: object) => void;
+  recordPageView: (pageId: string) => void;
+};
 
 jest.mock("next/navigation", () => ({
   usePathname: () => mockPathname,
 }));
 
 jest.mock("aws-rum-web", () => {
-  type MockPluginContext = {
-    record: (eventType: string, eventData: object) => void;
-    recordPageView: (pageId: string) => void;
-  };
   type MockPluginConfig = {
     readonly eventPluginsToLoad?: Array<{
       load?: (context: MockPluginContext) => void;
@@ -45,6 +48,26 @@ jest.mock("aws-rum-web", () => {
       }
     };
 
+  const createHttpPlugin = (pluginId: string, config?: unknown) => {
+    let loadedContext: MockPluginContext | undefined;
+
+    return {
+      config,
+      disable: jest.fn(),
+      enable: jest.fn(),
+      getLoadedContext: () => {
+        if (!loadedContext) {
+          throw new Error(`Expected the ${pluginId} plugin to be loaded`);
+        }
+        return loadedContext;
+      },
+      getPluginId: () => pluginId,
+      load: jest.fn((context: MockPluginContext) => {
+        loadedContext = context;
+      }),
+    };
+  };
+
   return {
     AwsRum: jest.fn(
       (
@@ -68,16 +91,20 @@ jest.mock("aws-rum-web", () => {
         return instance;
       }
     ),
-    FetchPlugin: createPlugin("fetch"),
+    FetchPlugin: jest.fn((config?: unknown) =>
+      createHttpPlugin("fetch", config)
+    ),
     JsErrorPlugin: createPlugin("js-error"),
     NavigationPlugin: createPlugin("navigation"),
     ResourcePlugin: createPlugin("resource"),
     WebVitalsPlugin: createPlugin("web-vitals"),
-    XhrPlugin: createPlugin("xhr"),
+    XhrPlugin: jest.fn((config?: unknown) => createHttpPlugin("xhr", config)),
   };
 });
 
 const mockAwsRum = AwsRum as jest.Mock;
+const mockFetchPlugin = FetchPlugin as unknown as jest.Mock;
+const mockXhrPlugin = XhrPlugin as unknown as jest.Mock;
 const originalPublicEnv = { ...publicEnv };
 
 type AwsRumHttpPluginConfig = {
@@ -88,6 +115,10 @@ type MockAwsRumInstance = {
   readonly disable: jest.Mock;
   readonly recordEvent: jest.Mock;
   readonly recordPageView: jest.Mock;
+};
+
+type MockHttpPlugin = {
+  readonly getLoadedContext: () => MockPluginContext;
 };
 
 describe("AwsRumProvider", () => {
@@ -103,6 +134,8 @@ describe("AwsRumProvider", () => {
     });
     mockPathname = `/waves/${WAVE_ID}`;
     mockAwsRum.mockClear();
+    mockFetchPlugin.mockClear();
+    mockXhrPlugin.mockClear();
     delete window.awsRum;
     warnSpy = jest.spyOn(console, "warn").mockImplementation();
   });
@@ -216,6 +249,43 @@ describe("AwsRumProvider", () => {
     expect(
       JSON.stringify(getMockAwsRumInstance().recordPageView.mock.calls)
     ).not.toContain("private-profile-handle");
+  });
+
+  it("filters exact aborts before retained HTTP events reach the privacy boundary", async () => {
+    render(
+      <AwsRumProvider>
+        <div>Child content</div>
+      </AwsRumProvider>
+    );
+
+    await waitFor(() => expect(mockAwsRum).toHaveBeenCalledTimes(1));
+
+    const record = getMockAwsRumInstance().recordEvent;
+    const context = getMockHttpPlugin(mockFetchPlugin).getLoadedContext();
+    const retainedEvent = {
+      request: { method: "GET", url: MEDIA_URL },
+      error: { type: "TypeError", message: "Failed to fetch" },
+    };
+
+    context.record("com.amazon.rum.http_event", retainedEvent);
+
+    expect(record).toHaveBeenCalledWith(
+      "com.amazon.rum.http_event",
+      expect.objectContaining({
+        request: expect.objectContaining({
+          url: expect.stringContaining("/author_id/"),
+        }),
+      })
+    );
+    expect(JSON.stringify(record.mock.calls)).not.toContain(TEST_AUTHOR_ID);
+
+    const recordedEventCount = record.mock.calls.length;
+    context.record("com.amazon.rum.http_event", {
+      request: { method: "GET", url: MEDIA_URL },
+      error: { type: "AbortError", message: "The operation was aborted" },
+    });
+
+    expect(record).toHaveBeenCalledTimes(recordedEventCount);
   });
 
   it("excludes third-party analytics noise without excluding app-owned APIs", async () => {
@@ -406,16 +476,29 @@ describe("AwsRumProvider", () => {
 });
 
 const getHttpUrlsToExclude = (): RegExp[] => {
-  const plugins = getAwsRumConfig().eventPluginsToLoad ?? [];
-  const xhrConfig = plugins.find((plugin) => plugin.getPluginId() === "xhr")
-    ?.config as AwsRumHttpPluginConfig | undefined;
-  const fetchConfig = plugins.find((plugin) => plugin.getPluginId() === "fetch")
-    ?.config as AwsRumHttpPluginConfig | undefined;
+  const xhrConfig = mockXhrPlugin.mock.calls[0]?.[0] as
+    | AwsRumHttpPluginConfig
+    | undefined;
+  const fetchConfig = mockFetchPlugin.mock.calls[0]?.[0] as
+    | AwsRumHttpPluginConfig
+    | undefined;
 
   expect(xhrConfig).toBeDefined();
   expect(fetchConfig?.urlsToExclude).toEqual(xhrConfig?.urlsToExclude);
 
   return xhrConfig?.urlsToExclude ?? [];
+};
+
+const getMockHttpPlugin = (pluginConstructor: jest.Mock): MockHttpPlugin => {
+  const plugin = pluginConstructor.mock.results[0]?.value as
+    | MockHttpPlugin
+    | undefined;
+
+  if (!plugin) {
+    throw new Error("AWS RUM HTTP plugin was not initialized");
+  }
+
+  return plugin;
 };
 
 const getAwsRumConfig = (): {

--- a/__tests__/components/monitoring/AwsRumProvider.test.tsx
+++ b/__tests__/components/monitoring/AwsRumProvider.test.tsx
@@ -251,42 +251,48 @@ describe("AwsRumProvider", () => {
     ).not.toContain("private-profile-handle");
   });
 
-  it("filters exact aborts before retained HTTP events reach the privacy boundary", async () => {
-    render(
-      <AwsRumProvider>
-        <div>Child content</div>
-      </AwsRumProvider>
-    );
+  it.each([
+    { pluginName: "Fetch", pluginConstructor: mockFetchPlugin },
+    { pluginName: "XHR", pluginConstructor: mockXhrPlugin },
+  ])(
+    "filters exact $pluginName aborts before retained HTTP events reach the privacy boundary",
+    async ({ pluginConstructor }) => {
+      render(
+        <AwsRumProvider>
+          <div>Child content</div>
+        </AwsRumProvider>
+      );
 
-    await waitFor(() => expect(mockAwsRum).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(mockAwsRum).toHaveBeenCalledTimes(1));
 
-    const record = getMockAwsRumInstance().recordEvent;
-    const context = getMockHttpPlugin(mockFetchPlugin).getLoadedContext();
-    const retainedEvent = {
-      request: { method: "GET", url: MEDIA_URL },
-      error: { type: "TypeError", message: "Failed to fetch" },
-    };
+      const record = getMockAwsRumInstance().recordEvent;
+      const context = getMockHttpPlugin(pluginConstructor).getLoadedContext();
+      const retainedEvent = {
+        request: { method: "GET", url: MEDIA_URL },
+        error: { type: "TypeError", message: "Failed to fetch" },
+      };
 
-    context.record("com.amazon.rum.http_event", retainedEvent);
+      context.record("com.amazon.rum.http_event", retainedEvent);
 
-    expect(record).toHaveBeenCalledWith(
-      "com.amazon.rum.http_event",
-      expect.objectContaining({
-        request: expect.objectContaining({
-          url: expect.stringContaining("/author_id/"),
-        }),
-      })
-    );
-    expect(JSON.stringify(record.mock.calls)).not.toContain(TEST_AUTHOR_ID);
+      expect(record).toHaveBeenCalledWith(
+        "com.amazon.rum.http_event",
+        expect.objectContaining({
+          request: expect.objectContaining({
+            url: expect.stringContaining("/author_id/"),
+          }),
+        })
+      );
+      expect(JSON.stringify(record.mock.calls)).not.toContain(TEST_AUTHOR_ID);
 
-    const recordedEventCount = record.mock.calls.length;
-    context.record("com.amazon.rum.http_event", {
-      request: { method: "GET", url: MEDIA_URL },
-      error: { type: "AbortError", message: "The operation was aborted" },
-    });
+      const recordedEventCount = record.mock.calls.length;
+      context.record("com.amazon.rum.http_event", {
+        request: { method: "GET", url: MEDIA_URL },
+        error: { type: "AbortError", message: "The operation was aborted" },
+      });
 
-    expect(record).toHaveBeenCalledTimes(recordedEventCount);
-  });
+      expect(record).toHaveBeenCalledTimes(recordedEventCount);
+    }
+  );
 
   it("excludes third-party analytics noise without excluding app-owned APIs", async () => {
     render(

--- a/__tests__/utils/monitoring/awsRumExpectedAbort.test.ts
+++ b/__tests__/utils/monitoring/awsRumExpectedAbort.test.ts
@@ -1,0 +1,172 @@
+import { AwsRumExpectedAbortPlugin } from "@/utils/monitoring/awsRumExpectedAbort";
+import type { Plugin, PluginContext } from "aws-rum-web";
+
+const HTTP_EVENT_TYPE = "com.amazon.rum.http_event";
+const RESOURCE_EVENT_TYPE = "com.amazon.rum.performance_resource_event";
+
+type PluginHarness = {
+  readonly delegateDisable: jest.Mock;
+  readonly delegateEnable: jest.Mock;
+  readonly delegateLoad: jest.Mock;
+  readonly delegateRecord: jest.Mock;
+  readonly delegateUpdate: jest.Mock;
+  readonly filteredContext: () => PluginContext;
+  readonly plugin: AwsRumExpectedAbortPlugin<string>;
+  readonly record: jest.Mock;
+};
+
+function createPluginHarness(record: jest.Mock = jest.fn()): PluginHarness {
+  const delegateLoad = jest.fn();
+  const delegateEnable = jest.fn();
+  const delegateDisable = jest.fn();
+  const delegateRecord = jest.fn();
+  const delegateUpdate = jest.fn();
+  const delegate: Plugin<string> = {
+    load: delegateLoad,
+    enable: delegateEnable,
+    disable: delegateDisable,
+    getPluginId: () => "fetch",
+    record: delegateRecord,
+    update: delegateUpdate,
+  };
+  const plugin = new AwsRumExpectedAbortPlugin(delegate);
+
+  plugin.load({ record } as unknown as PluginContext);
+
+  return {
+    delegateDisable,
+    delegateEnable,
+    delegateLoad,
+    delegateRecord,
+    delegateUpdate,
+    filteredContext: () => {
+      const context = delegateLoad.mock.calls[0]?.[0] as
+        | PluginContext
+        | undefined;
+      if (!context) {
+        throw new Error("Expected the delegate plugin to be loaded");
+      }
+      return context;
+    },
+    plugin,
+    record,
+  };
+}
+
+describe("AwsRumExpectedAbortPlugin", () => {
+  it.each([
+    { type: "AbortError", message: "The operation was aborted" },
+    { type: "TypeError", message: "signal is aborted without reason" },
+    { type: "TypeError", message: "Fetch is aborted" },
+  ])("drops an exact expected HTTP cancellation %#", (error) => {
+    const harness = createPluginHarness();
+
+    harness.filteredContext().record(HTTP_EVENT_TYPE, { error });
+
+    expect(harness.record).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "successful response",
+      eventData: { response: { status: 200 } },
+    },
+    {
+      name: "HTTP client error",
+      eventData: { response: { status: 404 } },
+    },
+    {
+      name: "HTTP server error",
+      eventData: { response: { status: 503 } },
+    },
+    {
+      name: "timeout",
+      eventData: {
+        error: { type: "String", message: "XMLHttpRequest timeout" },
+      },
+    },
+    {
+      name: "unverified XHR abort shape",
+      eventData: {
+        error: { type: "String", message: "XMLHttpRequest abort" },
+      },
+    },
+    {
+      name: "generic network failure",
+      eventData: {
+        error: { type: "TypeError", message: "Failed to fetch" },
+      },
+    },
+    {
+      name: "near-match cancellation message",
+      eventData: {
+        error: { type: "TypeError", message: "Fetch is aborted by timeout" },
+      },
+    },
+  ])("preserves a $name", ({ eventData }) => {
+    const harness = createPluginHarness();
+
+    harness.filteredContext().record(HTTP_EVENT_TYPE, eventData);
+
+    expect(harness.record).toHaveBeenCalledWith(HTTP_EVENT_TYPE, eventData);
+  });
+
+  it("preserves non-HTTP telemetry even when it contains an abort error", () => {
+    const harness = createPluginHarness();
+    const eventData = {
+      error: { type: "AbortError", message: "The operation was aborted" },
+    };
+
+    harness.filteredContext().record(RESOURCE_EVENT_TYPE, eventData);
+
+    expect(harness.record).toHaveBeenCalledWith(RESOURCE_EVENT_TYPE, eventData);
+  });
+
+  it("fails open when classification throws and stays non-blocking when recording throws", () => {
+    const classificationFailure = new Proxy(
+      {},
+      {
+        get: () => {
+          throw new Error("classification failed");
+        },
+      }
+    );
+    const record = jest
+      .fn()
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => {
+        throw new Error("recording failed");
+      });
+    const harness = createPluginHarness(record);
+
+    expect(() =>
+      harness.filteredContext().record(HTTP_EVENT_TYPE, classificationFailure)
+    ).not.toThrow();
+    expect(record).toHaveBeenCalledTimes(1);
+    expect(record.mock.calls[0]?.[0]).toBe(HTTP_EVENT_TYPE);
+    expect(record.mock.calls[0]?.[1]).toBe(classificationFailure);
+    expect(() =>
+      harness.filteredContext().record(HTTP_EVENT_TYPE, {
+        error: { type: "TypeError", message: "Failed to fetch" },
+      })
+    ).not.toThrow();
+    expect(record).toHaveBeenCalledTimes(2);
+  });
+
+  it("delegates the official plugin lifecycle and manual methods", () => {
+    const harness = createPluginHarness();
+    const manualEvent = { request: { method: "GET" } };
+
+    harness.plugin.enable();
+    harness.plugin.disable();
+    harness.plugin.record(manualEvent);
+    harness.plugin.update("next-config");
+
+    expect(harness.plugin.getPluginId()).toBe("fetch");
+    expect(harness.delegateLoad).toHaveBeenCalledTimes(1);
+    expect(harness.delegateEnable).toHaveBeenCalledTimes(1);
+    expect(harness.delegateDisable).toHaveBeenCalledTimes(1);
+    expect(harness.delegateRecord).toHaveBeenCalledWith(manualEvent);
+    expect(harness.delegateUpdate).toHaveBeenCalledWith("next-config");
+  });
+});

--- a/components/monitoring/AwsRumProvider.tsx
+++ b/components/monitoring/AwsRumProvider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { publicEnv } from "@/config/env";
+import { AwsRumExpectedAbortPlugin } from "@/utils/monitoring/awsRumExpectedAbort";
 import { createAwsRumPrivacyPlugin } from "@/utils/monitoring/awsRumPrivacy";
 import { getAwsRumPageId } from "@/utils/monitoring/mobileLaunchTimingSanitizers";
 import type { AwsRum as AwsRumInstance, AwsRumConfig } from "aws-rum-web";
@@ -95,8 +96,8 @@ export default function AwsRumProvider({
             new ResourcePlugin(),
             new WebVitalsPlugin(),
             new JsErrorPlugin(),
-            new XhrPlugin(httpPluginConfig),
-            new FetchPlugin(httpPluginConfig),
+            new AwsRumExpectedAbortPlugin(new XhrPlugin(httpPluginConfig)),
+            new AwsRumExpectedAbortPlugin(new FetchPlugin(httpPluginConfig)),
           ],
           allowCookies: true,
           enableXRay: false,

--- a/components/monitoring/README.md
+++ b/components/monitoring/README.md
@@ -53,7 +53,11 @@ The AWS RUM service will automatically create:
   service traffic, Google Analytics collect, Coinbase telemetry, Mixpanel
   track/engage, and WalletConnect RPC/identity requests are excluded from HTTP
   telemetry. The provider's `urlsToExclude` list is the source of truth for the
-  exact URL patterns.
+  exact URL patterns. The provider uses the SDK's official fetch and XHR
+  plugins behind a narrow record filter that drops only `AbortError`,
+  `signal is aborted without reason`, and `Fetch is aborted` cancellation
+  failures. Successful responses, non-2xx responses, timeouts, and other
+  network failures remain visible.
 - Custom-event ownership and compatibility status are catalogued in
   `ops/telemetry/registry.json`.
 

--- a/ops/telemetry/README.md
+++ b/ops/telemetry/README.md
@@ -74,6 +74,9 @@ narrow record filter. It drops only HTTP failures whose error type is
 network failures, near-match messages, and non-HTTP telemetry remain visible.
 The filter runs before the privacy boundary, so every retained HTTP event still
 receives the existing URL sanitization.
+Classification failures fail open and preserve the original event. If the AWS
+recorder itself throws, the wrapper stays intentionally silent and non-blocking
+instead of recursively trying to report a monitoring-path failure.
 
 The AWS RUM compatibility event `drop_popup_ready` and the legacy AWS RUM-owned
 events `ab_card_impression`, `ab_card_link_out`, and `ab_card_live_open` keep

--- a/ops/telemetry/README.md
+++ b/ops/telemetry/README.md
@@ -67,6 +67,14 @@ redacts only the known WalletConnect stale-session-topic hash shape in JS error
 messages and stacks. It does not change product requests, response status,
 error classification, or external AWS configuration.
 
+AWS RUM HTTP telemetry uses the SDK's official fetch and XHR plugins behind a
+narrow record filter. It drops only HTTP failures whose error type is
+`AbortError` or whose message is exactly `signal is aborted without reason` or
+`Fetch is aborted`. Successful responses, non-2xx responses, timeouts, generic
+network failures, near-match messages, and non-HTTP telemetry remain visible.
+The filter runs before the privacy boundary, so every retained HTTP event still
+receives the existing URL sanitization.
+
 The AWS RUM compatibility event `drop_popup_ready` and the legacy AWS RUM-owned
 events `ab_card_impression`, `ab_card_link_out`, and `ab_card_live_open` keep
 their stable event names. The Art Blocks signals answer product questions, but

--- a/ops/telemetry/registry.json
+++ b/ops/telemetry/registry.json
@@ -14,7 +14,7 @@
       "automatic": ["performance", "errors", "http"],
       "sampling": "AWS_RUM_SAMPLE_RATE per browser session; default 0.2",
       "release": "public VERSION as releaseId",
-      "notes": "X-Ray, interaction telemetry, and raw automatic page views are disabled; a first-loaded privacy plugin establishes the normalized initial page before automatic telemetry plugins, manually recorded navigation uses allowlisted App Router families, author UUID media segments are bounded, and the exact WalletConnect stale-topic message shape is redacted"
+      "notes": "X-Ray, interaction telemetry, and raw automatic page views are disabled; a first-loaded privacy plugin establishes the normalized initial page before automatic telemetry plugins, manually recorded navigation uses allowlisted App Router families, author UUID media segments are bounded, the exact WalletConnect stale-topic message shape is redacted, and official fetch/XHR plugins drop only exact expected abort failures while preserving HTTP statuses, timeouts, and other network failures"
     },
     {
       "id": "sentry",

--- a/utils/monitoring/awsRumExpectedAbort.ts
+++ b/utils/monitoring/awsRumExpectedAbort.ts
@@ -1,0 +1,98 @@
+import type { Plugin, PluginContext } from "aws-rum-web";
+
+const AWS_RUM_HTTP_EVENT_TYPE = "com.amazon.rum.http_event";
+const EXPECTED_ABORT_MESSAGES = new Set([
+  "signal is aborted without reason",
+  "Fetch is aborted",
+]);
+
+type AwsRumHttpEvent = {
+  readonly error?: unknown;
+};
+
+type AwsRumHttpError = {
+  readonly type?: unknown;
+  readonly message?: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isExpectedAbortHttpEvent(
+  eventType: string,
+  eventData: object
+): boolean {
+  if (eventType !== AWS_RUM_HTTP_EVENT_TYPE) {
+    return false;
+  }
+
+  const { error } = eventData as AwsRumHttpEvent;
+  if (!isRecord(error)) {
+    return false;
+  }
+
+  const { type, message } = error as AwsRumHttpError;
+  if (type === "AbortError") {
+    return true;
+  }
+
+  return typeof message === "string" && EXPECTED_ABORT_MESSAGES.has(message);
+}
+
+function createExpectedAbortFilter(
+  record: PluginContext["record"]
+): PluginContext["record"] {
+  return (eventType, eventData) => {
+    let shouldDrop = false;
+
+    try {
+      shouldDrop = isExpectedAbortHttpEvent(eventType, eventData);
+    } catch {
+      // Preserve the event when classification fails.
+    }
+
+    if (shouldDrop) {
+      return;
+    }
+
+    try {
+      record(eventType, eventData);
+    } catch {
+      // Monitoring must not change the outcome of an application request.
+    }
+  };
+}
+
+export class AwsRumExpectedAbortPlugin<
+  UpdateType = unknown,
+> implements Plugin<UpdateType> {
+  constructor(private readonly delegate: Plugin<UpdateType>) {}
+
+  public load(context: PluginContext): void {
+    this.delegate.load({
+      ...context,
+      record: createExpectedAbortFilter(context.record),
+    });
+  }
+
+  public enable(): void {
+    this.delegate.enable();
+  }
+
+  public disable(): void {
+    this.delegate.disable();
+  }
+
+  public getPluginId(): string {
+    return this.delegate.getPluginId();
+  }
+
+  public record(data: unknown): void {
+    this.delegate.record?.(data);
+  }
+
+  public update(updateWith: UpdateType): void {
+    this.delegate.update?.(updateWith);
+  }
+}

--- a/utils/monitoring/awsRumExpectedAbort.ts
+++ b/utils/monitoring/awsRumExpectedAbort.ts
@@ -1,6 +1,8 @@
 import type { Plugin, PluginContext } from "aws-rum-web";
 
 const AWS_RUM_HTTP_EVENT_TYPE = "com.amazon.rum.http_event";
+// These exact strings come from the pinned SDK/browser cancellation shapes.
+// Near matches intentionally fail open so new failure forms stay observable.
 const EXPECTED_ABORT_MESSAGES = new Set([
   "signal is aborted without reason",
   "Fetch is aborted",


### PR DESCRIPTION
## Issue

AWS RUM currently counts proven intentional request cancellations as HTTP failures. That inflates network-failure views and makes real request failures harder to see.

## Fix

Wrap the official AWS RUM Fetch and XHR plugins at their record boundary and drop only these exact HTTP-event cancellation forms:

- error type `AbortError`
- error message `signal is aborted without reason`
- error message `Fetch is aborted`

All successful requests, HTTP status failures, timeouts, generic network errors, near matches, unverified XHR aborts, and non-HTTP telemetry remain recorded.

## Notable changes

- Add a fail-open, non-blocking expected-abort plugin wrapper.
- Keep the existing privacy sanitizer first in the AWS RUM plugin list.
- Route retained Fetch/XHR events through the existing privacy sanitizer.
- Preserve the official Fetch/XHR plugin IDs and lifecycle methods.
- Add focused classifier, delegation, ordering, privacy, and near-match tests.
- Document the exact filter contract in the monitoring docs and telemetry registry.

## Validation

- Focused Jest: 3 suites, 28 tests passed.
- `lint:diff`: passed.
- `lint:uncommitted:tight`: passed.
- `typecheck:ci`: passed.
- React Doctor: 100/100.
- Production Next.js base build: passed with the required public endpoint variables supplied.
- `check:changed`: scoped typecheck and lint stages passed; the repository-wide Knip stage reports pre-existing unused files/exports unrelated to this diff.

## Risk and rollback

Risk is limited to AWS RUM HTTP-event classification; application requests and user behavior are unchanged. The matcher is intentionally exact and fails open. Rollback is a revert of this PR.

## Review notes

Please focus on the exact-match boundary, official-plugin delegation, and plugin ordering. In particular, unverified `XMLHttpRequest abort`, 4xx/5xx responses, timeouts, generic failures, and all non-HTTP events are deliberately retained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated AWS RUM HTTP telemetry handling by filtering out expected XHR/fetch abort/cancellation events while allowing normal outcomes (including non-2xx responses and timeouts).
  * Ensured monitoring remains non-blocking if classification fails or event recording throws.

* **Bug Fixes**
  * Improved HTTP URL exclusion logic to align with the active XHR/fetch plugin configuration.

* **Tests**
  * Added/expanded coverage for expected-abort dropping behavior, fail-open handling, and non-impact on delegate lifecycle.

* **Documentation**
  * Clarified AWS RUM HTTP filtering rules, privacy boundary behavior, and provider notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->