### PR TITLE
Fix enabled button cursor states

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -280,7 +280,11 @@ button {
   font-family: inherit;
 }
 
-button:not(:disabled):not([class*="tw-cursor-"]) {
+/* Variant cursor utilities (for example disabled:tw-cursor-not-allowed) do not
+   override the enabled pointer state. Preserve only explicit base overrides. */
+button:not(:disabled):not([class^="tw-cursor-"]):not(
+    [class*=" tw-cursor-"]
+  ) {
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Issue
- Enabled buttons that include a variant cursor utility such as `disabled:tw-cursor-not-allowed` can retain the default arrow cursor.
- This is visible across Drop Forge Launch controls even though equivalent Craft controls show the expected pointer cursor.

## Fix
- Narrow the global cursor-override exclusion to explicit base `tw-cursor-*` class tokens.
- Allow state variants such as `disabled:tw-cursor-not-allowed` to coexist with the enabled pointer rule.

## Changes
- Enabled clickable buttons receive the pointer cursor consistently.
- Disabled buttons continue using their existing disabled cursor utilities.
- No disabled conditions, permissions, event handlers, or Drop Forge flow logic changed.

## Validation
- Formatting and diff checks pass.
- Verified the selector remains gated by `:not(:disabled)` and preserves explicit base cursor overrides.

## Risk
- Level: Low
- Why: One global CSS selector changes cursor presentation only; button behavior and disabled state logic are untouched.
- Rollback: Revert the single CSS commit.

## Review Notes
- Please focus on the class-token boundary matching for explicit base cursor utilities versus variant-prefixed utilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved button cursor behavior so enabled and disabled pointer states display correctly.
  * Prevented global styling from overriding specific cursor-related classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->