### PR TITLE
Fix clipped notification reaction tooltips

### DIFF
--- a/__tests__/components/waves/drops/WaveDropReactions.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropReactions.test.tsx
@@ -1069,8 +1069,9 @@ describe("WaveDropReactions", () => {
     fireEvent.mouseEnter(reactionButton);
 
     await waitFor(() => {
-      const moreButton = screen.queryByText(/and 2 others/);
+      const moreButton = screen.getByText(/and 2 others/);
       expect(moreButton).toBeInTheDocument();
+      expect(moreButton.closest("body")).toBe(document.body);
       expect(container.contains(moreButton)).toBe(false);
     });
   });

--- a/__tests__/components/waves/drops/WaveDropReactions.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropReactions.test.tsx
@@ -1044,7 +1044,7 @@ describe("WaveDropReactions", () => {
       )
     );
 
-    render(
+    const { container } = render(
       <WaveDropReactions
         drop={
           createMockDrop({
@@ -1071,6 +1071,7 @@ describe("WaveDropReactions", () => {
     await waitFor(() => {
       const moreButton = screen.queryByText(/and 2 others/);
       expect(moreButton).toBeInTheDocument();
+      expect(container.contains(moreButton)).toBe(false);
     });
   });
 

--- a/components/waves/drops/WaveDropReactions.tsx
+++ b/components/waves/drops/WaveDropReactions.tsx
@@ -36,6 +36,7 @@ import React, {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
 import { createPortal } from "react-dom";
 import { Tooltip } from "react-tooltip";
@@ -79,6 +80,8 @@ type OwnedOptimisticRollback = {
   readonly mutationId: string;
   readonly rollback: () => void;
 } | null;
+
+const REACTION_TOOLTIP_Z_INDEX = 999;
 
 const combineRollbacks = (
   rollbacks: readonly OptimisticRollback[]
@@ -366,6 +369,11 @@ function WaveDropReaction({
   readonly isDetailsLoading: boolean;
   readonly isTouchDevice: boolean;
 }) {
+  const hydrated = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false
+  );
   const { setToast, connectedProfile, activeProfileProxy } = useAuth();
   const { applyOptimisticDropUpdate } = useMyStream();
   const { getEligibility, updateEligibility } = useWaveEligibility();
@@ -854,7 +862,7 @@ function WaveDropReaction({
         </div>
       </button>
       {!isTouchDevice &&
-        typeof document !== "undefined" &&
+        hydrated &&
         createPortal(
           <Tooltip
             id={tooltipId}
@@ -866,7 +874,7 @@ function WaveDropReaction({
             style={{
               backgroundColor: "#37373E",
               color: "white",
-              zIndex: 99999,
+              zIndex: REACTION_TOOLTIP_Z_INDEX,
             }}
           >
             <div className="tw-flex tw-items-center tw-gap-2">

--- a/components/waves/drops/WaveDropReactions.tsx
+++ b/components/waves/drops/WaveDropReactions.tsx
@@ -37,6 +37,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 import { Tooltip } from "react-tooltip";
 import {
   cloneReactionEntries,
@@ -852,21 +853,29 @@ function WaveDropReaction({
           </span>
         </div>
       </button>
-      {!isTouchDevice && (
-        <Tooltip
-          id={tooltipId}
-          delayShow={250}
-          place="bottom"
-          opacity={1}
-          clickable
-          style={{ backgroundColor: "#37373E", color: "white", zIndex: 50 }}
-        >
-          <div className="tw-flex tw-items-center tw-gap-2">
-            {emojiNodeTooltip}
-            {tooltipContent}
-          </div>
-        </Tooltip>
-      )}
+      {!isTouchDevice &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <Tooltip
+            id={tooltipId}
+            delayShow={250}
+            place="bottom"
+            positionStrategy="fixed"
+            opacity={1}
+            clickable
+            style={{
+              backgroundColor: "#37373E",
+              color: "white",
+              zIndex: 99999,
+            }}
+          >
+            <div className="tw-flex tw-items-center tw-gap-2">
+              {emojiNodeTooltip}
+              {tooltipContent}
+            </div>
+          </Tooltip>,
+          document.body
+        )}
     </>
   );
 }

--- a/pr-reports/3355.md
+++ b/pr-reports/3355.md
@@ -1,0 +1,30 @@
+# PR Report: Fix clipped notification reaction tooltips
+
+PR: https://github.com/6529-Collections/6529seize-frontend/pull/3355
+Branch: `codex/fix-notification-reaction-tooltip-clipping` -> `main`
+Related PRs: None
+
+## Summary
+
+Reaction detail tooltips now remain fully visible when a drop is rendered inside a paint-contained notification row.
+
+## What Changed
+
+- Rendered reaction tooltips in the document overlay layer instead of inside the drop subtree.
+- Used fixed positioning and the established overlay stacking level so notification containment cannot clip the tooltip.
+- Added regression coverage for the portal boundary.
+
+## Frontend Impact
+
+- Routes/views: Notifications and every surface that displays drop reaction chips.
+- Components: `WaveDropReactions`.
+- Generated API/client: Not affected.
+- User-visible behavior: Hovering or focusing a reaction chip shows the complete reaction detail tooltip.
+
+## Config / Env
+
+None.
+
+## Release Notes
+
+Fixed reaction detail popovers being cut off inside notifications while preserving notification scrolling performance.

--- a/pr-reports/3355.md
+++ b/pr-reports/3355.md
@@ -11,7 +11,7 @@ Reaction detail tooltips now remain fully visible when a drop is rendered inside
 ## What Changed
 
 - Rendered reaction tooltips in the document overlay layer instead of inside the drop subtree.
-- Used fixed positioning and the established overlay stacking level so notification containment cannot clip the tooltip.
+- Used fixed positioning and a named tooltip stacking value below modal layers so notification containment cannot clip the tooltip without covering dialogs.
 - Added regression coverage for the portal boundary.
 
 ## Frontend Impact


### PR DESCRIPTION
## Issue
- Reaction detail tooltips are clipped at notification-row boundaries after notification rows adopted paint containment for smoother scrolling.

## Fix
- Render reaction tooltips in a document-level portal with fixed positioning so they are not constrained by notification paint containment.

## Changes
- Keep the existing reaction chip and tooltip experience while moving only the tooltip overlay outside contained drop layouts.
- Raise the overlay stacking level to match other app-level overlays.
- Add regression coverage proving tooltip content renders outside the reaction component subtree.

## Validation
- `./bin/6529 run check:changed`
- Focused `WaveDropReactions` test suite
- React Doctor: 99/100; only the pre-existing component-size warning remains.
- No local dev server was started.

## Risk
- Level: Low
- Why: The change is isolated to reaction tooltip placement; reaction mutations and notification virtualization remain unchanged.
- Rollback: Revert the portal placement commit.

## Review Notes
- Verify reaction tooltips remain fully visible inside notification rows and other contained drop layouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reaction detail tooltips being clipped within paint-contained notification rows.
  * Reaction tooltips now render in the document overlay layer and use a fixed positioning/stacking setup, ensuring they remain fully visible when hovering or focusing reaction chips.
* **Tests**
  * Added/strengthened regression coverage to verify the “and X more” tooltip appears outside the component container and stays attached to the expected document layer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->