### PR TITLE
Fix aggregate subwave unread pill updates

### DIFF
--- a/__tests__/components/messages/quick-dms/QuickDmListPanel.test.tsx
+++ b/__tests__/components/messages/quick-dms/QuickDmListPanel.test.tsx
@@ -67,6 +67,7 @@ const createWave = (index: number): MinimalWave => ({
   followedSubwavesCount: 0,
   latestFollowedSubwaveDropTimestamp: null,
   unreadSubwaveDrops: 0,
+  apiUnreadDropsCount: 0,
   unreadDropsCount: 0,
   latestReadTimestamp: 0,
   firstUnreadDropSerialNo: null,

--- a/__tests__/contexts/wave/hooks/useEnhancedWavesListCore.test.tsx
+++ b/__tests__/contexts/wave/hooks/useEnhancedWavesListCore.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import useEnhancedWavesListCore from "@/contexts/wave/hooks/useEnhancedWavesListCore";
 import useNewDropCounter from "@/contexts/wave/hooks/useNewDropCounter";
 
@@ -305,5 +305,26 @@ describe("useEnhancedWavesListCore", () => {
     expect(result.current.waves[0]?.unreadDropsCount).toBe(3);
     expect(result.current.waves[0]?.apiUnreadDropsCount).toBe(3);
     expect(result.current.waves[0]?.firstUnreadDropSerialNo).toBe(10);
+  });
+
+  it("uses a forced API unread count as the aggregate baseline", () => {
+    const wavesData = createWavesData({
+      mainWavesRefetch: jest.fn(),
+      refetchAllWaves: jest.fn(),
+      waves: [createSidebarWave({ unreadDropsCount: 0 })],
+    });
+
+    const { result } = renderHook(() =>
+      useEnhancedWavesListCore(null, wavesData, {
+        supportsPinning: true,
+      })
+    );
+
+    act(() => {
+      result.current.restoreWaveUnreadCount("wave-1", 1);
+    });
+
+    expect(result.current.waves[0]?.apiUnreadDropsCount).toBe(1);
+    expect(result.current.waves[0]?.unreadDropsCount).toBe(1);
   });
 });

--- a/__tests__/contexts/wave/hooks/useEnhancedWavesListCore.test.tsx
+++ b/__tests__/contexts/wave/hooks/useEnhancedWavesListCore.test.tsx
@@ -303,6 +303,7 @@ describe("useEnhancedWavesListCore", () => {
     );
 
     expect(result.current.waves[0]?.unreadDropsCount).toBe(3);
+    expect(result.current.waves[0]?.apiUnreadDropsCount).toBe(3);
     expect(result.current.waves[0]?.firstUnreadDropSerialNo).toBe(10);
   });
 });

--- a/__tests__/hooks/useSidebarWaveTree.test.tsx
+++ b/__tests__/hooks/useSidebarWaveTree.test.tsx
@@ -257,6 +257,141 @@ describe("useSidebarWaveTree", () => {
     });
   });
 
+  it("removes a locally cleared loaded subwave from the aggregate", () => {
+    const wavesWithClearedSubwave = [
+      createMockMinimalWave({
+        id: "parent",
+        hasSubwaves: true,
+        unreadSubwaveDrops: 27,
+      }),
+      createMockMinimalWave({
+        id: "cleared-child",
+        parentWaveId: "parent",
+        apiUnreadDropsCount: 7,
+        unreadDropsCount: 0,
+      }),
+      createMockMinimalWave({
+        id: "unread-child",
+        parentWaveId: "parent",
+        unreadDropsCount: 20,
+      }),
+    ];
+    const { result } = renderHook(() =>
+      useSidebarWaveTree({
+        waves: wavesWithClearedSubwave,
+        activeWaveId: "cleared-child",
+      })
+    );
+
+    const rows = result.current.getRows(result.current.topLevelWaves);
+
+    expect(rows[0]).toMatchObject({
+      hasUnreadSubwaves: true,
+      unreadSubwaveDropsCount: 20,
+    });
+    expect(rows[1]).toMatchObject({
+      rowType: "subwaves-toggle",
+      unreadSubwaveDropsCount: 20,
+    });
+  });
+
+  it("clears the aggregate when all loaded subwave unread was read", () => {
+    const wavesWithClearedSubwave = [
+      createMockMinimalWave({
+        id: "parent",
+        hasSubwaves: true,
+        unreadSubwaveDrops: 27,
+      }),
+      createMockMinimalWave({
+        id: "cleared-child",
+        parentWaveId: "parent",
+        apiUnreadDropsCount: 27,
+        unreadDropsCount: 0,
+      }),
+    ];
+    const { result } = renderHook(() =>
+      useSidebarWaveTree({
+        waves: wavesWithClearedSubwave,
+        activeWaveId: "cleared-child",
+      })
+    );
+
+    const rows = result.current.getRows(result.current.topLevelWaves);
+
+    expect(rows[0]).toMatchObject({
+      hasUnreadSubwaves: false,
+      unreadSubwaveDropsCount: 0,
+    });
+    expect(rows[1]).toMatchObject({
+      rowType: "subwaves-toggle",
+      hasUnreadSubwaves: false,
+      unreadSubwaveDropsCount: 0,
+    });
+  });
+
+  it("keeps the server aggregate remainder for subwaves that are not loaded", () => {
+    const wavesWithUnloadedSubwaveUnread = [
+      createMockMinimalWave({
+        id: "parent",
+        hasSubwaves: true,
+        unreadSubwaveDrops: 27,
+      }),
+      createMockMinimalWave({
+        id: "cleared-child",
+        parentWaveId: "parent",
+        apiUnreadDropsCount: 7,
+        unreadDropsCount: 0,
+      }),
+    ];
+    const { result } = renderHook(() =>
+      useSidebarWaveTree({
+        waves: wavesWithUnloadedSubwaveUnread,
+        activeWaveId: "cleared-child",
+      })
+    );
+
+    const rows = result.current.getRows(result.current.topLevelWaves);
+
+    expect(rows[1]).toMatchObject({
+      rowType: "subwaves-toggle",
+      unreadSubwaveDropsCount: 20,
+    });
+  });
+
+  it("shows new websocket activity after a loaded subwave was cleared", () => {
+    const wavesWithNewSubwaveActivity = [
+      createMockMinimalWave({
+        id: "parent",
+        hasSubwaves: true,
+        unreadSubwaveDrops: 27,
+      }),
+      createMockMinimalWave({
+        id: "active-child",
+        parentWaveId: "parent",
+        apiUnreadDropsCount: 27,
+        unreadDropsCount: 0,
+        newDropsCount: {
+          count: 1,
+          latestDropTimestamp: 100,
+          firstUnreadSerialNo: 28,
+        },
+      }),
+    ];
+    const { result } = renderHook(() =>
+      useSidebarWaveTree({
+        waves: wavesWithNewSubwaveActivity,
+        activeWaveId: null,
+      })
+    );
+
+    const rows = result.current.getRows(result.current.topLevelWaves);
+
+    expect(rows[1]).toMatchObject({
+      rowType: "subwaves-toggle",
+      unreadSubwaveDropsCount: 1,
+    });
+  });
+
   it("auto-expands the active subwave parent without local storage", () => {
     const onParentExpand = jest.fn();
     const { result } = renderHook(() =>

--- a/__tests__/hooks/useSidebarWaveTree.test.tsx
+++ b/__tests__/hooks/useSidebarWaveTree.test.tsx
@@ -358,6 +358,36 @@ describe("useSidebarWaveTree", () => {
     });
   });
 
+  it("does not subtract a loaded muted subwave from the server aggregate", () => {
+    const wavesWithMutedSubwave = [
+      createMockMinimalWave({
+        id: "parent",
+        hasSubwaves: true,
+        unreadSubwaveDrops: 20,
+      }),
+      createMockMinimalWave({
+        id: "muted-child",
+        parentWaveId: "parent",
+        apiUnreadDropsCount: 7,
+        unreadDropsCount: 7,
+        isMuted: true,
+      }),
+    ];
+    const { result } = renderHook(() =>
+      useSidebarWaveTree({
+        waves: wavesWithMutedSubwave,
+        activeWaveId: null,
+      })
+    );
+
+    const rows = result.current.getRows(result.current.topLevelWaves);
+
+    expect(rows[1]).toMatchObject({
+      rowType: "subwaves-toggle",
+      unreadSubwaveDropsCount: 20,
+    });
+  });
+
   it("shows new websocket activity after a loaded subwave was cleared", () => {
     const wavesWithNewSubwaveActivity = [
       createMockMinimalWave({

--- a/__tests__/utils/mockFactories.ts
+++ b/__tests__/utils/mockFactories.ts
@@ -9,6 +9,8 @@ import { ApiWaveType } from "@/generated/models/ApiWaveType";
 export function createMockMinimalWave(
   overrides: Partial<MinimalWave> = {}
 ): MinimalWave {
+  const unreadDropsCount = overrides.unreadDropsCount ?? 0;
+
   return {
     id: "mock-wave-id",
     name: "Mock Wave",
@@ -26,7 +28,8 @@ export function createMockMinimalWave(
     isOfficial: false,
     parentWaveId: null,
     hasSubwaves: false,
-    unreadDropsCount: 0,
+    apiUnreadDropsCount: overrides.apiUnreadDropsCount ?? unreadDropsCount,
+    unreadDropsCount,
     latestReadTimestamp: 0,
     firstUnreadDropSerialNo: null,
     isMuted: false,

--- a/contexts/wave/hooks/useEnhancedWavesListCore.ts
+++ b/contexts/wave/hooks/useEnhancedWavesListCore.ts
@@ -28,6 +28,7 @@ export interface MinimalWave {
   followedSubwavesCount: number;
   latestFollowedSubwaveDropTimestamp: number | null;
   unreadSubwaveDrops: number;
+  apiUnreadDropsCount: number;
   unreadDropsCount: number;
   latestReadTimestamp: number;
   firstUnreadDropSerialNo: number | null;
@@ -248,6 +249,7 @@ function useEnhancedWavesListCore(
         latestFollowedSubwaveDropTimestamp:
           wave.latestFollowedSubwaveDropTimestamp,
         unreadSubwaveDrops: wave.unreadSubwaveDrops,
+        apiUnreadDropsCount: wave.unreadDropsCount,
         unreadDropsCount,
         latestReadTimestamp: wave.latestReadTimestamp,
         firstUnreadDropSerialNo,

--- a/contexts/wave/hooks/useEnhancedWavesListCore.ts
+++ b/contexts/wave/hooks/useEnhancedWavesListCore.ts
@@ -249,7 +249,7 @@ function useEnhancedWavesListCore(
         latestFollowedSubwaveDropTimestamp:
           wave.latestFollowedSubwaveDropTimestamp,
         unreadSubwaveDrops: wave.unreadSubwaveDrops,
-        apiUnreadDropsCount: wave.unreadDropsCount,
+        apiUnreadDropsCount: forcedCount ?? wave.unreadDropsCount,
         unreadDropsCount,
         latestReadTimestamp: wave.latestReadTimestamp,
         firstUnreadDropSerialNo,

--- a/hooks/useSidebarWaveTree.ts
+++ b/hooks/useSidebarWaveTree.ts
@@ -51,7 +51,9 @@ const getUnreadSubwaveDropsCount = (
   let loadedSubwaveApiUnreadCount = 0;
   for (const subwave of subwaves) {
     loadedSubwaveUnreadCount += getUnreadDropsCount(subwave);
-    loadedSubwaveApiUnreadCount += subwave.apiUnreadDropsCount;
+    if (!subwave.isMuted) {
+      loadedSubwaveApiUnreadCount += subwave.apiUnreadDropsCount;
+    }
   }
   // Replace the loaded children portion of the API aggregate with their live
   // client counts, while preserving unread from children that are not loaded.

--- a/hooks/useSidebarWaveTree.ts
+++ b/hooks/useSidebarWaveTree.ts
@@ -36,9 +36,6 @@ export interface SidebarWaveTreeRow {
   readonly isLastSubwave: boolean;
 }
 
-const hasUnreadDrops = (wave: MinimalWave) =>
-  !wave.isMuted && (wave.unreadDropsCount > 0 || wave.newDropsCount.count > 0);
-
 const getUnreadDropsCount = (wave: MinimalWave) =>
   wave.isMuted ? 0 : Math.max(wave.unreadDropsCount, wave.newDropsCount.count);
 
@@ -50,12 +47,20 @@ const getUnreadSubwaveDropsCount = (
     return 0;
   }
 
-  const loadedSubwaveUnreadCount = subwaves.reduce(
-    (total, subwave) => total + getUnreadDropsCount(subwave),
-    0
+  let loadedSubwaveUnreadCount = 0;
+  let loadedSubwaveApiUnreadCount = 0;
+  for (const subwave of subwaves) {
+    loadedSubwaveUnreadCount += getUnreadDropsCount(subwave);
+    loadedSubwaveApiUnreadCount += subwave.apiUnreadDropsCount;
+  }
+  // Replace the loaded children portion of the API aggregate with their live
+  // client counts, while preserving unread from children that are not loaded.
+  const unloadedSubwaveUnreadCount = Math.max(
+    0,
+    wave.unreadSubwaveDrops - loadedSubwaveApiUnreadCount
   );
 
-  return Math.max(wave.unreadSubwaveDrops, loadedSubwaveUnreadCount);
+  return unloadedSubwaveUnreadCount + loadedSubwaveUnreadCount;
 };
 
 const normalizeParentIds = (value: unknown): readonly string[] => {
@@ -324,9 +329,10 @@ export function useSidebarWaveTree({
 
   const getHasUnreadSubwaves = useCallback(
     (wave: MinimalWave) =>
-      !wave.isMuted &&
-      (wave.unreadSubwaveDrops > 0 ||
-        (subwavesByParentId.get(wave.id) ?? []).some(hasUnreadDrops)),
+      getUnreadSubwaveDropsCount(
+        wave,
+        subwavesByParentId.get(wave.id) ?? []
+      ) > 0,
     [subwavesByParentId]
   );
 

--- a/ops/docs/wave-subwave-interaction-model.md
+++ b/ops/docs/wave-subwave-interaction-model.md
@@ -109,7 +109,9 @@ API returns enough parent-container metadata to do so.
   Muting the parent or an individual subwave suppresses the applicable unread
   presentation.
 - Before child rows are loaded, the parent uses the server aggregate. After
-  loading, newer child-row unread activity can increase the displayed count.
+  loading, child read state can reduce the displayed count and newer child-row
+  activity can increase it. Any server-reported remainder for unloaded children
+  stays in the aggregate.
 - Subwaves are sorted by latest activity within an expanded parent.
 - Pinned and following root sections are activity-first; discovery sections are quality-first.
 - If a parent row is present only because a followed subwave needs a container,


### PR DESCRIPTION
## Issue

The parent Wave's aggregate subwave unread pill stayed stale after a user opened a child subwave and read its messages. For example, the parent could continue showing `27 new` even though the loaded child had been cleared locally.

## Fix

Preserve each loaded wave's API unread baseline separately from its live client unread count. The sidebar aggregate replaces the loaded-child portion of the server aggregate with current child counts while retaining the server-reported remainder for children that are not loaded.

The final reconciliation also handles two review-discovered edges:

- muted loaded children do not subtract from the server aggregate;
- a count returned by `Mark as unread` becomes the child's temporary API baseline, preventing a refreshed parent aggregate from counting it twice.

## Changes

- Add `apiUnreadDropsCount` to the enhanced minimal Wave model.
- Reconcile the parent aggregate from loaded child API baselines, live unread state, and unloaded-child remainder.
- Use the reconciled count for the parent unread boolean as well as the displayed pill.
- Cover partial clearing, complete clearing, unloaded children, muted children, mark-unread forced counts, and new websocket activity.
- Update Wave/subwave interaction documentation and shared test factories.

## Validation

- Final head `810e0bc3de`:
  - focused Jest: 3 suites, 29 tests passed;
  - standard ESLint on every changed TypeScript file: passed;
  - full TypeScript project check: passed;
  - React Doctor: 100/100, no issues.
- Latest-head App PR CI passed:
  - changed-source lint and type checking;
  - related Jest tests;
  - production build;
  - small Playwright smoke pack;
  - critical route-shell Playwright pack.
- DCO, CodeQL, SonarCloud, Snyk, secret scan, and debt ratchet passed.
- CodeRabbit completed with no new actionable comments after the follow-up.
- 6529bot follow-up verdict: no new findings.
- Manual staging-backed browser QA with two profiles and multiple child subwaves:
  - parent aggregate changed `3 new` → `1 new` after reading the first child;
  - the pill disappeared after reading the second child;
  - a hard reload preserved the cleared state.

## Risk

Low to moderate. The change is isolated to sidebar unread aggregation and adds no API requests or persistent client state. Unloaded child unread remains preserved from the server aggregate, muted child state is respected, mark-unread counts are not duplicated, and websocket-created unread continues to increase the live count.

Rollback is a two-commit revert.

## Review Notes

The reconciliation formula in `useSidebarWaveTree` subtracts unmuted loaded-child API baselines from the parent server aggregate, then adds their live client counts. `useEnhancedWavesListCore` supplies the mark-unread API response as the temporary loaded baseline until normal query data catches up.

Both inline review threads were addressed with focused regressions and resolved.