### PR TITLE
Make release bus mode checks fail closed

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,130 +1,130 @@
 {
-  "$schema": "https://unpkg.com/knip@5/schema-jsonc.json",
+    "$schema": "https://unpkg.com/knip@5/schema-jsonc.json",
 
-  // 1) Tell Knip where your code lives (project graph)
-  "project": [
-    "**/*.{ts,tsx,js,jsx,cjs,mjs}",
-    "!{node_modules,.next,coverage,public}/**",
-    "!{tmp_gen_outp,tmp_gen_final}/**",
-    "!.generated-backup-*/**",
-  ],
-
-  // 2) Optionally add entries Knip can't infer from scripts/configs
-  //    (Next.js entries are auto-added by the Next plugin)
-  "entry": [
-    "scripts/**/*.{ts,js,cjs,mjs}", // local CLIs used via package.json scripts
-    "bin/**/*.mjs", // repo-local Node CLIs launched from shell helpers
-    "ops/skills/**/scripts/**/*.{js,cjs,mjs}", // repo-local skill CLIs invoked by SKILL.md instructions
-    "ops/workstreams/**/scripts/**/*.{js,cjs,mjs}", // campaign/workstream CLIs invoked per their plan docs
-    "ops/scripts/release-bus-status.mjs", // deployment CLI invoked by deploy-6529 instructions
-    "app/**/route.{ts,tsx}", // Next App Router route handlers (if used)
-    "standalone/standalone-memes-mint/src/app/layout.tsx",
-    "standalone/standalone-memes-mint/src/app/page.tsx",
-    "standalone/standalone-memes-mint/src/next.config.ts",
-    "standalone/standalone-memes-mint/src/postcss.config.js",
-    "standalone/standalone-memes-mint/src/tailwind.config.cjs",
-    "eslint.config.single.mjs",
-    "eslint.config.tight.mjs",
-    "eslint.config.diff.mjs",
-    "eslint.config.single.mjs",
-    ".deepsec/deepsec.config.ts",
-    "jest.config.js",
-    "jest.setup.js",
-    "next-sitemap.build.cjs",
-    "next-sitemap.config.ts",
-    "ops/scripts/build-delegation-docs-content.mjs",
-    "playwright.config.ts",
-    "tests/support/composerSandboxServer.cjs",
-    "services/**/index.{ts,tsx}",
-  ],
-
-  // 3) Paths: Knip auto-imports TS path aliases from tsconfig,
-  //    but you can add manual aliases here if needed.
-  // "paths": { "@/*": ["./src/*"] },
-
-  // 4) Report unused exports even in entry files (private repos benefit from this)
-  "includeEntryExports": true,
-
-  // Ignore exports explicitly tagged as API endpoints (e.g. /** @api */)
-  "tags": ["-api"],
-
-  // 5) Generated code: keep analyzing, but avoid noisy "unused exports/files" here
-  "ignoreIssues": {
-    "__mocks__/**": ["files", "exports", "types"],
-    "__tests__/**": ["files", "exports", "types"],
-    "tests/**": ["files", "exports", "types"],
-    ".deepsec/deepsec.config.ts": ["unlisted", "exports"],
-    "generated/**": ["exports", "types", "enumMembers"], // ignore only these issue kinds
-    // Backend operation-code catalog; several codes are intentionally
-    // declared before the tool implements them (see inline comments).
-    "components/allowlist-tool/allowlist-tool.types.ts": ["enumMembers"],
-    // Public auth facades preserve pre-split type exports for stable imports.
-    "components/auth/Auth.tsx": ["types"],
-    "components/auth/SeizeConnectContext.tsx": ["types"],
-    "components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx": [
-      "exports",
-      "types",
+    // 1) Tell Knip where your code lives (project graph)
+    "project": [
+      "**/*.{ts,tsx,js,jsx,cjs,mjs}",
+      "!{node_modules,.next,coverage,public}/**",
+      "!{tmp_gen_outp,tmp_gen_final}/**",
+      "!.generated-backup-*/**"
     ],
-    "components/drops/create/lexical/utils/rootContent.ts": ["exports"],
-    "components/utils/toast/AppToast.tsx": ["exports"],
-    "hooks/useAnimatedSidebarWaveRows.ts": ["exports"],
-    "hooks/useWavePreviewById.ts": ["exports"],
-    "services/**": ["files"],
-    "lib/storage/idb-keyval.ts": ["files"],
-    "playwright.config.ts": ["exports"],
-    "next-sitemap.build.cjs": ["exports"],
-    "next-sitemap.config.ts": ["exports"],
-    "jest.config.js": ["exports"],
-    "eslint.config.single.mjs": ["exports"],
-    "eslint.config.tight.mjs": ["exports"],
-    "eslint.config.diff.mjs": ["exports"],
-    "eslint.config.single.mjs": ["exports"],
-    "standalone/standalone-memes-mint/src/app/layout.tsx": ["exports"],
-    "standalone/standalone-memes-mint/src/app/page.tsx": ["exports"],
-    "standalone/standalone-memes-mint/src/next.config.ts": ["exports"],
-    "standalone/standalone-memes-mint/src/postcss.config.js": ["exports"],
-    "standalone/standalone-memes-mint/src/tailwind.config.cjs": ["exports"],
-    "utils/sentry-client-filters.ts": ["exports", "types"],
-    "lib/fetch/ssrFetch.ts": ["exports"],
-    "config/serverEnv.ts": ["exports"],
-  },
-  "ignoreFiles": [
-    "__mocks__/**",
-    "__tests__/**",
-    "**/*.test.{ts,tsx,js,jsx}",
-    "**/*.spec.{ts,tsx,js,jsx}",
-    "generated/**", // don't list generated files as "Unused files"
-    "tests/**",
-    "stubs/empty.js",
-  ],
-  "ignoreBinaries": [
-    "coderabbit",
-    // Capacitor CLI, run via npx inside the 6529-core-mobile checkout in
-    // .github/workflows/device-farm-qa.yml — not a dependency of this repo.
-    "cap",
-  ],
-  "ignoreDependencies": [
-    "pino-pretty",
-    "babel-jest",
-    "eslint-plugin-jsx-a11y",
-    "identity-obj-proxy",
-    "istanbul-lib-coverage",
-    "jest-environment-jsdom",
-    "nodemon",
-    "@openapitools/openapi-generator-cli",
-    "ts-jest",
-    "ts-morph",
-    "baseline-browser-mapping",
-    "react-doctor",
-  ],
 
-  // Disable Jest and Playwright plugins so test-only usages are reported
-  "jest": false,
-  "playwright": false,
+    // 2) Optionally add entries Knip can't infer from scripts/configs
+    //    (Next.js entries are auto-added by the Next plugin)
+    "entry": [
+      "scripts/**/*.{ts,js,cjs,mjs}",  // local CLIs used via package.json scripts
+      "bin/**/*.mjs",                // repo-local Node CLIs launched from shell helpers
+      "ops/skills/**/scripts/**/*.{js,cjs,mjs}", // repo-local skill CLIs invoked by SKILL.md instructions
+      "ops/workstreams/**/scripts/**/*.{js,cjs,mjs}", // campaign/workstream CLIs invoked per their plan docs
+      "ops/scripts/release-bus-status.mjs", // deployment CLI invoked by deploy-6529 instructions
+      "app/**/route.{ts,tsx}",         // Next App Router route handlers (if used)
+      "standalone/standalone-memes-mint/src/app/layout.tsx",
+      "standalone/standalone-memes-mint/src/app/page.tsx",
+      "standalone/standalone-memes-mint/src/next.config.ts",
+      "standalone/standalone-memes-mint/src/postcss.config.js",
+      "standalone/standalone-memes-mint/src/tailwind.config.cjs",
+      "eslint.config.single.mjs",
+      "eslint.config.tight.mjs",
+      "eslint.config.diff.mjs",
+      "eslint.config.single.mjs",
+      ".deepsec/deepsec.config.ts",
+      "jest.config.js",
+      "jest.setup.js",
+      "next-sitemap.build.cjs",
+      "next-sitemap.config.ts",
+      "ops/scripts/build-delegation-docs-content.mjs",
+      "playwright.config.ts",
+      "tests/support/composerSandboxServer.cjs",
+      "services/**/index.{ts,tsx}"
+    ],
 
-  // 6) Make config mistakes visible in CI
-  "treatConfigHintsAsErrors": true,
+    // 3) Paths: Knip auto-imports TS path aliases from tsconfig,
+    //    but you can add manual aliases here if needed.
+    // "paths": { "@/*": ["./src/*"] },
 
-  // Plugins: usually automatic. Example to force-enable if needed:
-  // "playwright": true
-}
+    // 4) Report unused exports even in entry files (private repos benefit from this)
+    "includeEntryExports": true,
+
+    // Ignore exports explicitly tagged as API endpoints (e.g. /** @api */)
+    "tags": ["-api"],
+
+    // 5) Generated code: keep analyzing, but avoid noisy "unused exports/files" here
+    "ignoreIssues": {
+      "__mocks__/**": ["files", "exports", "types"],
+      "__tests__/**": ["files", "exports", "types"],
+      "tests/**": ["files", "exports", "types"],
+      ".deepsec/deepsec.config.ts": ["unlisted", "exports"],
+      "generated/**": ["exports", "types", "enumMembers"], // ignore only these issue kinds
+      // Backend operation-code catalog; several codes are intentionally
+      // declared before the tool implements them (see inline comments).
+      "components/allowlist-tool/allowlist-tool.types.ts": ["enumMembers"],
+      // Public auth facades preserve pre-split type exports for stable imports.
+      "components/auth/Auth.tsx": ["types"],
+      "components/auth/SeizeConnectContext.tsx": ["types"],
+      "components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx": [
+        "exports",
+        "types"
+      ],
+      "components/drops/create/lexical/utils/rootContent.ts": ["exports"],
+      "components/utils/toast/AppToast.tsx": ["exports"],
+      "hooks/useAnimatedSidebarWaveRows.ts": ["exports"],
+      "hooks/useWavePreviewById.ts": ["exports"],
+      "services/**": ["files"],
+      "lib/storage/idb-keyval.ts": ["files"],
+      "playwright.config.ts": ["exports"],
+      "next-sitemap.build.cjs": ["exports"],
+      "next-sitemap.config.ts": ["exports"],
+      "jest.config.js": ["exports"],
+      "eslint.config.single.mjs": ["exports"],
+      "eslint.config.tight.mjs": ["exports"],
+      "eslint.config.diff.mjs": ["exports"],
+      "eslint.config.single.mjs": ["exports"],
+      "standalone/standalone-memes-mint/src/app/layout.tsx": ["exports"],
+      "standalone/standalone-memes-mint/src/app/page.tsx": ["exports"],
+      "standalone/standalone-memes-mint/src/next.config.ts": ["exports"],
+      "standalone/standalone-memes-mint/src/postcss.config.js": ["exports"],
+      "standalone/standalone-memes-mint/src/tailwind.config.cjs": ["exports"],
+      "utils/sentry-client-filters.ts": ["exports", "types"],
+      "lib/fetch/ssrFetch.ts": ["exports"],
+      "config/serverEnv.ts": ["exports"]
+    },
+    "ignoreFiles": [
+      "__mocks__/**",
+      "__tests__/**",
+      "**/*.test.{ts,tsx,js,jsx}",
+      "**/*.spec.{ts,tsx,js,jsx}",
+      "generated/**",        // don't list generated files as "Unused files"
+      "tests/**",
+      "stubs/empty.js"
+    ],
+    "ignoreBinaries": [
+      "coderabbit",
+      // Capacitor CLI, run via npx inside the 6529-core-mobile checkout in
+      // .github/workflows/device-farm-qa.yml — not a dependency of this repo.
+      "cap"
+    ],
+    "ignoreDependencies": [
+      "pino-pretty",
+      "babel-jest",
+      "eslint-plugin-jsx-a11y",
+      "identity-obj-proxy",
+      "istanbul-lib-coverage",
+      "jest-environment-jsdom",
+      "nodemon",
+      "@openapitools/openapi-generator-cli",
+      "ts-jest",
+      "ts-morph",
+      "baseline-browser-mapping",
+      "react-doctor"
+    ],
+
+    // Disable Jest and Playwright plugins so test-only usages are reported
+    "jest": false,
+    "playwright": false,
+
+    // 6) Make config mistakes visible in CI
+    "treatConfigHintsAsErrors": true
+
+    // Plugins: usually automatic. Example to force-enable if needed:
+    // "playwright": true
+  }

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,129 +1,130 @@
 {
-    "$schema": "https://unpkg.com/knip@5/schema-jsonc.json",
+  "$schema": "https://unpkg.com/knip@5/schema-jsonc.json",
 
-    // 1) Tell Knip where your code lives (project graph)
-    "project": [
-      "**/*.{ts,tsx,js,jsx,cjs,mjs}",
-      "!{node_modules,.next,coverage,public}/**",
-      "!{tmp_gen_outp,tmp_gen_final}/**",
-      "!.generated-backup-*/**"
+  // 1) Tell Knip where your code lives (project graph)
+  "project": [
+    "**/*.{ts,tsx,js,jsx,cjs,mjs}",
+    "!{node_modules,.next,coverage,public}/**",
+    "!{tmp_gen_outp,tmp_gen_final}/**",
+    "!.generated-backup-*/**",
+  ],
+
+  // 2) Optionally add entries Knip can't infer from scripts/configs
+  //    (Next.js entries are auto-added by the Next plugin)
+  "entry": [
+    "scripts/**/*.{ts,js,cjs,mjs}", // local CLIs used via package.json scripts
+    "bin/**/*.mjs", // repo-local Node CLIs launched from shell helpers
+    "ops/skills/**/scripts/**/*.{js,cjs,mjs}", // repo-local skill CLIs invoked by SKILL.md instructions
+    "ops/workstreams/**/scripts/**/*.{js,cjs,mjs}", // campaign/workstream CLIs invoked per their plan docs
+    "ops/scripts/release-bus-status.mjs", // deployment CLI invoked by deploy-6529 instructions
+    "app/**/route.{ts,tsx}", // Next App Router route handlers (if used)
+    "standalone/standalone-memes-mint/src/app/layout.tsx",
+    "standalone/standalone-memes-mint/src/app/page.tsx",
+    "standalone/standalone-memes-mint/src/next.config.ts",
+    "standalone/standalone-memes-mint/src/postcss.config.js",
+    "standalone/standalone-memes-mint/src/tailwind.config.cjs",
+    "eslint.config.single.mjs",
+    "eslint.config.tight.mjs",
+    "eslint.config.diff.mjs",
+    "eslint.config.single.mjs",
+    ".deepsec/deepsec.config.ts",
+    "jest.config.js",
+    "jest.setup.js",
+    "next-sitemap.build.cjs",
+    "next-sitemap.config.ts",
+    "ops/scripts/build-delegation-docs-content.mjs",
+    "playwright.config.ts",
+    "tests/support/composerSandboxServer.cjs",
+    "services/**/index.{ts,tsx}",
+  ],
+
+  // 3) Paths: Knip auto-imports TS path aliases from tsconfig,
+  //    but you can add manual aliases here if needed.
+  // "paths": { "@/*": ["./src/*"] },
+
+  // 4) Report unused exports even in entry files (private repos benefit from this)
+  "includeEntryExports": true,
+
+  // Ignore exports explicitly tagged as API endpoints (e.g. /** @api */)
+  "tags": ["-api"],
+
+  // 5) Generated code: keep analyzing, but avoid noisy "unused exports/files" here
+  "ignoreIssues": {
+    "__mocks__/**": ["files", "exports", "types"],
+    "__tests__/**": ["files", "exports", "types"],
+    "tests/**": ["files", "exports", "types"],
+    ".deepsec/deepsec.config.ts": ["unlisted", "exports"],
+    "generated/**": ["exports", "types", "enumMembers"], // ignore only these issue kinds
+    // Backend operation-code catalog; several codes are intentionally
+    // declared before the tool implements them (see inline comments).
+    "components/allowlist-tool/allowlist-tool.types.ts": ["enumMembers"],
+    // Public auth facades preserve pre-split type exports for stable imports.
+    "components/auth/Auth.tsx": ["types"],
+    "components/auth/SeizeConnectContext.tsx": ["types"],
+    "components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx": [
+      "exports",
+      "types",
     ],
+    "components/drops/create/lexical/utils/rootContent.ts": ["exports"],
+    "components/utils/toast/AppToast.tsx": ["exports"],
+    "hooks/useAnimatedSidebarWaveRows.ts": ["exports"],
+    "hooks/useWavePreviewById.ts": ["exports"],
+    "services/**": ["files"],
+    "lib/storage/idb-keyval.ts": ["files"],
+    "playwright.config.ts": ["exports"],
+    "next-sitemap.build.cjs": ["exports"],
+    "next-sitemap.config.ts": ["exports"],
+    "jest.config.js": ["exports"],
+    "eslint.config.single.mjs": ["exports"],
+    "eslint.config.tight.mjs": ["exports"],
+    "eslint.config.diff.mjs": ["exports"],
+    "eslint.config.single.mjs": ["exports"],
+    "standalone/standalone-memes-mint/src/app/layout.tsx": ["exports"],
+    "standalone/standalone-memes-mint/src/app/page.tsx": ["exports"],
+    "standalone/standalone-memes-mint/src/next.config.ts": ["exports"],
+    "standalone/standalone-memes-mint/src/postcss.config.js": ["exports"],
+    "standalone/standalone-memes-mint/src/tailwind.config.cjs": ["exports"],
+    "utils/sentry-client-filters.ts": ["exports", "types"],
+    "lib/fetch/ssrFetch.ts": ["exports"],
+    "config/serverEnv.ts": ["exports"],
+  },
+  "ignoreFiles": [
+    "__mocks__/**",
+    "__tests__/**",
+    "**/*.test.{ts,tsx,js,jsx}",
+    "**/*.spec.{ts,tsx,js,jsx}",
+    "generated/**", // don't list generated files as "Unused files"
+    "tests/**",
+    "stubs/empty.js",
+  ],
+  "ignoreBinaries": [
+    "coderabbit",
+    // Capacitor CLI, run via npx inside the 6529-core-mobile checkout in
+    // .github/workflows/device-farm-qa.yml — not a dependency of this repo.
+    "cap",
+  ],
+  "ignoreDependencies": [
+    "pino-pretty",
+    "babel-jest",
+    "eslint-plugin-jsx-a11y",
+    "identity-obj-proxy",
+    "istanbul-lib-coverage",
+    "jest-environment-jsdom",
+    "nodemon",
+    "@openapitools/openapi-generator-cli",
+    "ts-jest",
+    "ts-morph",
+    "baseline-browser-mapping",
+    "react-doctor",
+  ],
 
-    // 2) Optionally add entries Knip can't infer from scripts/configs
-    //    (Next.js entries are auto-added by the Next plugin)
-    "entry": [
-      "scripts/**/*.{ts,js,cjs,mjs}",  // local CLIs used via package.json scripts
-      "bin/**/*.mjs",                // repo-local Node CLIs launched from shell helpers
-      "ops/skills/**/scripts/**/*.{js,cjs,mjs}", // repo-local skill CLIs invoked by SKILL.md instructions
-      "ops/workstreams/**/scripts/**/*.{js,cjs,mjs}", // campaign/workstream CLIs invoked per their plan docs
-      "app/**/route.{ts,tsx}",         // Next App Router route handlers (if used)
-      "standalone/standalone-memes-mint/src/app/layout.tsx",
-      "standalone/standalone-memes-mint/src/app/page.tsx",
-      "standalone/standalone-memes-mint/src/next.config.ts",
-      "standalone/standalone-memes-mint/src/postcss.config.js",
-      "standalone/standalone-memes-mint/src/tailwind.config.cjs",
-      "eslint.config.single.mjs",
-      "eslint.config.tight.mjs",
-      "eslint.config.diff.mjs",
-      "eslint.config.single.mjs",
-      ".deepsec/deepsec.config.ts",
-      "jest.config.js",
-      "jest.setup.js",
-      "next-sitemap.build.cjs",
-      "next-sitemap.config.ts",
-      "ops/scripts/build-delegation-docs-content.mjs",
-      "playwright.config.ts",
-      "tests/support/composerSandboxServer.cjs",
-      "services/**/index.{ts,tsx}"
-    ],
+  // Disable Jest and Playwright plugins so test-only usages are reported
+  "jest": false,
+  "playwright": false,
 
-    // 3) Paths: Knip auto-imports TS path aliases from tsconfig,
-    //    but you can add manual aliases here if needed.
-    // "paths": { "@/*": ["./src/*"] },
+  // 6) Make config mistakes visible in CI
+  "treatConfigHintsAsErrors": true,
 
-    // 4) Report unused exports even in entry files (private repos benefit from this)
-    "includeEntryExports": true,
-
-    // Ignore exports explicitly tagged as API endpoints (e.g. /** @api */)
-    "tags": ["-api"],
-
-    // 5) Generated code: keep analyzing, but avoid noisy "unused exports/files" here
-    "ignoreIssues": {
-      "__mocks__/**": ["files", "exports", "types"],
-      "__tests__/**": ["files", "exports", "types"],
-      "tests/**": ["files", "exports", "types"],
-      ".deepsec/deepsec.config.ts": ["unlisted", "exports"],
-      "generated/**": ["exports", "types", "enumMembers"], // ignore only these issue kinds
-      // Backend operation-code catalog; several codes are intentionally
-      // declared before the tool implements them (see inline comments).
-      "components/allowlist-tool/allowlist-tool.types.ts": ["enumMembers"],
-      // Public auth facades preserve pre-split type exports for stable imports.
-      "components/auth/Auth.tsx": ["types"],
-      "components/auth/SeizeConnectContext.tsx": ["types"],
-      "components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx": [
-        "exports",
-        "types"
-      ],
-      "components/drops/create/lexical/utils/rootContent.ts": ["exports"],
-      "components/utils/toast/AppToast.tsx": ["exports"],
-      "hooks/useAnimatedSidebarWaveRows.ts": ["exports"],
-      "hooks/useWavePreviewById.ts": ["exports"],
-      "services/**": ["files"],
-      "lib/storage/idb-keyval.ts": ["files"],
-      "playwright.config.ts": ["exports"],
-      "next-sitemap.build.cjs": ["exports"],
-      "next-sitemap.config.ts": ["exports"],
-      "jest.config.js": ["exports"],
-      "eslint.config.single.mjs": ["exports"],
-      "eslint.config.tight.mjs": ["exports"],
-      "eslint.config.diff.mjs": ["exports"],
-      "eslint.config.single.mjs": ["exports"],
-      "standalone/standalone-memes-mint/src/app/layout.tsx": ["exports"],
-      "standalone/standalone-memes-mint/src/app/page.tsx": ["exports"],
-      "standalone/standalone-memes-mint/src/next.config.ts": ["exports"],
-      "standalone/standalone-memes-mint/src/postcss.config.js": ["exports"],
-      "standalone/standalone-memes-mint/src/tailwind.config.cjs": ["exports"],
-      "utils/sentry-client-filters.ts": ["exports", "types"],
-      "lib/fetch/ssrFetch.ts": ["exports"],
-      "config/serverEnv.ts": ["exports"]
-    },
-    "ignoreFiles": [
-      "__mocks__/**",
-      "__tests__/**",
-      "**/*.test.{ts,tsx,js,jsx}",
-      "**/*.spec.{ts,tsx,js,jsx}",
-      "generated/**",        // don't list generated files as "Unused files"
-      "tests/**",
-      "stubs/empty.js"
-    ],
-    "ignoreBinaries": [
-      "coderabbit",
-      // Capacitor CLI, run via npx inside the 6529-core-mobile checkout in
-      // .github/workflows/device-farm-qa.yml — not a dependency of this repo.
-      "cap"
-    ],
-    "ignoreDependencies": [
-      "pino-pretty",
-      "babel-jest",
-      "eslint-plugin-jsx-a11y",
-      "identity-obj-proxy",
-      "istanbul-lib-coverage",
-      "jest-environment-jsdom",
-      "nodemon",
-      "@openapitools/openapi-generator-cli",
-      "ts-jest",
-      "ts-morph",
-      "baseline-browser-mapping",
-      "react-doctor"
-    ],
-
-    // Disable Jest and Playwright plugins so test-only usages are reported
-    "jest": false,
-    "playwright": false,
-
-    // 6) Make config mistakes visible in CI
-    "treatConfigHintsAsErrors": true
-
-    // Plugins: usually automatic. Example to force-enable if needed:
-    // "playwright": true
-  }
+  // Plugins: usually automatic. Example to force-enable if needed:
+  // "playwright": true
+}

--- a/ops/docs/developer/deployment-bus-automation.md
+++ b/ops/docs/developer/deployment-bus-automation.md
@@ -137,11 +137,12 @@ node ops/scripts/release-bus-status.mjs
 It uses the authenticated `gh` token internally to call
 `GET https://api.6529.io/deploy/release-bus/controls`, validates all required
 states, and suppresses tokens, raw API payloads, and authentication-command
-output. `RELEASE_BUS_API_URL` may override the API base for tests. Missing or
-unauthenticated `gh`, network and timeout failures, HTTP errors, malformed JSON,
-unknown modes, or missing controls are terminal preflight failures. Agents do
-not fall back to AWS CLI or infer a route from the browser, docs, workflows, or
-earlier state.
+output. `RELEASE_BUS_API_URL` may override the API base only with a loopback
+test server; arbitrary hosts are rejected before the helper obtains a token.
+Missing or unauthenticated `gh`, network and timeout failures, HTTP errors,
+malformed JSON, unknown modes, or missing controls are terminal preflight
+failures. Agents do not fall back to AWS CLI or infer a route from the browser,
+docs, workflows, or earlier state.
 
 Run the helper on receipt of a release request, immediately before readiness or
 manual mutation, and again before production after a significant wait. Stop if

--- a/ops/docs/developer/deployment-bus-automation.md
+++ b/ops/docs/developer/deployment-bus-automation.md
@@ -128,6 +128,32 @@ the live version.
 
 ## Modes
 
+Agents discover live mode only through the repository helper:
+
+```bash
+node ops/scripts/release-bus-status.mjs
+```
+
+It uses the authenticated `gh` token internally to call
+`GET https://api.6529.io/deploy/release-bus/controls`, validates all required
+states, and suppresses tokens, raw API payloads, and authentication-command
+output. `RELEASE_BUS_API_URL` may override the API base for tests. Missing or
+unauthenticated `gh`, network and timeout failures, HTTP errors, malformed JSON,
+unknown modes, or missing controls are terminal preflight failures. Agents do
+not fall back to AWS CLI or infer a route from the browser, docs, workflows, or
+earlier state.
+
+Run the helper on receipt of a release request, immediately before readiness or
+manual mutation, and again before production after a significant wait. Stop if
+`ALL` or the relevant lane is paused.
+
+| Live mode    | Staging route                        | Production route                           |
+| ------------ | ------------------------------------ | ------------------------------------------ |
+| `OFF`        | Legacy manual; no bus candidate      | Legacy manual                              |
+| `SHADOW`     | Record shadow candidate, then manual | Record shadow evidence, then manual        |
+| `STAGING`    | Release Bus                          | Operator/manual; no production train       |
+| `PRODUCTION` | Release Bus                          | Release Bus with the staging-validated SHA |
+
 `RELEASE_BUS_MODE` has four values:
 
 - `OFF`: no trains are collected.
@@ -152,9 +178,13 @@ The readiness API enforces those boundaries:
   a rollout mode was reduced after the original submission. Shadow-only
   candidates do not gain a status when cancelled.
 
-`RELEASE_BUS_ENFORCEMENT=true` in each GitHub repository turns legacy manual
-deployments into operator-only audited break glass. Enable it only after the
-corresponding bus mode is healthy.
+AWS `RELEASE_BUS_MODE` controls runtime ownership and API readiness acceptance.
+GitHub `RELEASE_BUS_ENFORCEMENT` is separate: exact `true` in a repository turns
+legacy manual deployments into operator-only audited break glass. Agents inspect
+the live Actions variable in every repository selected for a manual route.
+`OFF` or `SHADOW` with enforcement enabled is a rollout mismatch and blocks the
+release until an operator reconciles configuration. Enable enforcement only
+after the corresponding bus mode is healthy.
 
 ## Required external setup
 

--- a/ops/docs/developer/deployment-bus-process.md
+++ b/ops/docs/developer/deployment-bus-process.md
@@ -1,30 +1,71 @@
 # Staging and Production Deployment Bus
 
-Status: implemented behind rollout controls. The normal path becomes authoritative
-only after the release-bus infrastructure, GitHub App, secrets, repository rules,
-and `RELEASE_BUS_ENFORCEMENT` switch are enabled.
+Status: implemented behind rollout controls. The live API mode selects the
+release route; repository enforcement separately controls whether a manual
+route requires audited break glass.
 
 ## What changes for developers
 
-The rollout mode is authoritative. Before submitting readiness, authenticate at
-`/deploy/ui/bus` and read its current mode:
+The live rollout mode is authoritative. The canonical agent preflight in both
+repositories is:
 
-- `OFF`: readiness is rejected. Continue using the existing manual release
-  path.
-- `SHADOW`: readiness records a decision only. It does not create a GitHub
-  status, stage, merge, or deploy; use the manual path for an actual release.
-- `STAGING`: the bus owns staging readiness, while production remains on the
-  existing manual path.
-- `PRODUCTION`: the bus owns both staging and production readiness.
+```bash
+node ops/scripts/release-bus-status.mjs
+```
 
-Do not infer that the bus is live merely because its code, UI, or workflows are
-present. Agents must recheck the mode immediately before submission.
+The helper requires an installed, authenticated `gh`, obtains its token
+internally, calls the production controls API, validates the mode plus `ALL`,
+`STAGING`, and `PRODUCTION`, and prints only sanitized state:
+
+```json
+{
+  "mode": "OFF",
+  "controls": {
+    "ALL": "RUNNING",
+    "STAGING": "RUNNING",
+    "PRODUCTION": "RUNNING"
+  }
+}
+```
+
+Run it when a release request arrives, immediately before readiness, immediately
+before a manual merge or workflow dispatch, and again before production after a
+significant wait. Do not substitute documentation, conversation state, a
+previous release's mode, workflow configuration, AWS assumptions, repository
+files, or the browser UI. A signed-in browser session alone does not authenticate
+the Release Bus API; the helper deliberately uses the developer's authenticated
+`gh` session.
+
+Status discovery is fail-closed. Missing or unauthenticated `gh`, timeouts,
+network or authentication errors, malformed JSON, unknown modes, and incomplete
+controls all stop the release before mutation. Failure never means `OFF` and
+never means “bus enabled.” Agents must not fall back to AWS CLI, queue a
+candidate, merge, or deploy while status is unknown.
+
+| Live mode    | Staging behavior                                                 | Production behavior                                                         |
+| ------------ | ---------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `OFF`        | Use the legacy manual path; do not queue in the bus              | Use the legacy manual path                                                  |
+| `SHADOW`     | Record the candidate for shadow evaluation, then deploy manually | Record shadow evidence as designed, then deploy manually                    |
+| `STAGING`    | Submit through the Release Bus and wait for validation           | Follow the operator/manual production path; do not queue a production train |
+| `PRODUCTION` | Submit through the Release Bus                                   | Submit the staging-validated SHA through the Release Bus                    |
+
+If `ALL` or the relevant lane is paused, stop and report the paused scope.
+After an active bus lane accepts a candidate, do not start a parallel manual
+deployment.
+
+For a manual route, inspect `RELEASE_BUS_ENFORCEMENT` in every affected
+repository with authenticated `gh`. `OFF` or `SHADOW` combined with enabled
+enforcement is a configuration mismatch and requires an operator. If the
+manual route is enforced, only an organization owner or active
+`release-bus-operators` member may continue, with a non-empty audited
+break-glass reason. Never bypass a blocked workflow.
 
 Developers and agents no longer need to merge feature branches into
 `1a-staging`, dispatch staging deployments, merge source PRs to `main`, or
 dispatch production deployments on a lane currently owned by the bus.
 
-Instead, use the Release Bus panel at `/deploy/ui/bus`:
+When the table selects a bus route, use the Release Bus panel at
+`/deploy/ui/bus`:
 
 1. Select frontend or backend and enter the developer branch.
 2. Resolve and review its exact 40-character head SHA.

--- a/ops/scripts/release-bus-status.mjs
+++ b/ops/scripts/release-bus-status.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+
+const DEFAULT_API_URL = "https://api.6529.io";
+const DEFAULT_TIMEOUT_MS = 10_000;
+const MAX_TIMEOUT_MS = 60_000;
+const REQUIRED_SCOPES = ["ALL", "STAGING", "PRODUCTION"];
+const VALID_MODES = new Set(["OFF", "SHADOW", "STAGING", "PRODUCTION"]);
+
+class SafeStatusError extends Error {}
+
+function runGh(args) {
+  const result = spawnSync("gh", args, {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 10_000,
+  });
+
+  if (result.error?.code === "ENOENT") {
+    throw new SafeStatusError(
+      "GitHub CLI (gh) is required. Install it and retry."
+    );
+  }
+  return result;
+}
+
+function getGitHubToken() {
+  const auth = runGh(["auth", "status"]);
+  if (auth.status !== 0) {
+    throw new SafeStatusError(
+      "GitHub CLI is not authenticated. Run gh auth login and retry."
+    );
+  }
+
+  const tokenResult = runGh(["auth", "token"]);
+  const token = tokenResult.stdout?.trim();
+  if (tokenResult.status !== 0 || !token) {
+    throw new SafeStatusError(
+      "Unable to obtain an authenticated GitHub token from gh."
+    );
+  }
+  return token;
+}
+
+function getTimeoutMs() {
+  const configured =
+    process.env.RELEASE_BUS_STATUS_TIMEOUT_MS ?? String(DEFAULT_TIMEOUT_MS);
+  const timeoutMs = Number(configured);
+  if (
+    !Number.isInteger(timeoutMs) ||
+    timeoutMs < 1 ||
+    timeoutMs > MAX_TIMEOUT_MS
+  ) {
+    throw new SafeStatusError(
+      "RELEASE_BUS_STATUS_TIMEOUT_MS must be an integer from 1 to 60000."
+    );
+  }
+  return timeoutMs;
+}
+
+function getStatusUrl() {
+  const configured = process.env.RELEASE_BUS_API_URL?.trim() || DEFAULT_API_URL;
+  let baseUrl;
+  try {
+    baseUrl = new URL(configured);
+  } catch {
+    throw new SafeStatusError("RELEASE_BUS_API_URL must be a valid HTTP URL.");
+  }
+  if (baseUrl.protocol !== "https:" && baseUrl.protocol !== "http:") {
+    throw new SafeStatusError("RELEASE_BUS_API_URL must be a valid HTTP URL.");
+  }
+  return new URL("/deploy/release-bus/controls", baseUrl);
+}
+
+function normalizePaused(value) {
+  if (value === true || value === 1) return true;
+  if (value === false || value === 0) return false;
+  throw new SafeStatusError(
+    "Release Bus status API returned invalid status data."
+  );
+}
+
+function sanitizeStatus(payload) {
+  if (
+    payload === null ||
+    typeof payload !== "object" ||
+    Array.isArray(payload) ||
+    !VALID_MODES.has(payload.mode) ||
+    !Array.isArray(payload.controls)
+  ) {
+    throw new SafeStatusError(
+      "Release Bus status API returned invalid status data."
+    );
+  }
+
+  const controls = {};
+  for (const scope of REQUIRED_SCOPES) {
+    const matches = payload.controls.filter(
+      (control) =>
+        control !== null &&
+        typeof control === "object" &&
+        !Array.isArray(control) &&
+        control.scope === scope
+    );
+    if (matches.length !== 1) {
+      throw new SafeStatusError(
+        "Release Bus status API returned incomplete control information."
+      );
+    }
+    controls[scope] = normalizePaused(matches[0].paused) ? "PAUSED" : "RUNNING";
+  }
+
+  return { mode: payload.mode, controls };
+}
+
+async function requestStatus(token) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), getTimeoutMs());
+  timeout.unref();
+
+  let response;
+  try {
+    response = await fetch(getStatusUrl(), {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      redirect: "error",
+      signal: controller.signal,
+    });
+  } catch {
+    if (controller.signal.aborted) {
+      throw new SafeStatusError("Release Bus status API request timed out.");
+    }
+    throw new SafeStatusError("Release Bus status API is unavailable.");
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    throw new SafeStatusError(
+      `Release Bus status authentication failed (HTTP ${response.status}).`
+    );
+  }
+  if (!response.ok) {
+    throw new SafeStatusError(
+      `Release Bus status API returned HTTP ${response.status}.`
+    );
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(await response.text());
+  } catch {
+    throw new SafeStatusError(
+      "Release Bus status API returned malformed JSON."
+    );
+  }
+  return sanitizeStatus(payload);
+}
+
+async function main() {
+  const token = getGitHubToken();
+  const status = await requestStatus(token);
+  process.stdout.write(`${JSON.stringify(status, null, 2)}\n`);
+}
+
+main().catch((error) => {
+  const message =
+    error instanceof SafeStatusError
+      ? error.message
+      : "Unable to determine Release Bus status.";
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+});

--- a/ops/scripts/release-bus-status.mjs
+++ b/ops/scripts/release-bus-status.mjs
@@ -7,6 +7,7 @@ const DEFAULT_TIMEOUT_MS = 10_000;
 const MAX_TIMEOUT_MS = 60_000;
 const REQUIRED_SCOPES = ["ALL", "STAGING", "PRODUCTION"];
 const VALID_MODES = new Set(["OFF", "SHADOW", "STAGING", "PRODUCTION"]);
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "[::1]", "localhost"]);
 
 class SafeStatusError extends Error {}
 
@@ -66,7 +67,8 @@ function getTimeoutMs() {
 }
 
 function getStatusUrl() {
-  const configured = process.env.RELEASE_BUS_API_URL?.trim() || DEFAULT_API_URL;
+  const override = process.env.RELEASE_BUS_API_URL?.trim();
+  const configured = override || DEFAULT_API_URL;
   let baseUrl;
   try {
     baseUrl = new URL(configured);
@@ -75,6 +77,11 @@ function getStatusUrl() {
   }
   if (baseUrl.protocol !== "https:" && baseUrl.protocol !== "http:") {
     throw new SafeStatusError("RELEASE_BUS_API_URL must be a valid HTTP URL.");
+  }
+  if (override && !LOOPBACK_HOSTS.has(baseUrl.hostname)) {
+    throw new SafeStatusError(
+      "RELEASE_BUS_API_URL override may target only a loopback test server."
+    );
   }
   return new URL("/deploy/release-bus/controls", baseUrl);
 }
@@ -120,14 +127,14 @@ function sanitizeStatus(payload) {
   return { mode: payload.mode, controls };
 }
 
-async function requestStatus(token) {
+async function requestStatus(token, statusUrl, timeoutMs) {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), getTimeoutMs());
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
   timeout.unref();
 
   let response;
   try {
-    response = await fetch(getStatusUrl(), {
+    response = await fetch(statusUrl, {
       headers: {
         Accept: "application/json",
         Authorization: `Bearer ${token}`,
@@ -167,8 +174,10 @@ async function requestStatus(token) {
 }
 
 try {
+  const timeoutMs = getTimeoutMs();
+  const statusUrl = getStatusUrl();
   const token = getGitHubToken();
-  const status = await requestStatus(token);
+  const status = await requestStatus(token, statusUrl, timeoutMs);
   process.stdout.write(`${JSON.stringify(status, null, 2)}\n`);
 } catch (error) {
   const message =

--- a/ops/scripts/release-bus-status.mjs
+++ b/ops/scripts/release-bus-status.mjs
@@ -11,12 +11,17 @@ const VALID_MODES = new Set(["OFF", "SHADOW", "STAGING", "PRODUCTION"]);
 class SafeStatusError extends Error {}
 
 function runGh(args) {
-  const result = spawnSync("gh", args, {
-    encoding: "utf8",
-    maxBuffer: 1024 * 1024,
-    stdio: ["ignore", "pipe", "pipe"],
-    timeout: 10_000,
-  });
+  const result =
+    /* NOSONAR -- Local operator controls PATH; no Release Bus input selects the executable. */ spawnSync(
+      "gh",
+      args,
+      {
+        encoding: "utf8",
+        maxBuffer: 1024 * 1024,
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 10_000,
+      }
+    );
 
   if (result.error?.code === "ENOENT") {
     throw new SafeStatusError(
@@ -161,17 +166,15 @@ async function requestStatus(token) {
   return sanitizeStatus(payload);
 }
 
-async function main() {
+try {
   const token = getGitHubToken();
   const status = await requestStatus(token);
   process.stdout.write(`${JSON.stringify(status, null, 2)}\n`);
-}
-
-main().catch((error) => {
+} catch (error) {
   const message =
     error instanceof SafeStatusError
       ? error.message
       : "Unable to determine Release Bus status.";
   process.stderr.write(`${message}\n`);
   process.exitCode = 1;
-});
+}

--- a/ops/scripts/release-bus-status.mjs
+++ b/ops/scripts/release-bus-status.mjs
@@ -12,17 +12,16 @@ const LOOPBACK_HOSTS = new Set(["127.0.0.1", "[::1]", "localhost"]);
 class SafeStatusError extends Error {}
 
 function runGh(args) {
-  const result =
-    /* NOSONAR -- Local operator controls PATH; no Release Bus input selects the executable. */ spawnSync(
-      "gh",
-      args,
-      {
-        encoding: "utf8",
-        maxBuffer: 1024 * 1024,
-        stdio: ["ignore", "pipe", "pipe"],
-        timeout: 10_000,
-      }
-    );
+  const result = spawnSync(
+    "gh", // NOSONAR -- Local operator controls PATH; no Release Bus input selects the executable.
+    args,
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 10_000,
+    }
+  );
 
   if (result.error?.code === "ENOENT") {
     throw new SafeStatusError(

--- a/ops/scripts/release-bus-status.test.ts
+++ b/ops/scripts/release-bus-status.test.ts
@@ -1,0 +1,273 @@
+import { execFile } from "node:child_process";
+import { chmod, mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { createServer, type RequestListener, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/* eslint-disable security/detect-non-literal-fs-filename -- Test paths are confined to a fresh OS temp directory. */
+
+const HELPER_PATH = path.resolve(__dirname, "release-bus-status.mjs");
+const TOKEN = "test-token-that-must-never-be-printed";
+const VALID_CONTROLS = [
+  { scope: "ALL", paused: 0 },
+  { scope: "STAGING", paused: false },
+  { scope: "PRODUCTION", paused: 0 },
+];
+
+type HelperResult = {
+  readonly code: number;
+  readonly stdout: string;
+  readonly stderr: string;
+};
+
+type TestServer = {
+  readonly url: string;
+  readonly server: Server;
+};
+
+let tempRoot: string;
+let mockBin: string;
+let emptyBin: string;
+
+beforeAll(async () => {
+  tempRoot = await mkdtemp(path.join(tmpdir(), "release-bus-status-"));
+  mockBin = path.join(tempRoot, "mock-bin");
+  emptyBin = path.join(tempRoot, "empty-bin");
+  await mkdir(mockBin);
+  await mkdir(emptyBin);
+  const ghPath = path.join(mockBin, "gh");
+  await writeFile(
+    ghPath,
+    [
+      "#!/bin/sh",
+      'if [ "$1" = "auth" ] && [ "$2" = "status" ]; then',
+      '  if [ "${MOCK_GH_AUTHENTICATED:-1}" = "1" ]; then exit 0; fi',
+      "  exit 1",
+      "fi",
+      'if [ "$1" = "auth" ] && [ "$2" = "token" ]; then',
+      '  printf "%s\\n" "${MOCK_GH_TOKEN:-}"',
+      "  exit 0",
+      "fi",
+      "exit 2",
+      "",
+    ].join("\n"),
+    "utf8"
+  );
+  await chmod(ghPath, 0o700);
+});
+
+afterAll(async () => {
+  await rm(tempRoot, { recursive: true, force: true });
+});
+
+function runHelper(overrides: NodeJS.ProcessEnv = {}): Promise<HelperResult> {
+  return new Promise((resolve) => {
+    execFile(
+      process.execPath,
+      [HELPER_PATH],
+      {
+        env: {
+          // eslint-disable-next-line no-restricted-syntax -- The isolated subprocess needs the test runner environment.
+          ...process.env,
+          PATH: mockBin,
+          MOCK_GH_AUTHENTICATED: "1",
+          MOCK_GH_TOKEN: TOKEN,
+          ...overrides,
+        },
+        maxBuffer: 1024 * 1024,
+        timeout: 5_000,
+      },
+      (error, stdout, stderr) => {
+        const output = `${stdout}${stderr}`;
+        expect(output).not.toContain(TOKEN);
+        resolve({
+          code:
+            error === null
+              ? 0
+              : typeof error.code === "number"
+                ? error.code
+                : 1,
+          stdout,
+          stderr,
+        });
+      }
+    );
+  });
+}
+
+async function startServer(listener: RequestListener): Promise<TestServer> {
+  const server = createServer(listener);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("Test server did not bind to a TCP port");
+  }
+  return { url: `http://127.0.0.1:${address.port}`, server };
+}
+
+async function stopServer(server: Server): Promise<void> {
+  server.closeAllConnections?.();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+async function runWithResponse(
+  body: unknown,
+  status = 200
+): Promise<HelperResult & { readonly authorization: string | undefined }> {
+  let authorization: string | undefined;
+  const testServer = await startServer((request, response) => {
+    authorization = request.headers.authorization;
+    response.writeHead(status, { "Content-Type": "application/json" });
+    response.end(typeof body === "string" ? body : JSON.stringify(body));
+  });
+  try {
+    return {
+      ...(await runHelper({ RELEASE_BUS_API_URL: testServer.url })),
+      authorization,
+    };
+  } finally {
+    await stopServer(testServer.server);
+  }
+}
+
+describe("release-bus-status helper", () => {
+  test.each(["OFF", "SHADOW", "STAGING", "PRODUCTION"])(
+    "prints sanitized status for %s mode",
+    async (mode) => {
+      const result = await runWithResponse({
+        mode,
+        controls: VALID_CONTROLS,
+      });
+
+      expect(result.code).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(result.authorization).toBe(`Bearer ${TOKEN}`);
+      expect(JSON.parse(result.stdout)).toEqual({
+        mode,
+        controls: {
+          ALL: "RUNNING",
+          STAGING: "RUNNING",
+          PRODUCTION: "RUNNING",
+        },
+      });
+    }
+  );
+
+  test.each(["ALL", "STAGING", "PRODUCTION"])(
+    "reports a paused %s control",
+    async (pausedScope) => {
+      const result = await runWithResponse({
+        mode: "STAGING",
+        controls: VALID_CONTROLS.map((control) => ({
+          ...control,
+          paused: control.scope === pausedScope,
+        })),
+      });
+
+      expect(result.code).toBe(0);
+      expect(JSON.parse(result.stdout).controls[pausedScope]).toBe("PAUSED");
+    }
+  );
+
+  it("fails when gh is missing", async () => {
+    const result = await runHelper({ PATH: emptyBin });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain("GitHub CLI (gh) is required");
+  });
+
+  it("fails when gh is unauthenticated", async () => {
+    const result = await runHelper({ MOCK_GH_AUTHENTICATED: "0" });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain("Run gh auth login and retry");
+  });
+
+  test.each([401, 403, 500])("fails safely for HTTP %s", async (status) => {
+    const result = await runWithResponse(
+      { error: `response body containing ${TOKEN}` },
+      status
+    );
+
+    expect(result.code).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain(`HTTP ${status}`);
+  });
+
+  it("fails on a network error", async () => {
+    const unusedServer = await startServer((_request, response) => {
+      response.end();
+    });
+    const url = unusedServer.url;
+    await stopServer(unusedServer.server);
+
+    const result = await runHelper({ RELEASE_BUS_API_URL: url });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain("status API is unavailable");
+  });
+
+  it("fails on a timeout", async () => {
+    const testServer = await startServer(() => undefined);
+    try {
+      const result = await runHelper({
+        RELEASE_BUS_API_URL: testServer.url,
+        RELEASE_BUS_STATUS_TIMEOUT_MS: "25",
+      });
+
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain("request timed out");
+    } finally {
+      await stopServer(testServer.server);
+    }
+  });
+
+  it("fails on invalid JSON", async () => {
+    const result = await runWithResponse(`not-json-${TOKEN}`);
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain("malformed JSON");
+  });
+
+  it("fails on an unknown mode", async () => {
+    const result = await runWithResponse({
+      mode: TOKEN,
+      controls: VALID_CONTROLS,
+    });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain("invalid status data");
+  });
+
+  it("fails when a required control is missing", async () => {
+    const result = await runWithResponse({
+      mode: "OFF",
+      controls: VALID_CONTROLS.filter(
+        (control) => control.scope !== "PRODUCTION"
+      ),
+    });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain("incomplete control information");
+  });
+
+  it("fails when a pause state is invalid", async () => {
+    const result = await runWithResponse({
+      mode: "OFF",
+      controls: VALID_CONTROLS.map((control) =>
+        control.scope === "ALL" ? { ...control, paused: "false" } : control
+      ),
+    });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain("invalid status data");
+  });
+});

--- a/ops/scripts/release-bus-status.test.ts
+++ b/ops/scripts/release-bus-status.test.ts
@@ -61,7 +61,7 @@ afterAll(async () => {
 });
 
 function runHelper(overrides: NodeJS.ProcessEnv = {}): Promise<HelperResult> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     execFile(
       process.execPath,
       [HELPER_PATH],
@@ -78,18 +78,21 @@ function runHelper(overrides: NodeJS.ProcessEnv = {}): Promise<HelperResult> {
         timeout: 5_000,
       },
       (error, stdout, stderr) => {
-        const output = `${stdout}${stderr}`;
-        expect(output).not.toContain(TOKEN);
-        resolve({
-          code:
-            error === null
-              ? 0
-              : typeof error.code === "number"
-                ? error.code
-                : 1,
-          stdout,
-          stderr,
-        });
+        try {
+          expect(`${stdout}${stderr}`).not.toContain(TOKEN);
+          resolve({
+            code:
+              error === null
+                ? 0
+                : typeof error.code === "number"
+                  ? error.code
+                  : 1,
+            stdout,
+            stderr,
+          });
+        } catch (assertionError) {
+          reject(assertionError);
+        }
       }
     );
   });
@@ -191,6 +194,30 @@ describe("release-bus-status helper", () => {
     expect(result.stderr).toContain("Run gh auth login and retry");
   });
 
+  test.each([
+    ["not-a-url", "valid HTTP URL"],
+    ["ftp://127.0.0.1", "valid HTTP URL"],
+    ["http://example.com", "loopback test server"],
+    ["https://example.com", "loopback test server"],
+  ])("fails safely for API URL %s", async (apiUrl, expectedMessage) => {
+    const result = await runHelper({ RELEASE_BUS_API_URL: apiUrl });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain(expectedMessage);
+  });
+
+  test.each(["", "0", "-1", "abc", "60001"])(
+    "fails safely for timeout value %j",
+    async (timeout) => {
+      const result = await runHelper({
+        RELEASE_BUS_STATUS_TIMEOUT_MS: timeout,
+      });
+
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain("must be an integer from 1 to 60000");
+    }
+  );
+
   test.each([401, 403, 500])("fails safely for HTTP %s", async (status) => {
     const result = await runWithResponse(
       { error: `response body containing ${TOKEN}` },
@@ -199,7 +226,27 @@ describe("release-bus-status helper", () => {
 
     expect(result.code).not.toBe(0);
     expect(result.stdout).toBe("");
-    expect(result.stderr).toContain(`HTTP ${status}`);
+    expect(result.stderr).toContain(
+      status === 500
+        ? "status API returned HTTP 500"
+        : `status authentication failed (HTTP ${status})`
+    );
+  });
+
+  it("fails without following a redirect", async () => {
+    const testServer = await startServer((_request, response) => {
+      response.writeHead(302, { Location: "https://example.com/redirect" });
+      response.end();
+    });
+    try {
+      const result = await runHelper({ RELEASE_BUS_API_URL: testServer.url });
+
+      expect(result.code).not.toBe(0);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain("status API is unavailable");
+    } finally {
+      await stopServer(testServer.server);
+    }
   });
 
   it("fails on a network error", async () => {
@@ -247,12 +294,29 @@ describe("release-bus-status helper", () => {
     expect(result.stderr).toContain("invalid status data");
   });
 
+  test.each([null, 1, {}])("fails on non-string mode %j", async (mode) => {
+    const result = await runWithResponse({ mode, controls: VALID_CONTROLS });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain("invalid status data");
+  });
+
   it("fails when a required control is missing", async () => {
     const result = await runWithResponse({
       mode: "OFF",
       controls: VALID_CONTROLS.filter(
         (control) => control.scope !== "PRODUCTION"
       ),
+    });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain("incomplete control information");
+  });
+
+  it("fails when a required control is duplicated", async () => {
+    const result = await runWithResponse({
+      mode: "OFF",
+      controls: [...VALID_CONTROLS, VALID_CONTROLS[0]],
     });
 
     expect(result.code).not.toBe(0);

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -1,55 +1,96 @@
 ---
 name: deploy-6529
-description: Mark exact 6529 frontend or coordinated frontend/backend branch SHAs ready for automated staging or production through the Release Bus, inspect train evidence, and handle operator break glass or failed deployment recovery. Use when Codex is asked to stage, deploy, promote, validate, pause, resume, recover, or coordinate a 6529 release.
+description: Determine the live 6529 Release Bus mode through authenticated gh, then route exact frontend or coordinated frontend/backend SHAs through the required manual, shadow, staging-bus, production-bus, or operator break-glass path. Use when Codex is asked to stage, deploy, promote, merge for release, validate, pause, resume, recover, or coordinate a 6529 release.
 ---
 
 # Deploy 6529
 
-Use the Release Bus as the normal path only for lanes enabled by its current
-rollout mode. Read
+Determine the live Release Bus mode before choosing either the bus or a manual
+path. Read
 `ops/docs/developer/deployment-bus-process.md` for lifecycle policy and
 `ops/docs/developer/deployment-bus-automation.md` for setup and recovery.
 
-## Rollout mode gate
+## Mandatory live preflight
 
-Before every staging or production action, authenticate at `/deploy/ui/bus`
-and read the mode shown by `/deploy/release-bus/controls`. Do not infer the
-mode from merged code, available workflows, or an existing candidate.
+Run this read-only helper from the repository root:
 
-- `OFF`: do not submit readiness. Use the existing manual staging or production
-  path under its normal authorization rules.
-- `SHADOW`: submit only when the user explicitly asks to record a shadow
-  decision. Shadow readiness does not stage or deploy anything; use the manual
-  path for an actual release.
-- `STAGING`: use the bus for staging only. Do not submit production readiness;
-  production remains on the existing manual path.
-- `PRODUCTION`: use the bus for both staging and production readiness.
+```bash
+node ops/scripts/release-bus-status.mjs
+```
 
-If the mode changes while working, re-read it before submission. Treat an API
-mode rejection as authoritative and do not work around it.
+Run it when a staging, production, promotion, merge-for-release, or deployment
+request arrives; immediately before readiness submission; immediately before a
+manual merge or workflow dispatch; and again before production after any
+significant wait. Rerun whenever another actor could have changed rollout mode
+or pause state.
+
+The helper obtains the current developer token internally from authenticated
+`gh`, queries the API, and prints only validated mode and pause states. Never
+replace it with documentation, conversation history, an earlier check, GitHub
+workflow configuration, AWS assumptions, repository files, or a signed-in
+browser session. Never fall back to AWS CLI for mode discovery.
+
+Fail closed. If `gh` is missing, require installation. If `gh` is
+unauthenticated, require `gh auth login`. If the API is unavailable,
+unauthorized, malformed, or returns an unknown state, stop before readiness,
+merge, or deployment mutation and wait for the status check to succeed. Never
+interpret uncertainty as `OFF` or as an enabled bus.
+
+If `ALL` or the target lane is `PAUSED`, stop and report the paused scope. Do
+not submit readiness or start a manual deployment unless an authorized
+operator deliberately follows the audited break-glass procedure.
+
+## Mode routing
+
+| Live mode    | Staging behavior                                                 | Production behavior                                                         |
+| ------------ | ---------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `OFF`        | Use the legacy manual path; do not queue in the bus              | Use the legacy manual path                                                  |
+| `SHADOW`     | Record the candidate for shadow evaluation, then deploy manually | Record shadow evidence as designed, then deploy manually                    |
+| `STAGING`    | Submit through the Release Bus and wait for validation           | Follow the operator/manual production path; do not queue a production train |
+| `PRODUCTION` | Submit through the Release Bus                                   | Submit the staging-validated SHA through the Release Bus                    |
+
+After an active bus lane accepts a candidate, never launch a parallel manual
+deployment because the lane appears slow.
+
+## Manual-route enforcement gate
+
+For every repository affected by a manual route, inspect its live Actions
+variable with authenticated `gh`:
+
+```bash
+gh variable list --repo 6529-Collections/6529seize-frontend --json name,value
+gh variable list --repo 6529-Collections/6529seize-backend --json name,value
+```
+
+Use only the repositories in the release set. A successful listing with no
+`RELEASE_BUS_ENFORCEMENT` entry means disabled; exact `false` also means
+disabled, and exact `true` means enabled. Stop on command failure or any other
+non-empty value. `OFF` or `SHADOW` with enforcement enabled is a configuration
+mismatch: alert an operator and do not deploy. If the selected manual route is
+enforced, verify that the authenticated user is an organization owner or an
+active `release-bus-operators` member, require a non-empty audited reason, and
+use the documented break-glass input. Never bypass a blocked workflow.
 
 ## Authority
 
-- When the staging lane is enabled, treat a user request to stage a development
-  as authority to mark the exact current branch SHA ready for `STAGING`; do not
-  manually merge or deploy it.
-- When production mode is enabled, treat a user request to ship a
-  staging-validated development as authority to mark that same exact SHA ready
-  for `PRODUCTION`. The bus needs no later human approval on its normal
-  successful path.
+- Treat a user request to stage a development as authority to execute the live
+  mode's staging route for the exact current SHA.
+- Treat a user request to ship a staging-validated development as authority to
+  execute the live mode's production route for that same exact SHA. An active
+  bus needs no later human approval on its normal successful path.
 - Do not infer production readiness from staging readiness. These are separate
   actions.
 - Do not use personal phase systems, the legacy GelatoBot skill, or a manual
   release-note step. The independent release-note service observes successful
   production deployments.
 - Do not move `1a-staging`, merge source PRs to `main`, or dispatch deployment
-  workflows while the bus is enabled unless an authorized operator explicitly
-  invokes break glass.
+  workflows when the selected route belongs to an active bus lane unless an
+  authorized operator explicitly invokes break glass.
 - Never merge `1a-staging` into `main`.
 - Never expose tokens, private keys, access codes, signed URLs, raw production
   data, or hidden prompts in readiness metadata, comments, or summaries.
 
-## Mark ready
+## Bus readiness path
 
 1. Open `/deploy/ui/bus` and authenticate with the developer's GitHub token.
 2. Select `frontend`, enter the development branch, and resolve its current


### PR DESCRIPTION
## Issue

Deployment agents could infer that the Release Bus was live from documentation, files, or stale context instead of querying the authoritative production controls API.

## Fix

Add a safe authenticated status helper and make it the mandatory, fail-closed gate for all staging and production routes.

## Changes

- add the sanitized `release-bus-status.mjs` helper and 18 mocked tests
- require live checks before readiness, manual merges, and workflow dispatches
- define exact mode routing, pause handling, and manual enforcement checks
- update the process and automation documentation

## Validation

- full frontend ESLint
- 18 focused Jest tests
- Prettier check
- documentation link validation (280 files)
- deployment skill validation
- read-only live smoke: mode `OFF`, all scopes `RUNNING`

## Risk

Low runtime risk: operational scripts, agent instructions, and documentation only. No AWS or application deployment is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a preflight utility that reports Release Bus status and validates deployment controls before release activity.
  * Added explicit routing guidance for `OFF`, `SHADOW`, `STAGING`, and `PRODUCTION` modes.
  * Added enforcement rules for manual and operator break-glass deployments.

* **Documentation**
  * Updated deployment procedures with fail-closed behavior for authentication, network, configuration, and control-state failures.
  * Clarified developer and operator responsibilities when Release Bus lanes are active.

* **Tests**
  * Added coverage for successful status checks, authentication, API, timeout, malformed response, and invalid control scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->