### PR TITLE
Show direct message reactions as they happen

### DIFF
--- a/__tests__/services/useWebSocketMessage.test.ts
+++ b/__tests__/services/useWebSocketMessage.test.ts
@@ -12,27 +12,28 @@ describe('useWebSocketMessage', () => {
   beforeEach(() => {
     subscribe.mockReset();
     unsubscribe.mockReset();
+    subscribe.mockReturnValue(unsubscribe);
     (useWebSocket as jest.Mock).mockReturnValue({
-      subscribe: jest.fn(() => unsubscribe),
+      subscribe,
       status: WebSocketStatus.CONNECTED,
     });
   });
 
-  it('subscribes and unsubscribes when connected', () => {
+  it('subscribes and unsubscribes while mounted', () => {
     const cb = jest.fn();
     const { unmount } = renderHook(() => useWebSocketMessage('TYPE' as any, cb));
-    expect(useWebSocket().subscribe).toHaveBeenCalledWith('TYPE', cb);
+    expect(subscribe).toHaveBeenCalledWith('TYPE', expect.any(Function));
     unmount();
     expect(unsubscribe).toHaveBeenCalled();
   });
 
-  it('does not subscribe when not connected', () => {
+  it('keeps the listener registered while disconnected', () => {
     (useWebSocket as jest.Mock).mockReturnValue({
       subscribe,
       status: WebSocketStatus.DISCONNECTED,
     });
     renderHook(() => useWebSocketMessage('TYPE' as any, jest.fn()));
-    expect(subscribe).not.toHaveBeenCalled();
+    expect(subscribe).toHaveBeenCalledWith('TYPE', expect.any(Function));
   });
 });
 

--- a/__tests__/services/websocket/WebSocketProvider.test.tsx
+++ b/__tests__/services/websocket/WebSocketProvider.test.tsx
@@ -967,6 +967,44 @@ describe("WebSocketProvider", () => {
   });
 
   describe("Subscription Management", () => {
+    it("retains subscribers across a socket reconnect", () => {
+      jest.useFakeTimers();
+      const wrapper = createWrapper({ url: "ws://test" });
+      const { result } = renderHook(() => React.useContext(WebSocketContext)!, {
+        wrapper,
+      });
+      const callback = jest.fn();
+
+      act(() => {
+        result.current.subscribe(WsMessageType.DROP_UPDATE, callback);
+        result.current.connect("token");
+      });
+
+      const firstSocket = (
+        globalThis.WebSocket as jest.MockedFunction<typeof WebSocket>
+      ).mock.results[0]?.value as MockWebSocket;
+
+      act(() => {
+        firstSocket.triggerOpen();
+        firstSocket.triggerClose(1006, "Unexpected close");
+        jest.advanceTimersByTime(2000);
+      });
+
+      const reconnectedSocket = (
+        globalThis.WebSocket as jest.MockedFunction<typeof WebSocket>
+      ).mock.results[1]?.value as MockWebSocket;
+
+      act(() => {
+        reconnectedSocket.triggerOpen();
+        reconnectedSocket.triggerMessage({
+          type: WsMessageType.DROP_UPDATE,
+          data: { id: 1 },
+        });
+      });
+
+      expect(callback).toHaveBeenCalledWith({ id: 1 });
+    });
+
     it("manages multiple subscribers for same message type", () => {
       const wrapper = createWrapper({ url: "ws://test" });
       const { result } = renderHook(() => React.useContext(WebSocketContext)!, {

--- a/__tests__/services/websocket/useWebSocketMessage.test.ts
+++ b/__tests__/services/websocket/useWebSocketMessage.test.ts
@@ -9,24 +9,24 @@ jest.mock('@/services/websocket/useWebSocket', () => ({
 const { useWebSocket } = require('@/services/websocket/useWebSocket');
 
 describe('useWebSocketMessage', () => {
-  it('subscribes when connected and cleans up on unmount', () => {
+  it('subscribes while mounted and cleans up on unmount', () => {
     const unsubscribe = jest.fn();
     const subscribe = jest.fn().mockReturnValue(unsubscribe);
     useWebSocket.mockReturnValue({ subscribe, status: WebSocketStatus.CONNECTED });
     const callback = jest.fn();
     const { unmount, result } = renderHook(() => useWebSocketMessage('TYPE' as any, callback));
     expect(result.current.isConnected).toBe(true);
-    expect(subscribe).toHaveBeenCalledWith('TYPE', callback);
+    expect(subscribe).toHaveBeenCalledWith('TYPE', expect.any(Function));
     unmount();
     expect(unsubscribe).toHaveBeenCalled();
   });
 
-  it('does nothing when disconnected', () => {
+  it('keeps the listener registered while disconnected', () => {
     const subscribe = jest.fn();
     useWebSocket.mockReturnValue({ subscribe, status: WebSocketStatus.DISCONNECTED });
     const { result } = renderHook(() => useWebSocketMessage('T' as any, jest.fn()));
     expect(result.current.isConnected).toBe(false);
-    expect(subscribe).not.toHaveBeenCalled();
+    expect(subscribe).toHaveBeenCalledWith('T', expect.any(Function));
   });
 });
 

--- a/ops/docs/realtime/feature-authenticated-live-updates.md
+++ b/ops/docs/realtime/feature-authenticated-live-updates.md
@@ -52,6 +52,9 @@ updates. When auth is missing, the session disconnects and push updates pause.
   available, with broadcast-channel fallback (`auth-token-updates`) when not.
 - Temporary disconnects retry automatically while auth is still valid, using
   deterministic exponential backoff (`2s`, `3s`, `4.5s`, capped at `30s`).
+- Live-update listeners remain ready while the connection recovers, so Waves
+  and Messages resume receiving supported events as soon as reconnection and
+  authentication finish.
 
 ## Edge Cases
 
@@ -81,7 +84,8 @@ updates. When auth is missing, the session disconnects and push updates pause.
 
 - This behavior governs authenticated websocket session health, not guaranteed
   delivery of every individual event.
-- Subscribers attach only while status is `connected`; missed messages during a
+- Live-update listeners stay registered across connection changes, but messages
+  can only arrive while status is `connected`; missed messages during a
   disconnect window are not guaranteed to replay. Notification queries use
   their normal 30-second/15-second REST fallback until subscription
   acknowledgement, then retain a five-minute reconciliation poll.

--- a/ops/docs/realtime/troubleshooting-realtime-connectivity.md
+++ b/ops/docs/realtime/troubleshooting-realtime-connectivity.md
@@ -69,7 +69,8 @@ stale, stop arriving, or do not recover after auth changes.
 - If transport drops repeatedly, event-driven surfaces can keep cached data but
   stop receiving fresh push events.
 - There is no global websocket status banner or reconnect button in the UI.
-- Subscribers attach only while websocket status is `connected`.
+- Live-update listeners remain registered while the websocket reconnects, but
+  events can only arrive while its status is `connected`.
 - Once token checks pass and the socket reconnects, live updates resume without
   a full app restart.
 - If issues persist across multiple health cycles, refresh the tab for a clean

--- a/ops/docs/waves/drop-actions/feature-reactions-and-ratings.md
+++ b/ops/docs/waves/drop-actions/feature-reactions-and-ratings.md
@@ -47,6 +47,8 @@ rolls back if the request fails.
 - Quick-react options come from local emoji history. If history is empty, quick
   react falls back to `:+1:`.
 - Touch move inside the mobile emoji picker stays inside the picker dialog.
+- Reactions added or removed by other people appear live while the wave or
+  direct-message thread is open.
 - Repeated clap taps in a short burst are merged into one rating request.
 - Rating values are clamped to each drop's allowed min/max range.
 

--- a/services/websocket/useWebSocketHealth.ts
+++ b/services/websocket/useWebSocketHealth.ts
@@ -167,8 +167,9 @@ export function useWebSocketHealth() {
   }, [performHealthCheck]);
 
   useEffect(() => {
+    // Unexpected-close recovery belongs to WebSocketProvider's backoff loop.
     performHealthCheck();
-  }, [performHealthCheck, webSocketState.status]);
+  }, [performHealthCheck]);
 
   useEffect(() => {
     if (typeof document === "undefined") {

--- a/services/websocket/useWebSocketMessage.ts
+++ b/services/websocket/useWebSocketMessage.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useCallback } from "react";
+import { useEffect, useEffectEvent } from "react";
 import { useWebSocket } from "./useWebSocket";
 import { WebSocketStatus } from "./WebSocketTypes";
 import type { WsMessageType } from "@/helpers/Types";
@@ -21,25 +21,14 @@ export function useWebSocketMessage<T = any>(
   // Get WebSocket context
   const { subscribe, status } = useWebSocket();
 
-  // Memoize the callback to prevent unnecessary resubscriptions
-  const stableCallback = useCallback(callback, [callback]);
+  const onMessage = useEffectEvent(callback);
 
   // Is the WebSocket connected?
   const isConnected = status === WebSocketStatus.CONNECTED;
 
-  // Subscribe to the message type
   useEffect(() => {
-    // Only subscribe if connected
-    if (status !== WebSocketStatus.CONNECTED) {
-      return;
-    }
-
-    // Subscribe and get unsubscribe function
-    const unsubscribe = subscribe<T>(messageType, stableCallback);
-
-    // Clean up subscription on unmount or type change
-    return unsubscribe;
-  }, [messageType, subscribe, status, stableCallback]);
+    return subscribe<T>(messageType, onMessage);
+  }, [messageType, subscribe]);
 
   return {
     isConnected,


### PR DESCRIPTION
## Issue

- Reactions added or removed by another participant could remain invisible in an open direct-message thread until the conversation refetched.
- Repeated WebSocket close/reconnect cycles also created delivery gaps for other live updates.

## Fix

- Let the WebSocket provider exclusively own unexpected-close recovery and exponential backoff.
- Keep message listeners registered across connection and authentication state changes while delivering each listener's latest callback.
- Preserve the existing canonical reaction refetch and optimistic reconciliation behavior.

## Changes

- Removed socket status from the initial health-check effect so it no longer cancels a pending provider retry.
- Kept realtime subscribers attached through reconnects and component renders.
- Added focused coverage for listeners registered while disconnected and retained across socket replacement.
- Updated the realtime and reaction documentation.

## Validation

- `6529 run lint:changed`
- `6529 run typecheck:changed`
- `6529 run build`
- `6529 run react-doctor:diff` (100/100 on the source diff)
- Focused WebSocket test suites: 3 passed
- Documentation link validation
- Desktop and mobile local browser QA on an open direct-message thread: reaction controls and counts rendered, with no browser or WebSocket console errors
- A real conversation was not mutated to manufacture a second participant's reaction; deployed staging validation will cover recovery and live behavior where practical

## Risk

- Level: Medium.
- Reason: the code change is small, but it is in the shared WebSocket lifecycle used by all live events.
- Rollback: reverting the commits restores the previous status-driven reconnect and subscription behavior.

## Review Notes

- Please focus on the ownership split between the health hook and provider retry loop, plus subscriber lifetime across reconnects.
- The project uses React 19.2.4; its installed development and production runtimes both export `useEffectEvent` directly.
- The provider subscriber map is independent of socket instances; focused coverage now verifies delivery after a socket is replaced.
- Canonical reaction fetching and the optimistic mutation guard are intentionally unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified authenticated live-update and listener readiness during reconnects.
  * Documented that Waves and Messages resume supported live events immediately after reconnect+authentication.
  * Clarified that events only arrive while the WebSocket is connected, and missed messages aren’t guaranteed to replay.
  * Added guidance that reactions and ratings update live while a wave/DM thread is open.
* **Bug Fixes**
  * Improved real-time subscription behavior so listeners persist across unexpected reconnects.
  * Refined WebSocket health-check and message subscription handling.
* **Tests**
  * Updated and added coverage for reconnect persistence and subscription/unsubscription behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->