### PR TITLE
fix: Repaired the draft MetaMask telemetry filter so production-shaped anonymous Sentry frames match without w

### DIFF
--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -276,6 +276,83 @@ describe("instrumentation-client", () => {
     ) => BeforeSendResult;
   };
 
+  const loadBeforeSendWithAssociatedMetaMaskDiagnostics = (
+    originalException: TypeError
+  ) => {
+    let beforeSend:
+      | ((
+          event: Record<string, unknown>,
+          hint?: Record<string, unknown>
+        ) => BeforeSendResult)
+      | undefined;
+    let scheduledHandler: ((...args: unknown[]) => unknown) | undefined;
+
+    jest.isolateModules(() => {
+      const { installCyclicJsonTimerDiagnostics } =
+        require("@/utils/monitoring/cyclicJsonTimerDiagnostics") as typeof import("@/utils/monitoring/cyclicJsonTimerDiagnostics");
+      const target = {
+        setTimeout: jest.fn(
+          (
+            handler: ((...args: unknown[]) => unknown) | string,
+            _timeout?: number,
+            ..._args: unknown[]
+          ) => {
+            if (typeof handler === "function") {
+              scheduledHandler = handler;
+            }
+            return 73;
+          }
+        ),
+        navigator: {
+          userAgent:
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 MetaMaskMobile/1.0",
+        },
+        location: { hostname: "6529.io" },
+      };
+
+      expect(
+        installCyclicJsonTimerDiagnostics({
+          target,
+          sampleRate: 1 / 16,
+          random: () => 0,
+          stackFactory: () =>
+            [
+              "anonymous@data:text/javascript,synthetic-navigation:286:15",
+              "pushState@https://6529.io/_next/static/chunks/0synthetic-navigation.js:2:47863",
+            ].join("\n"),
+        })
+      ).toBe(true);
+
+      const anonymousCallback = () => {
+        throw originalException;
+      };
+      Object.defineProperty(anonymousCallback, "name", {
+        configurable: true,
+        value: "",
+      });
+      target.setTimeout(anonymousCallback, 100);
+
+      let thrownException: unknown;
+      try {
+        scheduledHandler?.();
+      } catch (error) {
+        thrownException = error;
+      }
+      expect(thrownException).toBe(originalException);
+
+      require("@/instrumentation-client");
+      const config = mockInit.mock.calls[0]?.[0];
+      expect(typeof config?.beforeSend).toBe("function");
+      beforeSend = config.beforeSend;
+    });
+
+    expect(typeof beforeSend).toBe("function");
+    return beforeSend as (
+      event: Record<string, unknown>,
+      hint?: Record<string, unknown>
+    ) => BeforeSendResult;
+  };
+
   const loadBeforeSendTransaction = () => {
     const config = loadSentryConfig();
     expect(typeof config.beforeSendTransaction).toBe("function");
@@ -428,6 +505,75 @@ describe("instrumentation-client", () => {
     ],
     ...overrides,
   });
+
+  const createMetaMaskMobileSpaNavigationCyclicJsonEvent = (
+    overrides: Record<string, unknown> = {}
+  ) =>
+    createSentryRouteParameterizationEvent(
+      [
+        {
+          filename: "app:///_next/static/chunks/0synthetic-monitoring.js",
+          abs_path: "app:///_next/static/chunks/0synthetic-monitoring.js",
+          function: "n",
+          lineno: 7,
+          colno: 4858,
+          in_app: true,
+        },
+        {
+          filename: "app:///_next/static/chunks/0synthetic-monitoring.js",
+          abs_path: "app:///_next/static/chunks/0synthetic-monitoring.js",
+          lineno: 21,
+          colno: 90001,
+          in_app: true,
+        },
+        nativeJsonStringifyFrame,
+      ],
+      {
+        timestamp: 1000.103,
+        transaction: "/waves",
+        tags: {
+          cyclic_json_timer_diagnostics: "v2",
+          cyclic_json_timer_schedule_origin: "first_party",
+        },
+        extra: {
+          arguments: ["synthetic-timer-argument"],
+          cyclicJsonTimerDiagnostics: {
+            schemaVersion: "v2",
+            timerSampleRate: 1 / 16,
+            callbackName: "anonymous",
+            webViewFamily: "metamask-mobile",
+            scheduleOrigin: "first_party",
+            schedulingFrames: [
+              {
+                file: "non-http-script",
+                function: "anonymous",
+                line: 286,
+                column: 15,
+                origin: "unknown",
+              },
+              {
+                file: "/_next/static/chunks/0synthetic-navigation.js",
+                function: "navigate",
+                line: 2,
+                column: 47863,
+                origin: "first_party",
+              },
+            ],
+          },
+        },
+        breadcrumbs: [
+          {
+            timestamp: 1000,
+            category: "navigation",
+            data: {
+              from: "/notifications",
+              to: "/waves/synthetic-wave",
+            },
+          },
+        ],
+        ...overrides,
+      }
+    );
 
   const createAppKitCoinbaseBreadcrumbs = () => [
     {
@@ -1385,13 +1531,54 @@ describe("instrumentation-client", () => {
     expect(result).not.toBeNull();
   });
 
-  it("keeps cyclic JSON timer errors for origin diagnostics", () => {
+  it("keeps unsampled cyclic JSON timer errors for origin diagnostics", () => {
     const beforeSend = loadBeforeSend();
     const event = createSentryRouteParameterizationEvent();
 
     const result = beforeSend(event);
 
     expect(result).not.toBeNull();
+  });
+
+  it("enriches the exact MetaMask timer error before filtering it", () => {
+    const originalException = new TypeError(sentryRouteParameterizationMessage);
+    const beforeSend =
+      loadBeforeSendWithAssociatedMetaMaskDiagnostics(originalException);
+    const event = createMetaMaskMobileSpaNavigationCyclicJsonEvent({
+      tags: {
+        browser: "Mobile Safari UI/WKWebView",
+        "browser.name": "Mobile Safari UI/WKWebView",
+      },
+      extra: {
+        arguments: ["synthetic-timer-argument"],
+      },
+    });
+
+    expect(event.tags).not.toHaveProperty("cyclic_json_timer_diagnostics");
+    expect(event.extra).not.toHaveProperty("cyclicJsonTimerDiagnostics");
+
+    const result = beforeSend(event, { originalException });
+
+    expect(result).toBeNull();
+    expect(event.extra).not.toHaveProperty("arguments");
+    expect(event.tags).toMatchObject({
+      cyclic_json_timer_diagnostics: "v2",
+      cyclic_json_timer_schedule_origin: "first_party",
+    });
+    expect(event.extra).toHaveProperty("cyclicJsonTimerDiagnostics");
+  });
+
+  it("keeps a v2 MetaMask timing near miss with sanitized diagnostics", () => {
+    const beforeSend = loadBeforeSend();
+    const event = createMetaMaskMobileSpaNavigationCyclicJsonEvent({
+      timestamp: 1000.5,
+    });
+
+    const result = beforeSend(event);
+
+    expect(result).not.toBeNull();
+    expect(event.extra).not.toHaveProperty("arguments");
+    expect(event.extra).toHaveProperty("cyclicJsonTimerDiagnostics");
   });
 
   it("keeps iOS WKWebView cyclic JSON timer errors without app context", () => {

--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -63,6 +63,9 @@ describe("instrumentation-client", () => {
     "JSON.stringify cannot serialize cyclic structures.";
   const sentryRouteParameterizationMechanismType =
     "auto.browser.browserapierrors.setTimeout";
+  const genericIosWkWebViewUserAgent =
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148";
+  const metaMaskMobileUserAgent = `${genericIosWkWebViewUserAgent} MetaMaskMobile/1.0`;
   const browserUnhandledRejectionMechanismType =
     "auto.browser.global_handlers.onunhandledrejection";
   const poperBlockerNetworkErrorMessage =
@@ -276,8 +279,9 @@ describe("instrumentation-client", () => {
     ) => BeforeSendResult;
   };
 
-  const loadBeforeSendWithAssociatedMetaMaskDiagnostics = (
-    originalException: TypeError
+  const loadBeforeSendWithAssociatedCyclicJsonDiagnostics = (
+    originalException: TypeError,
+    userAgent = metaMaskMobileUserAgent
   ) => {
     let beforeSend:
       | ((
@@ -304,8 +308,7 @@ describe("instrumentation-client", () => {
           }
         ),
         navigator: {
-          userAgent:
-            "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 MetaMaskMobile/1.0",
+          userAgent,
         },
         location: { hostname: "6529.io" },
       };
@@ -1543,7 +1546,7 @@ describe("instrumentation-client", () => {
   it("enriches the exact MetaMask timer error before filtering it", () => {
     const originalException = new TypeError(sentryRouteParameterizationMessage);
     const beforeSend =
-      loadBeforeSendWithAssociatedMetaMaskDiagnostics(originalException);
+      loadBeforeSendWithAssociatedCyclicJsonDiagnostics(originalException);
     const event = createMetaMaskMobileSpaNavigationCyclicJsonEvent({
       tags: {
         browser: "Mobile Safari UI/WKWebView",
@@ -1566,6 +1569,42 @@ describe("instrumentation-client", () => {
       cyclic_json_timer_schedule_origin: "first_party",
     });
     expect(event.extra).toHaveProperty("cyclicJsonTimerDiagnostics");
+  });
+
+  it("keeps a sampled v2 non-MetaMask timer error with sanitized diagnostics", () => {
+    const originalException = new TypeError(sentryRouteParameterizationMessage);
+    const beforeSend = loadBeforeSendWithAssociatedCyclicJsonDiagnostics(
+      originalException,
+      genericIosWkWebViewUserAgent
+    );
+    const event = createMetaMaskMobileSpaNavigationCyclicJsonEvent({
+      contexts: {
+        browser: {
+          name: "Mobile Safari UI/WKWebView",
+        },
+      },
+      tags: {
+        browser: "Mobile Safari UI/WKWebView",
+        "browser.name": "Mobile Safari UI/WKWebView",
+      },
+      extra: {
+        arguments: ["synthetic-timer-argument"],
+      },
+    });
+
+    const result = beforeSend(event, { originalException });
+
+    expect(result).not.toBeNull();
+    expect(event.extra).not.toHaveProperty("arguments");
+    expect(event.tags).toMatchObject({
+      cyclic_json_timer_diagnostics: "v2",
+      cyclic_json_timer_schedule_origin: "first_party",
+    });
+    expect(event.extra).toMatchObject({
+      cyclicJsonTimerDiagnostics: {
+        webViewFamily: "ios-wkwebview",
+      },
+    });
   });
 
   it("keeps a v2 MetaMask timing near miss with sanitized diagnostics", () => {

--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -66,6 +66,20 @@ describe("instrumentation-client", () => {
   const genericIosWkWebViewUserAgent =
     "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148";
   const metaMaskMobileUserAgent = `${genericIosWkWebViewUserAgent} MetaMaskMobile/1.0`;
+  const firstPartyMetaMaskSchedulingStack = [
+    "anonymous@data:text/javascript,synthetic-navigation:286:15",
+    "pushState@https://6529.io/_next/static/chunks/0synthetic-navigation.js:2:47863",
+  ];
+  const mixedOriginMetaMaskSchedulingStack = [
+    "anonymous@data:text/javascript,synthetic-navigation:293:15",
+    "anonymous@https://wallet-bridge.invalid/js:798:281",
+    "anonymous@https://6529.io/_next/static/chunks/0synthetic-navigation.js:51:8604",
+    "sy@https://6529.io/_next/static/chunks/0synthetic-navigation.js:21:208988",
+    "li@https://6529.io/_next/static/chunks/0synthetic-navigation.js:21:224897",
+    "lr@https://6529.io/_next/static/chunks/0synthetic-navigation.js:21:224732",
+    "li@https://6529.io/_next/static/chunks/0synthetic-navigation.js:21:224858",
+    "lr@https://6529.io/_next/static/chunks/0synthetic-navigation.js:21:224732",
+  ];
   const browserUnhandledRejectionMechanismType =
     "auto.browser.global_handlers.onunhandledrejection";
   const poperBlockerNetworkErrorMessage =
@@ -281,7 +295,8 @@ describe("instrumentation-client", () => {
 
   const loadBeforeSendWithAssociatedCyclicJsonDiagnostics = (
     originalException: TypeError,
-    userAgent = metaMaskMobileUserAgent
+    userAgent = metaMaskMobileUserAgent,
+    schedulingStack: readonly string[] = firstPartyMetaMaskSchedulingStack
   ) => {
     let beforeSend:
       | ((
@@ -318,11 +333,7 @@ describe("instrumentation-client", () => {
           target,
           sampleRate: 1 / 16,
           random: () => 0,
-          stackFactory: () =>
-            [
-              "anonymous@data:text/javascript,synthetic-navigation:286:15",
-              "pushState@https://6529.io/_next/static/chunks/0synthetic-navigation.js:2:47863",
-            ].join("\n"),
+          stackFactory: () => schedulingStack.join("\n"),
         })
       ).toBe(true);
 
@@ -525,6 +536,7 @@ describe("instrumentation-client", () => {
         {
           filename: "app:///_next/static/chunks/0synthetic-monitoring.js",
           abs_path: "app:///_next/static/chunks/0synthetic-monitoring.js",
+          function: "?",
           lineno: 21,
           colno: 90001,
           in_app: true,
@@ -1569,6 +1581,47 @@ describe("instrumentation-client", () => {
       cyclic_json_timer_schedule_origin: "first_party",
     });
     expect(event.extra).toHaveProperty("cyclicJsonTimerDiagnostics");
+  });
+
+  it("filters the mixed-origin MetaMask navigation signature after enrichment", () => {
+    const originalException = new TypeError(sentryRouteParameterizationMessage);
+    const beforeSend = loadBeforeSendWithAssociatedCyclicJsonDiagnostics(
+      originalException,
+      metaMaskMobileUserAgent,
+      mixedOriginMetaMaskSchedulingStack
+    );
+    const event = createMetaMaskMobileSpaNavigationCyclicJsonEvent({
+      tags: {
+        browser: "Mobile Safari UI/WKWebView",
+        "browser.name": "Mobile Safari UI/WKWebView",
+      },
+      extra: {
+        arguments: ["synthetic-timer-argument"],
+      },
+    });
+
+    const result = beforeSend(event, { originalException });
+
+    expect(result).toBeNull();
+    expect(event.extra).not.toHaveProperty("arguments");
+    expect(event.tags).toMatchObject({
+      cyclic_json_timer_diagnostics: "v2",
+      cyclic_json_timer_schedule_origin: "mixed",
+    });
+    expect(event.extra).toMatchObject({
+      cyclicJsonTimerDiagnostics: {
+        scheduleOrigin: "mixed",
+        schedulingFrames: expect.arrayContaining([
+          expect.objectContaining({
+            file: "external/js",
+            function: "anonymous",
+            line: 798,
+            column: 281,
+            origin: "third_party",
+          }),
+        ]),
+      },
+    });
   });
 
   it("keeps a sampled v2 non-MetaMask timer error with sanitized diagnostics", () => {

--- a/__tests__/utils/metamaskMobileNavigationFilter.test.ts
+++ b/__tests__/utils/metamaskMobileNavigationFilter.test.ts
@@ -1,0 +1,361 @@
+import {
+  shouldFilterMetaMaskMobileSpaNavigationCyclicJsonError,
+  type SentryClientEvent,
+  type SentryStackFrame,
+} from "@/utils/sentry-client-filters";
+
+const CYCLIC_JSON_MESSAGE =
+  "JSON.stringify cannot serialize cyclic structures.";
+const TIMER_MECHANISM = "auto.browser.browserapierrors.setTimeout";
+const RAW_CHUNK = "app:///_next/static/chunks/0synthetic-monitoring.js";
+
+const initialInjectedSchedulingFrame = {
+  file: "non-http-script",
+  function: "anonymous",
+  line: 286,
+  column: 15,
+  origin: "unknown",
+};
+
+function createRawExecutionFrames(): SentryStackFrame[] {
+  return [
+    {
+      filename: RAW_CHUNK,
+      abs_path: RAW_CHUNK,
+      function: "n",
+      lineno: 7,
+      colno: 4858,
+      in_app: true,
+    },
+    {
+      filename: RAW_CHUNK,
+      abs_path: RAW_CHUNK,
+      lineno: 21,
+      colno: 90001,
+      in_app: true,
+    },
+    {
+      filename: "[native code]",
+      abs_path: "[native code]",
+      function: "stringify",
+      in_app: true,
+    },
+  ];
+}
+
+type FixtureOptions = {
+  eventTimestamp?: number | null | undefined;
+  navigationTimestamp?: number | null | undefined;
+  navigationCategory?: string | undefined;
+  navigationData?: Record<string, unknown> | undefined;
+  navigationFunction?: string | undefined;
+  frames?: SentryStackFrame[] | undefined;
+  exceptionType?: string | undefined;
+  exceptionValue?: string | undefined;
+  mechanismType?: string | undefined;
+  handled?: boolean | undefined;
+  additionalException?: boolean | undefined;
+  diagnostics?: Record<string, unknown> | null | undefined;
+  diagnosticsOverrides?: Record<string, unknown> | undefined;
+  tags?: Record<string, unknown> | undefined;
+};
+
+function createDiagnostics(
+  navigationFunction: string,
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    schemaVersion: "v2",
+    timerSampleRate: 1 / 16,
+    callbackName: "anonymous",
+    webViewFamily: "metamask-mobile",
+    scheduleOrigin: "first_party",
+    schedulingFrames: [
+      initialInjectedSchedulingFrame,
+      {
+        file: "/_next/static/chunks/0synthetic-navigation.js",
+        function: navigationFunction,
+        line: 2,
+        column: 47863,
+        origin: "first_party",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function createEvent(options: FixtureOptions = {}): SentryClientEvent {
+  const diagnostics =
+    options.diagnostics === null
+      ? undefined
+      : (options.diagnostics ??
+        createDiagnostics(
+          options.navigationFunction ?? "navigate",
+          options.diagnosticsOverrides
+        ));
+  const exceptionValues = [
+    {
+      type: options.exceptionType ?? "TypeError",
+      value: options.exceptionValue ?? CYCLIC_JSON_MESSAGE,
+      mechanism: {
+        type: options.mechanismType ?? TIMER_MECHANISM,
+        handled: options.handled ?? false,
+      },
+      stacktrace: {
+        frames: options.frames ?? createRawExecutionFrames(),
+      },
+    },
+  ];
+  if (options.additionalException) {
+    exceptionValues.push({
+      type: "Error",
+      value: "Independent application failure",
+      mechanism: {
+        type: "generic",
+        handled: false,
+      },
+      stacktrace: {
+        frames: [
+          {
+            filename: "app:///utils/applicationSerializer.ts",
+            function: "serializeApplicationState",
+            in_app: true,
+          },
+        ],
+      },
+    });
+  }
+
+  return {
+    timestamp:
+      options.eventTimestamp === null
+        ? undefined
+        : (options.eventTimestamp ?? 1000.103),
+    transaction: "/waves",
+    exception: { values: exceptionValues },
+    tags: options.tags ?? {
+      cyclic_json_timer_diagnostics: "v2",
+      cyclic_json_timer_schedule_origin: "first_party",
+    },
+    extra: {
+      arguments: ["private timer argument"],
+      ...(diagnostics && { cyclicJsonTimerDiagnostics: diagnostics }),
+    },
+    breadcrumbs: [
+      {
+        timestamp:
+          options.navigationTimestamp === null
+            ? undefined
+            : (options.navigationTimestamp ?? 1000),
+        category: options.navigationCategory ?? "navigation",
+        data: options.navigationData ?? {
+          from: "/notifications",
+          to: "/waves/synthetic-wave",
+        },
+      },
+    ],
+  };
+}
+
+describe("MetaMask Mobile SPA navigation cyclic JSON filter", () => {
+  it.each(["pushState", "replaceState"])(
+    "filters the v2-enriched %s navigation signature",
+    (navigationFunction) => {
+      const event = createEvent({ navigationFunction });
+
+      expect(
+        shouldFilterMetaMaskMobileSpaNavigationCyclicJsonError(event)
+      ).toBe(true);
+    }
+  );
+
+  it.each([0.103, 0.145, 0.295])(
+    "filters the cohort-backed %.3f second navigation delay",
+    (delaySeconds) => {
+      const event = createEvent({ eventTimestamp: 1000 + delaySeconds });
+
+      expect(
+        shouldFilterMetaMaskMobileSpaNavigationCyclicJsonError(event)
+      ).toBe(true);
+    }
+  );
+
+  it.each([
+    ["generic iOS WKWebView", { webViewFamily: "ios-wkwebview" }],
+    ["another wallet WebView", { webViewFamily: "rabby-mobile" }],
+    ["a named callback", { callbackName: "updateUrl" }],
+    ["legacy diagnostics", { schemaVersion: "v1" }],
+    ["a changed sample rate", { timerSampleRate: 1 / 8 }],
+    ["mixed scheduling provenance", { scheduleOrigin: "mixed" }],
+  ])("preserves the near miss with %s", (_name, diagnosticsOverrides) => {
+    const event = createEvent({ diagnosticsOverrides });
+
+    expect(shouldFilterMetaMaskMobileSpaNavigationCyclicJsonError(event)).toBe(
+      false
+    );
+  });
+
+  it.each([
+    ["missing diagnostics", undefined, undefined],
+    ["a missing diagnostics tag", createDiagnostics("navigate"), {}],
+    [
+      "legacy diagnostic tags",
+      createDiagnostics("navigate", { schemaVersion: "v1" }),
+      {
+        cyclic_json_timer_diagnostics: "v1",
+        cyclic_json_timer_schedule_origin: "first_party",
+      },
+    ],
+    [
+      "a mismatched origin tag",
+      createDiagnostics("navigate"),
+      {
+        cyclic_json_timer_diagnostics: "v2",
+        cyclic_json_timer_schedule_origin: "mixed",
+      },
+    ],
+  ])("preserves %s", (_name, diagnostics, tags) => {
+    const event = createEvent({
+      diagnostics: diagnostics ?? null,
+      tags,
+    });
+
+    expect(shouldFilterMetaMaskMobileSpaNavigationCyclicJsonError(event)).toBe(
+      false
+    );
+  });
+
+  it.each([
+    ["no injected frame", []],
+    [
+      "a third-party injected origin",
+      [{ ...initialInjectedSchedulingFrame, origin: "third_party" }],
+    ],
+    [
+      "no first-party navigation frame",
+      [
+        initialInjectedSchedulingFrame,
+        {
+          file: "non-http-script",
+          function: "anonymous",
+          line: 290,
+          column: 20,
+          origin: "unknown",
+        },
+      ],
+    ],
+    [
+      "a third-party follow-up frame",
+      [
+        initialInjectedSchedulingFrame,
+        {
+          file: "external/inpage.js",
+          function: "navigate",
+          line: 10,
+          column: 20,
+          origin: "third_party",
+        },
+      ],
+    ],
+  ])("preserves diagnostics with %s", (_name, schedulingFrames) => {
+    const event = createEvent({ diagnosticsOverrides: { schedulingFrames } });
+
+    expect(shouldFilterMetaMaskMobileSpaNavigationCyclicJsonError(event)).toBe(
+      false
+    );
+  });
+
+  it.each([
+    ["a different exception type", { exceptionType: "Error" }],
+    [
+      "a different message",
+      { exceptionValue: "Converting circular structure to JSON" },
+    ],
+    [
+      "a different mechanism",
+      {
+        mechanismType: "auto.browser.browserapierrors.requestAnimationFrame",
+      },
+    ],
+    ["a handled exception", { handled: true }],
+    ["multiple exceptions", { additionalException: true }],
+  ] satisfies Array<[string, FixtureOptions]>)(
+    "preserves the event with %s",
+    (_name, options) => {
+      const event = createEvent(options);
+
+      expect(
+        shouldFilterMetaMaskMobileSpaNavigationCyclicJsonError(event)
+      ).toBe(false);
+    }
+  );
+
+  it.each([
+    [
+      "a missing native stringify frame",
+      createRawExecutionFrames().slice(0, 2),
+    ],
+    [
+      "a changed Sentry wrapper coordinate",
+      createRawExecutionFrames().map((frame, index) =>
+        index === 0 ? { ...frame, colno: 4859 } : frame
+      ),
+    ],
+    [
+      "a diagnostic wrapper from another chunk",
+      createRawExecutionFrames().map((frame, index) =>
+        index === 1
+          ? {
+              ...frame,
+              filename: "app:///_next/static/chunks/0other.js",
+              abs_path: "app:///_next/static/chunks/0other.js",
+            }
+          : frame
+      ),
+    ],
+    [
+      "a named application caller",
+      createRawExecutionFrames().map((frame, index) =>
+        index === 1
+          ? { ...frame, function: "serializeApplicationState" }
+          : frame
+      ),
+    ],
+    [
+      "an additional application serialization caller",
+      [
+        ...createRawExecutionFrames().slice(0, 2),
+        {
+          filename: "app:///utils/applicationSerializer.ts",
+          function: "serializeApplicationState",
+          in_app: true,
+        },
+        createRawExecutionFrames()[2],
+      ],
+    ],
+  ])("preserves the execution stack with %s", (_name, frames) => {
+    const event = createEvent({ frames });
+
+    expect(shouldFilterMetaMaskMobileSpaNavigationCyclicJsonError(event)).toBe(
+      false
+    );
+  });
+
+  it.each([
+    ["a missing event timestamp", { eventTimestamp: null }],
+    ["a missing breadcrumb timestamp", { navigationTimestamp: null }],
+    ["a 50 ms delay", { eventTimestamp: 1000.05 }],
+    ["a 500 ms delay", { eventTimestamp: 1000.5 }],
+    ["a non-navigation breadcrumb", { navigationCategory: "ui.click" }],
+    ["missing navigation data", { navigationData: {} }],
+  ] satisfies Array<[string, FixtureOptions]>)(
+    "preserves the timing near miss with %s",
+    (_name, options) => {
+      const event = createEvent(options);
+
+      expect(
+        shouldFilterMetaMaskMobileSpaNavigationCyclicJsonError(event)
+      ).toBe(false);
+    }
+  );
+});

--- a/__tests__/utils/metamaskMobileNavigationFilter.test.ts
+++ b/__tests__/utils/metamaskMobileNavigationFilter.test.ts
@@ -16,8 +16,40 @@ const initialInjectedSchedulingFrame = {
   column: 15,
   origin: "unknown",
 };
+const observedExternalSchedulingFrame = {
+  file: "external/js",
+  function: "anonymous",
+  line: 798,
+  column: 281,
+  origin: "third_party",
+};
 
-function createRawExecutionFrames(): SentryStackFrame[] {
+function createMixedOriginSchedulingFrames(
+  externalFrame: Record<string, unknown> = observedExternalSchedulingFrame
+): Record<string, unknown>[] {
+  return [
+    initialInjectedSchedulingFrame,
+    externalFrame,
+    {
+      file: "/_next/static/chunks/0synthetic-navigation.js",
+      function: "anonymous",
+      line: 51,
+      column: 8604,
+      origin: "first_party",
+    },
+    ...["sy", "li", "lr", "li", "lr"].map((functionName, index) => ({
+      file: "/_next/static/chunks/0synthetic-navigation.js",
+      function: functionName,
+      line: 21,
+      column: 200000 + index,
+      origin: "first_party",
+    })),
+  ];
+}
+
+function createRawExecutionFrames(
+  diagnosticFunction: "?" | null = "?"
+): SentryStackFrame[] {
   return [
     {
       filename: RAW_CHUNK,
@@ -30,6 +62,7 @@ function createRawExecutionFrames(): SentryStackFrame[] {
     {
       filename: RAW_CHUNK,
       abs_path: RAW_CHUNK,
+      ...(diagnosticFunction !== null && { function: diagnosticFunction }),
       lineno: 21,
       colno: 90001,
       in_app: true,
@@ -169,10 +202,44 @@ describe("MetaMask Mobile SPA navigation cyclic JSON filter", () => {
     }
   );
 
+  it.each([
+    ["the Sentry anonymous function sentinel", createRawExecutionFrames()],
+    ["an omitted function name", createRawExecutionFrames(null)],
+  ])("filters a raw diagnostic wrapper with %s", (_name, frames) => {
+    const event = createEvent({ frames });
+
+    expect(shouldFilterMetaMaskMobileSpaNavigationCyclicJsonError(event)).toBe(
+      true
+    );
+  });
+
   it.each([0.103, 0.145, 0.295])(
     "filters the cohort-backed %.3f second navigation delay",
     (delaySeconds) => {
       const event = createEvent({ eventTimestamp: 1000 + delaySeconds });
+
+      expect(
+        shouldFilterMetaMaskMobileSpaNavigationCyclicJsonError(event)
+      ).toBe(true);
+    }
+  );
+
+  it.each([790, 798])(
+    "filters the v2 mixed-origin navigation signature at external line %i",
+    (externalLine) => {
+      const event = createEvent({
+        diagnosticsOverrides: {
+          scheduleOrigin: "mixed",
+          schedulingFrames: createMixedOriginSchedulingFrames({
+            ...observedExternalSchedulingFrame,
+            line: externalLine,
+          }),
+        },
+        tags: {
+          cyclic_json_timer_diagnostics: "v2",
+          cyclic_json_timer_schedule_origin: "mixed",
+        },
+      });
 
       expect(
         shouldFilterMetaMaskMobileSpaNavigationCyclicJsonError(event)
@@ -259,6 +326,48 @@ describe("MetaMask Mobile SPA navigation cyclic JSON filter", () => {
     ],
   ])("preserves diagnostics with %s", (_name, schedulingFrames) => {
     const event = createEvent({ diagnosticsOverrides: { schedulingFrames } });
+
+    expect(shouldFilterMetaMaskMobileSpaNavigationCyclicJsonError(event)).toBe(
+      false
+    );
+  });
+
+  it.each([
+    [
+      "a different external script path",
+      createMixedOriginSchedulingFrames({
+        ...observedExternalSchedulingFrame,
+        file: "external/inpage.js",
+      }),
+    ],
+    [
+      "a changed external frame coordinate",
+      createMixedOriginSchedulingFrames({
+        ...observedExternalSchedulingFrame,
+        line: 799,
+      }),
+    ],
+    [
+      "a truncated scheduling stack",
+      createMixedOriginSchedulingFrames().slice(0, 7),
+    ],
+    [
+      "an additional third-party frame",
+      createMixedOriginSchedulingFrames().map((frame, index) =>
+        index === 2 ? observedExternalSchedulingFrame : frame
+      ),
+    ],
+  ])("preserves mixed-origin diagnostics with %s", (_name, schedulingFrames) => {
+    const event = createEvent({
+      diagnosticsOverrides: {
+        scheduleOrigin: "mixed",
+        schedulingFrames,
+      },
+      tags: {
+        cyclic_json_timer_diagnostics: "v2",
+        cyclic_json_timer_schedule_origin: "mixed",
+      },
+    });
 
     expect(shouldFilterMetaMaskMobileSpaNavigationCyclicJsonError(event)).toBe(
       false

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -31,6 +31,7 @@ import {
   shouldFilterDisconnectedWalletProviderRejection,
   shouldFilterInjectedProviderProxyStartsWithError,
   shouldFilterInjectedWalletCollision,
+  shouldFilterMetaMaskMobileSpaNavigationCyclicJsonError,
   shouldFilterReactDomInsertBeforeNotFoundError,
   shouldFilterReactDomRemoveChildNotFoundError,
   shouldFilterInjectedWasmCspUnsafeEval,
@@ -200,10 +201,9 @@ function shouldFilterEvent(
     return true;
   }
 
-  // Intentionally do not call shouldFilterSentryRouteParameterizationError.
-  // Keep all cyclic JSON timer failures while origin diagnostics are active.
-  // Generic Sentry/WKWebView frames do not prove third-party ownership, so
-  // retaining only the sampled diagnostic subset would hide genuine app errors.
+  if (shouldFilterMetaMaskMobileSpaNavigationCyclicJsonError(event)) {
+    return true;
+  }
 
   if (shouldFilterAppleWebKitSortedTrackListTypeError(event)) {
     return true;
@@ -467,11 +467,11 @@ Sentry.init({
   },
 
   beforeSend(event, hint) {
+    enrichCyclicJsonTimerEvent(event, hint);
+
     if (shouldFilterEvent(event, hint)) {
       return null;
     }
-
-    enrichCyclicJsonTimerEvent(event, hint);
 
     const error = hint?.originalException ?? hint?.syntheticException;
     const value = event.exception?.values?.[0];

--- a/ops/telemetry/registry.json
+++ b/ops/telemetry/registry.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastReviewed": "2026-07-17",
+  "lastReviewed": "2026-07-18",
   "operationalOwner": "frontend-platform",
   "providers": [
     {
@@ -406,15 +406,15 @@
     {
       "name": "cyclic_json_timer_diagnostics",
       "kind": "error-family",
-      "question": "Which code origin schedules exact cyclic JSON timer failures in iOS WKWebViews?",
+      "question": "Which code origin schedules exact cyclic JSON timer failures in iOS WKWebViews, and does v2 provenance match the narrow MetaMask Mobile SPA-navigation suppression signature?",
       "owner": "sentry",
       "producer": "utils/monitoring/cyclicJsonTimerDiagnostics.ts",
       "destinations": ["sentry:owner"],
       "sampling": "eligible function timers in iOS WKWebViews are sampled independently at 1/16; only exact unhandled cyclic-JSON timer errors receive sampled provenance",
       "privacy": "timer arguments are removed from every matching event; sampled extras contain bounded sanitized function names, script basenames, line and column numbers, origin enums, WebView family, and sample rate only",
-      "externalUsage": "v1 is live; Sentry dashboard, saved-search, and alert usage could not be verified because read-only endpoints returned 403",
+      "externalUsage": "Repository runtime consumer: instrumentation-client.ts enriches exact timer errors before shouldFilterMetaMaskMobileSpaNavigationCyclicJsonError requires the v2 tags and extra; v1 Sentry dashboard, saved-search, and alert usage could not be verified because read-only endpoints returned 403",
       "lifecycle": "temporary",
-      "replacement": "By the review date, verify or migrate every v1-keyed Sentry consumer to v2; remove the timer diagnostics after corrected provenance identifies the caller",
+      "replacement": "Keep v2 diagnostics while the MetaMask Mobile runtime filter depends on them. Before removal, replace that filter with an equally narrow independent signature or retire it; by the review date, also verify or migrate every v1-keyed Sentry consumer to v2",
       "reviewBy": "2026-08-17"
     },
     {

--- a/utils/sentry-client-filters.ts
+++ b/utils/sentry-client-filters.ts
@@ -28,6 +28,9 @@ export {
   shouldFilterTwitterConfigReferenceError,
 } from "./sentry-client-filters/errors";
 export {
+  shouldFilterMetaMaskMobileSpaNavigationCyclicJsonError,
+} from "./sentry-client-filters/metamask-mobile";
+export {
   shouldFilterBrowserExtensionMessagingConnectionError,
   shouldFilterBrowserExtensionSendMessageError,
 } from "./sentry-client-filters/extension-messaging";

--- a/utils/sentry-client-filters/metamask-mobile.ts
+++ b/utils/sentry-client-filters/metamask-mobile.ts
@@ -1,0 +1,196 @@
+import {
+  sentryRouteParameterizationMechanismType,
+  sentryRouteParameterizationMessage,
+} from "./constants";
+import type { SentryClientEvent, SentryStackFrame } from "./types";
+import { getBreadcrumbValues, getFramePaths, isRecord } from "./value-utils";
+
+const diagnosticsTag = "cyclic_json_timer_diagnostics";
+const scheduleOriginTag = "cyclic_json_timer_schedule_origin";
+const diagnosticsExtraKey = "cyclicJsonTimerDiagnostics";
+const diagnosticsVersion = "v2";
+const diagnosticSampleRate = 1 / 16;
+const minimumNavigationDelaySeconds = 0.075;
+const maximumNavigationDelaySeconds = 0.35;
+const rawNextChunkPathPattern =
+  /^app:\/\/\/_next\/static\/chunks\/[a-z0-9._~-]+\.js$/i;
+const sentryRawTimerWrapperLine = 7;
+const sentryRawTimerWrapperColumn = 4858;
+const maximumSchedulingFrames = 8;
+
+function isFiniteTimestamp(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isNativeStringifyFrame(frame: SentryStackFrame | undefined): boolean {
+  return (
+    frame?.filename === "[native code]" &&
+    (frame.abs_path === undefined || frame.abs_path === "[native code]") &&
+    frame.function === "stringify"
+  );
+}
+
+function isRawSentryTimerWrapperFrame(
+  frame: SentryStackFrame | undefined
+): boolean {
+  if (
+    frame?.function !== "n" ||
+    frame.lineno !== sentryRawTimerWrapperLine ||
+    frame.colno !== sentryRawTimerWrapperColumn
+  ) {
+    return false;
+  }
+
+  const paths = getFramePaths(frame);
+  return (
+    paths.length > 0 &&
+    paths.every((path) => rawNextChunkPathPattern.test(path))
+  );
+}
+
+function isRawDiagnosticWrapperFrame(
+  frame: SentryStackFrame | undefined,
+  sentryWrapper: SentryStackFrame | undefined
+): boolean {
+  if (
+    !frame ||
+    !sentryWrapper ||
+    (typeof frame.function === "string" && frame.function.length > 0) ||
+    !isValidFrameCoordinate(frame.lineno) ||
+    !isValidFrameCoordinate(frame.colno)
+  ) {
+    return false;
+  }
+
+  const wrapperPaths = getFramePaths(sentryWrapper);
+  const diagnosticPaths = getFramePaths(frame);
+  return (
+    diagnosticPaths.length > 0 &&
+    diagnosticPaths.length === wrapperPaths.length &&
+    diagnosticPaths.every((path) => wrapperPaths.includes(path))
+  );
+}
+
+function hasRawWrapperOnlyExecutionStack(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  if (!Array.isArray(frames) || frames.length !== 3) {
+    return false;
+  }
+
+  const [sentryWrapper, diagnosticWrapper, nativeStringify] = frames;
+  return (
+    isRawSentryTimerWrapperFrame(sentryWrapper) &&
+    isRawDiagnosticWrapperFrame(diagnosticWrapper, sentryWrapper) &&
+    isNativeStringifyFrame(nativeStringify)
+  );
+}
+
+function isValidFrameCoordinate(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 1;
+}
+
+function isInitialInjectedSchedulingFrame(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    value["file"] === "non-http-script" &&
+    value["function"] === "anonymous" &&
+    value["origin"] === "unknown" &&
+    isValidFrameCoordinate(value["line"]) &&
+    isValidFrameCoordinate(value["column"])
+  );
+}
+
+function isFirstPartyNavigationSchedulingFrame(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    typeof value["file"] === "string" &&
+    value["file"].startsWith("/_next/static/chunks/") &&
+    typeof value["function"] === "string" &&
+    value["function"].length > 0 &&
+    value["origin"] === "first_party" &&
+    isValidFrameCoordinate(value["line"]) &&
+    isValidFrameCoordinate(value["column"])
+  );
+}
+
+function hasExactV2MetaMaskDiagnostics(event: SentryClientEvent): boolean {
+  if (
+    event.tags?.[diagnosticsTag] !== diagnosticsVersion ||
+    event.tags[scheduleOriginTag] !== "first_party"
+  ) {
+    return false;
+  }
+
+  const diagnostics = event.extra?.[diagnosticsExtraKey];
+  if (
+    !isRecord(diagnostics) ||
+    diagnostics["schemaVersion"] !== diagnosticsVersion ||
+    diagnostics["timerSampleRate"] !== diagnosticSampleRate ||
+    diagnostics["callbackName"] !== "anonymous" ||
+    diagnostics["webViewFamily"] !== "metamask-mobile" ||
+    diagnostics["scheduleOrigin"] !== "first_party"
+  ) {
+    return false;
+  }
+
+  const schedulingFrames = diagnostics["schedulingFrames"];
+  return (
+    Array.isArray(schedulingFrames) &&
+    schedulingFrames.length >= 2 &&
+    schedulingFrames.length <= maximumSchedulingFrames &&
+    isInitialInjectedSchedulingFrame(schedulingFrames[0]) &&
+    schedulingFrames.slice(1).every(isFirstPartyNavigationSchedulingFrame)
+  );
+}
+
+function hasRecentSpaNavigation(event: SentryClientEvent): boolean {
+  const eventTimestamp = event.timestamp;
+  if (!isFiniteTimestamp(eventTimestamp)) {
+    return false;
+  }
+
+  return getBreadcrumbValues(event).some((breadcrumb) => {
+    const data = breadcrumb.data;
+    if (
+      breadcrumb.category !== "navigation" ||
+      !isFiniteTimestamp(breadcrumb.timestamp) ||
+      !data ||
+      typeof data["from"] !== "string" ||
+      typeof data["to"] !== "string"
+    ) {
+      return false;
+    }
+
+    const delaySeconds = eventTimestamp - breadcrumb.timestamp;
+    return (
+      delaySeconds >= minimumNavigationDelaySeconds &&
+      delaySeconds <= maximumNavigationDelaySeconds
+    );
+  });
+}
+
+export function shouldFilterMetaMaskMobileSpaNavigationCyclicJsonError(
+  event: SentryClientEvent
+): boolean {
+  const values = event.exception?.values;
+  if (!Array.isArray(values) || values.length !== 1) {
+    return false;
+  }
+
+  const [value] = values;
+  if (
+    value?.type !== "TypeError" ||
+    value.value !== sentryRouteParameterizationMessage ||
+    value.mechanism?.type !== sentryRouteParameterizationMechanismType ||
+    value.mechanism.handled !== false
+  ) {
+    return false;
+  }
+
+  return (
+    hasRawWrapperOnlyExecutionStack(value.stacktrace?.frames) &&
+    hasExactV2MetaMaskDiagnostics(event) &&
+    hasRecentSpaNavigation(event)
+  );
+}

--- a/utils/sentry-client-filters/metamask-mobile.ts
+++ b/utils/sentry-client-filters/metamask-mobile.ts
@@ -17,9 +17,21 @@ const rawNextChunkPathPattern =
 const sentryRawTimerWrapperLine = 7;
 const sentryRawTimerWrapperColumn = 4858;
 const maximumSchedulingFrames = 8;
+// Keep the mixed-origin branch tied to the two observed bridge bundles. Any
+// vendor coordinate or stack-shape drift must fail open and retain the event.
+const mixedOriginExternalFrameLines = new Set([790, 798]);
+const mixedOriginExternalFrameColumn = 281;
 
 function isFiniteTimestamp(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
+}
+
+function isAnonymousRawFrameFunction(value: string | undefined): boolean {
+  return value === undefined || value === "?";
+}
+
+function isUnknownArray(value: unknown): value is unknown[] {
+  return Array.isArray(value);
 }
 
 function isNativeStringifyFrame(frame: SentryStackFrame | undefined): boolean {
@@ -55,7 +67,7 @@ function isRawDiagnosticWrapperFrame(
   if (
     !frame ||
     !sentryWrapper ||
-    (typeof frame.function === "string" && frame.function.length > 0) ||
+    !isAnonymousRawFrameFunction(frame.function) ||
     !isValidFrameCoordinate(frame.lineno) ||
     !isValidFrameCoordinate(frame.colno)
   ) {
@@ -114,10 +126,51 @@ function isFirstPartyNavigationSchedulingFrame(value: unknown): boolean {
   );
 }
 
+function isObservedExternalNavigationFrame(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    value["file"] === "external/js" &&
+    value["function"] === "anonymous" &&
+    value["origin"] === "third_party" &&
+    typeof value["line"] === "number" &&
+    mixedOriginExternalFrameLines.has(value["line"]) &&
+    value["column"] === mixedOriginExternalFrameColumn
+  );
+}
+
+function hasCohortBackedSchedulingFrames(
+  schedulingFrames: unknown,
+  scheduleOrigin: "first_party" | "mixed"
+): boolean {
+  if (
+    !isUnknownArray(schedulingFrames) ||
+    schedulingFrames.length < 2 ||
+    schedulingFrames.length > maximumSchedulingFrames ||
+    !isInitialInjectedSchedulingFrame(schedulingFrames[0])
+  ) {
+    return false;
+  }
+
+  if (scheduleOrigin === "first_party") {
+    return schedulingFrames
+      .slice(1)
+      .every(isFirstPartyNavigationSchedulingFrame);
+  }
+
+  const [externalFrame, ...firstPartyFrames] = schedulingFrames.slice(1);
+  return (
+    schedulingFrames.length === maximumSchedulingFrames &&
+    isObservedExternalNavigationFrame(externalFrame) &&
+    firstPartyFrames.length > 0 &&
+    firstPartyFrames.every(isFirstPartyNavigationSchedulingFrame)
+  );
+}
+
 function hasExactV2MetaMaskDiagnostics(event: SentryClientEvent): boolean {
+  const scheduleOrigin = event.tags?.[scheduleOriginTag];
   if (
     event.tags?.[diagnosticsTag] !== diagnosticsVersion ||
-    event.tags[scheduleOriginTag] !== "first_party"
+    (scheduleOrigin !== "first_party" && scheduleOrigin !== "mixed")
   ) {
     return false;
   }
@@ -129,18 +182,14 @@ function hasExactV2MetaMaskDiagnostics(event: SentryClientEvent): boolean {
     diagnostics["timerSampleRate"] !== diagnosticSampleRate ||
     diagnostics["callbackName"] !== "anonymous" ||
     diagnostics["webViewFamily"] !== "metamask-mobile" ||
-    diagnostics["scheduleOrigin"] !== "first_party"
+    diagnostics["scheduleOrigin"] !== scheduleOrigin
   ) {
     return false;
   }
 
-  const schedulingFrames = diagnostics["schedulingFrames"];
-  return (
-    Array.isArray(schedulingFrames) &&
-    schedulingFrames.length >= 2 &&
-    schedulingFrames.length <= maximumSchedulingFrames &&
-    isInitialInjectedSchedulingFrame(schedulingFrames[0]) &&
-    schedulingFrames.slice(1).every(isFirstPartyNavigationSchedulingFrame)
+  return hasCohortBackedSchedulingFrames(
+    diagnostics["schedulingFrames"],
+    scheduleOrigin
   );
 }
 

--- a/utils/sentry-client-filters/types.ts
+++ b/utils/sentry-client-filters/types.ts
@@ -17,6 +17,7 @@ export type SentryTransactionSpan = {
 export type SentryContext = Record<string, unknown>;
 
 export type SentryBreadcrumb = {
+  timestamp?: number | undefined;
   type?: string | undefined;
   category?: string | undefined;
   level?: string | undefined;
@@ -57,6 +58,7 @@ export type SentryTags = Record<string, unknown>;
 
 export type SentryClientEvent = {
   event_id?: string | undefined;
+  timestamp?: number | undefined;
   transaction?: string | undefined;
   message?: string | undefined;
   exception?:


### PR DESCRIPTION
<!-- sentry-fix-job:27 issue:7615674739 -->
## Issue

- Sentry: [6529-FRONTEND-ET](https://seize-ff.sentry.io/issues/7615674739/)
- First seen: 2026-07-16T17:46:31.692Z
- Latest occurrence: 2026-08-03T00:38:46.000Z
- Automatic triage confidence: 97%

A draft telemetry fix is useful. The corrected v2 event identifies MetaMask Mobile’s injected navigation bridge, not 6529 or Sentry route parameterization, as the cyclic serializer. Replace the dormant broad WKWebView matcher with a narrow MetaMask-only, v2-diagnostics-backed filter while preserving all near-misses.

## Fix

MetaMask Mobile’s injected navigation bridge serializes a cyclic DOM element after SPA navigation. The repair defect was that Sentry 10.45.0 normalizes an anonymous parsed frame’s function to "?" before beforeSend, while the filter accepted only an omitted function value.

## Changes

- Accepted only an omitted function or Sentry’s exact "?" anonymous sentinel for the diagnostic wrapper frame.
- Updated unit and beforeSend integration fixtures to reproduce the SDK-normalized frame.
- Preserved the existing strict stack shape, MetaMask diagnostics, vendor coordinates, navigation timing, and named application-caller rejection.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Focused Jest passed: 3 suites.
- Changed-file ESLint passed.
- Changed-file typecheck passed for 4 TypeScript files.
- React Doctor passed at 100/100.
- git diff --check and added-line credential/local-path scan passed.

## Risk

- Assessed risk: low
- Changed files: 7
- Changed lines: 1021
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

Sentry does not identify the installed MetaMask app version. The telemetry filter remains deliberately tied to observed bridge signatures and fails open if they drift. Changes are uncommitted and unpushed for the trusted publisher.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
