### PR TITLE
Keep wave chat input visible above iPhone keyboards

### DIFF
--- a/__tests__/hooks/useNativeKeyboard.test.ts
+++ b/__tests__/hooks/useNativeKeyboard.test.ts
@@ -174,13 +174,24 @@ describe("useNativeKeyboard", () => {
     }
   });
 
-  it("keeps the native iOS inset authoritative while the keyboard opens", async () => {
+  it("keeps the native iOS inset authoritative after did-show", async () => {
     const originalInnerHeight = globalThis.innerHeight;
+    const originalVisualViewport = globalThis.visualViewport;
     const originalRequestAnimationFrame = window.requestAnimationFrame;
     const originalCancelAnimationFrame = window.cancelAnimationFrame;
+    let visualViewportHeight = 800;
+    const visualViewport = new EventTarget();
+    Object.defineProperties(visualViewport, {
+      height: { get: () => visualViewportHeight },
+      offsetTop: { value: 0 },
+    });
     Object.defineProperty(globalThis, "innerHeight", {
       configurable: true,
       value: 800,
+    });
+    Object.defineProperty(globalThis, "visualViewport", {
+      configurable: true,
+      value: visualViewport,
     });
     window.requestAnimationFrame = (callback: FrameRequestCallback) => {
       callback(0);
@@ -210,10 +221,32 @@ describe("useNativeKeyboard", () => {
           "--native-keyboard-inset-bottom"
         )
       ).toBe("320px");
+
+      act(() => {
+        listeners["keyboardDidShow"]?.({ keyboardHeight: 336 });
+      });
+
+      visualViewportHeight = 620;
+
+      act(() => {
+        visualViewport.dispatchEvent(new Event("resize"));
+      });
+
+      expect(result.current.phase).toBe("visible");
+      expect(result.current.keyboardHeight).toBe(336);
+      expect(
+        document.documentElement.style.getPropertyValue(
+          "--native-keyboard-inset-bottom"
+        )
+      ).toBe("336px");
     } finally {
       Object.defineProperty(globalThis, "innerHeight", {
         configurable: true,
         value: originalInnerHeight,
+      });
+      Object.defineProperty(globalThis, "visualViewport", {
+        configurable: true,
+        value: originalVisualViewport,
       });
       window.requestAnimationFrame = originalRequestAnimationFrame;
       window.cancelAnimationFrame = originalCancelAnimationFrame;

--- a/hooks/useNativeKeyboard.ts
+++ b/hooks/useNativeKeyboard.ts
@@ -324,13 +324,9 @@ function markKeyboardHiddenFromFallback(): void {
 }
 
 function syncKeyboardVisibilityFromViewport(): void {
-  // Native iOS will-events provide the final geometry before animation starts.
-  // Intermediate viewport frames must not replace that animation target.
-  if (
-    currentState.isIos &&
-    nativeKeyboardLifecycleActive &&
-    (currentState.phase === "showing" || currentState.phase === "hiding")
-  ) {
+  // Native iOS events provide the final keyboard frame. Viewport updates can
+  // arrive late and report device-specific intermediate geometry.
+  if (currentState.isIos && nativeKeyboardLifecycleActive) {
     return;
   }
 


### PR DESCRIPTION
## Issue
- On smaller iPhones, opening the keyboard in a wave chat could initially position the composer correctly and then let a late visual-viewport update move it behind the keyboard.
- The regression was reported on iPhone 11 Pro while larger iPhones remained stable.

## Fix
- Keep the native iOS keyboard frame authoritative from the first native show event until the native hide lifecycle completes.
- Continue using visual-viewport measurements as the fallback when no native iOS keyboard lifecycle is active.

## Changes
- Prevent late iOS visual-viewport updates from overwriting the native keyboard inset after `keyboardDidShow`.
- Extend the keyboard hook regression test to reproduce a delayed viewport resize after the native keyboard is visible.

## Validation
- Focused Jest keyboard-hook test: passed.
- Changed-file lint: passed.
- TypeScript checks: passed.
- React Doctor: 100/100, no issues.
- Native QA: iPhone 11 Pro simulator passed open, type, clear, and close with the composer visible above the software keyboard.
- Physical-device regression QA: iPhone 14 Pro Max passed open, type, clear, close, and reopen. The draft was cleared and nothing was posted.
- Responsive QA: desktop (1280px) and tablet-width (768px) layouts kept the composer pinned and visible.
- `check:changed` completed its task-specific typecheck, formatting, and lint steps; its global Knip step reported existing unused files/exports outside this two-file change.

## Risk
- Level: Medium
- Why: the change is small and iOS-native-specific, but the shared keyboard hook serves multiple native composer surfaces.
- Rollback: revert the single commit to restore the previous viewport fallback behavior.

## Review Notes
- Please focus on the boundary between authoritative native iOS events and the visual-viewport fallback.
- The fallback still resumes after `keyboardDidHide` and remains unchanged for Android and non-native browsers.