### PR TITLE
Fix draft wave mention autocomplete

### DIFF
--- a/__tests__/components/drops/create/lexical/plugins/mentions/MentionsPlugin.test.tsx
+++ b/__tests__/components/drops/create/lexical/plugins/mentions/MentionsPlugin.test.tsx
@@ -105,8 +105,25 @@ describe("MentionsPlugin", () => {
     );
 
     expect(useIdentitiesSearch).toHaveBeenCalledWith({
+      draftScope: {
+        kind: "group",
+        visibilityGroupId: "visibility-group",
+      },
       handle: "",
-      visibilityGroupId: "visibility-group",
+      waveId: null,
+    });
+  });
+
+  it("uses an explicit disabled draft scope without a provider", () => {
+    (useIdentitiesSearch as jest.Mock).mockReturnValue({ identities: [] });
+
+    render(
+      <NewMentionsPlugin waveId={null} onSelect={jest.fn()} ref={createRef()} />
+    );
+
+    expect(useIdentitiesSearch).toHaveBeenCalledWith({
+      draftScope: { kind: "disabled" },
+      handle: "",
       waveId: null,
     });
   });

--- a/__tests__/components/drops/create/lexical/plugins/mentions/MentionsPlugin.test.tsx
+++ b/__tests__/components/drops/create/lexical/plugins/mentions/MentionsPlugin.test.tsx
@@ -3,6 +3,7 @@ import { render, act } from "@testing-library/react";
 import NewMentionsPlugin, {
   MentionTypeaheadOption,
 } from "@/components/drops/create/lexical/plugins/mentions/MentionsPlugin";
+import { MentionSearchScopeProvider } from "@/components/drops/create/lexical/plugins/mentions/MentionSearchScopeContext";
 
 jest.mock("@lexical/react/LexicalComposerContext", () => ({
   useLexicalComposerContext: () => [{ update: (fn: any) => fn() }],
@@ -45,6 +46,10 @@ const {
 } = require("@/components/drops/create/lexical/nodes/GroupMentionNode");
 
 describe("MentionsPlugin", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("builds options from identities and exposes open state", () => {
     (useIdentitiesSearch as jest.Mock).mockReturnValue({
       identities: [{ id: "1", handle: "alice", display: "Alice", pfp: null }],
@@ -84,6 +89,26 @@ describe("MentionsPlugin", () => {
       handle_in_content: option.handle,
     });
     expect(close).toHaveBeenCalled();
+  });
+
+  it("passes the draft visibility group to identity search", () => {
+    (useIdentitiesSearch as jest.Mock).mockReturnValue({ identities: [] });
+
+    render(
+      <MentionSearchScopeProvider visibilityGroupId="visibility-group">
+        <NewMentionsPlugin
+          waveId={null}
+          onSelect={jest.fn()}
+          ref={createRef()}
+        />
+      </MentionSearchScopeProvider>
+    );
+
+    expect(useIdentitiesSearch).toHaveBeenCalledWith({
+      handle: "",
+      visibilityGroupId: "visibility-group",
+      waveId: null,
+    });
   });
 
   it("renders the menu wrapper on the raised typeahead layer", () => {

--- a/__tests__/components/waves/create-wave/description/CreateWaveDescription.test.tsx
+++ b/__tests__/components/waves/create-wave/description/CreateWaveDescription.test.tsx
@@ -23,9 +23,9 @@ jest.mock("@/components/drops/create/DropEditor", () =>
     } = require("@/components/waves/CreateDropEmojiPickerLayerContext");
     const emojiPickerLayer = useCreateDropEmojiPickerLayer();
     const {
-      useDraftMentionVisibilityGroupId,
+      useDraftMentionSearchScope,
     } = require("@/components/drops/create/lexical/plugins/mentions/MentionSearchScopeContext");
-    const visibilityGroupId = useDraftMentionVisibilityGroupId();
+    const draftMentionSearchScope = useDraftMentionSearchScope();
 
     React.useImperativeHandle(ref, () => ({
       getDropSnapshot: () => ({ content: "snapshot drop" }),
@@ -49,7 +49,9 @@ jest.mock("@/components/drops/create/DropEditor", () =>
         <div data-testid="wave-name">{props.wave?.name}</div>
         <div data-testid="wave-image">{props.wave?.image}</div>
         <div data-testid="wave-id-prop">{props.wave?.id}</div>
-        <div data-testid="visibility-group-id">{visibilityGroupId}</div>
+        <div data-testid="draft-mention-search-scope">
+          {JSON.stringify(draftMentionSearchScope)}
+        </div>
         <div data-testid="emoji-picker-desktop-z-index">
           {emojiPickerLayer.desktopZIndex}
         </div>
@@ -139,8 +141,21 @@ describe("CreateWaveDescription", () => {
       "https://example.com/image.png"
     );
     expect(screen.getByTestId("wave-id-prop")).toHaveTextContent("wave-123");
-    expect(screen.getByTestId("visibility-group-id")).toHaveTextContent(
-      "visibility-group"
+    expect(screen.getByTestId("draft-mention-search-scope")).toHaveTextContent(
+      JSON.stringify({
+        kind: "group",
+        visibilityGroupId: "visibility-group",
+      })
+    );
+  });
+
+  it("uses the explicit public draft mention scope", () => {
+    render(
+      <CreateWaveDescription {...defaultProps} visibilityGroupId={null} />
+    );
+
+    expect(screen.getByTestId("draft-mention-search-scope")).toHaveTextContent(
+      JSON.stringify({ kind: "public" })
     );
   });
 

--- a/__tests__/components/waves/create-wave/description/CreateWaveDescription.test.tsx
+++ b/__tests__/components/waves/create-wave/description/CreateWaveDescription.test.tsx
@@ -22,6 +22,10 @@ jest.mock("@/components/drops/create/DropEditor", () =>
       useCreateDropEmojiPickerLayer,
     } = require("@/components/waves/CreateDropEmojiPickerLayerContext");
     const emojiPickerLayer = useCreateDropEmojiPickerLayer();
+    const {
+      useDraftMentionVisibilityGroupId,
+    } = require("@/components/drops/create/lexical/plugins/mentions/MentionSearchScopeContext");
+    const visibilityGroupId = useDraftMentionVisibilityGroupId();
 
     React.useImperativeHandle(ref, () => ({
       getDropSnapshot: () => ({ content: "snapshot drop" }),
@@ -45,6 +49,7 @@ jest.mock("@/components/drops/create/DropEditor", () =>
         <div data-testid="wave-name">{props.wave?.name}</div>
         <div data-testid="wave-image">{props.wave?.image}</div>
         <div data-testid="wave-id-prop">{props.wave?.id}</div>
+        <div data-testid="visibility-group-id">{visibilityGroupId}</div>
         <div data-testid="emoji-picker-desktop-z-index">
           {emojiPickerLayer.desktopZIndex}
         </div>
@@ -89,6 +94,7 @@ describe("CreateWaveDescription", () => {
     wave: mockWave,
     submitting: false,
     showDropError: false,
+    visibilityGroupId: "visibility-group",
     onHaveDropToSubmitChange: jest.fn(),
   };
 
@@ -133,6 +139,9 @@ describe("CreateWaveDescription", () => {
       "https://example.com/image.png"
     );
     expect(screen.getByTestId("wave-id-prop")).toHaveTextContent("wave-123");
+    expect(screen.getByTestId("visibility-group-id")).toHaveTextContent(
+      "visibility-group"
+    );
   });
 
   it("scopes emoji picker layer above the create-wave modal", () => {

--- a/__tests__/hooks/useIdentitiesSearch.test.tsx
+++ b/__tests__/hooks/useIdentitiesSearch.test.tsx
@@ -9,11 +9,17 @@ jest.mock("@/services/api/common-api");
 function TestComponent({
   handle,
   waveId,
+  visibilityGroupId,
 }: {
   handle: string;
   waveId: string | null;
+  visibilityGroupId?: string | null | undefined;
 }) {
-  const { identities } = useIdentitiesSearch({ handle, waveId });
+  const { identities } = useIdentitiesSearch({
+    handle,
+    visibilityGroupId,
+    waveId,
+  });
   return <div>{identities.map((i) => i.handle).join(",")}</div>;
 }
 
@@ -96,7 +102,47 @@ describe("useIdentitiesSearch", () => {
     await waitFor(() => expect(commonApiFetch).not.toHaveBeenCalled());
   });
 
-  it("skips fetch when there is no wave to derive eligibility from", async () => {
+  it("searches the selected visibility group for a private draft wave", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TestComponent
+          handle="ali"
+          waveId={null}
+          visibilityGroupId="visibility-group"
+        />
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => expect(commonApiFetch).toHaveBeenCalled());
+    expect(commonApiFetch).toHaveBeenCalledWith({
+      endpoint: "v2/waves/mention-search",
+      params: {
+        handle: "ali",
+        limit: "5",
+        visibility_group_id: "visibility-group",
+      },
+      signal: expect.any(AbortSignal),
+    });
+    await screen.findByText("alice");
+  });
+
+  it("searches the public audience for a public draft wave", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TestComponent handle="ali" waveId={null} visibilityGroupId={null} />
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => expect(commonApiFetch).toHaveBeenCalled());
+    expect(commonApiFetch).toHaveBeenCalledWith({
+      endpoint: "v2/waves/mention-search",
+      params: { handle: "ali", limit: "5" },
+      signal: expect.any(AbortSignal),
+    });
+    await screen.findByText("alice");
+  });
+
+  it("skips fetch when there is no wave or draft visibility scope", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <TestComponent handle="alice" waveId={null} />

--- a/__tests__/hooks/useIdentitiesSearch.test.tsx
+++ b/__tests__/hooks/useIdentitiesSearch.test.tsx
@@ -3,21 +3,25 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useIdentitiesSearch } from "@/hooks/useIdentitiesSearch";
 import { commonApiFetch } from "@/services/api/common-api";
+import {
+  DISABLED_DRAFT_MENTION_SEARCH_SCOPE,
+  type DraftMentionSearchScope,
+} from "@/components/drops/create/lexical/plugins/mentions/MentionSearchScopeContext";
 
 jest.mock("@/services/api/common-api");
 
 function TestComponent({
+  draftScope = DISABLED_DRAFT_MENTION_SEARCH_SCOPE,
   handle,
   waveId,
-  visibilityGroupId,
 }: {
+  draftScope?: DraftMentionSearchScope;
   handle: string;
   waveId: string | null;
-  visibilityGroupId?: string | null | undefined;
 }) {
   const { identities } = useIdentitiesSearch({
+    draftScope,
     handle,
-    visibilityGroupId,
     waveId,
   });
   return <div>{identities.map((i) => i.handle).join(",")}</div>;
@@ -106,9 +110,12 @@ describe("useIdentitiesSearch", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <TestComponent
+          draftScope={{
+            kind: "group",
+            visibilityGroupId: "visibility-group",
+          }}
           handle="ali"
           waveId={null}
-          visibilityGroupId="visibility-group"
         />
       </QueryClientProvider>
     );
@@ -129,7 +136,11 @@ describe("useIdentitiesSearch", () => {
   it("searches the public audience for a public draft wave", async () => {
     render(
       <QueryClientProvider client={queryClient}>
-        <TestComponent handle="ali" waveId={null} visibilityGroupId={null} />
+        <TestComponent
+          draftScope={{ kind: "public" }}
+          handle="ali"
+          waveId={null}
+        />
       </QueryClientProvider>
     );
 
@@ -150,5 +161,46 @@ describe("useIdentitiesSearch", () => {
     );
 
     await waitFor(() => expect(commonApiFetch).not.toHaveBeenCalled());
+  });
+
+  it("clears placeholder suggestions when the draft group changes", async () => {
+    let resolveSecondSearch:
+      | ((value: Array<{ handle: string }>) => void)
+      | null = null;
+    (commonApiFetch as jest.Mock)
+      .mockResolvedValueOnce([{ handle: "alice" }])
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSecondSearch = resolve;
+          })
+      );
+
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <TestComponent
+          draftScope={{ kind: "group", visibilityGroupId: "group-a" }}
+          handle="ali"
+          waveId={null}
+        />
+      </QueryClientProvider>
+    );
+    await screen.findByText("alice");
+
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <TestComponent
+          draftScope={{ kind: "group", visibilityGroupId: "group-b" }}
+          handle="ali"
+          waveId={null}
+        />
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => expect(commonApiFetch).toHaveBeenCalledTimes(2));
+    expect(screen.queryByText("alice")).not.toBeInTheDocument();
+
+    resolveSecondSearch?.([{ handle: "alicia" }]);
+    await screen.findByText("alicia");
   });
 });

--- a/__tests__/hooks/useIdentitiesSearch.test.tsx
+++ b/__tests__/hooks/useIdentitiesSearch.test.tsx
@@ -3,10 +3,11 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useIdentitiesSearch } from "@/hooks/useIdentitiesSearch";
 import { commonApiFetch } from "@/services/api/common-api";
-import {
-  DISABLED_DRAFT_MENTION_SEARCH_SCOPE,
-  type DraftMentionSearchScope,
-} from "@/components/drops/create/lexical/plugins/mentions/MentionSearchScopeContext";
+import type { DraftMentionSearchScope } from "@/components/drops/create/lexical/plugins/mentions/MentionSearchScopeContext";
+
+const DISABLED_DRAFT_MENTION_SEARCH_SCOPE: DraftMentionSearchScope = {
+  kind: "disabled",
+};
 
 jest.mock("@/services/api/common-api");
 

--- a/components/drops/create/lexical/plugins/mentions/MentionSearchScopeContext.tsx
+++ b/components/drops/create/lexical/plugins/mentions/MentionSearchScopeContext.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+
+type DraftVisibilityGroupId = string | null | undefined;
+
+const MentionSearchScopeContext =
+  createContext<DraftVisibilityGroupId>(undefined);
+
+export function MentionSearchScopeProvider({
+  children,
+  visibilityGroupId,
+}: {
+  readonly children: ReactNode;
+  readonly visibilityGroupId: string | null;
+}) {
+  return (
+    <MentionSearchScopeContext.Provider value={visibilityGroupId}>
+      {children}
+    </MentionSearchScopeContext.Provider>
+  );
+}
+
+export function useDraftMentionVisibilityGroupId(): DraftVisibilityGroupId {
+  return useContext(MentionSearchScopeContext);
+}

--- a/components/drops/create/lexical/plugins/mentions/MentionSearchScopeContext.tsx
+++ b/components/drops/create/lexical/plugins/mentions/MentionSearchScopeContext.tsx
@@ -1,11 +1,19 @@
 "use client";
 
-import { createContext, useContext, type ReactNode } from "react";
+import { createContext, useContext, useMemo, type ReactNode } from "react";
 
-type DraftVisibilityGroupId = string | null | undefined;
+export type DraftMentionSearchScope =
+  | { readonly kind: "disabled" }
+  | { readonly kind: "public" }
+  | { readonly kind: "group"; readonly visibilityGroupId: string };
 
-const MentionSearchScopeContext =
-  createContext<DraftVisibilityGroupId>(undefined);
+export const DISABLED_DRAFT_MENTION_SEARCH_SCOPE: DraftMentionSearchScope = {
+  kind: "disabled",
+};
+
+const MentionSearchScopeContext = createContext<DraftMentionSearchScope>(
+  DISABLED_DRAFT_MENTION_SEARCH_SCOPE
+);
 
 export function MentionSearchScopeProvider({
   children,
@@ -14,13 +22,21 @@ export function MentionSearchScopeProvider({
   readonly children: ReactNode;
   readonly visibilityGroupId: string | null;
 }) {
+  const scope = useMemo<DraftMentionSearchScope>(
+    () =>
+      visibilityGroupId === null
+        ? { kind: "public" }
+        : { kind: "group", visibilityGroupId },
+    [visibilityGroupId]
+  );
+
   return (
-    <MentionSearchScopeContext.Provider value={visibilityGroupId}>
+    <MentionSearchScopeContext.Provider value={scope}>
       {children}
     </MentionSearchScopeContext.Provider>
   );
 }
 
-export function useDraftMentionVisibilityGroupId(): DraftVisibilityGroupId {
+export function useDraftMentionSearchScope(): DraftMentionSearchScope {
   return useContext(MentionSearchScopeContext);
 }

--- a/components/drops/create/lexical/plugins/mentions/MentionSearchScopeContext.tsx
+++ b/components/drops/create/lexical/plugins/mentions/MentionSearchScopeContext.tsx
@@ -7,7 +7,7 @@ export type DraftMentionSearchScope =
   | { readonly kind: "public" }
   | { readonly kind: "group"; readonly visibilityGroupId: string };
 
-export const DISABLED_DRAFT_MENTION_SEARCH_SCOPE: DraftMentionSearchScope = {
+const DISABLED_DRAFT_MENTION_SEARCH_SCOPE: DraftMentionSearchScope = {
   kind: "disabled",
 };
 

--- a/components/drops/create/lexical/plugins/mentions/MentionsPlugin.tsx
+++ b/components/drops/create/lexical/plugins/mentions/MentionsPlugin.tsx
@@ -28,6 +28,7 @@ import {
   useIdentitiesSearch,
 } from "@/hooks/useIdentitiesSearch";
 import { isInCodeContext } from "@/components/drops/create/lexical/utils/codeContextDetection";
+import { useDraftMentionVisibilityGroupId } from "./MentionSearchScopeContext";
 
 const PUNCTUATION =
   "\\.,\\+\\*\\?\\$\\@\\|#{}\\(\\)\\^\\-\\[\\]\\\\/!%'\"~=<>_:;";
@@ -173,9 +174,11 @@ const NewMentionsPlugin = forwardRef<
 >(({ waveId, onSelect, canMentionAll = false, onSelectGroupMention }, ref) => {
   const [editor] = useLexicalComposerContext();
   const [queryString, setQueryString] = useState<string | null>(null);
+  const visibilityGroupId = useDraftMentionVisibilityGroupId();
   const { identities } = useIdentitiesSearch({
     handle: queryString ?? "",
     waveId,
+    visibilityGroupId,
   });
   const [isOpen, setIsOpen] = useState(false);
   const modalRef = useRef<HTMLDivElement>(null);

--- a/components/drops/create/lexical/plugins/mentions/MentionsPlugin.tsx
+++ b/components/drops/create/lexical/plugins/mentions/MentionsPlugin.tsx
@@ -28,7 +28,7 @@ import {
   useIdentitiesSearch,
 } from "@/hooks/useIdentitiesSearch";
 import { isInCodeContext } from "@/components/drops/create/lexical/utils/codeContextDetection";
-import { useDraftMentionVisibilityGroupId } from "./MentionSearchScopeContext";
+import { useDraftMentionSearchScope } from "./MentionSearchScopeContext";
 
 const PUNCTUATION =
   "\\.,\\+\\*\\?\\$\\@\\|#{}\\(\\)\\^\\-\\[\\]\\\\/!%'\"~=<>_:;";
@@ -174,11 +174,11 @@ const NewMentionsPlugin = forwardRef<
 >(({ waveId, onSelect, canMentionAll = false, onSelectGroupMention }, ref) => {
   const [editor] = useLexicalComposerContext();
   const [queryString, setQueryString] = useState<string | null>(null);
-  const visibilityGroupId = useDraftMentionVisibilityGroupId();
+  const draftScope = useDraftMentionSearchScope();
   const { identities } = useIdentitiesSearch({
+    draftScope,
     handle: queryString ?? "",
     waveId,
-    visibilityGroupId,
   });
   const [isOpen, setIsOpen] = useState(false);
   const modalRef = useRef<HTMLDivElement>(null);

--- a/components/waves/create-wave/CreateWaveStepContent.tsx
+++ b/components/waves/create-wave/CreateWaveStepContent.tsx
@@ -178,6 +178,7 @@ export default function CreateWaveStepContent({
           profile={profile}
           submitting={submitting}
           showDropError={showDropError}
+          visibilityGroupId={config.groups.canView}
           wave={{
             name: config.overview.name,
             image: config.overview.image

--- a/components/waves/create-wave/description/CreateWaveDescription.tsx
+++ b/components/waves/create-wave/description/CreateWaveDescription.tsx
@@ -9,6 +9,7 @@ import { CreateDropEmojiPickerLayerProvider } from "@/components/waves/CreateDro
 import { profileAndConsolidationsToProfileMin } from "@/helpers/ProfileHelpers";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import { CreateDropType } from "@/components/drops/create/types";
+import { MentionSearchScopeProvider } from "@/components/drops/create/lexical/plugins/mentions/MentionSearchScopeContext";
 export interface CreateWaveDescriptionHandles {
   requestDrop: () => CreateDropConfig | null;
   getDropSnapshot: () => CreateDropConfig | null;
@@ -25,6 +26,7 @@ interface CreateWaveDescriptionProps {
   readonly wave: CreateWaveDescriptionWaveProps;
   readonly submitting: boolean;
   readonly showDropError: boolean;
+  readonly visibilityGroupId: string | null;
   readonly onHaveDropToSubmitChange: (canSubmit: boolean) => void;
 }
 
@@ -33,7 +35,14 @@ const CreateWaveDescription = forwardRef<
   CreateWaveDescriptionProps
 >(
   (
-    { profile, submitting, showDropError, wave, onHaveDropToSubmitChange },
+    {
+      profile,
+      submitting,
+      showDropError,
+      visibilityGroupId,
+      wave,
+      onHaveDropToSubmitChange,
+    },
     ref
   ) => {
     const dropEditorRef = useRef<DropEditorHandles | null>(null);
@@ -68,21 +77,23 @@ const CreateWaveDescription = forwardRef<
             desktopZIndex={10000}
             mobileZIndexClassName="tw-z-[10000]"
           >
-            <DropEditor
-              ref={dropEditorRef}
-              waveId={null}
-              profile={profileMin}
-              quotedDrop={null}
-              type={CreateDropType.DROP}
-              loading={submitting}
-              showSubmit={false}
-              submitOnEnter={false}
-              dropEditorRefreshKey={1}
-              showDropError={showDropError}
-              wave={wave}
-              onSubmitDrop={() => {}}
-              onCanSubmitChange={onHaveDropToSubmitChange}
-            />
+            <MentionSearchScopeProvider visibilityGroupId={visibilityGroupId}>
+              <DropEditor
+                ref={dropEditorRef}
+                waveId={null}
+                profile={profileMin}
+                quotedDrop={null}
+                type={CreateDropType.DROP}
+                loading={submitting}
+                showSubmit={false}
+                submitOnEnter={false}
+                dropEditorRefreshKey={1}
+                showDropError={showDropError}
+                wave={wave}
+                onSubmitDrop={() => {}}
+                onCanSubmitChange={onHaveDropToSubmitChange}
+              />
+            </MentionSearchScopeProvider>
           </CreateDropEmojiPickerLayerProvider>
         </div>
       </div>

--- a/hooks/useIdentitiesSearch.tsx
+++ b/hooks/useIdentitiesSearch.tsx
@@ -2,12 +2,13 @@ import { useQuery } from "@tanstack/react-query";
 import type { ApiWaveMentionSearchResult } from "@/generated/models/ApiWaveMentionSearchResult";
 import { commonApiFetch } from "@/services/api/common-api";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
+import type { DraftMentionSearchScope } from "@/components/drops/create/lexical/plugins/mentions/MentionSearchScopeContext";
 import { useDebouncedValue } from "./useDebouncedValue";
 
 interface UseIdentitiesSearchProps {
+  readonly draftScope: DraftMentionSearchScope;
   readonly handle: string;
   readonly waveId: string | null;
-  readonly visibilityGroupId?: string | null | undefined;
 }
 
 export const IDENTITY_SEARCH_MIN_HANDLE_LENGTH = 3;
@@ -19,17 +20,21 @@ const isSearchableHandle = (handle: string) =>
   handle.length <= IDENTITY_SEARCH_MAX_HANDLE_LENGTH;
 
 export function useIdentitiesSearch({
+  draftScope,
   handle,
   waveId,
-  visibilityGroupId,
 }: UseIdentitiesSearchProps) {
   const debouncedHandle = useDebouncedValue(handle, 200);
-  const hasSearchScope = !!waveId || visibilityGroupId !== undefined;
+  const draftScopeKey =
+    draftScope.kind === "group"
+      ? `group:${draftScope.visibilityGroupId}`
+      : draftScope.kind;
+  const hasSearchScope = !!waveId || draftScope.kind !== "disabled";
 
   const { data: identities } = useQuery<ApiWaveMentionSearchResult[]>({
     queryKey: [
       QueryKey.IDENTITY_SEARCH,
-      { handle: debouncedHandle, visibilityGroupId, waveId },
+      { draftScopeKey, handle: debouncedHandle, waveId },
     ],
     queryFn: async ({ signal }) => {
       if (!hasSearchScope) {
@@ -40,8 +45,8 @@ export function useIdentitiesSearch({
         handle: debouncedHandle,
         limit: "5",
       };
-      if (!waveId && visibilityGroupId) {
-        params["visibility_group_id"] = visibilityGroupId;
+      if (!waveId && draftScope.kind === "group") {
+        params["visibility_group_id"] = draftScope.visibilityGroupId;
       }
       return await commonApiFetch<ApiWaveMentionSearchResult[]>({
         endpoint: waveId
@@ -54,12 +59,12 @@ export function useIdentitiesSearch({
     placeholderData: (previousData, previousQuery) => {
       const previousParams = previousQuery?.queryKey[1] as
         | {
-            visibilityGroupId?: string | null;
+            draftScopeKey?: string;
             waveId?: string | null;
           }
         | undefined;
       return previousParams?.waveId === waveId &&
-        previousParams.visibilityGroupId === visibilityGroupId
+        previousParams.draftScopeKey === draftScopeKey
         ? previousData
         : undefined;
     },

--- a/hooks/useIdentitiesSearch.tsx
+++ b/hooks/useIdentitiesSearch.tsx
@@ -7,6 +7,7 @@ import { useDebouncedValue } from "./useDebouncedValue";
 interface UseIdentitiesSearchProps {
   readonly handle: string;
   readonly waveId: string | null;
+  readonly visibilityGroupId?: string | null | undefined;
 }
 
 export const IDENTITY_SEARCH_MIN_HANDLE_LENGTH = 3;
@@ -20,36 +21,57 @@ const isSearchableHandle = (handle: string) =>
 export function useIdentitiesSearch({
   handle,
   waveId,
+  visibilityGroupId,
 }: UseIdentitiesSearchProps) {
   const debouncedHandle = useDebouncedValue(handle, 200);
+  const hasSearchScope = !!waveId || visibilityGroupId !== undefined;
 
   const { data: identities } = useQuery<ApiWaveMentionSearchResult[]>({
-    queryKey: [QueryKey.IDENTITY_SEARCH, { handle: debouncedHandle, waveId }],
+    queryKey: [
+      QueryKey.IDENTITY_SEARCH,
+      { handle: debouncedHandle, visibilityGroupId, waveId },
+    ],
     queryFn: async ({ signal }) => {
-      if (!waveId) {
+      if (!hasSearchScope) {
         return [];
       }
+
+      const params: Record<string, string> = {
+        handle: debouncedHandle,
+        limit: "5",
+      };
+      if (!waveId && visibilityGroupId) {
+        params["visibility_group_id"] = visibilityGroupId;
+      }
       return await commonApiFetch<ApiWaveMentionSearchResult[]>({
-        endpoint: `v2/waves/${encodeURIComponent(waveId)}/mention-search`,
-        params: { handle: debouncedHandle, limit: "5" },
+        endpoint: waveId
+          ? `v2/waves/${encodeURIComponent(waveId)}/mention-search`
+          : "v2/waves/mention-search",
+        params,
         signal,
       });
     },
     placeholderData: (previousData, previousQuery) => {
       const previousParams = previousQuery?.queryKey[1] as
-        | { waveId?: string | null }
+        | {
+            visibilityGroupId?: string | null;
+            waveId?: string | null;
+          }
         | undefined;
-      return previousParams?.waveId === waveId ? previousData : undefined;
+      return previousParams?.waveId === waveId &&
+        previousParams.visibilityGroupId === visibilityGroupId
+        ? previousData
+        : undefined;
     },
     enabled:
-      !!waveId &&
+      hasSearchScope &&
       isSearchableHandle(debouncedHandle) &&
       debouncedHandle === handle,
   });
 
   const normalizedHandle = handle.toLowerCase();
   const visibleIdentities =
-    waveId && isSearchableHandle(handle)
+    hasSearchScope && isSearchableHandle(handle)
       ? (identities ?? []).filter((identity) =>
           identity.handle.toLowerCase().startsWith(normalizedHandle)
         )

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9979,8 +9979,6 @@ paths:
           description: Authentication required
         "403":
           description: An acting profile is required
-        "404":
-          description: Visibility group not found or not visible to the caller
   /v2/waves/{waveId}/mention-search:
     get:
       tags:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9924,6 +9924,63 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiDropsLeaderboardPageV2"
+  /v2/waves/mention-search:
+    get:
+      tags:
+        - WavesV2
+      summary: Search draft-wave-eligible profiles for user mentions
+      description: >-
+        Returns profiles whose handles start with the requested value and who
+        are eligible for the selected draft wave visibility group. Omitting the
+        visibility group searches the public-wave audience. Results are ranked
+        by profile level and exclude the authenticated acting profile.
+      operationId: searchDraftWaveMentions
+      x-6529-router:
+        enabled: true
+        auth: required
+        handler:
+          import: "@/api/waves/wave-mention-search.handler"
+          name: handleSearchDraftWaveMentions
+      parameters:
+        - name: handle
+          in: query
+          required: true
+          schema:
+            type: string
+            minLength: 3
+            maxLength: 15
+            pattern: ^\w{3,15}$
+        - name: visibility_group_id
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 20
+            default: 5
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ApiWaveMentionSearchResult"
+        "400":
+          description: Invalid search request
+        "401":
+          description: Authentication required
+        "403":
+          description: An acting profile is required
+        "404":
+          description: Visibility group not found or not visible to the caller
   /v2/waves/{waveId}/mention-search:
     get:
       tags:

--- a/ops/docs/waves/create/feature-description-step.md
+++ b/ops/docs/waves/create/feature-description-step.md
@@ -29,6 +29,9 @@ You write the first wave drop here, then click `Complete`.
 - Same editor features as wave drop composer:
   mentions, wave mentions, hashtag/NFT references, markdown, emoji, metadata,
   drag/paste media, and optional storm mode (`Break into storm`)
+- Individual `@` mention suggestions use the draft wave's `Who can view`
+  group. Public drafts search all profiles; private drafts suggest only profiles
+  eligible for the selected visibility group.
 
 ## Submit Flow
 

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -1751,6 +1751,7 @@
         "Inline identity groups warn when the connected creator is excluded, because excluding yourself from a view group can prevent you from opening the created wave.",
         "All wave types include a Rules step; Rank and Approve waves also include Dates, Drops, Voting, and Outcomes steps.",
         "The Rules step previews automatic rules generated from wave setup and lets creators add optional custom creator rules.",
+        "In Description, individual @ mention suggestions follow the draft wave's Who can view group; private drafts suggest only eligible profiles.",
         "The docs for wave creation live under ops/docs/waves/create; on web, use /waves?create=wave to open create-wave mode."
       ],
       "canonical_path": "/waves?create=wave",
@@ -1760,7 +1761,8 @@
         "ops/docs/waves/create/README.md",
         "ops/docs/waves/create/feature-overview-step.md",
         "ops/docs/waves/create/feature-groups-step.md",
-        "ops/docs/waves/create/feature-rules-step.md"
+        "ops/docs/waves/create/feature-rules-step.md",
+        "ops/docs/waves/create/feature-description-step.md"
       ]
     },
     {

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -1751,6 +1751,7 @@
         "Inline identity groups warn when the connected creator is excluded, because excluding yourself from a view group can prevent you from opening the created wave.",
         "All wave types include a Rules step; Rank and Approve waves also include Dates, Drops, Voting, and Outcomes steps.",
         "The Rules step previews automatic rules generated from wave setup and lets creators add optional custom creator rules.",
+        "In Description, individual @ mention suggestions follow the draft wave's Who can view group; private drafts suggest only eligible profiles.",
         "The docs for wave creation live under ops/docs/waves/create; on web, use /waves?create=wave to open create-wave mode."
       ],
       "canonical_path": "/waves?create=wave",
@@ -1760,7 +1761,8 @@
         "ops/docs/waves/create/README.md",
         "ops/docs/waves/create/feature-overview-step.md",
         "ops/docs/waves/create/feature-groups-step.md",
-        "ops/docs/waves/create/feature-rules-step.md"
+        "ops/docs/waves/create/feature-rules-step.md",
+        "ops/docs/waves/create/feature-description-step.md"
       ]
     },
     {


### PR DESCRIPTION
## Issue

The create-wave description editor has no persisted wave ID. The mention hook therefore disables identity autocomplete, making it impossible to tag participants in the introductory message.

## Fix

Scope the description editor with the draft's selected `Who can view` group and use the authenticated draft mention-search endpoint whenever no wave ID exists.

## Changes

- pass the draft visibility group into the description editor
- provide that scope to the existing mention plugin without changing persisted-wave callers
- query the draft route for public and private drafts while keeping results isolated in the React Query key
- update focused hook/editor/plugin tests
- document the user-visible behavior and sync the public help index

## Validation

- focused mention/editor suites: 4 suites and 29 tests passed
- `typecheck`, repository lint, `lint:changed`, and `check:changed`
- React Doctor: 100/100, no issues across 8 changed source files
- production Next build passed with inert localhost endpoints in the clean worktree

## Risk

Low. Persisted-wave autocomplete keeps its existing URL and scope. Draft search is enabled only when the create-wave provider supplies an explicit public or private visibility scope.

## Review Notes

Depends on backend PR https://github.com/6529-Collections/6529seize-backend/pull/1768 and must be deployed after the backend API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Mention suggestions during wave creation are now scoped to the draft’s “Who can view” group.
  - Public drafts can suggest all profiles, while private drafts suggest only eligible profiles.
  - Added support for visibility-aware mention searching.

- **Documentation**
  - Updated wave creation guidance and help content to explain mention visibility rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->