### PR TITLE
Fix NextGen staging E2E selectors

### DIFF
--- a/pr-reports/3373.md
+++ b/pr-reports/3373.md
@@ -1,0 +1,39 @@
+# PR Report: Fix NextGen staging E2E selectors
+
+PR: https://github.com/6529-Collections/6529seize-frontend/pull/3373
+Branch: agent/fix-nextgen-staging-e2e-selectors -> main
+Related PRs: https://github.com/6529-Collections/6529seize-frontend/pull/3357
+
+## Summary
+
+Updates the public NextGen read-only browser coverage to follow the accessible
+roles and names introduced by the NextGen page modernization.
+
+## What Changed
+
+- Targets NextGen section navigation through its public links.
+- Targets the collection status filter through its labeled trigger button.
+- Matches the combined collection-and-artist heading on collection details.
+- Preserves the existing desktop and mobile route coverage.
+
+## Frontend Impact
+
+- Routes/views: No runtime changes; coverage remains focused on public NextGen
+  landing, collection list, and collection detail routes.
+- Components: Not affected.
+- Generated API/client: Not affected.
+- User-visible behavior: Not affected.
+
+## Config / Env
+
+None.
+
+## Release Notes
+
+Repairs staging validation for the modernized public NextGen experience without
+changing application behavior.
+
+## Risks / Follow-Ups
+
+The selector changes are grounded in the captured staging accessibility tree;
+the credentialed deployed-environment pack remains the final confirmation.

--- a/tests/collections/nextgen-collections-readonly.spec.ts
+++ b/tests/collections/nextgen-collections-readonly.spec.ts
@@ -115,7 +115,9 @@ test.describe("NextGen and collections read-only coverage @surface @medium @larg
       page.getByRole("navigation", { name: "NextGen sections" })
     ).toBeVisible();
     await expect(
-      page.locator("main").getByRole("heading", { level: 1 }).first()
+      page
+        .locator("main")
+        .getByRole("heading", { level: 1, name: "Pebbles", exact: true })
     ).toBeVisible();
     for (const item of ["Collections", "Artists", "About"]) {
       await expect(nextGenSectionLink(page, item)).toBeVisible();

--- a/tests/collections/nextgen-collections-readonly.spec.ts
+++ b/tests/collections/nextgen-collections-readonly.spec.ts
@@ -79,6 +79,12 @@ function mainButton(page: Page, name: string) {
   return page.locator("main").getByRole("button", { name });
 }
 
+function nextGenSectionLink(page: Page, name: string) {
+  return page
+    .getByRole("navigation", { name: "NextGen sections" })
+    .getByRole("link", { name, exact: true });
+}
+
 function detailButton(page: Page, name: string) {
   return mainButton(page, name).last();
 }
@@ -105,21 +111,17 @@ test.describe("NextGen and collections read-only coverage @surface @medium @larg
     await gotoReady(page, "/nextgen");
 
     await expect(page).toHaveTitle(/NextGen/);
-    await expectAnyVisible(
-      [
-        page.getByAltText("nextgen"),
-        page.getByRole("button", { name: "Collections" }),
-      ],
-      "Expected the NextGen header to render"
-    );
     await expect(
-      page.locator("main").getByRole("heading", { name: "Featured" }).first()
+      page.getByRole("navigation", { name: "NextGen sections" })
+    ).toBeVisible();
+    await expect(
+      page.locator("main").getByRole("heading", { level: 1 }).first()
     ).toBeVisible();
     for (const item of ["Collections", "Artists", "About"]) {
-      await expect(mainButton(page, item).first()).toBeVisible();
+      await expect(nextGenSectionLink(page, item)).toBeVisible();
     }
     await expect(
-      page.getByRole("button", { name: "Explore Collection" })
+      page.getByRole("link", { name: "Explore Collection" })
     ).toBeVisible();
     await expect(
       page.getByRole("heading", { name: "Featured Artist" })
@@ -155,9 +157,11 @@ test.describe("NextGen and collections read-only coverage @surface @medium @larg
     await expect(
       page.getByRole("heading", { level: 1, name: "Collections" })
     ).toBeVisible();
-    const statusFilter = page.getByRole("combobox", { name: "Status:" });
+    const statusFilter = page.getByRole("button", {
+      name: "Filter collections by status",
+    });
     await expect(statusFilter).toBeVisible();
-    await expect(statusFilter).toHaveValue("ALL");
+    await expect(statusFilter).toHaveText("All statuses");
     await expectCardsOrEmpty(
       page,
       page.locator('main a[href*="/nextgen/collection/"]'),
@@ -170,7 +174,7 @@ test.describe("NextGen and collections read-only coverage @surface @medium @larg
 
     await expect(page).toHaveTitle(/Pebbles.*NextGen/);
     await expect(
-      page.getByText("Pebbles", { exact: true }).first()
+      page.getByRole("heading", { level: 1, name: /^Pebbles by/ })
     ).toBeVisible();
     for (const tab of ["Overview", "About", "Provenance", "Trait Sets"]) {
       await expect(detailButton(page, tab)).toBeVisible();


### PR DESCRIPTION
## Issue

The automatic staging E2E run failed after the public NextGen modernization because three Playwright assertions still targeted the former control semantics and title text.

## Fix

Align the read-only NextGen collection pack with the current accessible UI contract.

## Changes

- target the NextGen section navigation as links
- target the collection status filter by its trigger button label and visible state
- assert the combined collection heading instead of an obsolete exact text node
- keep the existing desktop and mobile coverage intact

## Validation

- `./bin/6529 run check:changed`
- local staging execution reached the staging access gate but could not continue because the staging credential is available only to GitHub Actions in this environment

## Risk

- Level: Low
- Why: test-only selector updates; no application or deployment behavior changes
- Rollback: revert the test commit

## Review Notes

Confirm the role/name selectors match the accessibility tree introduced by PR #3357.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated end-to-end validation for the modernized NextGen experience.
  * Improved coverage for section navigation, collection status filtering, and collection detail headings.
  * Preserved desktop and mobile route coverage for public collection pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->