### PR TITLE
Fix subscription report active drop timing

### DIFF
--- a/__tests__/app/tools/subscriptions-report.test.tsx
+++ b/__tests__/app/tools/subscriptions-report.test.tsx
@@ -29,6 +29,12 @@ jest.mock("@/components/meme-calendar/meme-calendar.helpers", () => ({
   displayedSeasonNumberFromIndex: jest.fn((index: number) => index + 1),
   formatFullDate: jest.fn((date: Date) => date.toISOString().slice(0, 10)),
   getCardsRemainingUntilEndOf: jest.fn(() => 2),
+  getMintTimelineDetails: jest.fn((mintNumber: number) => ({
+    mintNumber,
+    mintDayUtc: new Date("2026-07-22T00:00:00.000Z"),
+    instantUtc: new Date("2026-07-22T14:40:00.000Z"),
+    seasonIndex: 15,
+  })),
   getUpcomingMintsAcrossSeasons: jest.fn(() => []),
 }));
 
@@ -61,6 +67,7 @@ jest.mock("@/services/api/common-api", () => ({
 const { commonApiFetch } = require("@/services/api/common-api");
 const {
   getCardsRemainingUntilEndOf,
+  getMintTimelineDetails,
   getUpcomingMintsAcrossSeasons,
 } = require("@/components/meme-calendar/meme-calendar.helpers");
 
@@ -326,7 +333,7 @@ describe("Subscriptions report page", () => {
     });
   });
 
-  it("keeps a redeemed mint-day card active before minting starts without shifting upcoming dates", async () => {
+  it("keeps a redeemed mint-day card active and derives a missing upcoming calendar row by token id", async () => {
     const todayUtc = new Date().toISOString().slice(0, 10);
     getUpcomingMintsAcrossSeasons.mockReturnValue([
       {
@@ -334,18 +341,19 @@ describe("Subscriptions report page", () => {
         seasonIndex: 15,
         utcDay: new Date("2026-07-20T00:00:00.000Z"),
       },
-      {
-        meme: 701,
-        seasonIndex: 15,
-        utcDay: new Date("2026-07-22T00:00:00.000Z"),
-      },
     ]);
+    getMintTimelineDetails.mockReturnValue({
+      mintNumber: 701,
+      mintDayUtc: new Date("2026-07-22T00:00:00.000Z"),
+      instantUtc: new Date("2026-07-22T14:40:00.000Z"),
+      seasonIndex: 15,
+    });
     mockCurrentMemeCalendar({
       status: "none",
       current: null,
       next: {
         mint_number: 700,
-        mint_date: todayUtc,
+        mint_date: `${todayUtc}T14:40:00.000Z`,
       },
     });
     commonApiFetch.mockImplementation(buildReportCountsApiMock({}));
@@ -372,6 +380,7 @@ describe("Subscriptions report page", () => {
     expect(upcomingDrops).toHaveTextContent("The Memes #701");
     expect(upcomingDrops).toHaveTextContent("2026-07-22");
     expect(upcomingDrops).not.toHaveTextContent("2026-07-20");
+    expect(getMintTimelineDetails).toHaveBeenCalledWith(701);
   });
 
   it("exposes semantic row-wide meme card links", async () => {

--- a/__tests__/app/tools/subscriptions-report.test.tsx
+++ b/__tests__/app/tools/subscriptions-report.test.tsx
@@ -27,7 +27,7 @@ jest.mock("@/components/about/AboutSubscriptionsProfileButton", () => ({
 jest.mock("@/components/meme-calendar/meme-calendar.helpers", () => ({
   __esModule: true,
   displayedSeasonNumberFromIndex: jest.fn((index: number) => index + 1),
-  formatFullDate: jest.fn(() => "Jan 1, 2026"),
+  formatFullDate: jest.fn((date: Date) => date.toISOString().slice(0, 10)),
   getCardsRemainingUntilEndOf: jest.fn(() => 2),
   getUpcomingMintsAcrossSeasons: jest.fn(() => []),
 }));
@@ -89,7 +89,11 @@ const mockDefaultCommonApiFetch = (opts: any) => {
 };
 
 const mockCurrentMemeCalendar = (
-  body: { status: string; current: { mint_number: number } | null },
+  body: {
+    status: string;
+    current: { mint_number: number } | null;
+    next?: { mint_number: number; mint_date: string };
+  },
   ok = true
 ) => {
   mockFetch.mockResolvedValue({
@@ -262,6 +266,7 @@ describe("Subscriptions report page", () => {
   it("moves the live calendar mint into the active drop section", async () => {
     getUpcomingMintsAcrossSeasons.mockReturnValue([
       {
+        meme: 701,
         seasonIndex: 15,
         utcDay: new Date("2026-01-03T00:00:00.000Z"),
       },
@@ -321,9 +326,58 @@ describe("Subscriptions report page", () => {
     });
   });
 
+  it("keeps a redeemed mint-day card active before minting starts without shifting upcoming dates", async () => {
+    const todayUtc = new Date().toISOString().slice(0, 10);
+    getUpcomingMintsAcrossSeasons.mockReturnValue([
+      {
+        meme: 700,
+        seasonIndex: 15,
+        utcDay: new Date("2026-07-20T00:00:00.000Z"),
+      },
+      {
+        meme: 701,
+        seasonIndex: 15,
+        utcDay: new Date("2026-07-22T00:00:00.000Z"),
+      },
+    ]);
+    mockCurrentMemeCalendar({
+      status: "none",
+      current: null,
+      next: {
+        mint_number: 700,
+        mint_date: todayUtc,
+      },
+    });
+    commonApiFetch.mockImplementation(buildReportCountsApiMock({}));
+
+    render(
+      <AuthContext.Provider value={{ setToast } as any}>
+        <CookieConsentProvider>
+          <Page />
+        </CookieConsentProvider>
+      </AuthContext.Provider>
+    );
+
+    const activeDrop = await screen.findByTestId(
+      "subscriptions-report-active-drop"
+    );
+    expect(activeDrop).toHaveTextContent("#700 - Active Meme");
+
+    const pastDrops = screen.getByTestId("subscriptions-report-past-drops");
+    expect(within(pastDrops).queryByText("#700 - Active Meme")).toBeNull();
+
+    const upcomingDrops = screen.getByTestId(
+      "subscriptions-report-upcoming-drops"
+    );
+    expect(upcomingDrops).toHaveTextContent("The Memes #701");
+    expect(upcomingDrops).toHaveTextContent("2026-07-22");
+    expect(upcomingDrops).not.toHaveTextContent("2026-07-20");
+  });
+
   it("exposes semantic row-wide meme card links", async () => {
     getUpcomingMintsAcrossSeasons.mockReturnValue([
       {
+        meme: 701,
         seasonIndex: 15,
         utcDay: new Date("2026-01-03T00:00:00.000Z"),
       },
@@ -407,6 +461,7 @@ describe("Subscriptions report page", () => {
   it("formats active, upcoming, and past counts with locale separators", async () => {
     getUpcomingMintsAcrossSeasons.mockReturnValue([
       {
+        meme: 701,
         seasonIndex: 15,
         utcDay: new Date("2026-01-03T00:00:00.000Z"),
       },

--- a/components/subscriptions-report/SubscriptionsReport.tsx
+++ b/components/subscriptions-report/SubscriptionsReport.tsx
@@ -130,7 +130,7 @@ function getDisplayedRedeemedTotal(
   return Math.max(totalRedeemed - 1, 0);
 }
 
-async function fetchReportActiveMintNumber() {
+async function fetchReportActiveMintNumber(now: Date) {
   const response = await fetch("/api/meme-calendar/current");
 
   if (!response.ok) {
@@ -140,7 +140,7 @@ async function fetchReportActiveMintNumber() {
   }
 
   const currentMint = (await response.json()) as MemeCalendarCurrentResponse;
-  return getReportActiveMintNumber(currentMint);
+  return getReportActiveMintNumber(currentMint, now);
 }
 
 export default function SubscriptionsReportComponent() {
@@ -240,12 +240,12 @@ export default function SubscriptionsReportComponent() {
       let activeRedeemedDrop: RedeemedSubscriptionCounts | null = null;
       let activeTokenId: number | null = null;
       let reportActiveMintNumber: number | null = null;
-      const reportActiveMintNumberPromise = fetchReportActiveMintNumber().catch(
-        (error: unknown) => {
-          console.error("Failed to fetch current meme calendar mint:", error);
-          return null;
-        }
-      );
+      const reportActiveMintNumberPromise = fetchReportActiveMintNumber(
+        now
+      ).catch((error: unknown) => {
+        console.error("Failed to fetch current meme calendar mint:", error);
+        return null;
+      });
 
       try {
         const [redeemed, activeMintNumber] = await Promise.all([

--- a/components/subscriptions-report/SubscriptionsReport.tsx
+++ b/components/subscriptions-report/SubscriptionsReport.tsx
@@ -49,18 +49,24 @@ type MemeCalendarCurrentResponse = {
   readonly current: {
     readonly mint_number: number;
   } | null;
+  readonly next?: {
+    readonly mint_number: number;
+    readonly mint_date: string;
+  };
 };
 
-function getCurrentLiveMintNumber(
-  currentMint: MemeCalendarCurrentResponse
+function getReportActiveMintNumber(
+  currentMint: MemeCalendarCurrentResponse,
+  now: Date = new Date()
 ): number | null {
-  if (currentMint.status !== "live") {
-    return null;
+  if (currentMint.status === "live") {
+    return normalizeMemeTokenId(currentMint.current?.mint_number);
   }
 
-  const mintNumber = currentMint.current?.mint_number;
-  return typeof mintNumber === "number" && Number.isSafeInteger(mintNumber)
-    ? mintNumber
+  const nextMint = currentMint.next;
+  const todayUtc = now.toISOString().slice(0, 10);
+  return currentMint.status === "none" && nextMint?.mint_date === todayUtc
+    ? normalizeMemeTokenId(nextMint.mint_number)
     : null;
 }
 
@@ -101,7 +107,7 @@ function getDisplayedRedeemedTotal(
   return Math.max(totalRedeemed - 1, 0);
 }
 
-async function fetchCurrentLiveMintNumber() {
+async function fetchReportActiveMintNumber() {
   const response = await fetch("/api/meme-calendar/current");
 
   if (!response.ok) {
@@ -111,7 +117,7 @@ async function fetchCurrentLiveMintNumber() {
   }
 
   const currentMint = (await response.json()) as MemeCalendarCurrentResponse;
-  return getCurrentLiveMintNumber(currentMint);
+  return getReportActiveMintNumber(currentMint);
 }
 
 export default function SubscriptionsReportComponent() {
@@ -159,6 +165,10 @@ export default function SubscriptionsReportComponent() {
     () => getUpcomingMintsAcrossSeasons(upcomingCounts.length || 50, now),
     [now, upcomingCounts.length]
   );
+  const rowsByMeme = useMemo(
+    () => new Map(rows.map((row) => [row.meme, row])),
+    [rows]
+  );
 
   async function fetchUpcomingCounts(count: number) {
     return await commonApiFetch<SubscriptionCounts[]>({
@@ -193,8 +203,8 @@ export default function SubscriptionsReportComponent() {
       let remainingCountForSeason = getCardsRemainingUntilEndOf("szn");
       let activeRedeemedDrop: RedeemedSubscriptionCounts | null = null;
       let activeTokenId: number | null = null;
-      let currentLiveMintNumber: number | null = null;
-      const currentLiveMintNumberPromise = fetchCurrentLiveMintNumber().catch(
+      let reportActiveMintNumber: number | null = null;
+      const reportActiveMintNumberPromise = fetchReportActiveMintNumber().catch(
         (error: unknown) => {
           console.error("Failed to fetch current meme calendar mint:", error);
           return null;
@@ -202,14 +212,14 @@ export default function SubscriptionsReportComponent() {
       );
 
       try {
-        const [redeemed, liveMintNumber] = await Promise.all([
+        const [redeemed, activeMintNumber] = await Promise.all([
           fetchRedeemedCounts(1),
-          currentLiveMintNumberPromise,
+          reportActiveMintNumberPromise,
         ]);
-        currentLiveMintNumber = liveMintNumber;
+        reportActiveMintNumber = activeMintNumber;
         activeRedeemedDrop = getActiveRedeemedDrop(
           redeemed.data,
-          currentLiveMintNumber
+          reportActiveMintNumber
         );
         activeTokenId = activeRedeemedDrop
           ? normalizeMemeTokenId(activeRedeemedDrop.token_id)
@@ -229,7 +239,7 @@ export default function SubscriptionsReportComponent() {
         setTotalRedeemed(0);
       }
 
-      if (currentLiveMintNumber !== null && !activeRedeemedDrop) {
+      if (reportActiveMintNumber !== null && !activeRedeemedDrop) {
         remainingCountForSeason += 1;
       }
 
@@ -465,7 +475,10 @@ export default function SubscriptionsReportComponent() {
                     .map((count, index) => {
                       const isNew =
                         animateFromIndex !== null && index >= animateFromIndex;
-                      return (
+                      const tokenId = normalizeMemeTokenId(count.token_id);
+                      const date =
+                        tokenId === null ? undefined : rowsByMeme.get(tokenId);
+                      return date ? (
                         <SubscriptionDayRow
                           key={getMemeTokenIdKey(count.token_id)}
                           ref={
@@ -477,10 +490,10 @@ export default function SubscriptionsReportComponent() {
                               : "tw-bg-iron-900",
                             isNew ? styles["upcomingRowNew"] : "",
                           ].join(" ")}
-                          date={rows[index]!}
+                          date={date}
                           count={count}
                         />
-                      );
+                      ) : null;
                     })}
                 </div>
               </div>

--- a/components/subscriptions-report/SubscriptionsReport.tsx
+++ b/components/subscriptions-report/SubscriptionsReport.tsx
@@ -23,6 +23,7 @@ import type { MemeSeason } from "@/entities/ISeason";
 import type { SeasonMintRow } from "@/components/meme-calendar/meme-calendar.helpers";
 import {
   getCardsRemainingUntilEndOf,
+  getMintTimelineDetails,
   getUpcomingMintsAcrossSeasons,
 } from "@/components/meme-calendar/meme-calendar.helpers";
 import type { Paginated } from "@/components/pagination/Pagination";
@@ -55,6 +56,11 @@ type MemeCalendarCurrentResponse = {
   };
 };
 
+function getUtcDateKey(value: string): string | null {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString().slice(0, 10);
+}
+
 function getReportActiveMintNumber(
   currentMint: MemeCalendarCurrentResponse,
   now: Date = new Date()
@@ -65,9 +71,26 @@ function getReportActiveMintNumber(
 
   const nextMint = currentMint.next;
   const todayUtc = now.toISOString().slice(0, 10);
-  return currentMint.status === "none" && nextMint?.mint_date === todayUtc
+  return currentMint.status === "none" &&
+    nextMint &&
+    getUtcDateKey(nextMint.mint_date) === todayUtc
     ? normalizeMemeTokenId(nextMint.mint_number)
     : null;
+}
+
+function getMintRowForTokenId(tokenId: unknown): SeasonMintRow | null {
+  const normalizedTokenId = normalizeMemeTokenId(tokenId);
+  if (normalizedTokenId === null) {
+    return null;
+  }
+
+  const timeline = getMintTimelineDetails(normalizedTokenId);
+  return {
+    meme: timeline.mintNumber,
+    utcDay: timeline.mintDayUtc,
+    instantUtc: timeline.instantUtc,
+    seasonIndex: timeline.seasonIndex,
+  };
 }
 
 function getActiveRedeemedDrop(
@@ -168,6 +191,19 @@ export default function SubscriptionsReportComponent() {
   const rowsByMeme = useMemo(
     () => new Map(rows.map((row) => [row.meme, row])),
     [rows]
+  );
+  const upcomingRows = useMemo(
+    () =>
+      upcomingCounts.flatMap((count, index) => {
+        const tokenId = normalizeMemeTokenId(count.token_id);
+        const date =
+          (tokenId === null ? null : rowsByMeme.get(tokenId)) ??
+          getMintRowForTokenId(count.token_id) ??
+          rows[index];
+
+        return date ? [{ count, date }] : [];
+      }),
+    [rows, rowsByMeme, upcomingCounts]
   );
 
   async function fetchUpcomingCounts(count: number) {
@@ -456,7 +492,7 @@ export default function SubscriptionsReportComponent() {
         data-testid="subscriptions-report-upcoming-drops"
       >
         <div>
-          {upcomingCounts?.length > 0 ? (
+          {upcomingRows.length > 0 ? (
             <>
               <div className="tw-overflow-hidden tw-rounded-xl tw-border tw-border-iron-700 tw-bg-iron-900">
                 <span className="tw-sr-only">
@@ -470,15 +506,12 @@ export default function SubscriptionsReportComponent() {
                   <span className="tw-text-center">Subscriptions</span>
                 </div>
                 <div>
-                  {upcomingCounts
+                  {upcomingRows
                     .slice(0, upcomingVisible)
-                    .map((count, index) => {
+                    .map(({ count, date }, index) => {
                       const isNew =
                         animateFromIndex !== null && index >= animateFromIndex;
-                      const tokenId = normalizeMemeTokenId(count.token_id);
-                      const date =
-                        tokenId === null ? undefined : rowsByMeme.get(tokenId);
-                      return date ? (
+                      return (
                         <SubscriptionDayRow
                           key={getMemeTokenIdKey(count.token_id)}
                           ref={
@@ -493,13 +526,13 @@ export default function SubscriptionsReportComponent() {
                           date={date}
                           count={count}
                         />
-                      ) : null;
+                      );
                     })}
                 </div>
               </div>
-              {upcomingCounts.length > UPCOMING_PAGE_SIZE && (
+              {upcomingRows.length > UPCOMING_PAGE_SIZE && (
                 <div ref={upcomingToggleRef} className="tw-pt-3 tw-text-center">
-                  {upcomingVisible < upcomingCounts.length ? (
+                  {upcomingVisible < upcomingRows.length ? (
                     <ShowMoreButton
                       expanded={false}
                       setExpanded={() => {
@@ -507,7 +540,7 @@ export default function SubscriptionsReportComponent() {
                         setUpcomingVisible((prev) =>
                           Math.min(
                             prev + UPCOMING_PAGE_SIZE,
-                            upcomingCounts.length
+                            upcomingRows.length
                           )
                         );
                       }}


### PR DESCRIPTION
## Issue
- A redeemed mint-day card was shown under Past Drops until its official mint window began.
- During that pre-mint gap, upcoming subscription counts were paired with calendar rows by array index, causing the next card to inherit today's date.

## Fix
- Treat today's next scheduled card as the report's active candidate once redeemed data exists, while preserving live-window handling across midnight.
- Match upcoming calendar rows to subscription counts by Meme token ID instead of list position.

## Changes
- Extend the current-calendar response handling to use today's `next` mint during the pre-mint window.
- Build the upcoming date lookup by Meme number.
- Add regression coverage for the redeemed-before-mint-start state and the following card's date.

## Validation
- Targeted subscriptions-report tests pass, including the reproduced regression.
- Changed-file type checking, formatting, linting, and React diagnostics completed successfully.

## Risk
- Level: Low
- Why: The change is isolated to subscriptions-report classification and date selection.
- Rollback: Revert the single commit.

## Review Notes
- Please focus on the boundary between redeemed data availability and the official live mint window.