### PR TITLE
Harden Release Bus frontend validation

### DIFF
--- a/.github/workflows/app-pr-ci.yml
+++ b/.github/workflows/app-pr-ci.yml
@@ -235,6 +235,20 @@ jobs:
         if: needs.plan.outputs.agent_files_sync_required == 'true'
         run: ./bin/6529 run test:no-coverage -- __tests__/scripts/sync-agent-files.test.ts
 
+      - name: Verify Release Bus gate command contract
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet "origin/${BASE_REF}...HEAD" -- \
+            .github/workflows/release-bus-*.yml \
+            scripts/release-bus-frontend-gate.sh \
+            __tests__/scripts/release-bus-frontend-gate.test.ts; then
+            echo "Release Bus gate files are unchanged."
+            exit 0
+          fi
+          ./scripts/release-bus-frontend-gate.sh contract
+
       - name: Lint changed source
         if: needs.plan.outputs.lint_changed_required == 'true'
         run: ./bin/6529 run lint:changed

--- a/.github/workflows/release-bus-base-canary.yml
+++ b/.github/workflows/release-bus-base-canary.yml
@@ -1,0 +1,101 @@
+name: Release Bus - Frontend Base Canary
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_train_id: { type: string, required: true }
+      release_train_revision: { type: string, required: true }
+      operation_key: { type: string, required: true }
+      base_sha: { type: string, required: true }
+      expected_sha: { type: string, required: true }
+
+permissions: {}
+
+run-name: Canary frontend base ${{ inputs.base_sha }} [${{ inputs.operation_key }}]
+
+jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Validate and authorize immutable inputs
+        env:
+          BASE_SHA: ${{ inputs.base_sha }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          OPERATION_KEY: ${{ inputs.operation_key }}
+          RELEASE_BUS_API_URL: ${{ vars.RELEASE_BUS_API_URL }}
+          RELEASE_BUS_WORKFLOW_AUTH_TOKEN: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
+          TRAIN_ID: ${{ inputs.release_train_id }}
+          TRAIN_REVISION: ${{ inputs.release_train_revision }}
+        run: |
+          set -euo pipefail
+          [[ "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]]
+          test "$BASE_SHA" = "$EXPECTED_SHA"
+          [[ "$TRAIN_ID" =~ ^[A-Za-z0-9._-]{1,100}$ ]]
+          [[ "$TRAIN_REVISION" =~ ^[1-9][0-9]{0,8}$ ]]
+          [[ "$OPERATION_KEY" =~ ^[A-Za-z0-9:._-]{1,180}$ ]]
+          payload="$(jq -n --arg train_id "$TRAIN_ID" --arg operation_key "$OPERATION_KEY" --arg workflow_run_id "$GITHUB_RUN_ID" --arg expected_sha "$EXPECTED_SHA" '{train_id:$train_id,operation_key:$operation_key,workflow_run_id:$workflow_run_id,artifact_run_id:null,repository:"frontend",environment:"orchestration",service:null,expected_sha:$expected_sha,artifact_digest:null}')"
+          curl --fail-with-body --silent --show-error \
+            -H "Authorization: Bearer $RELEASE_BUS_WORKFLOW_AUTH_TOKEN" \
+            -H 'Content-Type: application/json' \
+            --data "$payload" \
+            "$RELEASE_BUS_API_URL/deploy/release-bus/authorize"
+
+  gate:
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - name: Check out exact frontend base
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.base_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Verify immutable source
+        env:
+          BASE_SHA: ${{ inputs.base_sha }}
+        run: test "$(git rev-parse HEAD)" = "$BASE_SHA"
+      - name: Install Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with: { node-version: "22" }
+      - name: Activate pinned pnpm
+        run: |
+          corepack enable pnpm
+          corepack prepare "$(node -p 'require("./package.json").packageManager')" --activate
+      - name: Install Socket Firewall
+        id: socket-firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with: { mode: firewall }
+      - name: Install frozen dependencies
+        env:
+          SFW_BIN: ${{ steps.socket-firewall.outputs.firewall-path-binary }}
+        run: ./bin/6529 install:frozen
+      - name: Run exact-base Release Bus gate
+        env:
+          NODE_ENV: production
+          API_ENDPOINT: https://api.staging.6529.io
+          WS_ENDPOINT: wss://ws.staging.6529.io
+          ALLOWLIST_API_ENDPOINT: https://allowlist-api.staging.6529.io
+          BASE_ENDPOINT: https://staging.6529.io
+          VERSION: ${{ inputs.base_sha }}
+          VERSION_BUILD_TIMESTAMP: "1970-01-01T00:00:00Z"
+          ALCHEMY_API_KEY: release-bus-canary
+          NEXTGEN_CHAIN_ID: "11155111"
+          MOBILE_APP_SCHEME: mobile6529
+          CORE_SCHEME: core6529
+          IPFS_API_ENDPOINT: https://api-ipfs.6529.io
+          IPFS_GATEWAY_ENDPOINT: https://ipfs.6529.io
+          GIPHY_API_KEY: release-bus-canary
+          AWS_RUM_APP_ID: release-bus-canary
+          AWS_RUM_REGION: us-east-1
+          AWS_RUM_SAMPLE_RATE: "0"
+          NEXT_PUBLIC_MIXPANEL_TOKEN: release-bus-canary
+          ASSETS_FROM_S3: "false"
+          SENTRY_AUTH_TOKEN: ""
+          SENTRY_DSN: ""
+        run: ./scripts/release-bus-frontend-gate.sh full
+      - name: Verify gate did not mutate source
+        run: git diff --exit-code

--- a/.github/workflows/release-bus-base-canary.yml
+++ b/.github/workflows/release-bus-base-canary.yml
@@ -49,15 +49,15 @@ jobs:
       contents: read
     steps:
       - name: Check out exact frontend base
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          ref: ${{ inputs.base_sha }}
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Verify immutable source
         env:
           BASE_SHA: ${{ inputs.base_sha }}
-        run: test "$(git rev-parse HEAD)" = "$BASE_SHA"
+        run: |
+          set -euo pipefail
+          git init .
+          git remote add origin https://github.com/6529-Collections/6529seize-frontend.git
+          git fetch --no-tags origin "$BASE_SHA"
+          git checkout --detach "$BASE_SHA"
+          test "$(git rev-parse HEAD)" = "$BASE_SHA"
       - name: Install Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with: { node-version: "22" }
@@ -82,7 +82,7 @@ jobs:
           BASE_ENDPOINT: https://staging.6529.io
           VERSION: ${{ inputs.base_sha }}
           VERSION_BUILD_TIMESTAMP: "1970-01-01T00:00:00Z"
-          ALCHEMY_API_KEY: release-bus-canary
+          ALCHEMY_API_KEY: canary
           NEXTGEN_CHAIN_ID: "11155111"
           MOBILE_APP_SCHEME: mobile6529
           CORE_SCHEME: core6529

--- a/.github/workflows/release-bus-base-canary.yml
+++ b/.github/workflows/release-bus-base-canary.yml
@@ -53,6 +53,7 @@ jobs:
           BASE_SHA: ${{ inputs.base_sha }}
         run: |
           set -euo pipefail
+          [[ "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]]
           git init .
           git remote add origin https://github.com/6529-Collections/6529seize-frontend.git
           git fetch --no-tags origin "$BASE_SHA"

--- a/.github/workflows/release-bus-isolate-candidate.yml
+++ b/.github/workflows/release-bus-isolate-candidate.yml
@@ -106,21 +106,19 @@ jobs:
             corepack enable pnpm
             corepack prepare "$(node -p 'require("./package.json").packageManager')" --activate
             ./bin/6529 install:frozen
-            ./bin/6529 run lint
-            ./bin/6529 run typecheck:ci
-            ./bin/6529 run test:no-coverage -- --runInBand
-            NODE_ENV=production \
-              API_ENDPOINT='https://api.staging.6529.io' \
-              WS_ENDPOINT='wss://ws.staging.6529.io' \
-              ALLOWLIST_API_ENDPOINT='https://allowlist-api.staging.6529.io' \
-              BASE_ENDPOINT='https://staging.6529.io' \
-              MOBILE_APP_SCHEME='mobile6529' \
-              CORE_SCHEME='core6529' \
-              IPFS_API_ENDPOINT='https://api-ipfs.6529.io' \
-              IPFS_GATEWAY_ENDPOINT='https://ipfs.6529.io' \
-              VERSION="$EXPECTED_SHA" \
-              VERSION_BUILD_TIMESTAMP="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
-              ./bin/6529 run build
+            export NODE_ENV=production
+            export API_ENDPOINT='https://api.staging.6529.io'
+            export WS_ENDPOINT='wss://ws.staging.6529.io'
+            export ALLOWLIST_API_ENDPOINT='https://allowlist-api.staging.6529.io'
+            export BASE_ENDPOINT='https://staging.6529.io'
+            export MOBILE_APP_SCHEME='mobile6529'
+            export CORE_SCHEME='core6529'
+            export IPFS_API_ENDPOINT='https://api-ipfs.6529.io'
+            export IPFS_GATEWAY_ENDPOINT='https://ipfs.6529.io'
+            export VERSION="$EXPECTED_SHA"
+            export VERSION_BUILD_TIMESTAMP="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+            ./scripts/release-bus-frontend-gate.sh full
+            git diff --exit-code
           } > >(tee isolation.log) 2>&1
       - name: Upload isolation log
         if: always()

--- a/.github/workflows/release-bus-preflight.yml
+++ b/.github/workflows/release-bus-preflight.yml
@@ -82,16 +82,13 @@ jobs:
         env:
           SFW_BIN: ${{ steps.socket-firewall.outputs.firewall-path-binary }}
         run: ./bin/6529 install:frozen
-      - name: Typecheck
+      - name: Run exact train validation gate
+        if: matrix.environment == 'staging'
+        run: ./scripts/release-bus-frontend-gate.sh validate
+      - name: Typecheck production artifact source
+        if: matrix.environment == 'production'
         run: ./bin/6529 run typecheck:ci
-      - name: Lint exact train
-        if: matrix.environment == 'staging'
-        run: ./bin/6529 run lint
-      - name: Run frontend unit tests
-        if: matrix.environment == 'staging'
-        run: ./bin/6529 run test:no-coverage -- --runInBand
       - name: Verify validation did not mutate source
-        if: matrix.environment == 'staging'
         run: git diff --exit-code
       - name: Capture build timestamp
         run: printf 'VERSION_BUILD_TIMESTAMP=%s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_ENV"

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const read = (relativePath: string) =>
+  fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+
+describe("Release Bus frontend gate contract", () => {
+  const gate = read("scripts/release-bus-frontend-gate.sh");
+  const preflight = read(".github/workflows/release-bus-preflight.yml");
+  const isolation = read(".github/workflows/release-bus-isolate-candidate.yml");
+  const canary = read(".github/workflows/release-bus-base-canary.yml");
+  const appPrCi = read(".github/workflows/app-pr-ci.yml");
+
+  it("owns the only Release Bus Jest invocation", () => {
+    expect(gate).toContain('./bin/6529 run test:no-coverage --runInBand "$@"');
+    expect(gate).not.toContain("test:no-coverage -- --runInBand");
+
+    for (const workflow of [preflight, isolation, canary]) {
+      expect(workflow).not.toContain("test:no-coverage");
+    }
+  });
+
+  it("is shared by preflight, isolation, and exact-base canary", () => {
+    expect(preflight).toContain(
+      "./scripts/release-bus-frontend-gate.sh validate"
+    );
+    expect(isolation).toContain("./scripts/release-bus-frontend-gate.sh full");
+    expect(canary).toContain("./scripts/release-bus-frontend-gate.sh full");
+  });
+
+  it("executes its argument-forwarding contract in ordinary PR CI", () => {
+    expect(appPrCi).toContain(
+      "./scripts/release-bus-frontend-gate.sh contract"
+    );
+  });
+});

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -26,6 +26,8 @@ describe("Release Bus frontend gate contract", () => {
     );
     expect(isolation).toContain("./scripts/release-bus-frontend-gate.sh full");
     expect(canary).toContain("./scripts/release-bus-frontend-gate.sh full");
+    expect(canary).toContain('git fetch --no-tags origin "$BASE_SHA"');
+    expect(canary).not.toContain("ref: ${{ inputs.base_sha }}");
   });
 
   it("executes its argument-forwarding contract in ordinary PR CI", () => {

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -1,5 +1,7 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
 
 const read = (relativePath: string) =>
   fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
@@ -12,11 +14,49 @@ describe("Release Bus frontend gate contract", () => {
   const appPrCi = read(".github/workflows/app-pr-ci.yml");
 
   it("owns the only Release Bus Jest invocation", () => {
-    expect(gate).toContain('./bin/6529 run test:no-coverage --runInBand "$@"');
+    expect(gate).toContain(
+      '"$SEIZE_BIN" run test:no-coverage --runInBand "$@"'
+    );
     expect(gate).not.toContain("test:no-coverage -- --runInBand");
 
     for (const workflow of [preflight, isolation, canary]) {
       expect(workflow).not.toContain("test:no-coverage");
+    }
+  });
+
+  it("forwards the contract arguments to the 6529 runner exactly", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "release-bus-gate-"));
+    const runner = path.join(tempDir, "fake-6529");
+    const argumentLog = path.join(tempDir, "arguments.txt");
+    try {
+      fs.writeFileSync(
+        runner,
+        '#!/usr/bin/env bash\nprintf "%s\\n" "$@" > "$RELEASE_BUS_ARGS_LOG"\n'
+      );
+      fs.chmodSync(runner, 0o755);
+
+      execFileSync(
+        "bash",
+        ["scripts/release-bus-frontend-gate.sh", "contract"],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...process.env,
+            RELEASE_BUS_6529_BIN: runner,
+            RELEASE_BUS_ARGS_LOG: argumentLog,
+          },
+        }
+      );
+
+      expect(fs.readFileSync(argumentLog, "utf8").trim().split("\n")).toEqual([
+        "run",
+        "test:no-coverage",
+        "--runInBand",
+        "--runTestsByPath",
+        "__tests__/scripts/release-bus-frontend-gate.test.ts",
+      ]);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
     }
   });
 

--- a/ops/docs/developer/deployment-bus-automation.md
+++ b/ops/docs/developer/deployment-bus-automation.md
@@ -89,6 +89,20 @@ Both repositories contain release-bus workflows for:
 - deterministic candidate isolation with optional read-only Codex diagnostics;
 - post-production `main` to `1a-staging` synchronization.
 
+Frontend Release Bus validation is centralized in
+`scripts/release-bus-frontend-gate.sh`. Preflight and candidate isolation call
+that gate instead of maintaining independent Jest command lines. Ordinary
+frontend PR CI runs the gate contract whenever the gate or any Release Bus
+workflow changes, preventing an invalid argument-forwarding change from being
+merged unnoticed.
+
+Before composing a train that contains frontend work, the worker dispatches
+`release-bus-base-canary.yml` against the train's exact recorded frontend base
+SHA. The canary runs lint, typecheck, the complete Jest suite, and a production
+build. Failure requeues the train's candidates, pauses the lane, and records the
+exact Actions run as operator evidence; it never attributes the base failure to
+a candidate. Backend-only trains skip this frontend canary.
+
 Backend deployment continues through the generated per-service workflow, now
 with exact SHA, preflight run, checksum, operation, and authorization gates.
 The deploy registry supplies adapters, environments, regions, verification
@@ -254,10 +268,20 @@ private keys or workflow credentials into chat or committed files.
 Gate enforcement is last. Existing deployment workflows remain usable while
 the bus is `OFF` or in its initial shadow rollout.
 
+When rolling out the frontend base-canary control specifically, merge its
+workflow and shared gate into both frontend `main` and `1a-staging` before
+deploying the worker that dispatches it. This ensures every recorded frontend
+base and temporary train branch contains the canonical gate. Deploy the backend
+`api` next, then `releaseBus`; resume a paused lane only after both deployments
+are verified.
+
 ## Operations and recovery
 
 - Pause/resume at `/deploy/ui/bus`; every change requires a reason and is
   recorded in `release_train_events`.
+- Controls show the current reason and actor. Trusted frontend/backend GitHub
+  Actions run URLs embedded in an automatic pause are rendered as direct
+  failure-evidence links.
 - A paused train heartbeats owned leases but does not start the next
   irreversible operation.
 - A missed workflow response remains `AMBIGUOUS` until exact-run reconciliation

--- a/ops/docs/developer/deployment-bus-process.md
+++ b/ops/docs/developer/deployment-bus-process.md
@@ -125,6 +125,9 @@ order.
 
 It then:
 
+- runs the shared frontend validation/build gate against the exact fresh
+  `1a-staging` base before composing any frontend candidate, so a broken base or
+  control-plane command cannot be blamed on candidate code;
 - runs immutable preflight builds;
 - deploys backend units in service-DAG order;
 - deploys frontend after backend succeeds;
@@ -194,6 +197,12 @@ publishes release notes nor invokes the legacy GelatoBot skill.
   failure or combined-only interaction pauses the lane instead of guessing.
   Independent candidates return to the queue and a proved offender's PR
   receives a diagnostic link.
+- Frontend lint, typecheck, Jest, and build commands are owned by one shared
+  Release Bus gate. Pull-request CI executes the gate's regression contract
+  whenever that gate or a Release Bus workflow changes. Before candidate
+  composition, the bus also runs the full gate against the exact recorded
+  frontend base SHA. A base-canary failure requeues every candidate and pauses
+  the lane without quarantining a developer branch.
 - Ambiguous external calls are reconciled by exact operation key before any
   retry. A timeout is not treated as proof that an operation did not happen.
 - Before production mutation, an unexpected target-branch move safely cancels
@@ -208,6 +217,10 @@ publishes release notes nor invokes the legacy GelatoBot skill.
 The operator controls are on `/deploy/ui/bus`. Members of the configured
 `release-bus-operators` GitHub team, plus organization owners, may pause or
 resume `ALL`, `STAGING`, or `PRODUCTION`, with an audited reason.
+
+Each control shows its current reason and actor. When an automatic pause came
+from a trusted 6529 GitHub Actions run, the control also links directly to that
+failure evidence.
 
 A pause prevents the next irreversible operation; it does not interrupt an AWS
 deployment already mutating an environment.

--- a/scripts/release-bus-frontend-gate.sh
+++ b/scripts/release-bus-frontend-gate.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+run_unit_tests() {
+  ./bin/6529 run test:no-coverage --runInBand "$@"
+}
+
+run_validation() {
+  ./bin/6529 run lint
+  ./bin/6529 run typecheck:ci
+  run_unit_tests
+}
+
+case "${1:-full}" in
+  contract)
+    run_unit_tests --runTestsByPath __tests__/scripts/release-bus-frontend-gate.test.ts
+    ;;
+  validate)
+    run_validation
+    ;;
+  full)
+    run_validation
+    ./bin/6529 run build
+    ;;
+  *)
+    echo "Usage: scripts/release-bus-frontend-gate.sh [contract|validate|full]" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/release-bus-frontend-gate.sh
+++ b/scripts/release-bus-frontend-gate.sh
@@ -4,16 +4,17 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SEIZE_BIN="${RELEASE_BUS_6529_BIN:-./bin/6529}"
 
 cd "$REPO_ROOT"
 
 run_unit_tests() {
-  ./bin/6529 run test:no-coverage --runInBand "$@"
+  "$SEIZE_BIN" run test:no-coverage --runInBand "$@"
 }
 
 run_validation() {
-  ./bin/6529 run lint
-  ./bin/6529 run typecheck:ci
+  "$SEIZE_BIN" run lint
+  "$SEIZE_BIN" run typecheck:ci
   run_unit_tests
 }
 
@@ -26,7 +27,7 @@ case "${1:-full}" in
     ;;
   full)
     run_validation
-    ./bin/6529 run build
+    "$SEIZE_BIN" run build
     ;;
   *)
     echo "Usage: scripts/release-bus-frontend-gate.sh [contract|validate|full]" >&2


### PR DESCRIPTION
## Issue
- A Release Bus workflow passed an extra argument separator to Jest, so the fresh frontend base reported "No tests found" and paused STAGING.
- The live control panel did not expose enough failure context to make an automatic pause self-explanatory.

## Fix
- Centralize frontend Release Bus validation in one executable gate and enforce its command contract in ordinary PR CI.
- Add a full canary for the exact recorded frontend base before any frontend candidate is composed.

## Changes
- Adds the shared lint, typecheck, Jest, and build gate.
- Makes preflight and candidate isolation call the shared gate.
- Adds an exact-base canary workflow authorized by the Release Bus operation ledger.
- Adds a PR regression test that rejects direct or malformed Release Bus Jest invocations.
- Documents failure behavior, evidence, and zero-downtime rollout ordering.
- Companion backend PR: https://github.com/6529-Collections/6529seize-backend/pull/1774

## Validation
- Shared gate contract: 3 tests passed.
- Full frontend gate: lint, typecheck, 2,030 suites / 12,004 tests passed.
- Production-equivalent Next.js build passed.
- Prettier and workflow YAML parsing passed.
- Git diff checks passed.
- GitHub Actions semantic validation remains to run on this PR; local `actionlint` was not installed.

## Risk
- Level: Medium
- Why: Changes release-control workflows and adds one full validation/build canary to frontend trains, increasing train latency while reducing false candidate blame.
- Rollback: Revert this PR before or after disabling/pausing the Release Bus; no application data or schema changes are involved.

## Review Notes
- Verify the Jest argument forwarding, immutable-SHA authorization, and that the base canary runs before backend composition is enabled.
- Rollout must put this workflow/gate on frontend `main` and `1a-staging` before the companion backend worker is deployed.
