### PR TITLE
Keep leaderboard media neatly inside drop cards

### DIFF
--- a/components/memes/drops/MemesLeaderboardDrop.tsx
+++ b/components/memes/drops/MemesLeaderboardDrop.tsx
@@ -183,7 +183,7 @@ export const MemesLeaderboardDrop: React.FC<MemesLeaderboardDropProps> = ({
 
               {artworkMedia && (
                 <div
-                  className={`tw-flex tw-h-96 tw-justify-center ${
+                  className={`tw-flex tw-h-96 tw-justify-center tw-overflow-hidden ${
                     location === DropLocation.WAVE
                       ? "tw-bg-iron-950"
                       : "tw-bg-iron-900/40"
@@ -193,6 +193,7 @@ export const MemesLeaderboardDrop: React.FC<MemesLeaderboardDropProps> = ({
                     media_mime_type={artworkMedia.mime_type}
                     media_url={artworkMedia.url}
                     isCompetitionDrop={true}
+                    fillVideoContainer={true}
                     imageScale={mediaImageScale}
                   />
                 </div>

--- a/components/waves/leaderboard/gallery/WaveLeaderboardGalleryItem.tsx
+++ b/components/waves/leaderboard/gallery/WaveLeaderboardGalleryItem.tsx
@@ -206,6 +206,7 @@ export const WaveLeaderboardGalleryItem = memo<WaveLeaderboardGalleryItemProps>(
               media_mime_type={primaryMedia?.mime_type ?? "image/jpeg"}
               media_url={primaryMedia?.url ?? ""}
               disableMediaInteraction={true}
+              fillVideoContainer={true}
               imageScale={mediaImageScale}
               previewImageUrl={previewImageUrl}
             />

--- a/components/waves/leaderboard/grid/WaveLeaderboardGridItemViewport.tsx
+++ b/components/waves/leaderboard/grid/WaveLeaderboardGridItemViewport.tsx
@@ -192,6 +192,7 @@ export const WaveLeaderboardGridItemViewport: React.FC<
               media_mime_type={mediaMimeType}
               media_url={mediaUrl}
               disableMediaInteraction={true}
+              fillVideoContainer={true}
               imageScale={ImageScale.AUTOx450}
               previewImageUrl={mediaPreviewImageUrl}
             />


### PR DESCRIPTION
## Issue
- Video and animated GIF drops could escape the rounded leaderboard card bounds or render taller than their fixed media area, especially in list view and portrait-oriented grid tiles.

## Fix
- Reuse the existing fixed-container video mode that already keeps chat/drop media inside bounded layouts.
- Clip the fixed-height list media area so every media type respects the card boundary.

## Changes
- Opt the Memes leaderboard list media into fixed-container video sizing.
- Opt both leaderboard grid/gallery media renderers into the same fixed-container behavior.
- Keep the shared media defaults unchanged so natural-height media elsewhere is unaffected.

## Validation
- `6529 run lint:changed`
- `6529 run typecheck:changed`
- `6529 run check:changed`
- `6529 run react-doctor:diff` (99/100; existing warnings only)
- Manual browser QA with real GIF, MOV, and MP4 drops at desktop and 390px mobile widths.
- Verified List and Grid layouts across Current Vote, Projected Vote, Hot, and Newest.
- Confirmed portrait and landscape media, video controls, rank badges, and image/GIF rendering stay within the rounded card bounds.

## Risk
- Level: Low
- Why: The change only enables an existing media sizing mode at fixed-size leaderboard call sites and adds clipping to the existing list media slot.
- Rollback: Revert the single commit to restore the prior leaderboard rendering.

## Review Notes
- Please focus on whether every fixed-size leaderboard media call site is covered without changing the shared default behavior.
- This intentionally mirrors the recent chat/drop media containment approach instead of introducing new media logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video and artwork media rendering in leaderboard views.
  * Media now fills its available container more consistently.
  * Prevented artwork content from overflowing its designated display area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->