### PR TITLE
Repair Release Bus frontend base canary

### DIFF
--- a/__tests__/app/wavesCreatePageClient.test.tsx
+++ b/__tests__/app/wavesCreatePageClient.test.tsx
@@ -10,6 +10,7 @@ jest.mock("next/navigation", () => ({
   useRouter: () => ({
     replace: mockReplace,
   }),
+  usePathname: () => "/waves/create",
 }));
 
 jest.mock("@/components/auth/Auth", () => ({


### PR DESCRIPTION
## Issue
- The frontend staging base contains `usePathname()` in `WavesLayout`, but the local `next/navigation` mock in `wavesCreatePageClient.test.tsx` does not expose it.
- The Release Bus base canary therefore fails before it can compose unrelated candidates.

## Fix
- Add the missing `usePathname` mock to the staging base.
- This is the already-reviewed fix from frontend PR #3301, isolated so the bus can validate the base without including that PR as a candidate.

## Changes
- One test-only mock entry; no runtime behavior changes.

## Validation
- `6529 run test -- __tests__/app/wavesCreatePageClient.test.tsx --runInBand`
- Result: PASS.

## Risk
- Level: Low
- Why: test-only change matching the current `/waves/create` test scenario.
- Rollback: revert this one commit.

## Review Notes
- This PR targets `1a-staging` as an operational base-canary repair. PR #3301 has been cancelled from the Release Bus queue.
