### PR TITLE
Preserve hidden files in immutable Release Bus artifacts

### DIFF
--- a/.github/workflows/release-bus-preflight.yml
+++ b/.github/workflows/release-bus-preflight.yml
@@ -145,7 +145,7 @@ jobs:
           done
           (cd release-bus-artifact/bundle && zip -yr ../target/package.zip .)
           jq -n --arg train_id "$TRAIN_ID" --arg source_sha "$EXPECTED_SHA" --arg environment "$BUILD_ENVIRONMENT" '{train_id:$train_id,source_sha:$source_sha,environment:$environment}' > release-bus-artifact/manifest.json
-          (cd release-bus-artifact && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)
+          (cd release-bus-artifact && find . -type f ! -path ./SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)
       - name: Upload immutable frontend artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/.github/workflows/release-bus-preflight.yml
+++ b/.github/workflows/release-bus-preflight.yml
@@ -151,5 +151,6 @@ jobs:
         with:
           name: release-bus-frontend-${{ inputs.release_train_id }}-r${{ inputs.release_train_revision }}-${{ matrix.environment }}
           path: release-bus-artifact
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 90

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -46,6 +46,20 @@ describe("release bus optional Codex workflow", () => {
   });
 });
 
+describe("release bus immutable frontend artifact", () => {
+  const preflightWorkflow = fs.readFileSync(
+    path.join(process.cwd(), ".github/workflows/release-bus-preflight.yml"),
+    "utf8"
+  );
+
+  it("uploads hidden bundle files covered by the checksum manifest", () => {
+    expect(preflightWorkflow).toContain("find . -type f ! -name SHA256SUMS");
+    expect(preflightWorkflow).toMatch(
+      /name: Upload immutable frontend artifact[\s\S]*?include-hidden-files: true/
+    );
+  });
+});
+
 function releaseArtifact(uri, metadata) {
   return {
     uri,

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -21,6 +21,7 @@ const childProcess = require("node:child_process");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const YAML = require("yaml");
 
 const STAGING_SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const MAIN_SHA = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
@@ -47,16 +48,33 @@ describe("release bus optional Codex workflow", () => {
 });
 
 describe("release bus immutable frontend artifact", () => {
-  const preflightWorkflow = fs.readFileSync(
-    path.join(process.cwd(), ".github/workflows/release-bus-preflight.yml"),
-    "utf8"
+  const preflightWorkflow = YAML.parse(
+    fs.readFileSync(
+      path.join(process.cwd(), ".github/workflows/release-bus-preflight.yml"),
+      "utf8"
+    )
   );
 
   it("uploads hidden bundle files covered by the checksum manifest", () => {
-    expect(preflightWorkflow).toContain("find . -type f ! -name SHA256SUMS");
-    expect(preflightWorkflow).toMatch(
-      /name: Upload immutable frontend artifact[\s\S]*?include-hidden-files: true/
+    const packageStep = preflightWorkflow.jobs.build.steps.find(
+      (step: { name?: string }) => step.name === "Package immutable bundle"
     );
+    const uploadStep = preflightWorkflow.jobs.build.steps.find(
+      (step: { name?: string }) =>
+        step.name === "Upload immutable frontend artifact"
+    );
+
+    expect(packageStep.run).toContain("find . -type f ! -path ./SHA256SUMS");
+    expect(packageStep.run).toContain("sha256sum > SHA256SUMS");
+    expect(uploadStep).toMatchObject({
+      uses: expect.stringContaining("actions/upload-artifact@"),
+      with: {
+        path: "release-bus-artifact",
+        "include-hidden-files": true,
+        "if-no-files-found": "error",
+        "retention-days": 90,
+      },
+    });
   });
 });
 


### PR DESCRIPTION
## Issue
- Release Bus staging train `def335a5-12eb-4491-8959-ed2a21a117bf` failed before AWS credentials at immutable artifact verification.
- `SHA256SUMS` covered hidden bundle directories such as `.next` and `.ebextensions`, but `actions/upload-artifact@v4` omitted them by default.

## Fix
- Upload the immutable preflight artifact with `include-hidden-files: true`, preserving the existing exact checksum binding.

## Changes
- Enable hidden-file inclusion only for the immutable frontend artifact upload.
- Exclude only the root checksum manifest from hashing so a nested same-named file remains integrity-bound.
- Add a parsed workflow contract regression proving the package and upload steps remain aligned.

## Validation
- `./bin/6529 run lint:changed`
- `./bin/6529 run test:no-coverage --testPathPatterns=__tests__/scripts/deployment-bus.test.ts --runInBand` (48/48)
- Prettier check passed for both changed files.
- Workflow YAML parsed successfully.
- The exact pinned `actions/upload-artifact` commit declares the `include-hidden-files` input.
- The failed train is deterministic before-state evidence; no AWS mutation occurred because credential configuration and deploy steps were skipped.

## Risk
- Level: Medium
- Why: this changes deployment artifact contents, but only restores files already covered by the immutable manifest and required by the application bundle.
- Rollback: revert this commit; the Release Bus lane remains fail-closed if verification cannot bind the artifact.

## Review Notes
- This is a workflow-only prerequisite dispatched from `main`. It must land before retrying preflight for the foundational observability candidate.
