### PR TITLE
Small Collected page styling follow-up

### DIFF
--- a/__tests__/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable.test.tsx
+++ b/__tests__/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable.test.tsx
@@ -83,7 +83,7 @@ describe("UserPageStatsActivityWalletTable", () => {
       ),
     });
     expect(table).toBeInTheDocument();
-    expect(table.querySelector("tbody")).toHaveClass("tw-bg-white/[0.02]");
+    expect(table.querySelector("tbody")).not.toHaveClass("tw-bg-white/[0.02]");
     expect(RowMock).toHaveBeenCalledTimes(2);
     expect(RowMock.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({ locale })

--- a/__tests__/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTableWrapper.test.tsx
+++ b/__tests__/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTableWrapper.test.tsx
@@ -95,6 +95,9 @@ describe("UserPageStatsActivityWalletTableWrapper", () => {
     expect(screen.getByTestId("table")).toBeInTheDocument();
     expect(screen.getByTestId("table")).toHaveAttribute("data-locale", "de-DE");
     expect(screen.getByTestId("pagination")).toHaveAttribute("data-total", "2");
+    expect(screen.getByTestId("filter").closest(".tw-rounded-xl")).toHaveClass(
+      "tw-bg-white/[0.04]"
+    );
   });
 
   it("shows no data message when list empty", () => {

--- a/components/user/collected/UserPageCollectedStats.tsx
+++ b/components/user/collected/UserPageCollectedStats.tsx
@@ -158,43 +158,41 @@ export default function UserPageCollectedStats({
   return (
     <section className="tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-iron-800 tw-bg-black">
       <div className="tw-p-4 sm:tw-p-5">
-        <div className="tw-space-y-4">
-          <CollectedStatsHeader
-            metrics={mainMetrics}
-            activeCollection={activeCollection}
-            isDetailsOpen={isDetailsOpen}
-            detailsId={detailsId}
-            locale={locale}
-            onToggleDetails={() => setIsDetailsOpen((current) => !current)}
-            onCollectionShortcut={onCollectionShortcut}
-          />
-
-          <CollectedStatsSeasons
-            allSeasonCount={allSeasons.length}
-            startedSeasons={startedSeasons}
-            visibleStartedSeasons={visibleStartedSeasons}
-            hiddenStartedSeasonCount={hiddenStartedSeasonCount}
-            notStartedSeasons={notStartedSeasons}
-            activeSeasonId={activeSeasonId}
-            activeSeasonNumber={activeSeasonNumber}
-            locale={locale}
-            hasTouchScreen={hasTouchScreen}
-            isDesktopLayout={isDesktopSeasonsLayout}
-            isDesktopSeasonListExpanded={isDesktopSeasonListExpanded}
-            desktopSeasonsRef={desktopSeasonsRef}
-            onActivateSeason={(seasonId) =>
-              setPreferredSeasonPreview({
-                seasonId,
-                activeSeasonFilterId,
-              })
-            }
-            onSeasonShortcut={onSeasonShortcut}
-            onToggleExpanded={() =>
-              setIsDesktopSeasonListExpanded((current) => !current)
-            }
-          />
-        </div>
+        <CollectedStatsHeader
+          metrics={mainMetrics}
+          activeCollection={activeCollection}
+          isDetailsOpen={isDetailsOpen}
+          detailsId={detailsId}
+          locale={locale}
+          onToggleDetails={() => setIsDetailsOpen((current) => !current)}
+          onCollectionShortcut={onCollectionShortcut}
+        />
       </div>
+
+      <CollectedStatsSeasons
+        allSeasonCount={allSeasons.length}
+        startedSeasons={startedSeasons}
+        visibleStartedSeasons={visibleStartedSeasons}
+        hiddenStartedSeasonCount={hiddenStartedSeasonCount}
+        notStartedSeasons={notStartedSeasons}
+        activeSeasonId={activeSeasonId}
+        activeSeasonNumber={activeSeasonNumber}
+        locale={locale}
+        hasTouchScreen={hasTouchScreen}
+        isDesktopLayout={isDesktopSeasonsLayout}
+        isDesktopSeasonListExpanded={isDesktopSeasonListExpanded}
+        desktopSeasonsRef={desktopSeasonsRef}
+        onActivateSeason={(seasonId) =>
+          setPreferredSeasonPreview({
+            seasonId,
+            activeSeasonFilterId,
+          })
+        }
+        onSeasonShortcut={onSeasonShortcut}
+        onToggleExpanded={() =>
+          setIsDesktopSeasonListExpanded((current) => !current)
+        }
+      />
 
       <CollectedStatsDetailsPanel
         isOpen={isDetailsOpen}

--- a/components/user/collected/stats/subcomponents/CollectedStatsSeasons.tsx
+++ b/components/user/collected/stats/subcomponents/CollectedStatsSeasons.tsx
@@ -123,7 +123,7 @@ export function CollectedStatsSeasons({
   );
 
   return (
-    <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-800 tw-pt-4">
+    <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-800 tw-bg-gradient-to-b tw-from-iron-900/50 tw-via-iron-950/40 tw-to-black tw-px-4 tw-pb-4 tw-pt-4 tw-ring-1 tw-ring-inset tw-ring-white/[0.04] sm:tw-px-5 sm:tw-pb-5">
       <div className="tw-flex tw-items-baseline tw-gap-2 tw-px-1">
         <span className="tw-text-xs tw-font-semibold tw-tracking-tight tw-text-iron-400">
           {title}

--- a/components/user/stats/UserPageStatsTableShared.tsx
+++ b/components/user/stats/UserPageStatsTableShared.tsx
@@ -12,7 +12,7 @@ export const STATS_TABLE_CLASS =
   "tw-w-full tw-border-collapse tw-text-left tw-text-sm";
 
 export const STATS_TABLE_HEAD_CLASS =
-  "tw-bg-white/[0.04] tw-text-xs tw-font-semibold tw-uppercase tw-tracking-wide tw-text-iron-500";
+  "tw-bg-white/[0.04] tw-text-[10px] tw-font-semibold tw-uppercase tw-tracking-wide tw-text-iron-500";
 
 export const STATS_TABLE_HEADER_CELL_CLASS =
   "tw-whitespace-nowrap tw-px-4 tw-py-3 tw-font-semibold";

--- a/components/user/stats/UserPageStatsTableShared.tsx
+++ b/components/user/stats/UserPageStatsTableShared.tsx
@@ -12,7 +12,7 @@ export const STATS_TABLE_CLASS =
   "tw-w-full tw-border-collapse tw-text-left tw-text-sm";
 
 export const STATS_TABLE_HEAD_CLASS =
-  "tw-bg-white/[0.04] tw-text-[10px] tw-font-semibold tw-uppercase tw-tracking-wide tw-text-iron-500";
+  "tw-bg-white/[0.04] tw-text-[10px] tw-font-semibold tw-uppercase tw-tracking-wide tw-text-iron-400";
 
 export const STATS_TABLE_HEADER_CELL_CLASS =
   "tw-whitespace-nowrap tw-px-4 tw-py-3 tw-font-semibold";

--- a/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable.tsx
+++ b/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable.tsx
@@ -31,7 +31,7 @@ export default function UserPageStatsActivityWalletTable({
             locale
           )}
         </caption>
-        <tbody className="tw-divide-x-0 tw-divide-y tw-divide-solid tw-divide-white/[0.06] tw-bg-white/[0.02]">
+        <tbody className="tw-divide-x-0 tw-divide-y tw-divide-solid tw-divide-white/[0.06]">
           {transactions.map((transaction) => (
             <UserPageStatsActivityWalletTableRow
               key={`${transaction.from_address}-${transaction.to_address}-${transaction.transaction}-${transaction.token_id}`}

--- a/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTableWrapper.tsx
+++ b/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTableWrapper.tsx
@@ -8,7 +8,7 @@ import type { Transaction } from "@/entities/ITransaction";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
 import UserPageStatsActivityWalletFilter from "../filter/UserPageStatsActivityWalletFilter";
-import { UserPageStatsActivityWalletFilterType } from "../UserPageStatsActivityWallet.types";
+import type { UserPageStatsActivityWalletFilterType } from "../UserPageStatsActivityWallet.types";
 import {
   getWalletActivityEmptyMessage,
   getWalletActivityMessage,
@@ -54,7 +54,7 @@ export default function UserPageStatsActivityWalletTableWrapper({
   }
 
   return (
-    <div className="tw-mt-2 tw-rounded-xl tw-border tw-border-solid tw-border-white/[0.08] tw-bg-white/[0.02] lg:tw-mt-4">
+    <div className="tw-mt-2 tw-rounded-xl tw-border tw-border-solid tw-border-white/[0.08] tw-bg-white/[0.04] lg:tw-mt-4">
       <div className="tw-mt-6 tw-inline-flex tw-w-full tw-items-center tw-justify-between tw-space-x-4 tw-px-4 sm:tw-px-6">
         <UserPageStatsActivityWalletFilter
           activeFilter={filter}


### PR DESCRIPTION
## Issue
- Wallet Activity used a shorter table-body background, so taller thumbnails and avatars appeared to extend beyond the row bands.
- Uppercase season breakdown headers were visually too prominent.
- The Seasons circle strip did not share the same surface treatment as the expandable Details section.

## Fix
- Let the complete Wallet Activity card own one continuous background, including the filter and every row.
- Use the existing compact label size for season breakdown headers.
- Give the full-width Seasons strip the same gradient and inset ring as Details while preserving its existing spacing and responsive scrolling.

## Notable changes
- Tailwind-only visual updates; no data, filtering, links, or behavior changed.
- Includes one type-only import cleanup required by the repository lint rules.

## Validation
- `./bin/6529 run typecheck`
- `./bin/6529 run lint:uncommitted:tight`
- `./bin/6529 run check:changed`
- `./bin/6529 run react-doctor:diff` (99/100; one existing `useSearchParams` warning on main)
- Desktop QA at 1440×1000
- Mobile QA at 390×844
- Verified no document overflow, intended inner horizontal scrolling, contained Wallet Activity media, 10px headers, and matching Seasons/Details gradients

## Risk
Low. The change is limited to Tailwind classes and one wrapper boundary on the existing Collected stats card.

## Review notes
Please focus on the continuous Wallet Activity surface, the subtler table labels, and the full-width Seasons surface at desktop and mobile widths.