### PR TITLE
Accelerate frontend base canary safely

### DIFF
--- a/.github/workflows/app-pr-ci.yml
+++ b/.github/workflows/app-pr-ci.yml
@@ -243,10 +243,13 @@ jobs:
           if git diff --quiet "origin/${BASE_REF}...HEAD" -- \
             .github/workflows/release-bus-*.yml \
             scripts/release-bus-frontend-gate.sh \
+            scripts/release-bus-gate-evidence.cjs \
             scripts/release-bus-summarize-jest.mjs \
             scripts/release-bus-report-progress.mjs \
             __tests__/scripts/release-bus-frontend-gate.test.ts \
-            __tests__/scripts/release-bus-jest-reporting.test.ts; then
+            __tests__/scripts/release-bus-gate-evidence.test.ts \
+            __tests__/scripts/release-bus-jest-reporting.test.ts \
+            __tests__/scripts/release-bus-shard-injection.test.ts; then
             echo "Release Bus gate files are unchanged."
             exit 0
           fi

--- a/.github/workflows/app-pr-ci.yml
+++ b/.github/workflows/app-pr-ci.yml
@@ -241,6 +241,11 @@ jobs:
         run: |
           set -euo pipefail
           if git diff --quiet "origin/${BASE_REF}...HEAD" -- \
+            bin/6529 \
+            jest.config.js \
+            jest.setup.js \
+            package.json \
+            pnpm-lock.yaml \
             .github/workflows/release-bus-*.yml \
             scripts/release-bus-frontend-gate.sh \
             scripts/release-bus-gate-evidence.cjs \

--- a/.github/workflows/release-bus-base-canary.yml
+++ b/.github/workflows/release-bus-base-canary.yml
@@ -514,6 +514,7 @@ jobs:
             -H 'X-GitHub-Api-Version: 2022-11-28' \
             "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs?filter=latest&per_page=100" \
             > "$RUNNER_TEMP/release-bus-jobs.json"
+      - *source-mutation
       - name: Aggregate fail-closed evidence
         id: aggregate
         if: always()
@@ -525,6 +526,7 @@ jobs:
           JEST_RESULT: ${{ needs.jest.result }}
           LEGACY_RESULT: ${{ needs.legacy.result }}
           LINT_RESULT: ${{ needs.lint.result }}
+          MUTATION_RESULT: ${{ steps.source-mutation.outcome }}
           PASSED_GATE_FINGERPRINT: ${{ needs.authorize.outputs.gate_fingerprint }}
           PASSED_BEHAVIOR_DIGEST: ${{ needs.authorize.outputs.behavior_digest }}
           PASSED_PACKAGE_MANAGER: ${{ needs.authorize.outputs.package_manager }}
@@ -556,7 +558,8 @@ jobs:
             --arg build "$BUILD_RESULT" \
             --arg inventory "$INVENTORY_RESULT" \
             --arg jest "$JEST_RESULT" \
-            '{legacy:$legacy,lint:$lint,typecheck:$typecheck,build:$build,inventory:$inventory,jest:$jest}' \
+            --arg source_mutation "$MUTATION_RESULT" \
+            '{legacy:$legacy,lint:$lint,typecheck:$typecheck,build:$build,inventory:$inventory,jest:$jest,source_mutation:$source_mutation}' \
             > "$RUNNER_TEMP/release-bus-job-results.json"
           node "$RELEASE_BUS_EVIDENCE_TOOL" aggregate \
             --mode "${{ needs.authorize.outputs.gate_mode }}" \
@@ -597,7 +600,6 @@ jobs:
           set -euo pipefail
           test -f "$RUNNER_TEMP/release-bus-base-canary-summary.json"
           node "$RELEASE_BUS_REPORT_TOOL"
-      - *source-mutation
       - name: Return aggregate result
         if: always()
         env:

--- a/.github/workflows/release-bus-base-canary.yml
+++ b/.github/workflows/release-bus-base-canary.yml
@@ -8,6 +8,14 @@ on:
       operation_key: { type: string, required: true }
       base_sha: { type: string, required: true }
       expected_sha: { type: string, required: true }
+      evidence_environment:
+        { type: string, required: false, default: "orchestration" }
+      gate_fingerprint: { type: string, required: false, default: "" }
+      workflow_sha: { type: string, required: false, default: "" }
+      workflow_digest: { type: string, required: false, default: "" }
+      package_manager: { type: string, required: false, default: "" }
+      gate_mode: { type: string, required: false, default: "" }
+      shard_count: { type: string, required: false, default: "" }
 
 permissions: {}
 
@@ -17,23 +25,68 @@ jobs:
   authorize:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    outputs:
+      gate_mode: ${{ steps.contract.outputs.gate_mode }}
+      shard_count: ${{ steps.contract.outputs.shard_count }}
+      shard_matrix: ${{ steps.contract.outputs.shard_matrix }}
+      gate_fingerprint: ${{ steps.contract.outputs.gate_fingerprint }}
+      workflow_sha: ${{ steps.contract.outputs.workflow_sha }}
+      workflow_digest: ${{ steps.contract.outputs.workflow_digest }}
+      evidence_environment: ${{ steps.contract.outputs.evidence_environment }}
+      package_manager: ${{ steps.contract.outputs.package_manager }}
     steps:
       - name: Validate and authorize immutable inputs
+        id: contract
         env:
           BASE_SHA: ${{ inputs.base_sha }}
+          EVIDENCE_ENVIRONMENT: ${{ inputs.evidence_environment }}
+          FRONTEND_GATE_SHARD_COUNT_INPUT: ${{ inputs.shard_count }}
+          GATE_FINGERPRINT: ${{ inputs.gate_fingerprint }}
+          GATE_MODE_INPUT: ${{ inputs.gate_mode }}
+          INPUT_WORKFLOW_DIGEST: ${{ inputs.workflow_digest }}
+          INPUT_WORKFLOW_SHA: ${{ inputs.workflow_sha }}
           EXPECTED_SHA: ${{ inputs.expected_sha }}
           OPERATION_KEY: ${{ inputs.operation_key }}
+          PACKAGE_MANAGER: ${{ inputs.package_manager }}
           RELEASE_BUS_API_URL: ${{ vars.RELEASE_BUS_API_URL }}
           RELEASE_BUS_WORKFLOW_AUTH_TOKEN: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
           TRAIN_ID: ${{ inputs.release_train_id }}
           TRAIN_REVISION: ${{ inputs.release_train_revision }}
         run: |
           set -euo pipefail
+          GATE_MODE="${GATE_MODE_INPUT:-${{ vars.RELEASE_BUS_FRONTEND_GATE_MODE || 'legacy' }}}"
+          FRONTEND_GATE_SHARD_COUNT="${FRONTEND_GATE_SHARD_COUNT_INPUT:-${{ vars.FRONTEND_GATE_SHARD_COUNT || '1' }}}"
           [[ "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]]
           test "$BASE_SHA" = "$EXPECTED_SHA"
           [[ "$TRAIN_ID" =~ ^[A-Za-z0-9._-]{1,100}$ ]]
           [[ "$TRAIN_REVISION" =~ ^[1-9][0-9]{0,8}$ ]]
           [[ "$OPERATION_KEY" =~ ^[A-Za-z0-9:._-]{1,180}$ ]]
+          [[ "$GATE_MODE" =~ ^(legacy|shadow|sharded)$ ]]
+          [[ "$FRONTEND_GATE_SHARD_COUNT" =~ ^(1|2|4)$ ]]
+          [[ "$EVIDENCE_ENVIRONMENT" =~ ^(orchestration|staging|prod)$ ]]
+          workflow_sha="${INPUT_WORKFLOW_SHA:-$GITHUB_SHA}"
+          workflow_digest="${INPUT_WORKFLOW_DIGEST:-unversioned}"
+          gate_fingerprint="${GATE_FINGERPRINT:-unversioned}"
+          [[ "$workflow_sha" =~ ^[a-f0-9]{40}$ ]]
+          test "$workflow_sha" = "$GITHUB_SHA"
+          [[ "$workflow_digest" = unversioned || "$workflow_digest" =~ ^[a-f0-9]{64}$ ]]
+          [[ "$gate_fingerprint" = unversioned || "$gate_fingerprint" =~ ^[a-f0-9]{64}$ ]]
+          test "${#PACKAGE_MANAGER}" -le 100
+          case "$FRONTEND_GATE_SHARD_COUNT" in
+            1) shard_matrix='{"include":[{"index":1,"total":1}]}' ;;
+            2) shard_matrix='{"include":[{"index":1,"total":2},{"index":2,"total":2}]}' ;;
+            4) shard_matrix='{"include":[{"index":1,"total":4},{"index":2,"total":4},{"index":3,"total":4},{"index":4,"total":4}]}' ;;
+          esac
+          {
+            echo "gate_mode=$GATE_MODE"
+            echo "shard_count=$FRONTEND_GATE_SHARD_COUNT"
+            echo "shard_matrix=$shard_matrix"
+            echo "gate_fingerprint=$gate_fingerprint"
+            echo "workflow_sha=$workflow_sha"
+            echo "workflow_digest=$workflow_digest"
+            echo "evidence_environment=$EVIDENCE_ENVIRONMENT"
+            echo "package_manager=$PACKAGE_MANAGER"
+          } >> "$GITHUB_OUTPUT"
           payload="$(jq -n --arg train_id "$TRAIN_ID" --arg operation_key "$OPERATION_KEY" --arg workflow_run_id "$GITHUB_RUN_ID" --arg expected_sha "$EXPECTED_SHA" '{train_id:$train_id,operation_key:$operation_key,workflow_run_id:$workflow_run_id,artifact_run_id:null,repository:"frontend",environment:"orchestration",service:null,expected_sha:$expected_sha,artifact_digest:null}')"
           curl --fail-with-body --silent --show-error \
             -H "Authorization: Bearer $RELEASE_BUS_WORKFLOW_AUTH_TOKEN" \
@@ -41,14 +94,16 @@ jobs:
             --data "$payload" \
             "$RELEASE_BUS_API_URL/deploy/release-bus/authorize"
 
-  gate:
+  legacy:
+    if: needs.authorize.outputs.gate_mode != 'sharded'
     needs: authorize
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
       contents: read
     steps:
-      - name: Check out exact frontend base
+      - &checkout
+        name: Check out exact frontend base
         env:
           BASE_SHA: ${{ inputs.base_sha }}
         run: |
@@ -59,23 +114,29 @@ jobs:
           git fetch --no-tags origin "$BASE_SHA"
           git checkout --detach "$BASE_SHA"
           test "$(git rev-parse HEAD)" = "$BASE_SHA"
-      - name: Install Node.js
+      - &setup-node
+        name: Install Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with: { node-version: "22" }
-      - name: Activate pinned pnpm
+      - &activate-pnpm
+        name: Activate pinned pnpm
         run: |
           corepack enable pnpm
           corepack prepare "$(node -p 'require("./package.json").packageManager')" --activate
-      - name: Install Socket Firewall
+      - &socket-firewall
+        name: Install Socket Firewall
         id: socket-firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
         with: { mode: firewall }
-      - name: Install frozen dependencies
+      - &install
+        name: Install frozen dependencies
         env:
           SFW_BIN: ${{ steps.socket-firewall.outputs.firewall-path-binary }}
         run: ./bin/6529 install:frozen
-      - name: Run exact-base Release Bus gate
-        env:
+      - name: Run authoritative serial gate
+        id: gate
+        continue-on-error: true
+        env: &build-env
           NODE_ENV: production
           API_ENDPOINT: https://api.staging.6529.io
           WS_ENDPOINT: wss://ws.staging.6529.io
@@ -97,6 +158,359 @@ jobs:
           ASSETS_FROM_S3: "false"
           SENTRY_AUTH_TOKEN: ""
           SENTRY_DSN: ""
-        run: ./scripts/release-bus-frontend-gate.sh full
-      - name: Verify gate did not mutate source
-        run: git diff --exit-code
+        run: ./scripts/release-bus-frontend-gate.sh serial "$RUNNER_TEMP/release-bus-evidence"
+      - &source-mutation
+        name: Verify gate did not mutate source
+        id: source-mutation
+        if: always()
+        run: test -z "$(git status --porcelain --untracked-files=all)"
+      - name: Upload serial evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-bus-base-canary-legacy-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-evidence/*.json
+          if-no-files-found: error
+          retention-days: 14
+      - name: Return authoritative serial result
+        if: always()
+        env:
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+          MUTATION_OUTCOME: ${{ steps.source-mutation.outcome }}
+        run: test "$GATE_OUTCOME" = success -a "$MUTATION_OUTCOME" = success
+
+  lint:
+    if: needs.authorize.outputs.gate_mode != 'legacy'
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - *checkout
+      - *setup-node
+      - *activate-pnpm
+      - *socket-firewall
+      - *install
+      - name: Run lint
+        id: gate
+        continue-on-error: true
+        run: ./scripts/release-bus-frontend-gate.sh phase lint "$RUNNER_TEMP/release-bus-evidence"
+      - *source-mutation
+      - name: Upload lint evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-bus-base-canary-lint-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-evidence/*.json
+          if-no-files-found: error
+          retention-days: 14
+      - name: Return lint result
+        if: always()
+        env:
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+          MUTATION_OUTCOME: ${{ steps.source-mutation.outcome }}
+        run: test "$GATE_OUTCOME" = success -a "$MUTATION_OUTCOME" = success
+
+  typecheck:
+    if: needs.authorize.outputs.gate_mode != 'legacy'
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - *checkout
+      - *setup-node
+      - *activate-pnpm
+      - *socket-firewall
+      - *install
+      - name: Run typecheck
+        id: gate
+        continue-on-error: true
+        run: ./scripts/release-bus-frontend-gate.sh phase typecheck "$RUNNER_TEMP/release-bus-evidence"
+      - *source-mutation
+      - name: Upload typecheck evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-bus-base-canary-typecheck-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-evidence/*.json
+          if-no-files-found: error
+          retention-days: 14
+      - name: Return typecheck result
+        if: always()
+        env:
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+          MUTATION_OUTCOME: ${{ steps.source-mutation.outcome }}
+        run: test "$GATE_OUTCOME" = success -a "$MUTATION_OUTCOME" = success
+
+  production-build:
+    if: needs.authorize.outputs.gate_mode != 'legacy'
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - *checkout
+      - *setup-node
+      - *activate-pnpm
+      - *socket-firewall
+      - *install
+      - name: Run production build
+        id: gate
+        continue-on-error: true
+        env: *build-env
+        run: ./scripts/release-bus-frontend-gate.sh phase build "$RUNNER_TEMP/release-bus-evidence"
+      - *source-mutation
+      - name: Upload build evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-bus-base-canary-build-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-evidence/*.json
+          if-no-files-found: error
+          retention-days: 14
+      - name: Return build result
+        if: always()
+        env:
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+          MUTATION_OUTCOME: ${{ steps.source-mutation.outcome }}
+        run: test "$GATE_OUTCOME" = success -a "$MUTATION_OUTCOME" = success
+
+  jest-inventory:
+    if: needs.authorize.outputs.gate_mode != 'legacy'
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - *checkout
+      - *setup-node
+      - *activate-pnpm
+      - *socket-firewall
+      - *install
+      - name: Capture complete Jest inventory
+        id: gate
+        continue-on-error: true
+        run: ./scripts/release-bus-frontend-gate.sh inventory "$RUNNER_TEMP/release-bus-evidence"
+      - *source-mutation
+      - name: Upload complete Jest inventory
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-bus-base-canary-inventory-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-evidence/*.json
+          if-no-files-found: error
+          retention-days: 14
+      - name: Return inventory result
+        if: always()
+        env:
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+          MUTATION_OUTCOME: ${{ steps.source-mutation.outcome }}
+        run: test "$GATE_OUTCOME" = success -a "$MUTATION_OUTCOME" = success
+
+  jest:
+    if: needs.authorize.outputs.gate_mode != 'legacy'
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.authorize.outputs.shard_matrix) }}
+    name: Jest shard ${{ matrix.index }}/${{ matrix.total }}
+    steps:
+      - *checkout
+      - *setup-node
+      - *activate-pnpm
+      - *socket-firewall
+      - *install
+      - name: Run complete deterministic Jest shard
+        id: gate
+        continue-on-error: true
+        run: ./scripts/release-bus-frontend-gate.sh jest "${{ matrix.index }}" "${{ matrix.total }}" "$RUNNER_TEMP/release-bus-evidence"
+      - *source-mutation
+      - name: Upload sanitized shard evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-bus-base-canary-jest-${{ matrix.index }}-of-${{ matrix.total }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-evidence/*.json
+          if-no-files-found: error
+          retention-days: 14
+      - name: Return first-run shard result
+        if: always()
+        env:
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+          MUTATION_OUTCOME: ${{ steps.source-mutation.outcome }}
+        run: test "$GATE_OUTCOME" = success -a "$MUTATION_OUTCOME" = success
+
+  aggregate:
+    if: always() && needs.authorize.result == 'success'
+    needs:
+      [authorize, legacy, lint, typecheck, production-build, jest-inventory, jest]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - *checkout
+      - *setup-node
+      - *activate-pnpm
+      - *socket-firewall
+      - *install
+      - name: Download all gate evidence
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: release-bus-base-canary-*-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-evidence
+      - name: Capture public job links
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          curl --fail-with-body --silent --show-error \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs?filter=latest&per_page=100" \
+            > "$RUNNER_TEMP/release-bus-jobs.json"
+      - name: Aggregate fail-closed evidence
+        id: aggregate
+        continue-on-error: true
+        env:
+          BUILD_RESULT: ${{ needs.production-build.result }}
+          INVENTORY_RESULT: ${{ needs.jest-inventory.result }}
+          JEST_RESULT: ${{ needs.jest.result }}
+          LEGACY_RESULT: ${{ needs.legacy.result }}
+          LINT_RESULT: ${{ needs.lint.result }}
+          PACKAGE_MANAGER_INPUT: ${{ needs.authorize.outputs.package_manager }}
+          TYPECHECK_RESULT: ${{ needs.typecheck.result }}
+        run: |
+          set -euo pipefail
+          package_manager="$PACKAGE_MANAGER_INPUT"
+          if [ -z "$package_manager" ]; then
+            package_manager="$(node -p 'require("./package.json").packageManager')"
+          fi
+          jq -n \
+            --arg legacy "$LEGACY_RESULT" \
+            --arg lint "$LINT_RESULT" \
+            --arg typecheck "$TYPECHECK_RESULT" \
+            --arg build "$BUILD_RESULT" \
+            --arg inventory "$INVENTORY_RESULT" \
+            --arg jest "$JEST_RESULT" \
+            '{legacy:$legacy,lint:$lint,typecheck:$typecheck,build:$build,inventory:$inventory,jest:$jest}' \
+            > "$RUNNER_TEMP/release-bus-job-results.json"
+          node scripts/release-bus-gate-evidence.cjs aggregate \
+            --mode "${{ needs.authorize.outputs.gate_mode }}" \
+            --shard-count "${{ needs.authorize.outputs.shard_count }}" \
+            --evidence-root "$RUNNER_TEMP/release-bus-evidence" \
+            --job-results "$RUNNER_TEMP/release-bus-job-results.json" \
+            --base-sha "${{ inputs.base_sha }}" \
+            --environment "${{ needs.authorize.outputs.evidence_environment }}" \
+            --gate-fingerprint "${{ needs.authorize.outputs.gate_fingerprint }}" \
+            --workflow-sha "${{ needs.authorize.outputs.workflow_sha }}" \
+            --workflow-digest "${{ needs.authorize.outputs.workflow_digest }}" \
+            --node-version "22" \
+            --package-manager "$package_manager" \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --jobs-file "$RUNNER_TEMP/release-bus-jobs.json" \
+            --artifact-name "release-bus-base-canary-summary-$GITHUB_RUN_ID" \
+            --output "$RUNNER_TEMP/release-bus-base-canary-summary.json"
+      - name: Upload deterministic aggregate summary
+        id: summary-artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-bus-base-canary-summary-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-base-canary-summary.json
+          if-no-files-found: error
+          retention-days: 14
+      - name: Report sanitized terminal evidence
+        if: always()
+        env:
+          OPERATION_KEY: ${{ inputs.operation_key }}
+          RELEASE_BUS_API_URL: ${{ vars.RELEASE_BUS_API_URL }}
+          RELEASE_BUS_WORKFLOW_AUTH_TOKEN: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
+          SUMMARY_ARTIFACT_DIGEST: ${{ steps.summary-artifact.outputs.artifact-digest }}
+          TRAIN_ID: ${{ inputs.release_train_id }}
+        run: |
+          set -euo pipefail
+          test -f "$RUNNER_TEMP/release-bus-base-canary-summary.json"
+          payload="$(jq \
+            --arg train_id "$TRAIN_ID" \
+            --arg operation_key "$OPERATION_KEY" \
+            --arg workflow_run_id "$GITHUB_RUN_ID" \
+            --arg artifact_digest "$SUMMARY_ARTIFACT_DIGEST" \
+            '{
+              train_id:$train_id,
+              operation_key:$operation_key,
+              workflow_run_id:$workflow_run_id,
+              phase:"complete",
+              status:.status,
+              stages:((.phases // []) | map({name,status})),
+              jest:{
+                num_failed_test_suites:(.totals.failed_test_suites // 0),
+                num_failed_tests:(.totals.failed_tests // 0),
+                failing_suites:(.failing_suites // []),
+                failing_tests:(.failing_tests // [])
+              },
+              summary:{
+                base_sha,
+                environment,
+                gate_fingerprint,
+                workflow_sha,
+                workflow_digest,
+                node_version,
+                package_manager,
+                shard_count,
+                summary_artifact_name,
+                summary_artifact_digest:$artifact_digest,
+                phase_durations_ms:(.phase_durations_ms + {
+                  total:(if .gate_mode == "sharded"
+                    then ([.phase_durations_ms[]] | max // 0)
+                    else ([.phase_durations_ms[]] | add // 0)
+                  end)
+                }),
+                totals:{
+                  files:(.totals.test_files // 0),
+                  test_suites:(.totals.test_suites // 0),
+                  tests:(.totals.tests // 0),
+                  failed_test_suites:(.totals.failed_test_suites // 0),
+                  failed_tests:(.totals.failed_tests // 0),
+                  skipped_tests:((.totals.pending_tests // 0) + (.totals.todo_tests // 0))
+                },
+                fresh_or_reused,
+                shards:[(.shards // [])[] | {
+                  index,
+                  count,
+                  coordinate:("\(.index)/\(.count)"),
+                  status,
+                  duration_ms,
+                  files:(.counts.test_files // 0),
+                  test_suites:(.counts.test_suites // 0),
+                  tests:(.counts.tests // 0),
+                  failed_test_suites:(.counts.failed_test_suites // 0),
+                  failed_tests:(.counts.failed_tests // 0)
+                }],
+                missing_files:(.missing_files // []),
+                duplicate_files:(.duplicate_files // [])
+              }
+            }' \
+            "$RUNNER_TEMP/release-bus-base-canary-summary.json")"
+          curl --fail-with-body --silent --show-error \
+            -H "Authorization: Bearer $RELEASE_BUS_WORKFLOW_AUTH_TOKEN" \
+            -H 'Content-Type: application/json' \
+            --data "$payload" \
+            "$RELEASE_BUS_API_URL/deploy/release-bus/report-progress"
+      - *source-mutation
+      - name: Return aggregate result
+        if: always()
+        env:
+          AGGREGATE_OUTCOME: ${{ steps.aggregate.outcome }}
+          MUTATION_OUTCOME: ${{ steps.source-mutation.outcome }}
+        run: test "$AGGREGATE_OUTCOME" = success -a "$MUTATION_OUTCOME" = success

--- a/.github/workflows/release-bus-base-canary.yml
+++ b/.github/workflows/release-bus-base-canary.yml
@@ -465,13 +465,27 @@ jobs:
           JEST_RESULT: ${{ needs.jest.result }}
           LEGACY_RESULT: ${{ needs.legacy.result }}
           LINT_RESULT: ${{ needs.lint.result }}
-          PACKAGE_MANAGER_INPUT: ${{ needs.authorize.outputs.package_manager }}
+          PASSED_GATE_FINGERPRINT: ${{ needs.authorize.outputs.gate_fingerprint }}
+          PASSED_PACKAGE_MANAGER: ${{ needs.authorize.outputs.package_manager }}
+          PASSED_WORKFLOW_DIGEST: ${{ needs.authorize.outputs.workflow_digest }}
           TYPECHECK_RESULT: ${{ needs.typecheck.result }}
         run: |
           set -euo pipefail
-          package_manager="$PACKAGE_MANAGER_INPUT"
-          if [ -z "$package_manager" ]; then
-            package_manager="$(node -p 'require("./package.json").packageManager')"
+          contract="$RUNNER_TEMP/release-bus-gate-contract.json"
+          node "$RELEASE_BUS_EVIDENCE_TOOL" fingerprint \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --base-sha "${{ inputs.base_sha }}" \
+            --workflow-sha "${{ needs.authorize.outputs.workflow_sha }}" \
+            --mode "${{ needs.authorize.outputs.gate_mode }}" \
+            --shard-count "${{ needs.authorize.outputs.shard_count }}" \
+            --output "$contract"
+          gate_fingerprint="$(jq -r '.gate_fingerprint' "$contract")"
+          workflow_digest="$(jq -r '.workflow_digest' "$contract")"
+          package_manager="$(jq -r '.package_manager' "$contract")"
+          if [ "$PASSED_GATE_FINGERPRINT" != unversioned ]; then
+            test "$PASSED_GATE_FINGERPRINT" = "$gate_fingerprint"
+            test "$PASSED_WORKFLOW_DIGEST" = "$workflow_digest"
+            test "$PASSED_PACKAGE_MANAGER" = "$package_manager"
           fi
           jq -n \
             --arg legacy "$LEGACY_RESULT" \
@@ -489,9 +503,9 @@ jobs:
             --job-results "$RUNNER_TEMP/release-bus-job-results.json" \
             --base-sha "${{ inputs.base_sha }}" \
             --environment "${{ needs.authorize.outputs.evidence_environment }}" \
-            --gate-fingerprint "${{ needs.authorize.outputs.gate_fingerprint }}" \
+            --gate-fingerprint "$gate_fingerprint" \
             --workflow-sha "${{ needs.authorize.outputs.workflow_sha }}" \
-            --workflow-digest "${{ needs.authorize.outputs.workflow_digest }}" \
+            --workflow-digest "$workflow_digest" \
             --node-version "22" \
             --package-manager "$package_manager" \
             --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \

--- a/.github/workflows/release-bus-base-canary.yml
+++ b/.github/workflows/release-bus-base-canary.yml
@@ -516,6 +516,7 @@ jobs:
         if: always()
         continue-on-error: true
         env:
+          BASE_SHA: ${{ inputs.base_sha }}
           BUILD_RESULT: ${{ needs.production-build.result }}
           INVENTORY_RESULT: ${{ needs.jest-inventory.result }}
           JEST_RESULT: ${{ needs.jest.result }}
@@ -527,10 +528,11 @@ jobs:
           TYPECHECK_RESULT: ${{ needs.typecheck.result }}
         run: |
           set -euo pipefail
+          [[ "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]]
           contract="$RUNNER_TEMP/release-bus-gate-contract.json"
           node "$RELEASE_BUS_EVIDENCE_TOOL" fingerprint \
             --repo-root "$GITHUB_WORKSPACE" \
-            --base-sha "${{ inputs.base_sha }}" \
+            --base-sha "$BASE_SHA" \
             --workflow-sha "${{ needs.authorize.outputs.workflow_sha }}" \
             --mode "${{ needs.authorize.outputs.gate_mode }}" \
             --shard-count "${{ needs.authorize.outputs.shard_count }}" \
@@ -555,7 +557,7 @@ jobs:
             --shard-count "${{ needs.authorize.outputs.shard_count }}" \
             --evidence-root "$RUNNER_TEMP/release-bus-evidence" \
             --job-results "$RUNNER_TEMP/release-bus-job-results.json" \
-            --base-sha "${{ inputs.base_sha }}" \
+            --base-sha "$BASE_SHA" \
             --environment "${{ needs.authorize.outputs.evidence_environment }}" \
             --gate-fingerprint "$gate_fingerprint" \
             --workflow-sha "${{ needs.authorize.outputs.workflow_sha }}" \

--- a/.github/workflows/release-bus-base-canary.yml
+++ b/.github/workflows/release-bus-base-canary.yml
@@ -24,6 +24,8 @@ on:
           default: "4",
           options: ["1", "2", "4"],
         }
+      validation_inject_failure:
+        { type: boolean, required: false, default: false }
 
 permissions: {}
 
@@ -55,6 +57,7 @@ jobs:
           TRAIN_ID: ${{ inputs.release_train_id }}
           TRAIN_REVISION: ${{ inputs.release_train_revision }}
           VALIDATION_GATE_MODE: ${{ inputs.validation_gate_mode }}
+          VALIDATION_INJECT_FAILURE: ${{ inputs.validation_inject_failure }}
           VALIDATION_ONLY: ${{ inputs.validation_only }}
           VALIDATION_SHARD_COUNT: ${{ inputs.validation_shard_count }}
         run: |
@@ -64,6 +67,10 @@ jobs:
           [[ "$TRAIN_ID" =~ ^[A-Za-z0-9._-]{1,100}$ ]]
           [[ "$TRAIN_REVISION" =~ ^[1-9][0-9]{0,8}$ ]]
           [[ "$OPERATION_KEY" =~ ^[A-Za-z0-9:._-]{1,180}$ ]]
+          [[ "$VALIDATION_INJECT_FAILURE" =~ ^(true|false)$ ]]
+          if [ "$VALIDATION_INJECT_FAILURE" = true ]; then
+            test "$VALIDATION_ONLY" = true
+          fi
           workflow_sha="$GITHUB_SHA"
           workflow_digest=unversioned
           gate_fingerprint=unversioned
@@ -395,6 +402,8 @@ jobs:
       - name: Run complete deterministic Jest shard
         id: gate
         continue-on-error: true
+        env:
+          RELEASE_BUS_INJECT_SHARD_FAILURE: ${{ inputs.validation_inject_failure && '1' || '0' }}
         run: RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE" "$RELEASE_BUS_GATE_TOOL" jest "${{ matrix.index }}" "${{ matrix.total }}" "$RUNNER_TEMP/release-bus-evidence"
       - *source-mutation
       - name: Upload sanitized shard evidence

--- a/.github/workflows/release-bus-base-canary.yml
+++ b/.github/workflows/release-bus-base-canary.yml
@@ -8,14 +8,22 @@ on:
       operation_key: { type: string, required: true }
       base_sha: { type: string, required: true }
       expected_sha: { type: string, required: true }
-      evidence_environment:
-        { type: string, required: false, default: "orchestration" }
-      gate_fingerprint: { type: string, required: false, default: "" }
-      workflow_sha: { type: string, required: false, default: "" }
-      workflow_digest: { type: string, required: false, default: "" }
-      package_manager: { type: string, required: false, default: "" }
-      gate_mode: { type: string, required: false, default: "" }
-      shard_count: { type: string, required: false, default: "" }
+      gate_contract: { type: string, required: false, default: "" }
+      validation_only: { type: boolean, required: false, default: false }
+      validation_gate_mode:
+        {
+          type: choice,
+          required: false,
+          default: "shadow",
+          options: [shadow, sharded],
+        }
+      validation_shard_count:
+        {
+          type: choice,
+          required: false,
+          default: "4",
+          options: ["1", "2", "4"],
+        }
 
 permissions: {}
 
@@ -39,39 +47,63 @@ jobs:
         id: contract
         env:
           BASE_SHA: ${{ inputs.base_sha }}
-          EVIDENCE_ENVIRONMENT: ${{ inputs.evidence_environment }}
-          FRONTEND_GATE_SHARD_COUNT_INPUT: ${{ inputs.shard_count }}
-          GATE_FINGERPRINT: ${{ inputs.gate_fingerprint }}
-          GATE_MODE_INPUT: ${{ inputs.gate_mode }}
-          INPUT_WORKFLOW_DIGEST: ${{ inputs.workflow_digest }}
-          INPUT_WORKFLOW_SHA: ${{ inputs.workflow_sha }}
           EXPECTED_SHA: ${{ inputs.expected_sha }}
+          GATE_CONTRACT_INPUT: ${{ inputs.gate_contract }}
           OPERATION_KEY: ${{ inputs.operation_key }}
-          PACKAGE_MANAGER: ${{ inputs.package_manager }}
           RELEASE_BUS_API_URL: ${{ vars.RELEASE_BUS_API_URL }}
           RELEASE_BUS_WORKFLOW_AUTH_TOKEN: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
           TRAIN_ID: ${{ inputs.release_train_id }}
           TRAIN_REVISION: ${{ inputs.release_train_revision }}
+          VALIDATION_GATE_MODE: ${{ inputs.validation_gate_mode }}
+          VALIDATION_ONLY: ${{ inputs.validation_only }}
+          VALIDATION_SHARD_COUNT: ${{ inputs.validation_shard_count }}
         run: |
           set -euo pipefail
-          GATE_MODE="${GATE_MODE_INPUT:-${{ vars.RELEASE_BUS_FRONTEND_GATE_MODE || 'legacy' }}}"
-          FRONTEND_GATE_SHARD_COUNT="${FRONTEND_GATE_SHARD_COUNT_INPUT:-${{ vars.FRONTEND_GATE_SHARD_COUNT || '1' }}}"
           [[ "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]]
           test "$BASE_SHA" = "$EXPECTED_SHA"
           [[ "$TRAIN_ID" =~ ^[A-Za-z0-9._-]{1,100}$ ]]
           [[ "$TRAIN_REVISION" =~ ^[1-9][0-9]{0,8}$ ]]
           [[ "$OPERATION_KEY" =~ ^[A-Za-z0-9:._-]{1,180}$ ]]
+          workflow_sha="$GITHUB_SHA"
+          workflow_digest=unversioned
+          gate_fingerprint=unversioned
+          evidence_environment=orchestration
+          package_manager=""
+          if [ "$VALIDATION_ONLY" = true ]; then
+            test -z "$GATE_CONTRACT_INPUT"
+            GATE_MODE="$VALIDATION_GATE_MODE"
+            FRONTEND_GATE_SHARD_COUNT="$VALIDATION_SHARD_COUNT"
+          elif [ -n "$GATE_CONTRACT_INPUT" ]; then
+            test "${#GATE_CONTRACT_INPUT}" -le 10000
+            jq -e \
+              --arg base_sha "$BASE_SHA" \
+              --arg workflow_sha "$GITHUB_SHA" \
+              'type == "object" and
+               .schema_version == 1 and
+               .repository == "frontend" and
+               .environment == "orchestration" and
+               .base_sha == $base_sha and
+               .workflow_sha == $workflow_sha and
+               .node_version == "22" and
+               (.gate_mode | IN("legacy", "shadow", "sharded")) and
+               (.shard_count | IN(1, 2, 4))' \
+              <<< "$GATE_CONTRACT_INPUT" >/dev/null
+            GATE_MODE="$(jq -r '.gate_mode' <<< "$GATE_CONTRACT_INPUT")"
+            FRONTEND_GATE_SHARD_COUNT="$(jq -r '.shard_count' <<< "$GATE_CONTRACT_INPUT")"
+            workflow_digest="$(jq -r '.workflow_digest' <<< "$GATE_CONTRACT_INPUT")"
+            gate_fingerprint="$(jq -r '.gate_fingerprint' <<< "$GATE_CONTRACT_INPUT")"
+            package_manager="$(jq -r '.package_manager' <<< "$GATE_CONTRACT_INPUT")"
+          else
+            GATE_MODE="${{ vars.RELEASE_BUS_FRONTEND_GATE_MODE || 'legacy' }}"
+            FRONTEND_GATE_SHARD_COUNT="${{ vars.FRONTEND_GATE_SHARD_COUNT || '1' }}"
+          fi
           [[ "$GATE_MODE" =~ ^(legacy|shadow|sharded)$ ]]
           [[ "$FRONTEND_GATE_SHARD_COUNT" =~ ^(1|2|4)$ ]]
-          [[ "$EVIDENCE_ENVIRONMENT" =~ ^(orchestration|staging|prod)$ ]]
-          workflow_sha="${INPUT_WORKFLOW_SHA:-$GITHUB_SHA}"
-          workflow_digest="${INPUT_WORKFLOW_DIGEST:-unversioned}"
-          gate_fingerprint="${GATE_FINGERPRINT:-unversioned}"
           [[ "$workflow_sha" =~ ^[a-f0-9]{40}$ ]]
           test "$workflow_sha" = "$GITHUB_SHA"
           [[ "$workflow_digest" = unversioned || "$workflow_digest" =~ ^[a-f0-9]{64}$ ]]
           [[ "$gate_fingerprint" = unversioned || "$gate_fingerprint" =~ ^[a-f0-9]{64}$ ]]
-          test "${#PACKAGE_MANAGER}" -le 100
+          test "${#package_manager}" -le 100
           case "$FRONTEND_GATE_SHARD_COUNT" in
             1) shard_matrix='{"include":[{"index":1,"total":1}]}' ;;
             2) shard_matrix='{"include":[{"index":1,"total":2},{"index":2,"total":2}]}' ;;
@@ -84,15 +116,17 @@ jobs:
             echo "gate_fingerprint=$gate_fingerprint"
             echo "workflow_sha=$workflow_sha"
             echo "workflow_digest=$workflow_digest"
-            echo "evidence_environment=$EVIDENCE_ENVIRONMENT"
-            echo "package_manager=$PACKAGE_MANAGER"
+            echo "evidence_environment=$evidence_environment"
+            echo "package_manager=$package_manager"
           } >> "$GITHUB_OUTPUT"
-          payload="$(jq -n --arg train_id "$TRAIN_ID" --arg operation_key "$OPERATION_KEY" --arg workflow_run_id "$GITHUB_RUN_ID" --arg expected_sha "$EXPECTED_SHA" '{train_id:$train_id,operation_key:$operation_key,workflow_run_id:$workflow_run_id,artifact_run_id:null,repository:"frontend",environment:"orchestration",service:null,expected_sha:$expected_sha,artifact_digest:null}')"
-          curl --fail-with-body --silent --show-error \
-            -H "Authorization: Bearer $RELEASE_BUS_WORKFLOW_AUTH_TOKEN" \
-            -H 'Content-Type: application/json' \
-            --data "$payload" \
-            "$RELEASE_BUS_API_URL/deploy/release-bus/authorize"
+          if [ "$VALIDATION_ONLY" != true ]; then
+            payload="$(jq -n --arg train_id "$TRAIN_ID" --arg operation_key "$OPERATION_KEY" --arg workflow_run_id "$GITHUB_RUN_ID" --arg expected_sha "$EXPECTED_SHA" '{train_id:$train_id,operation_key:$operation_key,workflow_run_id:$workflow_run_id,artifact_run_id:null,repository:"frontend",environment:"orchestration",service:null,expected_sha:$expected_sha,artifact_digest:null}')"
+            curl --fail-with-body --silent --show-error \
+              -H "Authorization: Bearer $RELEASE_BUS_WORKFLOW_AUTH_TOKEN" \
+              -H 'Content-Type: application/json' \
+              --data "$payload" \
+              "$RELEASE_BUS_API_URL/deploy/release-bus/authorize"
+          fi
 
   legacy:
     if: needs.authorize.outputs.gate_mode != 'sharded'
@@ -114,6 +148,30 @@ jobs:
           git fetch --no-tags origin "$BASE_SHA"
           git checkout --detach "$BASE_SHA"
           test "$(git rev-parse HEAD)" = "$BASE_SHA"
+      - &stage-tooling
+        name: Stage immutable gate tooling
+        env:
+          WORKFLOW_SHA: ${{ needs.authorize.outputs.workflow_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$WORKFLOW_SHA" =~ ^[a-f0-9]{40}$ ]]
+          git cat-file -e "$WORKFLOW_SHA^{commit}" 2>/dev/null || \
+            git fetch --no-tags origin "$WORKFLOW_SHA"
+          tooling="$RUNNER_TEMP/release-bus-tooling/scripts"
+          mkdir -p "$tooling"
+          for file in \
+            scripts/release-bus-frontend-gate.sh \
+            scripts/release-bus-gate-evidence.cjs \
+            scripts/release-bus-report-progress.mjs
+          do
+            git show "$WORKFLOW_SHA:$file" > "$RUNNER_TEMP/release-bus-tooling/$file"
+          done
+          chmod +x "$tooling/release-bus-frontend-gate.sh"
+          {
+            echo "RELEASE_BUS_GATE_TOOL=$tooling/release-bus-frontend-gate.sh"
+            echo "RELEASE_BUS_EVIDENCE_TOOL=$tooling/release-bus-gate-evidence.cjs"
+            echo "RELEASE_BUS_REPORT_TOOL=$tooling/release-bus-report-progress.mjs"
+          } >> "$GITHUB_ENV"
       - &setup-node
         name: Install Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -158,7 +216,7 @@ jobs:
           ASSETS_FROM_S3: "false"
           SENTRY_AUTH_TOKEN: ""
           SENTRY_DSN: ""
-        run: ./scripts/release-bus-frontend-gate.sh serial "$RUNNER_TEMP/release-bus-evidence"
+        run: RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE" "$RELEASE_BUS_GATE_TOOL" serial "$RUNNER_TEMP/release-bus-evidence"
       - &source-mutation
         name: Verify gate did not mutate source
         id: source-mutation
@@ -188,6 +246,7 @@ jobs:
       contents: read
     steps:
       - *checkout
+      - *stage-tooling
       - *setup-node
       - *activate-pnpm
       - *socket-firewall
@@ -195,7 +254,7 @@ jobs:
       - name: Run lint
         id: gate
         continue-on-error: true
-        run: ./scripts/release-bus-frontend-gate.sh phase lint "$RUNNER_TEMP/release-bus-evidence"
+        run: RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE" "$RELEASE_BUS_GATE_TOOL" phase lint "$RUNNER_TEMP/release-bus-evidence"
       - *source-mutation
       - name: Upload lint evidence
         if: always()
@@ -221,6 +280,7 @@ jobs:
       contents: read
     steps:
       - *checkout
+      - *stage-tooling
       - *setup-node
       - *activate-pnpm
       - *socket-firewall
@@ -228,7 +288,7 @@ jobs:
       - name: Run typecheck
         id: gate
         continue-on-error: true
-        run: ./scripts/release-bus-frontend-gate.sh phase typecheck "$RUNNER_TEMP/release-bus-evidence"
+        run: RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE" "$RELEASE_BUS_GATE_TOOL" phase typecheck "$RUNNER_TEMP/release-bus-evidence"
       - *source-mutation
       - name: Upload typecheck evidence
         if: always()
@@ -254,6 +314,7 @@ jobs:
       contents: read
     steps:
       - *checkout
+      - *stage-tooling
       - *setup-node
       - *activate-pnpm
       - *socket-firewall
@@ -262,7 +323,7 @@ jobs:
         id: gate
         continue-on-error: true
         env: *build-env
-        run: ./scripts/release-bus-frontend-gate.sh phase build "$RUNNER_TEMP/release-bus-evidence"
+        run: RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE" "$RELEASE_BUS_GATE_TOOL" phase build "$RUNNER_TEMP/release-bus-evidence"
       - *source-mutation
       - name: Upload build evidence
         if: always()
@@ -288,6 +349,7 @@ jobs:
       contents: read
     steps:
       - *checkout
+      - *stage-tooling
       - *setup-node
       - *activate-pnpm
       - *socket-firewall
@@ -295,7 +357,7 @@ jobs:
       - name: Capture complete Jest inventory
         id: gate
         continue-on-error: true
-        run: ./scripts/release-bus-frontend-gate.sh inventory "$RUNNER_TEMP/release-bus-evidence"
+        run: RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE" "$RELEASE_BUS_GATE_TOOL" inventory "$RUNNER_TEMP/release-bus-evidence"
       - *source-mutation
       - name: Upload complete Jest inventory
         if: always()
@@ -325,6 +387,7 @@ jobs:
     name: Jest shard ${{ matrix.index }}/${{ matrix.total }}
     steps:
       - *checkout
+      - *stage-tooling
       - *setup-node
       - *activate-pnpm
       - *socket-firewall
@@ -332,7 +395,7 @@ jobs:
       - name: Run complete deterministic Jest shard
         id: gate
         continue-on-error: true
-        run: ./scripts/release-bus-frontend-gate.sh jest "${{ matrix.index }}" "${{ matrix.total }}" "$RUNNER_TEMP/release-bus-evidence"
+        run: RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE" "$RELEASE_BUS_GATE_TOOL" jest "${{ matrix.index }}" "${{ matrix.total }}" "$RUNNER_TEMP/release-bus-evidence"
       - *source-mutation
       - name: Upload sanitized shard evidence
         if: always()
@@ -352,7 +415,15 @@ jobs:
   aggregate:
     if: always() && needs.authorize.result == 'success'
     needs:
-      [authorize, legacy, lint, typecheck, production-build, jest-inventory, jest]
+      [
+        authorize,
+        legacy,
+        lint,
+        typecheck,
+        production-build,
+        jest-inventory,
+        jest,
+      ]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -360,16 +431,21 @@ jobs:
       contents: read
     steps:
       - *checkout
+      - *stage-tooling
       - *setup-node
       - *activate-pnpm
       - *socket-firewall
       - *install
       - name: Download all gate evidence
+        id: evidence-download
+        continue-on-error: true
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: release-bus-base-canary-*-${{ github.run_id }}
           path: ${{ runner.temp }}/release-bus-evidence
       - name: Capture public job links
+        if: always()
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -381,6 +457,7 @@ jobs:
             > "$RUNNER_TEMP/release-bus-jobs.json"
       - name: Aggregate fail-closed evidence
         id: aggregate
+        if: always()
         continue-on-error: true
         env:
           BUILD_RESULT: ${{ needs.production-build.result }}
@@ -405,7 +482,7 @@ jobs:
             --arg jest "$JEST_RESULT" \
             '{legacy:$legacy,lint:$lint,typecheck:$typecheck,build:$build,inventory:$inventory,jest:$jest}' \
             > "$RUNNER_TEMP/release-bus-job-results.json"
-          node scripts/release-bus-gate-evidence.cjs aggregate \
+          node "$RELEASE_BUS_EVIDENCE_TOOL" aggregate \
             --mode "${{ needs.authorize.outputs.gate_mode }}" \
             --shard-count "${{ needs.authorize.outputs.shard_count }}" \
             --evidence-root "$RUNNER_TEMP/release-bus-evidence" \
@@ -431,82 +508,18 @@ jobs:
           if-no-files-found: error
           retention-days: 14
       - name: Report sanitized terminal evidence
-        if: always()
+        if: always() && inputs.validation_only != true
         env:
-          OPERATION_KEY: ${{ inputs.operation_key }}
           RELEASE_BUS_API_URL: ${{ vars.RELEASE_BUS_API_URL }}
           RELEASE_BUS_WORKFLOW_AUTH_TOKEN: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
-          SUMMARY_ARTIFACT_DIGEST: ${{ steps.summary-artifact.outputs.artifact-digest }}
-          TRAIN_ID: ${{ inputs.release_train_id }}
+          RELEASE_BUS_AGGREGATE_SUMMARY: ${{ runner.temp }}/release-bus-base-canary-summary.json
+          RELEASE_BUS_OPERATION_KEY: ${{ inputs.operation_key }}
+          RELEASE_BUS_SUMMARY_ARTIFACT_DIGEST: ${{ steps.summary-artifact.outputs.artifact-digest }}
+          RELEASE_BUS_TRAIN_ID: ${{ inputs.release_train_id }}
         run: |
           set -euo pipefail
           test -f "$RUNNER_TEMP/release-bus-base-canary-summary.json"
-          payload="$(jq \
-            --arg train_id "$TRAIN_ID" \
-            --arg operation_key "$OPERATION_KEY" \
-            --arg workflow_run_id "$GITHUB_RUN_ID" \
-            --arg artifact_digest "$SUMMARY_ARTIFACT_DIGEST" \
-            '{
-              train_id:$train_id,
-              operation_key:$operation_key,
-              workflow_run_id:$workflow_run_id,
-              phase:"complete",
-              status:.status,
-              stages:((.phases // []) | map({name,status})),
-              jest:{
-                num_failed_test_suites:(.totals.failed_test_suites // 0),
-                num_failed_tests:(.totals.failed_tests // 0),
-                failing_suites:(.failing_suites // []),
-                failing_tests:(.failing_tests // [])
-              },
-              summary:{
-                base_sha,
-                environment,
-                gate_fingerprint,
-                workflow_sha,
-                workflow_digest,
-                node_version,
-                package_manager,
-                shard_count,
-                summary_artifact_name,
-                summary_artifact_digest:$artifact_digest,
-                phase_durations_ms:(.phase_durations_ms + {
-                  total:(if .gate_mode == "sharded"
-                    then ([.phase_durations_ms[]] | max // 0)
-                    else ([.phase_durations_ms[]] | add // 0)
-                  end)
-                }),
-                totals:{
-                  files:(.totals.test_files // 0),
-                  test_suites:(.totals.test_suites // 0),
-                  tests:(.totals.tests // 0),
-                  failed_test_suites:(.totals.failed_test_suites // 0),
-                  failed_tests:(.totals.failed_tests // 0),
-                  skipped_tests:((.totals.pending_tests // 0) + (.totals.todo_tests // 0))
-                },
-                fresh_or_reused,
-                shards:[(.shards // [])[] | {
-                  index,
-                  count,
-                  coordinate:("\(.index)/\(.count)"),
-                  status,
-                  duration_ms,
-                  files:(.counts.test_files // 0),
-                  test_suites:(.counts.test_suites // 0),
-                  tests:(.counts.tests // 0),
-                  failed_test_suites:(.counts.failed_test_suites // 0),
-                  failed_tests:(.counts.failed_tests // 0)
-                }],
-                missing_files:(.missing_files // []),
-                duplicate_files:(.duplicate_files // [])
-              }
-            }' \
-            "$RUNNER_TEMP/release-bus-base-canary-summary.json")"
-          curl --fail-with-body --silent --show-error \
-            -H "Authorization: Bearer $RELEASE_BUS_WORKFLOW_AUTH_TOKEN" \
-            -H 'Content-Type: application/json' \
-            --data "$payload" \
-            "$RELEASE_BUS_API_URL/deploy/release-bus/report-progress"
+          node "$RELEASE_BUS_REPORT_TOOL"
       - *source-mutation
       - name: Return aggregate result
         if: always()

--- a/.github/workflows/release-bus-base-canary.yml
+++ b/.github/workflows/release-bus-base-canary.yml
@@ -36,24 +36,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      gate_mode: ${{ steps.contract.outputs.gate_mode }}
-      shard_count: ${{ steps.contract.outputs.shard_count }}
-      shard_matrix: ${{ steps.contract.outputs.shard_matrix }}
-      gate_fingerprint: ${{ steps.contract.outputs.gate_fingerprint }}
-      workflow_sha: ${{ steps.contract.outputs.workflow_sha }}
-      workflow_digest: ${{ steps.contract.outputs.workflow_digest }}
-      evidence_environment: ${{ steps.contract.outputs.evidence_environment }}
-      package_manager: ${{ steps.contract.outputs.package_manager }}
+      gate_mode: ${{ steps.inputs.outputs.gate_mode }}
+      shard_count: ${{ steps.inputs.outputs.shard_count }}
+      shard_matrix: ${{ steps.inputs.outputs.shard_matrix }}
+      gate_fingerprint: ${{ steps.fingerprint.outputs.gate_fingerprint }}
+      workflow_sha: ${{ steps.fingerprint.outputs.workflow_sha }}
+      workflow_digest: ${{ steps.fingerprint.outputs.workflow_digest }}
+      evidence_environment: ${{ steps.fingerprint.outputs.evidence_environment }}
+      package_manager: ${{ steps.fingerprint.outputs.package_manager }}
     steps:
-      - name: Validate and authorize immutable inputs
-        id: contract
+      - name: Validate immutable inputs
+        id: inputs
         env:
           BASE_SHA: ${{ inputs.base_sha }}
           EXPECTED_SHA: ${{ inputs.expected_sha }}
           GATE_CONTRACT_INPUT: ${{ inputs.gate_contract }}
           OPERATION_KEY: ${{ inputs.operation_key }}
-          RELEASE_BUS_API_URL: ${{ vars.RELEASE_BUS_API_URL }}
-          RELEASE_BUS_WORKFLOW_AUTH_TOKEN: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
           TRAIN_ID: ${{ inputs.release_train_id }}
           TRAIN_REVISION: ${{ inputs.release_train_revision }}
           VALIDATION_GATE_MODE: ${{ inputs.validation_gate_mode }}
@@ -71,11 +69,6 @@ jobs:
           if [ "$VALIDATION_INJECT_FAILURE" = true ]; then
             test "$VALIDATION_ONLY" = true
           fi
-          workflow_sha="$GITHUB_SHA"
-          workflow_digest=unversioned
-          gate_fingerprint=unversioned
-          evidence_environment=orchestration
-          package_manager=""
           if [ "$VALIDATION_ONLY" = true ]; then
             test -z "$GATE_CONTRACT_INPUT"
             GATE_MODE="$VALIDATION_GATE_MODE"
@@ -97,20 +90,12 @@ jobs:
               <<< "$GATE_CONTRACT_INPUT" >/dev/null
             GATE_MODE="$(jq -r '.gate_mode' <<< "$GATE_CONTRACT_INPUT")"
             FRONTEND_GATE_SHARD_COUNT="$(jq -r '.shard_count' <<< "$GATE_CONTRACT_INPUT")"
-            workflow_digest="$(jq -r '.workflow_digest' <<< "$GATE_CONTRACT_INPUT")"
-            gate_fingerprint="$(jq -r '.gate_fingerprint' <<< "$GATE_CONTRACT_INPUT")"
-            package_manager="$(jq -r '.package_manager' <<< "$GATE_CONTRACT_INPUT")"
           else
             GATE_MODE="${{ vars.RELEASE_BUS_FRONTEND_GATE_MODE || 'legacy' }}"
             FRONTEND_GATE_SHARD_COUNT="${{ vars.FRONTEND_GATE_SHARD_COUNT || '1' }}"
           fi
           [[ "$GATE_MODE" =~ ^(legacy|shadow|sharded)$ ]]
           [[ "$FRONTEND_GATE_SHARD_COUNT" =~ ^(1|2|4)$ ]]
-          [[ "$workflow_sha" =~ ^[a-f0-9]{40}$ ]]
-          test "$workflow_sha" = "$GITHUB_SHA"
-          [[ "$workflow_digest" = unversioned || "$workflow_digest" =~ ^[a-f0-9]{64}$ ]]
-          [[ "$gate_fingerprint" = unversioned || "$gate_fingerprint" =~ ^[a-f0-9]{64}$ ]]
-          test "${#package_manager}" -le 100
           case "$FRONTEND_GATE_SHARD_COUNT" in
             1) shard_matrix='{"include":[{"index":1,"total":1}]}' ;;
             2) shard_matrix='{"include":[{"index":1,"total":2},{"index":2,"total":2}]}' ;;
@@ -120,29 +105,7 @@ jobs:
             echo "gate_mode=$GATE_MODE"
             echo "shard_count=$FRONTEND_GATE_SHARD_COUNT"
             echo "shard_matrix=$shard_matrix"
-            echo "gate_fingerprint=$gate_fingerprint"
-            echo "workflow_sha=$workflow_sha"
-            echo "workflow_digest=$workflow_digest"
-            echo "evidence_environment=$evidence_environment"
-            echo "package_manager=$package_manager"
           } >> "$GITHUB_OUTPUT"
-          if [ "$VALIDATION_ONLY" != true ]; then
-            payload="$(jq -n --arg train_id "$TRAIN_ID" --arg operation_key "$OPERATION_KEY" --arg workflow_run_id "$GITHUB_RUN_ID" --arg expected_sha "$EXPECTED_SHA" '{train_id:$train_id,operation_key:$operation_key,workflow_run_id:$workflow_run_id,artifact_run_id:null,repository:"frontend",environment:"orchestration",service:null,expected_sha:$expected_sha,artifact_digest:null}')"
-            curl --fail-with-body --silent --show-error \
-              -H "Authorization: Bearer $RELEASE_BUS_WORKFLOW_AUTH_TOKEN" \
-              -H 'Content-Type: application/json' \
-              --data "$payload" \
-              "$RELEASE_BUS_API_URL/deploy/release-bus/authorize"
-          fi
-
-  legacy:
-    if: needs.authorize.outputs.gate_mode != 'sharded'
-    needs: authorize
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    permissions:
-      contents: read
-    steps:
       - &checkout
         name: Check out exact frontend base
         env:
@@ -155,13 +118,93 @@ jobs:
           git fetch --no-tags origin "$BASE_SHA"
           git checkout --detach "$BASE_SHA"
           test "$(git rev-parse HEAD)" = "$BASE_SHA"
-      - &stage-tooling
-        name: Stage immutable gate tooling
+      - &setup-node
+        name: Install Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with: { node-version: "22" }
+      - name: Derive and verify immutable gate fingerprint
+        id: fingerprint
         env:
-          WORKFLOW_SHA: ${{ needs.authorize.outputs.workflow_sha }}
+          BASE_SHA: ${{ inputs.base_sha }}
+          GATE_CONTRACT_INPUT: ${{ inputs.gate_contract }}
+          GATE_MODE: ${{ steps.inputs.outputs.gate_mode }}
+          SHARD_COUNT: ${{ steps.inputs.outputs.shard_count }}
+          WORKFLOW_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           [[ "$WORKFLOW_SHA" =~ ^[a-f0-9]{40}$ ]]
+          git cat-file -e "$WORKFLOW_SHA^{commit}" 2>/dev/null || \
+            git fetch --no-tags origin "$WORKFLOW_SHA"
+          evidence_tool="$RUNNER_TEMP/release-bus-gate-evidence.cjs"
+          contract="$RUNNER_TEMP/release-bus-gate-contract.json"
+          git show "$WORKFLOW_SHA:scripts/release-bus-gate-evidence.cjs" > "$evidence_tool"
+          node "$evidence_tool" fingerprint \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --base-sha "$BASE_SHA" \
+            --workflow-sha "$WORKFLOW_SHA" \
+            --mode "$GATE_MODE" \
+            --shard-count "$SHARD_COUNT" \
+            --output "$contract"
+          gate_fingerprint="$(jq -r '.gate_fingerprint' "$contract")"
+          workflow_digest="$(jq -r '.workflow_digest' "$contract")"
+          package_manager="$(jq -r '.package_manager' "$contract")"
+          if [ -n "$GATE_CONTRACT_INPUT" ]; then
+            test "$(jq -r '.gate_fingerprint' <<< "$GATE_CONTRACT_INPUT")" = "$gate_fingerprint"
+            test "$(jq -r '.workflow_digest' <<< "$GATE_CONTRACT_INPUT")" = "$workflow_digest"
+            test "$(jq -r '.package_manager' <<< "$GATE_CONTRACT_INPUT")" = "$package_manager"
+          fi
+          {
+            echo "gate_fingerprint=$gate_fingerprint"
+            echo "workflow_sha=$WORKFLOW_SHA"
+            echo "workflow_digest=$workflow_digest"
+            echo "evidence_environment=orchestration"
+            echo "package_manager=$package_manager"
+          } >> "$GITHUB_OUTPUT"
+      - name: Authorize Release Bus operation
+        if: inputs.validation_only != true
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          OPERATION_KEY: ${{ inputs.operation_key }}
+          RELEASE_BUS_API_URL: ${{ vars.RELEASE_BUS_API_URL }}
+          RELEASE_BUS_WORKFLOW_AUTH_TOKEN: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
+          TRAIN_ID: ${{ inputs.release_train_id }}
+        run: |
+          set -euo pipefail
+          payload="$(jq -n --arg train_id "$TRAIN_ID" --arg operation_key "$OPERATION_KEY" --arg workflow_run_id "$GITHUB_RUN_ID" --arg expected_sha "$EXPECTED_SHA" '{train_id:$train_id,operation_key:$operation_key,workflow_run_id:$workflow_run_id,artifact_run_id:null,repository:"frontend",environment:"orchestration",service:null,expected_sha:$expected_sha,artifact_digest:null}')"
+          curl --fail-with-body --silent --show-error \
+            -H "Authorization: Bearer $RELEASE_BUS_WORKFLOW_AUTH_TOKEN" \
+            -H 'Content-Type: application/json' \
+            --data "$payload" \
+            "$RELEASE_BUS_API_URL/deploy/release-bus/authorize"
+      - name: Verify authorization did not mutate source
+        run: test -z "$(git status --porcelain --untracked-files=all)"
+
+  legacy:
+    if: needs.authorize.outputs.gate_mode != 'sharded'
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - *checkout
+      - &stage-tooling
+        name: Stage immutable gate tooling
+        env:
+          BASE_SHA: ${{ inputs.base_sha }}
+          EVIDENCE_ENVIRONMENT: ${{ needs.authorize.outputs.evidence_environment }}
+          GATE_FINGERPRINT: ${{ needs.authorize.outputs.gate_fingerprint }}
+          PACKAGE_MANAGER: ${{ needs.authorize.outputs.package_manager }}
+          WORKFLOW_SHA: ${{ needs.authorize.outputs.workflow_sha }}
+          WORKFLOW_DIGEST: ${{ needs.authorize.outputs.workflow_digest }}
+        run: |
+          set -euo pipefail
+          [[ "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]]
+          test "$EVIDENCE_ENVIRONMENT" = orchestration
+          [[ "$GATE_FINGERPRINT" =~ ^[a-f0-9]{64}$ ]]
+          [[ "$PACKAGE_MANAGER" =~ ^pnpm@[A-Za-z0-9.+-]{1,122}$ ]]
+          [[ "$WORKFLOW_SHA" =~ ^[a-f0-9]{40}$ ]]
+          [[ "$WORKFLOW_DIGEST" =~ ^[a-f0-9]{64}$ ]]
           git cat-file -e "$WORKFLOW_SHA^{commit}" 2>/dev/null || \
             git fetch --no-tags origin "$WORKFLOW_SHA"
           tooling="$RUNNER_TEMP/release-bus-tooling/scripts"
@@ -178,11 +221,15 @@ jobs:
             echo "RELEASE_BUS_GATE_TOOL=$tooling/release-bus-frontend-gate.sh"
             echo "RELEASE_BUS_EVIDENCE_TOOL=$tooling/release-bus-gate-evidence.cjs"
             echo "RELEASE_BUS_REPORT_TOOL=$tooling/release-bus-report-progress.mjs"
+            echo "RELEASE_BUS_BASE_SHA=$BASE_SHA"
+            echo "RELEASE_BUS_EVIDENCE_ENVIRONMENT=$EVIDENCE_ENVIRONMENT"
+            echo "RELEASE_BUS_GATE_FINGERPRINT=$GATE_FINGERPRINT"
+            echo "RELEASE_BUS_WORKFLOW_SHA=$WORKFLOW_SHA"
+            echo "RELEASE_BUS_WORKFLOW_DIGEST=$WORKFLOW_DIGEST"
+            echo "RELEASE_BUS_NODE_VERSION=22"
+            echo "RELEASE_BUS_PACKAGE_MANAGER=$PACKAGE_MANAGER"
           } >> "$GITHUB_ENV"
-      - &setup-node
-        name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with: { node-version: "22" }
+      - *setup-node
       - &activate-pnpm
         name: Activate pinned pnpm
         run: |
@@ -491,11 +538,9 @@ jobs:
           gate_fingerprint="$(jq -r '.gate_fingerprint' "$contract")"
           workflow_digest="$(jq -r '.workflow_digest' "$contract")"
           package_manager="$(jq -r '.package_manager' "$contract")"
-          if [ "$PASSED_GATE_FINGERPRINT" != unversioned ]; then
-            test "$PASSED_GATE_FINGERPRINT" = "$gate_fingerprint"
-            test "$PASSED_WORKFLOW_DIGEST" = "$workflow_digest"
-            test "$PASSED_PACKAGE_MANAGER" = "$package_manager"
-          fi
+          test "$PASSED_GATE_FINGERPRINT" = "$gate_fingerprint"
+          test "$PASSED_WORKFLOW_DIGEST" = "$workflow_digest"
+          test "$PASSED_PACKAGE_MANAGER" = "$package_manager"
           jq -n \
             --arg legacy "$LEGACY_RESULT" \
             --arg lint "$LINT_RESULT" \

--- a/.github/workflows/release-bus-base-canary.yml
+++ b/.github/workflows/release-bus-base-canary.yml
@@ -40,6 +40,7 @@ jobs:
       shard_count: ${{ steps.inputs.outputs.shard_count }}
       shard_matrix: ${{ steps.inputs.outputs.shard_matrix }}
       gate_fingerprint: ${{ steps.fingerprint.outputs.gate_fingerprint }}
+      behavior_digest: ${{ steps.fingerprint.outputs.behavior_digest }}
       workflow_sha: ${{ steps.fingerprint.outputs.workflow_sha }}
       workflow_digest: ${{ steps.fingerprint.outputs.workflow_digest }}
       evidence_environment: ${{ steps.fingerprint.outputs.evidence_environment }}
@@ -146,6 +147,7 @@ jobs:
             --shard-count "$SHARD_COUNT" \
             --output "$contract"
           gate_fingerprint="$(jq -r '.gate_fingerprint' "$contract")"
+          behavior_digest="$(jq -r '.behavior_digest' "$contract")"
           workflow_digest="$(jq -r '.workflow_digest' "$contract")"
           package_manager="$(jq -r '.package_manager' "$contract")"
           if [ -n "$GATE_CONTRACT_INPUT" ]; then
@@ -155,6 +157,7 @@ jobs:
           fi
           {
             echo "gate_fingerprint=$gate_fingerprint"
+            echo "behavior_digest=$behavior_digest"
             echo "workflow_sha=$WORKFLOW_SHA"
             echo "workflow_digest=$workflow_digest"
             echo "evidence_environment=orchestration"
@@ -523,6 +526,7 @@ jobs:
           LEGACY_RESULT: ${{ needs.legacy.result }}
           LINT_RESULT: ${{ needs.lint.result }}
           PASSED_GATE_FINGERPRINT: ${{ needs.authorize.outputs.gate_fingerprint }}
+          PASSED_BEHAVIOR_DIGEST: ${{ needs.authorize.outputs.behavior_digest }}
           PASSED_PACKAGE_MANAGER: ${{ needs.authorize.outputs.package_manager }}
           PASSED_WORKFLOW_DIGEST: ${{ needs.authorize.outputs.workflow_digest }}
           TYPECHECK_RESULT: ${{ needs.typecheck.result }}
@@ -538,9 +542,11 @@ jobs:
             --shard-count "${{ needs.authorize.outputs.shard_count }}" \
             --output "$contract"
           gate_fingerprint="$(jq -r '.gate_fingerprint' "$contract")"
+          behavior_digest="$(jq -r '.behavior_digest' "$contract")"
           workflow_digest="$(jq -r '.workflow_digest' "$contract")"
           package_manager="$(jq -r '.package_manager' "$contract")"
           test "$PASSED_GATE_FINGERPRINT" = "$gate_fingerprint"
+          test "$PASSED_BEHAVIOR_DIGEST" = "$behavior_digest"
           test "$PASSED_WORKFLOW_DIGEST" = "$workflow_digest"
           test "$PASSED_PACKAGE_MANAGER" = "$package_manager"
           jq -n \
@@ -560,6 +566,7 @@ jobs:
             --base-sha "$BASE_SHA" \
             --environment "${{ needs.authorize.outputs.evidence_environment }}" \
             --gate-fingerprint "$gate_fingerprint" \
+            --behavior-digest "$behavior_digest" \
             --workflow-sha "${{ needs.authorize.outputs.workflow_sha }}" \
             --workflow-digest "$workflow_digest" \
             --node-version "22" \

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -55,6 +55,9 @@ describe("Release Bus frontend gate contract", () => {
         "--bail=0",
         "--runTestsByPath",
         "__tests__/scripts/release-bus-frontend-gate.test.ts",
+        "__tests__/scripts/release-bus-gate-evidence.test.ts",
+        "__tests__/scripts/release-bus-jest-reporting.test.ts",
+        "__tests__/scripts/release-bus-shard-injection.test.ts",
       ]);
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
@@ -66,12 +69,14 @@ describe("Release Bus frontend gate contract", () => {
       "./scripts/release-bus-frontend-gate.sh validate"
     );
     expect(isolation).toContain("./scripts/release-bus-frontend-gate.sh full");
-    expect(canary).toContain("./scripts/release-bus-frontend-gate.sh serial");
-    expect(canary).toContain("./scripts/release-bus-frontend-gate.sh phase lint");
-    expect(canary).toContain("./scripts/release-bus-frontend-gate.sh phase typecheck");
-    expect(canary).toContain("./scripts/release-bus-frontend-gate.sh phase build");
-    expect(canary).toContain("./scripts/release-bus-frontend-gate.sh jest");
+    expect(canary).toContain('"$RELEASE_BUS_GATE_TOOL" serial');
+    expect(canary).toContain('"$RELEASE_BUS_GATE_TOOL" phase lint');
+    expect(canary).toContain('"$RELEASE_BUS_GATE_TOOL" phase typecheck');
+    expect(canary).toContain('"$RELEASE_BUS_GATE_TOOL" phase build');
+    expect(canary).toContain('"$RELEASE_BUS_GATE_TOOL" jest');
     expect(canary).toContain('git fetch --no-tags origin "$BASE_SHA"');
+    expect(canary).toContain('git show "$WORKFLOW_SHA:$file"');
+    expect(canary).toContain('RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE"');
     expect(canary).not.toContain("ref: ${{ inputs.base_sha }}");
   });
 
@@ -84,6 +89,8 @@ describe("Release Bus frontend gate contract", () => {
     expect(canary).toContain("fail-fast: false");
     expect(canary).toContain("FRONTEND_GATE_SHARD_COUNT");
     expect(canary).toContain("RELEASE_BUS_FRONTEND_GATE_MODE");
+    expect(canary).toContain("validation_only");
+    expect(canary).toContain("inputs.validation_only != true");
   });
 
   it("executes its argument-forwarding contract in ordinary PR CI", () => {

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -64,6 +64,60 @@ describe("Release Bus frontend gate contract", () => {
     }
   });
 
+  it("binds immutable identity to emitted phase evidence", () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "release-bus-evidence-")
+    );
+    const runner = path.join(tempDir, "fake-6529");
+    const outputDir = path.join(tempDir, "evidence");
+    const identity = {
+      RELEASE_BUS_BASE_SHA: "a".repeat(40),
+      RELEASE_BUS_EVIDENCE_ENVIRONMENT: "orchestration",
+      RELEASE_BUS_GATE_FINGERPRINT: "b".repeat(64),
+      RELEASE_BUS_WORKFLOW_SHA: "c".repeat(40),
+      RELEASE_BUS_WORKFLOW_DIGEST: "d".repeat(64),
+      RELEASE_BUS_NODE_VERSION: "22",
+      RELEASE_BUS_PACKAGE_MANAGER: "pnpm@10.14.0",
+    };
+    try {
+      fs.writeFileSync(runner, "#!/usr/bin/env bash\nexit 0\n");
+      fs.chmodSync(runner, 0o755);
+
+      execFileSync(
+        "bash",
+        ["scripts/release-bus-frontend-gate.sh", "phase", "lint", outputDir],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...process.env,
+            ...identity,
+            RELEASE_BUS_6529_BIN: runner,
+          },
+        }
+      );
+
+      expect(
+        JSON.parse(
+          fs.readFileSync(path.join(outputDir, "phase-lint.json"), "utf8")
+        )
+      ).toMatchObject({
+        kind: "phase",
+        source: "parallel",
+        name: "lint",
+        status: "SUCCEEDED",
+        base_sha: identity.RELEASE_BUS_BASE_SHA,
+        environment: identity.RELEASE_BUS_EVIDENCE_ENVIRONMENT,
+        gate_fingerprint: identity.RELEASE_BUS_GATE_FINGERPRINT,
+        workflow_sha: identity.RELEASE_BUS_WORKFLOW_SHA,
+        workflow_digest: identity.RELEASE_BUS_WORKFLOW_DIGEST,
+        node_version: identity.RELEASE_BUS_NODE_VERSION,
+        package_manager: identity.RELEASE_BUS_PACKAGE_MANAGER,
+      });
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("is shared by preflight, isolation, and exact-base canary", () => {
     expect(preflight).toContain(
       "./scripts/release-bus-frontend-gate.sh validate"
@@ -76,6 +130,9 @@ describe("Release Bus frontend gate contract", () => {
     expect(canary).toContain('"$RELEASE_BUS_GATE_TOOL" jest');
     expect(canary).toContain('git fetch --no-tags origin "$BASE_SHA"');
     expect(canary).toContain('git show "$WORKFLOW_SHA:$file"');
+    expect(canary).toContain("Derive and verify immutable gate fingerprint");
+    expect(canary).toContain("RELEASE_BUS_GATE_FINGERPRINT=$GATE_FINGERPRINT");
+    expect(canary).not.toContain("gate_fingerprint=unversioned");
     expect(canary).toContain('RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE"');
     expect(canary).not.toContain("ref: ${{ inputs.base_sha }}");
   });
@@ -89,6 +146,17 @@ describe("Release Bus frontend gate contract", () => {
     expect(gate).toContain('raw_dir="$(mktemp -d');
     expect(gate).toContain('results="$raw_dir/jest-results.json"');
     expect(gate).not.toContain('results="$output_dir/jest-results');
+    for (const identityFlag of [
+      "--base-sha",
+      "--environment",
+      "--gate-fingerprint",
+      "--workflow-sha",
+      "--workflow-digest",
+      "--node-version",
+      "--package-manager",
+    ]) {
+      expect(gate).toContain(identityFlag);
+    }
     expect(canary).toContain("fail-fast: false");
     expect(canary).toContain("FRONTEND_GATE_SHARD_COUNT");
     expect(canary).toContain("RELEASE_BUS_FRONTEND_GATE_MODE");

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -71,6 +71,18 @@ describe("Release Bus frontend gate contract", () => {
     }
   });
 
+  it("runs the contract when any fingerprinted base file changes", () => {
+    for (const baseFile of [
+      "bin/6529",
+      "jest.config.js",
+      "jest.setup.js",
+      "package.json",
+      "pnpm-lock.yaml",
+    ]) {
+      expect(appPrCi).toContain(`${baseFile} \\`);
+    }
+  });
+
   it("forwards the contract arguments to the 6529 runner exactly", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "release-bus-gate-"));
     const runner = path.join(tempDir, "fake-6529");

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -91,6 +91,9 @@ describe("Release Bus frontend gate contract", () => {
     expect(canary).toContain("RELEASE_BUS_FRONTEND_GATE_MODE");
     expect(canary).toContain("validation_only");
     expect(canary).toContain("inputs.validation_only != true");
+    expect(canary).toContain("validation_inject_failure");
+    expect(canary).toContain('test "$VALIDATION_ONLY" = true');
+    expect(canary).toContain("RELEASE_BUS_INJECT_SHARD_FAILURE");
   });
 
   it("executes its argument-forwarding contract in ordinary PR CI", () => {

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -15,7 +15,7 @@ describe("Release Bus frontend gate contract", () => {
 
   it("owns the only Release Bus Jest invocation", () => {
     expect(gate).toContain(
-      '"$SEIZE_BIN" run test:no-coverage --runInBand "$@"'
+      '"$SEIZE_BIN" run test:no-coverage --runInBand --bail=0 "$@"'
     );
     expect(gate).not.toContain("test:no-coverage -- --runInBand");
 
@@ -52,6 +52,7 @@ describe("Release Bus frontend gate contract", () => {
         "run",
         "test:no-coverage",
         "--runInBand",
+        "--bail=0",
         "--runTestsByPath",
         "__tests__/scripts/release-bus-frontend-gate.test.ts",
       ]);
@@ -65,9 +66,24 @@ describe("Release Bus frontend gate contract", () => {
       "./scripts/release-bus-frontend-gate.sh validate"
     );
     expect(isolation).toContain("./scripts/release-bus-frontend-gate.sh full");
-    expect(canary).toContain("./scripts/release-bus-frontend-gate.sh full");
+    expect(canary).toContain("./scripts/release-bus-frontend-gate.sh serial");
+    expect(canary).toContain("./scripts/release-bus-frontend-gate.sh phase lint");
+    expect(canary).toContain("./scripts/release-bus-frontend-gate.sh phase typecheck");
+    expect(canary).toContain("./scripts/release-bus-frontend-gate.sh phase build");
+    expect(canary).toContain("./scripts/release-bus-frontend-gate.sh jest");
     expect(canary).toContain('git fetch --no-tags origin "$BASE_SHA"');
     expect(canary).not.toContain("ref: ${{ inputs.base_sha }}");
+  });
+
+  it("keeps all required phases and deterministic shard controls", () => {
+    for (const phase of ["lint", "typecheck", "unit_tests", "build"]) {
+      expect(gate).toContain(phase);
+    }
+    expect(gate).toContain('--shard="$shard_index/$shard_count"');
+    expect(gate).toContain("--bail=0");
+    expect(canary).toContain("fail-fast: false");
+    expect(canary).toContain("FRONTEND_GATE_SHARD_COUNT");
+    expect(canary).toContain("RELEASE_BUS_FRONTEND_GATE_MODE");
   });
 
   it("executes its argument-forwarding contract in ordinary PR CI", () => {

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -86,6 +86,9 @@ describe("Release Bus frontend gate contract", () => {
     }
     expect(gate).toContain('--shard="$shard_index/$shard_count"');
     expect(gate).toContain("--bail=0");
+    expect(gate).toContain('raw_dir="$(mktemp -d');
+    expect(gate).toContain('results="$raw_dir/jest-results.json"');
+    expect(gate).not.toContain('results="$output_dir/jest-results');
     expect(canary).toContain("fail-fast: false");
     expect(canary).toContain("FRONTEND_GATE_SHARD_COUNT");
     expect(canary).toContain("RELEASE_BUS_FRONTEND_GATE_MODE");

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -143,6 +143,8 @@ describe("Release Bus frontend gate contract", () => {
     expect(canary).toContain('git show "$WORKFLOW_SHA:$file"');
     expect(canary).toContain("Derive and verify immutable gate fingerprint");
     expect(canary).toContain("RELEASE_BUS_GATE_FINGERPRINT=$GATE_FINGERPRINT");
+    expect(canary).toContain("behavior_digest");
+    expect(canary).toContain('--behavior-digest "$behavior_digest"');
     expect(canary).not.toContain("gate_fingerprint=unversioned");
     expect(canary).toContain('RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE"');
     expect(canary).not.toContain("ref: ${{ inputs.base_sha }}");

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -197,8 +197,14 @@ describe("Release Bus frontend gate contract", () => {
       (step) => step.name === "Aggregate fail-closed evidence"
     );
     expect(aggregate?.env?.BASE_SHA).toBe("${{ inputs.base_sha }}");
+    expect(aggregate?.env?.MUTATION_RESULT).toBe(
+      "${{ steps.source-mutation.outcome }}"
+    );
     expect(aggregate?.run).toContain('[[ "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]]');
     expect(aggregate?.run?.match(/--base-sha "\$BASE_SHA"/g)).toHaveLength(2);
+    expect(aggregate?.run).toContain(
+      '--arg source_mutation "$MUTATION_RESULT"'
+    );
 
     const report = steps.find(
       (step) => step.name === "Report sanitized terminal evidence"
@@ -213,6 +219,20 @@ describe("Release Bus frontend gate contract", () => {
       "${{ inputs.release_train_id }}"
     );
     expect(report?.run).toContain('node "$RELEASE_BUS_REPORT_TOOL"');
+
+    const aggregateSteps = canaryWorkflow.jobs?.aggregate?.steps ?? [];
+    const sourceMutationIndex = aggregateSteps.findIndex(
+      (step) => step.name === "Verify gate did not mutate source"
+    );
+    const aggregateIndex = aggregateSteps.findIndex(
+      (step) => step.name === "Aggregate fail-closed evidence"
+    );
+    const reportIndex = aggregateSteps.findIndex(
+      (step) => step.name === "Report sanitized terminal evidence"
+    );
+    expect(sourceMutationIndex).toBeGreaterThanOrEqual(0);
+    expect(sourceMutationIndex).toBeLessThan(aggregateIndex);
+    expect(aggregateIndex).toBeLessThan(reportIndex);
 
     const tempDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "release-bus-input-")

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
+import { parse as parseYaml } from "yaml";
 
 const read = (relativePath: string) =>
   fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
@@ -12,6 +13,16 @@ describe("Release Bus frontend gate contract", () => {
   const isolation = read(".github/workflows/release-bus-isolate-candidate.yml");
   const canary = read(".github/workflows/release-bus-base-canary.yml");
   const appPrCi = read(".github/workflows/app-pr-ci.yml");
+
+  type WorkflowStep = {
+    env?: Record<string, string>;
+    name?: string;
+    run?: string;
+  };
+
+  const canaryWorkflow = parseYaml(canary) as {
+    jobs?: Record<string, { steps?: WorkflowStep[] }>;
+  };
 
   it("owns the only Release Bus Jest invocation", () => {
     expect(gate).toContain(
@@ -135,6 +146,45 @@ describe("Release Bus frontend gate contract", () => {
     expect(canary).not.toContain("gate_fingerprint=unversioned");
     expect(canary).toContain('RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE"');
     expect(canary).not.toContain("ref: ${{ inputs.base_sha }}");
+  });
+
+  it("passes untrusted workflow inputs through the environment before shell use", () => {
+    const steps = Object.values(canaryWorkflow.jobs ?? {}).flatMap(
+      (job) => job.steps ?? []
+    );
+    for (const step of steps) {
+      expect(step.run ?? "").not.toMatch(/\$\{\{\s*inputs\./);
+    }
+
+    const aggregate = steps.find(
+      (step) => step.name === "Aggregate fail-closed evidence"
+    );
+    expect(aggregate?.env?.BASE_SHA).toBe("${{ inputs.base_sha }}");
+    expect(aggregate?.run).toContain('[[ "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]]');
+    expect(aggregate?.run?.match(/--base-sha "\$BASE_SHA"/g)).toHaveLength(2);
+
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "release-bus-input-")
+    );
+    const marker = path.join(tempDir, "shell-interpolation-ran");
+    const validator = path.join(tempDir, "validate-base-sha");
+    const maliciousBaseSha = `$(touch ${marker})`;
+    try {
+      fs.writeFileSync(
+        validator,
+        '#!/usr/bin/env bash\nset -euo pipefail\n[[ "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]]\n'
+      );
+      fs.chmodSync(validator, 0o755);
+      expect(() =>
+        execFileSync(validator, [], {
+          env: { ...process.env, BASE_SHA: maliciousBaseSha },
+          stdio: "ignore",
+        })
+      ).toThrow();
+      expect(fs.existsSync(marker)).toBe(false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("keeps all required phases and deterministic shard controls", () => {

--- a/__tests__/scripts/release-bus-gate-evidence.test.ts
+++ b/__tests__/scripts/release-bus-gate-evidence.test.ts
@@ -1,0 +1,298 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const {
+  buildGateSummary,
+  finalSummary,
+  jestRecord,
+  manifestFromRaw,
+  phaseRecord,
+  safeText,
+}: {
+  buildGateSummary: (input: Record<string, unknown>) => Record<string, any>;
+  finalSummary: (input: Record<string, unknown>) => Record<string, any>;
+  jestRecord: (input: Record<string, unknown>) => Record<string, any>;
+  manifestFromRaw: (raw: string, root: string) => string[];
+  phaseRecord: (input: Record<string, unknown>) => Record<string, any>;
+  safeText: (value: unknown, maximum?: number) => string;
+} = require("../../scripts/release-bus-gate-evidence.cjs");
+
+describe("Release Bus gate evidence", () => {
+  it("normalizes an exact repository-local test inventory", () => {
+    const root = path.join(os.tmpdir(), "release-bus-evidence-root");
+    const raw = [
+      "pnpm wrapper output",
+      path.join(root, "__tests__/b.test.ts"),
+      path.join(root, "__tests__/a.test.ts"),
+    ].join("\n");
+
+    expect(manifestFromRaw(raw, root)).toEqual([
+      "__tests__/a.test.ts",
+      "__tests__/b.test.ts",
+    ]);
+  });
+
+  it("sanitizes bounded operator-facing strings", () => {
+    expect(safeText("failed\n\u0000suite", 20)).toBe("failed suite");
+    expect(safeText("x".repeat(50), 10)).toHaveLength(10);
+  });
+
+  it("proves every expected Jest file executed exactly once", () => {
+    const root = path.join(os.tmpdir(), "release-bus-evidence-root");
+    const files = ["__tests__/a.test.ts", "__tests__/b.test.ts"];
+    const records = [
+      {
+        kind: "manifest",
+        source: "parallel",
+        scope: "all",
+        files,
+      },
+      ...files.map((file, index) => ({
+        kind: "manifest",
+        source: "parallel",
+        scope: "shard",
+        shard_index: index + 1,
+        shard_count: 2,
+        files: [file],
+      })),
+      ...files.map((file, index) =>
+        jestRecord({
+          result: {
+            success: true,
+            numTotalTestSuites: 1,
+            numPassedTestSuites: 1,
+            numFailedTestSuites: 0,
+            numTotalTests: 2,
+            numPassedTests: 2,
+            numFailedTests: 0,
+            testResults: [
+              {
+                name: path.join(root, file),
+                status: "passed",
+                assertionResults: [],
+              },
+            ],
+          },
+          manifest: { files: [file] },
+          repoRoot: root,
+          shardIndex: index + 1,
+          shardCount: 2,
+          durationMs: 10 + index,
+          exitCode: 0,
+          source: "parallel",
+        })
+      ),
+      ...["lint", "typecheck", "build"].map((name) =>
+        phaseRecord({
+          name,
+          status: "SUCCEEDED",
+          durationMs: 10,
+          exitCode: 0,
+          source: "parallel",
+        })
+      ),
+    ];
+
+    const summary = buildGateSummary({
+      records,
+      source: "parallel",
+      shardCount: 2,
+      jobResults: {
+        lint: "success",
+        typecheck: "success",
+        build: "success",
+        inventory: "success",
+        jest: "success",
+      },
+    });
+
+    expect(summary).toMatchObject({
+      status: "SUCCEEDED",
+      counts: { test_files: 2, test_suites: 2, tests: 4 },
+      missing_files: [],
+      duplicate_files: [],
+    });
+  });
+
+  it("fails closed for a duplicate, omitted, or failed shard", () => {
+    const records = [
+      {
+        kind: "manifest",
+        source: "parallel",
+        scope: "all",
+        files: ["a.test.ts", "b.test.ts"],
+      },
+      {
+        kind: "manifest",
+        source: "parallel",
+        scope: "shard",
+        files: ["a.test.ts"],
+      },
+      {
+        kind: "jest_shard",
+        source: "parallel",
+        shard_index: 1,
+        shard_count: 2,
+        status: "FAILED",
+        duration_ms: 1,
+        counts: {},
+        executed_test_files: ["a.test.ts", "a.test.ts"],
+      },
+    ];
+
+    const summary = buildGateSummary({
+      records,
+      source: "parallel",
+      shardCount: 2,
+      jobResults: { jest: "failure" },
+    });
+
+    expect(summary.status).toBe("FAILED");
+    expect(summary.missing_files).toContain("b.test.ts");
+    expect(summary.duplicate_files).toContain("a.test.ts");
+  });
+
+  it("fails when an individual shard does not execute its exact plan", () => {
+    const records = [
+      {
+        kind: "manifest",
+        source: "parallel",
+        scope: "all",
+        files: ["a.test.ts", "b.test.ts"],
+      },
+      {
+        kind: "manifest",
+        source: "parallel",
+        scope: "shard",
+        shard_index: 1,
+        shard_count: 2,
+        files: ["a.test.ts"],
+      },
+      {
+        kind: "manifest",
+        source: "parallel",
+        scope: "shard",
+        shard_index: 2,
+        shard_count: 2,
+        files: ["b.test.ts"],
+      },
+      {
+        kind: "jest_shard",
+        source: "parallel",
+        shard_index: 1,
+        shard_count: 2,
+        status: "SUCCEEDED",
+        duration_ms: 1,
+        counts: {},
+        executed_test_files: ["b.test.ts"],
+      },
+      {
+        kind: "jest_shard",
+        source: "parallel",
+        shard_index: 2,
+        shard_count: 2,
+        status: "SUCCEEDED",
+        duration_ms: 1,
+        counts: {},
+        executed_test_files: ["a.test.ts"],
+      },
+    ];
+
+    const summary = buildGateSummary({
+      records,
+      source: "parallel",
+      shardCount: 2,
+      jobResults: { jest: "success" },
+    });
+
+    expect(summary.status).toBe("FAILED");
+    expect(summary.errors).toContain("Jest shard 1/2 did not execute its exact plan");
+    expect(summary.errors).toContain("Jest shard 2/2 did not execute its exact plan");
+  });
+
+  it("keeps serial authoritative in shadow mode and records equivalence", () => {
+    const evidenceRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "release-bus-final-summary-")
+    );
+    const jobsFile = path.join(evidenceRoot, "jobs.json");
+    fs.writeFileSync(jobsFile, JSON.stringify({ jobs: [] }));
+    const records: Array<Record<string, unknown>> = [];
+    for (const source of ["legacy", "parallel"] as const) {
+      records.push({ kind: "manifest", source, scope: "all", files: ["a.test.ts"] });
+      records.push({
+        kind: "manifest",
+        source,
+        scope: "shard",
+        shard_index: 1,
+        shard_count: 1,
+        files: ["a.test.ts"],
+      });
+      records.push({
+        kind: "jest_shard",
+        source,
+        shard_index: 1,
+        shard_count: 1,
+        status: "SUCCEEDED",
+        duration_ms: 1,
+        counts: {
+          test_files: 1,
+          test_suites: 1,
+          passed_test_suites: 1,
+          failed_test_suites: 0,
+          pending_test_suites: 0,
+          tests: 2,
+          passed_tests: 2,
+          failed_tests: 0,
+          pending_tests: 0,
+          todo_tests: 0,
+        },
+        executed_test_files: ["a.test.ts"],
+      });
+      for (const name of ["lint", "typecheck", "build"]) {
+        records.push(
+          phaseRecord({
+            name,
+            status: "SUCCEEDED",
+            durationMs: 1,
+            exitCode: 0,
+            source,
+          })
+        );
+      }
+    }
+
+    const summary = finalSummary({
+      args: {
+        mode: "shadow",
+        "shard-count": "1",
+        "run-url":
+          "https://github.com/6529-Collections/6529seize-frontend/actions/runs/123",
+        "base-sha": "a".repeat(40),
+        environment: "STAGING",
+        "gate-fingerprint": "b".repeat(64),
+        "workflow-sha": "c".repeat(40),
+        "workflow-digest": "d".repeat(64),
+        "node-version": "22",
+        "package-manager": "pnpm@10.14.0",
+        "artifact-name": "release-bus-base-canary-summary-123",
+        "jobs-file": jobsFile,
+      },
+      records,
+      jobResults: {
+        legacy: "success",
+        lint: "success",
+        typecheck: "success",
+        build: "success",
+        inventory: "success",
+        jest: "success",
+      },
+    });
+
+    expect(summary).toMatchObject({
+      status: "SUCCEEDED",
+      gate_mode: "shadow",
+      equivalence: { equivalent: true },
+    });
+  });
+});

--- a/__tests__/scripts/release-bus-gate-evidence.test.ts
+++ b/__tests__/scripts/release-bus-gate-evidence.test.ts
@@ -253,6 +253,67 @@ describe("Release Bus gate evidence", () => {
     expect(summary.duplicate_files).toContain("a.test.ts");
   });
 
+  it("fails closed when Jest reports a skipped or todo test", () => {
+    const records = [
+      {
+        kind: "manifest",
+        source: "parallel",
+        scope: "all",
+        files: ["a.test.ts"],
+      },
+      {
+        kind: "manifest",
+        source: "parallel",
+        scope: "shard",
+        shard_index: 1,
+        shard_count: 1,
+        files: ["a.test.ts"],
+      },
+      {
+        kind: "jest_shard",
+        source: "parallel",
+        shard_index: 1,
+        shard_count: 1,
+        status: "SUCCEEDED",
+        duration_ms: 1,
+        counts: {
+          test_files: 1,
+          test_suites: 1,
+          passed_test_suites: 1,
+          failed_test_suites: 0,
+          pending_test_suites: 0,
+          tests: 2,
+          passed_tests: 1,
+          failed_tests: 0,
+          pending_tests: 1,
+          todo_tests: 0,
+        },
+        executed_test_files: ["a.test.ts"],
+      },
+      ...["lint", "typecheck", "build"].map((name) =>
+        phaseRecord({
+          name,
+          status: "SUCCEEDED",
+          durationMs: 1,
+          exitCode: 0,
+          source: "parallel",
+        })
+      ),
+    ];
+
+    expect(
+      buildGateSummary({
+        records,
+        source: "parallel",
+        shardCount: 1,
+        jobResults: { jest: "success" },
+      })
+    ).toMatchObject({
+      status: "FAILED",
+      errors: expect.arrayContaining(["Jest reported skipped or todo tests"]),
+    });
+  });
+
   it("fails when an individual shard does not execute its exact plan", () => {
     const records = [
       {

--- a/__tests__/scripts/release-bus-gate-evidence.test.ts
+++ b/__tests__/scripts/release-bus-gate-evidence.test.ts
@@ -758,8 +758,6 @@ describe("Release Bus gate evidence", () => {
       },
     });
     expect(mutated.status).toBe("FAILED");
-    expect(mutated.errors).toContain(
-      "source_mutation job did not succeed"
-    );
+    expect(mutated.errors).toContain("source_mutation job did not succeed");
   });
 });

--- a/__tests__/scripts/release-bus-gate-evidence.test.ts
+++ b/__tests__/scripts/release-bus-gate-evidence.test.ts
@@ -221,6 +221,7 @@ describe("Release Bus gate evidence", () => {
         build: "success",
         inventory: "success",
         jest: "success",
+        source_mutation: "success",
       },
       identity: evidenceIdentity,
     });
@@ -677,6 +678,7 @@ describe("Release Bus gate evidence", () => {
         build: "success",
         inventory: "success",
         jest: "success",
+        source_mutation: "success",
       },
     });
 
@@ -722,8 +724,42 @@ describe("Release Bus gate evidence", () => {
         build: "success",
         inventory: "success",
         jest: "success",
+        source_mutation: "success",
       },
     });
     expect(skippedLegacy.status).toBe("FAILED");
+
+    const mutated = finalSummary({
+      args: {
+        mode: "sharded",
+        "shard-count": "1",
+        "run-url":
+          "https://github.com/6529-Collections/6529seize-frontend/actions/runs/123",
+        "base-sha": evidenceIdentity.base_sha,
+        environment: evidenceIdentity.environment,
+        "gate-fingerprint": evidenceIdentity.gate_fingerprint,
+        "behavior-digest": "e".repeat(64),
+        "workflow-sha": evidenceIdentity.workflow_sha,
+        "workflow-digest": evidenceIdentity.workflow_digest,
+        "node-version": evidenceIdentity.node_version,
+        "package-manager": evidenceIdentity.package_manager,
+        "artifact-name": "release-bus-base-canary-summary-123",
+        "jobs-file": jobsFile,
+      },
+      records: records.filter((record) => record.source === "parallel"),
+      jobResults: {
+        legacy: "skipped",
+        lint: "success",
+        typecheck: "success",
+        build: "success",
+        inventory: "success",
+        jest: "success",
+        source_mutation: "failure",
+      },
+    });
+    expect(mutated.status).toBe("FAILED");
+    expect(mutated.errors).toContain(
+      "source_mutation job did not succeed"
+    );
   });
 });

--- a/__tests__/scripts/release-bus-gate-evidence.test.ts
+++ b/__tests__/scripts/release-bus-gate-evidence.test.ts
@@ -57,6 +57,8 @@ describe("Release Bus gate evidence", () => {
     const baseline = frontendGateContract(input);
     expect(frontendGateContract(input)).toEqual(baseline);
     expect(baseline).toMatchObject({
+      behavior_digest:
+        "56bdbaf1d0a50a6f6bd34149014bc9a0da9d69d38019e9013cdb888b08da6107",
       gate_fingerprint:
         "78870a761c2c085d2ca6a9386a3c6e77ccda5348667526972718a5832c530b49",
       workflow_digest:
@@ -68,6 +70,48 @@ describe("Release Bus gate evidence", () => {
         baseFileContents: { ...baseFileContents, "jest.config.js": "changed" },
       }).gate_fingerprint
     ).not.toBe(baseline.gate_fingerprint);
+    expect(
+      frontendGateContract({
+        ...input,
+        baseSha: "c".repeat(40),
+        workflowSha: "d".repeat(40),
+      }).behavior_digest
+    ).toBe(baseline.behavior_digest);
+    for (const file of Object.keys(baseFileContents)) {
+      const changedContents =
+        file === "package.json"
+          ? JSON.stringify({ packageManager: "pnpm@10.15.0" })
+          : `${baseFileContents[file]} changed`;
+      expect(
+        frontendGateContract({
+          ...input,
+          baseFileContents: {
+            ...baseFileContents,
+            [file]: changedContents,
+          },
+        }).behavior_digest
+      ).not.toBe(baseline.behavior_digest);
+    }
+    for (const file of Object.keys(workflowFileContents)) {
+      expect(
+        frontendGateContract({
+          ...input,
+          workflowFileContents: {
+            ...workflowFileContents,
+            [file]: `${workflowFileContents[file]} changed`,
+          },
+        }).behavior_digest
+      ).not.toBe(baseline.behavior_digest);
+    }
+    expect(
+      frontendGateContract({ ...input, shardCount: 2 }).behavior_digest
+    ).not.toBe(baseline.behavior_digest);
+    expect(
+      frontendGateContract({ ...input, gateMode: "shadow" }).behavior_digest
+    ).not.toBe(baseline.behavior_digest);
+    expect(
+      frontendGateContract({ ...input, nodeVersion: "24" }).behavior_digest
+    ).not.toBe(baseline.behavior_digest);
     expect(
       frontendGateContract({
         ...input,
@@ -537,6 +581,7 @@ describe("Release Bus gate evidence", () => {
         "base-sha": evidenceIdentity.base_sha,
         environment: evidenceIdentity.environment,
         "gate-fingerprint": evidenceIdentity.gate_fingerprint,
+        "behavior-digest": "e".repeat(64),
         "workflow-sha": evidenceIdentity.workflow_sha,
         "workflow-digest": evidenceIdentity.workflow_digest,
         "node-version": evidenceIdentity.node_version,
@@ -581,6 +626,7 @@ describe("Release Bus gate evidence", () => {
         "base-sha": evidenceIdentity.base_sha,
         environment: evidenceIdentity.environment,
         "gate-fingerprint": evidenceIdentity.gate_fingerprint,
+        "behavior-digest": "e".repeat(64),
         "workflow-sha": evidenceIdentity.workflow_sha,
         "workflow-digest": evidenceIdentity.workflow_digest,
         "node-version": evidenceIdentity.node_version,

--- a/__tests__/scripts/release-bus-gate-evidence.test.ts
+++ b/__tests__/scripts/release-bus-gate-evidence.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 const {
   buildGateSummary,
   finalSummary,
+  frontendGateContract,
   jestRecord,
   manifestFromRaw,
   phaseRecord,
@@ -12,6 +13,7 @@ const {
 }: {
   buildGateSummary: (input: Record<string, unknown>) => Record<string, any>;
   finalSummary: (input: Record<string, unknown>) => Record<string, any>;
+  frontendGateContract: (input: Record<string, unknown>) => Record<string, any>;
   jestRecord: (input: Record<string, unknown>) => Record<string, any>;
   manifestFromRaw: (raw: string, root: string) => string[];
   phaseRecord: (input: Record<string, unknown>) => Record<string, any>;
@@ -19,6 +21,54 @@ const {
 } = require("../../scripts/release-bus-gate-evidence.cjs");
 
 describe("Release Bus gate evidence", () => {
+  it("fingerprints base policy and pinned workflow tooling deterministically", () => {
+    const baseFileContents = {
+      "bin/6529": "runner",
+      "jest.config.js": "config",
+      "jest.setup.js": "setup",
+      "package.json": JSON.stringify({ packageManager: "pnpm@10.14.0" }),
+      "pnpm-lock.yaml": "lockfile",
+    };
+    const workflowFileContents = {
+      ".github/workflows/release-bus-base-canary.yml": "workflow",
+      "scripts/release-bus-frontend-gate.sh": "gate",
+      "scripts/release-bus-gate-evidence.cjs": "evidence",
+      "scripts/release-bus-report-progress.mjs": "reporter",
+    };
+    const input = {
+      baseSha: "a".repeat(40),
+      workflowSha: "b".repeat(40),
+      baseFileContents,
+      workflowFileContents,
+      gateMode: "sharded",
+      shardCount: 4,
+    };
+
+    const baseline = frontendGateContract(input);
+    expect(frontendGateContract(input)).toEqual(baseline);
+    expect(baseline).toMatchObject({
+      gate_fingerprint:
+        "78870a761c2c085d2ca6a9386a3c6e77ccda5348667526972718a5832c530b49",
+      workflow_digest:
+        "da7f739f627198465eeab537a6f7a435dc4a0c332f9e4a8462293eb3f4ab7ee0",
+    });
+    expect(
+      frontendGateContract({
+        ...input,
+        baseFileContents: { ...baseFileContents, "jest.config.js": "changed" },
+      }).gate_fingerprint
+    ).not.toBe(baseline.gate_fingerprint);
+    expect(
+      frontendGateContract({
+        ...input,
+        workflowFileContents: {
+          ...workflowFileContents,
+          "scripts/release-bus-gate-evidence.cjs": "changed",
+        },
+      }).gate_fingerprint
+    ).not.toBe(baseline.gate_fingerprint);
+  });
+
   it("normalizes an exact repository-local test inventory", () => {
     const root = path.join(os.tmpdir(), "release-bus-evidence-root");
     const raw = [

--- a/__tests__/scripts/release-bus-gate-evidence.test.ts
+++ b/__tests__/scripts/release-bus-gate-evidence.test.ts
@@ -207,8 +207,81 @@ describe("Release Bus gate evidence", () => {
     });
 
     expect(summary.status).toBe("FAILED");
-    expect(summary.errors).toContain("Jest shard 1/2 did not execute its exact plan");
-    expect(summary.errors).toContain("Jest shard 2/2 did not execute its exact plan");
+    expect(summary.errors).toContain(
+      "Jest shard 1/2 did not execute its exact plan"
+    );
+    expect(summary.errors).toContain(
+      "Jest shard 2/2 did not execute its exact plan"
+    );
+  });
+
+  it("attributes a deliberate first-run failure to its exact shard", () => {
+    const files = Array.from({ length: 4 }, (_, index) => `${index}.test.ts`);
+    const records = [
+      {
+        kind: "manifest",
+        source: "parallel",
+        scope: "all",
+        files,
+      },
+      ...files.map((file, index) => ({
+        kind: "manifest",
+        source: "parallel",
+        scope: "shard",
+        shard_index: index + 1,
+        shard_count: 4,
+        files: [file],
+      })),
+      ...files.map((file, index) => ({
+        kind: "jest_shard",
+        source: "parallel",
+        shard_index: index + 1,
+        shard_count: 4,
+        status: index === 2 ? "FAILED" : "SUCCEEDED",
+        duration_ms: 10,
+        counts: {
+          test_files: 1,
+          test_suites: 1,
+          passed_test_suites: index === 2 ? 0 : 1,
+          failed_test_suites: index === 2 ? 1 : 0,
+          pending_test_suites: 0,
+          tests: 1,
+          passed_tests: index === 2 ? 0 : 1,
+          failed_tests: index === 2 ? 1 : 0,
+          pending_tests: 0,
+          todo_tests: 0,
+        },
+        executed_test_files: [file],
+        failing_suites: index === 2 ? [file] : [],
+        failing_tests:
+          index === 2 ? [{ suite: file, test: "deliberate failure" }] : [],
+      })),
+      ...["lint", "typecheck", "build"].map((name) =>
+        phaseRecord({
+          name,
+          status: "SUCCEEDED",
+          durationMs: 1,
+          exitCode: 0,
+          source: "parallel",
+        })
+      ),
+    ];
+
+    const summary = buildGateSummary({
+      records,
+      source: "parallel",
+      shardCount: 4,
+      jobResults: { jest: "failure" },
+    });
+
+    expect(summary).toMatchObject({
+      status: "FAILED",
+      shards: expect.arrayContaining([
+        expect.objectContaining({ index: 3, status: "FAILED" }),
+      ]),
+      failing_suites: ["2.test.ts"],
+      failing_tests: [{ suite: "2.test.ts", test: "deliberate failure" }],
+    });
   });
 
   it("keeps serial authoritative in shadow mode and records equivalence", () => {
@@ -219,7 +292,12 @@ describe("Release Bus gate evidence", () => {
     fs.writeFileSync(jobsFile, JSON.stringify({ jobs: [] }));
     const records: Array<Record<string, unknown>> = [];
     for (const source of ["legacy", "parallel"] as const) {
-      records.push({ kind: "manifest", source, scope: "all", files: ["a.test.ts"] });
+      records.push({
+        kind: "manifest",
+        source,
+        scope: "all",
+        files: ["a.test.ts"],
+      });
       records.push({
         kind: "manifest",
         source,

--- a/__tests__/scripts/release-bus-gate-evidence.test.ts
+++ b/__tests__/scripts/release-bus-gate-evidence.test.ts
@@ -21,6 +21,16 @@ const {
 } = require("../../scripts/release-bus-gate-evidence.cjs");
 
 describe("Release Bus gate evidence", () => {
+  const evidenceIdentity = {
+    base_sha: "a".repeat(40),
+    environment: "orchestration",
+    gate_fingerprint: "b".repeat(64),
+    workflow_sha: "c".repeat(40),
+    workflow_digest: "d".repeat(64),
+    node_version: "22",
+    package_manager: "pnpm@10.14.0",
+  };
+
   it("fingerprints base policy and pinned workflow tooling deterministically", () => {
     const baseFileContents = {
       "bin/6529": "runner",
@@ -67,6 +77,15 @@ describe("Release Bus gate evidence", () => {
         },
       }).gate_fingerprint
     ).not.toBe(baseline.gate_fingerprint);
+    expect(() =>
+      frontendGateContract({
+        ...input,
+        baseFileContents: {
+          ...baseFileContents,
+          "package.json": JSON.stringify({ packageManager: "pnpm@10\nunsafe" }),
+        },
+      })
+    ).toThrow("Invalid package-manager contract");
   });
 
   it("normalizes an exact repository-local test inventory", () => {
@@ -94,12 +113,14 @@ describe("Release Bus gate evidence", () => {
     const records = [
       {
         kind: "manifest",
+        ...evidenceIdentity,
         source: "parallel",
         scope: "all",
         files,
       },
       ...files.map((file, index) => ({
         kind: "manifest",
+        ...evidenceIdentity,
         source: "parallel",
         scope: "shard",
         shard_index: index + 1,
@@ -131,6 +152,7 @@ describe("Release Bus gate evidence", () => {
           durationMs: 10 + index,
           exitCode: 0,
           source: "parallel",
+          identity: evidenceIdentity,
         })
       ),
       ...["lint", "typecheck", "build"].map((name) =>
@@ -140,6 +162,7 @@ describe("Release Bus gate evidence", () => {
           durationMs: 10,
           exitCode: 0,
           source: "parallel",
+          identity: evidenceIdentity,
         })
       ),
     ];
@@ -155,6 +178,7 @@ describe("Release Bus gate evidence", () => {
         inventory: "success",
         jest: "success",
       },
+      identity: evidenceIdentity,
     });
 
     expect(summary).toMatchObject({
@@ -162,6 +186,32 @@ describe("Release Bus gate evidence", () => {
       counts: { test_files: 2, test_suites: 2, tests: 4 },
       missing_files: [],
       duplicate_files: [],
+    });
+
+    const mismatched = records.map((record) =>
+      record.kind === "jest_shard"
+        ? { ...record, gate_fingerprint: "e".repeat(64) }
+        : record
+    );
+    expect(
+      buildGateSummary({
+        records: mismatched,
+        source: "parallel",
+        shardCount: 2,
+        jobResults: {
+          lint: "success",
+          typecheck: "success",
+          build: "success",
+          inventory: "success",
+          jest: "success",
+        },
+        identity: evidenceIdentity,
+      })
+    ).toMatchObject({
+      status: "FAILED",
+      errors: expect.arrayContaining([
+        "evidence identity is missing or mismatched",
+      ]),
     });
   });
 
@@ -344,12 +394,14 @@ describe("Release Bus gate evidence", () => {
     for (const source of ["legacy", "parallel"] as const) {
       records.push({
         kind: "manifest",
+        ...evidenceIdentity,
         source,
         scope: "all",
         files: ["a.test.ts"],
       });
       records.push({
         kind: "manifest",
+        ...evidenceIdentity,
         source,
         scope: "shard",
         shard_index: 1,
@@ -358,6 +410,7 @@ describe("Release Bus gate evidence", () => {
       });
       records.push({
         kind: "jest_shard",
+        ...evidenceIdentity,
         source,
         shard_index: 1,
         shard_count: 1,
@@ -385,6 +438,7 @@ describe("Release Bus gate evidence", () => {
             durationMs: 1,
             exitCode: 0,
             source,
+            identity: evidenceIdentity,
           })
         );
       }
@@ -396,13 +450,13 @@ describe("Release Bus gate evidence", () => {
         "shard-count": "1",
         "run-url":
           "https://github.com/6529-Collections/6529seize-frontend/actions/runs/123",
-        "base-sha": "a".repeat(40),
-        environment: "STAGING",
-        "gate-fingerprint": "b".repeat(64),
-        "workflow-sha": "c".repeat(40),
-        "workflow-digest": "d".repeat(64),
-        "node-version": "22",
-        "package-manager": "pnpm@10.14.0",
+        "base-sha": evidenceIdentity.base_sha,
+        environment: evidenceIdentity.environment,
+        "gate-fingerprint": evidenceIdentity.gate_fingerprint,
+        "workflow-sha": evidenceIdentity.workflow_sha,
+        "workflow-digest": evidenceIdentity.workflow_digest,
+        "node-version": evidenceIdentity.node_version,
+        "package-manager": evidenceIdentity.package_manager,
         "artifact-name": "release-bus-base-canary-summary-123",
         "jobs-file": jobsFile,
       },
@@ -420,7 +474,18 @@ describe("Release Bus gate evidence", () => {
     expect(summary).toMatchObject({
       status: "SUCCEEDED",
       gate_mode: "shadow",
-      equivalence: { equivalent: true },
+      equivalence: {
+        equivalent: true,
+        sharded_phase_durations_ms: {
+          lint: 1,
+          typecheck: 1,
+          unit_tests: 1,
+          build: 1,
+        },
+        sharded_shards: [
+          expect.objectContaining({ index: 1, count: 1, duration_ms: 1 }),
+        ],
+      },
     });
   });
 });

--- a/__tests__/scripts/release-bus-gate-evidence.test.ts
+++ b/__tests__/scripts/release-bus-gate-evidence.test.ts
@@ -107,7 +107,7 @@ describe("Release Bus gate evidence", () => {
     expect(safeText("x".repeat(50), 10)).toHaveLength(10);
   });
 
-  it("proves every expected Jest file executed exactly once", () => {
+  it("proves every expected Jest file executed exactly once and required jobs cannot skip", () => {
     const root = path.join(os.tmpdir(), "release-bus-evidence-root");
     const files = ["__tests__/a.test.ts", "__tests__/b.test.ts"];
     const records = [
@@ -187,6 +187,29 @@ describe("Release Bus gate evidence", () => {
       missing_files: [],
       duplicate_files: [],
     });
+
+    for (const requiredJob of ["lint", "typecheck", "jest"] as const) {
+      const evidenceWithoutSkippedJob = records.filter((record) =>
+        requiredJob === "jest"
+          ? record.kind !== "jest_shard"
+          : !(record.kind === "phase" && record.name === requiredJob)
+      );
+      expect(
+        buildGateSummary({
+          records: evidenceWithoutSkippedJob,
+          source: "parallel",
+          shardCount: 2,
+          jobResults: {
+            lint: requiredJob === "lint" ? "skipped" : "success",
+            typecheck: requiredJob === "typecheck" ? "skipped" : "success",
+            build: "success",
+            inventory: "success",
+            jest: requiredJob === "jest" ? "skipped" : "success",
+          },
+          identity: evidenceIdentity,
+        })
+      ).toMatchObject({ status: "FAILED" });
+    }
 
     const mismatched = records.map((record) =>
       record.kind === "jest_shard"
@@ -548,5 +571,33 @@ describe("Release Bus gate evidence", () => {
         ],
       },
     });
+
+    const skippedLegacy = finalSummary({
+      args: {
+        mode: "shadow",
+        "shard-count": "1",
+        "run-url":
+          "https://github.com/6529-Collections/6529seize-frontend/actions/runs/123",
+        "base-sha": evidenceIdentity.base_sha,
+        environment: evidenceIdentity.environment,
+        "gate-fingerprint": evidenceIdentity.gate_fingerprint,
+        "workflow-sha": evidenceIdentity.workflow_sha,
+        "workflow-digest": evidenceIdentity.workflow_digest,
+        "node-version": evidenceIdentity.node_version,
+        "package-manager": evidenceIdentity.package_manager,
+        "artifact-name": "release-bus-base-canary-summary-123",
+        "jobs-file": jobsFile,
+      },
+      records: records.filter((record) => record.source !== "legacy"),
+      jobResults: {
+        legacy: "skipped",
+        lint: "success",
+        typecheck: "success",
+        build: "success",
+        inventory: "success",
+        jest: "success",
+      },
+    });
+    expect(skippedLegacy.status).toBe("FAILED");
   });
 });

--- a/__tests__/scripts/release-bus-jest-reporting.test.ts
+++ b/__tests__/scripts/release-bus-jest-reporting.test.ts
@@ -386,6 +386,28 @@ describe("Release Bus structured Jest reporting", () => {
           "workflow_sha",
         ].sort()
       );
+
+      const shadowAggregate = {
+        ...JSON.parse(fs.readFileSync(aggregatePath, "utf8")),
+        gate_mode: "shadow",
+      };
+      fs.writeFileSync(aggregatePath, JSON.stringify(shadowAggregate));
+      const shadowOutput = execFileSync(
+        process.execPath,
+        ["scripts/release-bus-report-progress.mjs", "--payload-only"],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...process.env,
+            GITHUB_RUN_ID: "123",
+            RELEASE_BUS_AGGREGATE_SUMMARY: aggregatePath,
+            RELEASE_BUS_SUMMARY_ARTIFACT_DIGEST: "e".repeat(64),
+          },
+        }
+      );
+      const shadowPayload = JSON.parse(shadowOutput.toString("utf8"));
+      expect(payload.summary.phase_durations_ms.total).toBe(40);
+      expect(shadowPayload.summary.phase_durations_ms.total).toBe(100);
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }

--- a/__tests__/scripts/release-bus-jest-reporting.test.ts
+++ b/__tests__/scripts/release-bus-jest-reporting.test.ts
@@ -56,7 +56,7 @@ describe("Release Bus structured Jest reporting", () => {
 
     expect(
       Object.keys(workflow.on?.workflow_dispatch?.inputs ?? {})
-    ).toHaveLength(9);
+    ).toHaveLength(10);
 
     for (const name of requiredJobs) {
       const steps = workflow.jobs?.[name]?.steps ?? [];

--- a/__tests__/scripts/release-bus-jest-reporting.test.ts
+++ b/__tests__/scripts/release-bus-jest-reporting.test.ts
@@ -11,10 +11,20 @@ type WorkflowStep = {
   if?: string;
   env?: Record<string, string>;
   run?: string;
+  uses?: string;
 };
 
 type Workflow = {
-  jobs?: Record<string, { steps?: WorkflowStep[] }>;
+  on?: { workflow_dispatch?: { inputs?: Record<string, unknown> } };
+  jobs?: Record<
+    string,
+    {
+      if?: string;
+      needs?: string | string[];
+      steps?: WorkflowStep[];
+      strategy?: { "fail-fast"?: boolean; matrix?: unknown };
+    }
+  >;
 };
 
 function readWorkflow(filename: string): Workflow {
@@ -30,6 +40,58 @@ function findStep(workflow: Workflow, name: string): WorkflowStep | undefined {
 }
 
 describe("Release Bus structured Jest reporting", () => {
+  it("keeps the base canary fail-closed and exact-SHA isolated", () => {
+    const workflow = readWorkflow(
+      ".github/workflows/release-bus-base-canary.yml"
+    );
+    const requiredJobs = [
+      "legacy",
+      "lint",
+      "typecheck",
+      "production-build",
+      "jest-inventory",
+      "jest",
+      "aggregate",
+    ];
+
+    expect(
+      Object.keys(workflow.on?.workflow_dispatch?.inputs ?? {})
+    ).toHaveLength(9);
+
+    for (const name of requiredJobs) {
+      const steps = workflow.jobs?.[name]?.steps ?? [];
+      expect(steps.map((step) => step.name)).toEqual(
+        expect.arrayContaining([
+          "Check out exact frontend base",
+          "Stage immutable gate tooling",
+          "Install frozen dependencies",
+          "Verify gate did not mutate source",
+        ])
+      );
+    }
+    expect(workflow.jobs?.jest?.strategy?.["fail-fast"]).toBe(false);
+    expect(workflow.jobs?.aggregate?.needs).toEqual(
+      expect.arrayContaining(
+        requiredJobs.filter((name) => name !== "aggregate")
+      )
+    );
+    expect(workflow.jobs?.aggregate?.if).toContain("always()");
+
+    const actionRefs = Object.values(workflow.jobs ?? {})
+      .flatMap((job) => job.steps ?? [])
+      .map((step) => step.uses)
+      .filter(Boolean);
+    for (const ref of actionRefs) {
+      expect(ref).toMatch(/@[a-f0-9]{40}$/);
+    }
+    const workflowText = fs.readFileSync(
+      path.join(process.cwd(), ".github/workflows/release-bus-base-canary.yml"),
+      "utf8"
+    );
+    expect(workflowText).not.toContain("node_modules");
+    expect(workflowText).not.toContain("actions/cache");
+  });
+
   it("surfaces exact suites and tests without failure messages or raw logs", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "release-bus-jest-"));
     const input = path.join(tempDir, "jest.json");
@@ -210,6 +272,162 @@ describe("Release Bus structured Jest reporting", () => {
 
     expect(result.status).toBe(0);
     expect(result.stderr).toContain("not configured; skipping");
+  });
+
+  it("projects a versioned aggregate into the strict reusable summary", () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "release-bus-aggregate-")
+    );
+    const aggregatePath = path.join(tempDir, "aggregate.json");
+    try {
+      fs.writeFileSync(
+        aggregatePath,
+        JSON.stringify({
+          status: "SUCCEEDED",
+          gate_mode: "sharded",
+          base_sha: "a".repeat(40),
+          environment: "orchestration",
+          gate_fingerprint: "b".repeat(64),
+          workflow_sha: "c".repeat(40),
+          workflow_digest: "d".repeat(64),
+          node_version: "22",
+          package_manager: "pnpm@10.14.0",
+          shard_count: 1,
+          summary_artifact_name: "release-bus-base-canary-summary-123",
+          phase_durations_ms: {
+            lint: 10,
+            typecheck: 20,
+            unit_tests: 30,
+            build: 40,
+          },
+          phases: [
+            { name: "lint", status: "SUCCEEDED" },
+            { name: "typecheck", status: "SUCCEEDED" },
+            { name: "unit_tests", status: "SUCCEEDED" },
+            { name: "build", status: "SUCCEEDED" },
+          ],
+          totals: {
+            test_files: 2,
+            test_suites: 2,
+            tests: 3,
+            failed_test_suites: 0,
+            failed_tests: 0,
+            pending_tests: 0,
+            todo_tests: 0,
+          },
+          shards: [
+            {
+              index: 1,
+              count: 1,
+              status: "SUCCEEDED",
+              duration_ms: 30,
+              counts: {
+                test_files: 2,
+                test_suites: 2,
+                tests: 3,
+                failed_test_suites: 0,
+                failed_tests: 0,
+              },
+            },
+          ],
+          missing_files: [],
+          duplicate_files: [],
+          failing_suites: [],
+          failing_tests: [],
+          raw_log: "must never leave the runner",
+        })
+      );
+
+      const output = execFileSync(
+        process.execPath,
+        ["scripts/release-bus-report-progress.mjs", "--payload-only"],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...process.env,
+            GITHUB_RUN_ID: "123",
+            RELEASE_BUS_AGGREGATE_SUMMARY: aggregatePath,
+            RELEASE_BUS_SUMMARY_ARTIFACT_DIGEST: "e".repeat(64),
+          },
+        }
+      );
+      const payload = JSON.parse(output.toString("utf8"));
+
+      expect(payload).toMatchObject({
+        status: "SUCCEEDED",
+        summary: {
+          base_sha: "a".repeat(40),
+          shard_count: 1,
+          summary_artifact_digest: "e".repeat(64),
+          phase_durations_ms: { total: 40 },
+          totals: { files: 2, tests: 3, failed_tests: 0 },
+          fresh_or_reused: "fresh",
+          shards: [{ coordinate: "1/1", status: "SUCCEEDED" }],
+        },
+      });
+      expect(JSON.stringify(payload)).not.toContain("raw_log");
+      expect(Object.keys(payload.summary).sort()).toEqual(
+        [
+          "base_sha",
+          "duplicate_files",
+          "environment",
+          "fresh_or_reused",
+          "gate_fingerprint",
+          "missing_files",
+          "node_version",
+          "package_manager",
+          "phase_durations_ms",
+          "shard_count",
+          "shards",
+          "summary_artifact_digest",
+          "summary_artifact_name",
+          "totals",
+          "workflow_digest",
+          "workflow_sha",
+        ].sort()
+      );
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps legacy aggregate reporting compatible without reusable identity", () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "release-bus-aggregate-legacy-")
+    );
+    const aggregatePath = path.join(tempDir, "aggregate.json");
+    try {
+      fs.writeFileSync(
+        aggregatePath,
+        JSON.stringify({
+          status: "SUCCEEDED",
+          base_sha: "a".repeat(40),
+          environment: "orchestration",
+          gate_fingerprint: "unversioned",
+          workflow_sha: "c".repeat(40),
+          workflow_digest: "unversioned",
+          phases: [],
+          totals: {},
+        })
+      );
+      const output = execFileSync(
+        process.execPath,
+        ["scripts/release-bus-report-progress.mjs", "--payload-only"],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...process.env,
+            RELEASE_BUS_AGGREGATE_SUMMARY: aggregatePath,
+          },
+        }
+      );
+      expect(JSON.parse(output.toString("utf8"))).toMatchObject({
+        status: "SUCCEEDED",
+        summary: null,
+      });
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("reports preflight and isolation independently of optional Codex", () => {

--- a/__tests__/scripts/release-bus-shard-injection.test.ts
+++ b/__tests__/scripts/release-bus-shard-injection.test.ts
@@ -1,0 +1,5 @@
+describe("Release Bus shard failure injection fixture", () => {
+  it("fails only when deliberate validation injection is enabled", () => {
+    expect(process.env.RELEASE_BUS_INJECT_SHARD_FAILURE).not.toBe("1");
+  });
+});

--- a/ops/docs/developer/deployment-bus-automation.md
+++ b/ops/docs/developer/deployment-bus-automation.md
@@ -131,9 +131,10 @@ The frontend base canary has three independently selectable execution modes:
 `legacy` keeps the original serial gate authoritative. `shadow` runs that
 serial gate and the parallel lint, typecheck, production-build, inventory, and
 Jest shard jobs against the same SHA, but only the serial outcome controls the
-train. `sharded` makes the parallel aggregate authoritative. Jest continues to
-use `--runInBand --bail=0` inside every deterministic Jest `--shard=N/M`; the
-matrix has `fail-fast: false` and no automatic retry. Returning to
+train. `sharded` makes the parallel aggregate authoritative. Every deterministic
+Jest `--shard=N/M` uses `--maxWorkers=2 --bail=0`, bounding memory and process
+fan-out without forcing serial execution. The matrix has `fail-fast: false` and
+no automatic retry. Returning to
 `legacy`/one shard is the no-code rollback.
 
 Each validation job detaches the exact base SHA, installs frozen dependencies

--- a/ops/docs/developer/deployment-bus-automation.md
+++ b/ops/docs/developer/deployment-bus-automation.md
@@ -147,9 +147,13 @@ covered policy invalidates older evidence.
 
 Every shard uploads bounded JSON counts, timing, its planned manifest, its
 executed-file manifest, exact shard coordinates, and failing suite/test
-identities. The fail-closed aggregate requires every selected job to succeed,
-requires every expected Jest file in exactly one shard, compares each shard's
-plan to execution, and rejects missing, duplicate, unexpected, malformed,
+identities. Every phase, manifest, and shard record also repeats the exact base
+SHA, `orchestration` environment, gate fingerprint, workflow SHA/digest, Node
+version, and package-manager contract. The authorize job derives that identity
+from the immutable base and workflow commits before calling the Release Bus
+API. The fail-closed aggregate requires every selected job to succeed, requires
+every expected Jest file in exactly one shard, compares each shard's plan to
+execution, and rejects missing, duplicate, unexpected, malformed, mismatched,
 cancelled, or failed evidence. Artifacts are retained for 14 days and never
 contain raw logs or failure messages. Dependency-store caching is intentionally
 deferred: the measured frozen install is small compared with Jest, and neither

--- a/ops/docs/developer/deployment-bus-automation.md
+++ b/ops/docs/developer/deployment-bus-automation.md
@@ -145,6 +145,16 @@ the workflow and this tooling at the workflow SHA, plus the Jest configuration,
 package manager, lockfile, and approved runner at the base SHA. Changing any
 covered policy invalidates older evidence.
 
+The exact-SHA `gate_fingerprint` remains the authoritative reuse key and
+includes the base and workflow commit SHAs. The aggregate artifact also records
+a separate `behavior_digest`, derived from the complete covered file digests,
+Node/package-manager contract, gate mode, and shard count but not Git ancestry.
+That content address is the equivalence-continuity key: a merge commit may keep
+prior behavior evidence only when the digest is byte-identical. Workflow and
+base SHAs remain mandatory provenance, and any covered byte, action pin,
+runtime, package-manager, mode, or shard-count change invalidates continuity
+fail-closed.
+
 Every shard uploads bounded JSON counts, timing, its planned manifest, its
 executed-file manifest, exact shard coordinates, and failing suite/test
 identities. Every phase, manifest, and shard record also repeats the exact base

--- a/ops/docs/developer/deployment-bus-automation.md
+++ b/ops/docs/developer/deployment-bus-automation.md
@@ -121,6 +121,79 @@ build. Failure requeues the train's candidates, pauses the lane, and records the
 exact Actions run as operator evidence; it never attributes the base failure to
 a candidate. Backend-only trains skip this frontend canary.
 
+The frontend base canary has three independently selectable execution modes:
+
+| GitHub Actions variable          | Allowed values                | Safe default |
+| -------------------------------- | ----------------------------- | ------------ |
+| `RELEASE_BUS_FRONTEND_GATE_MODE` | `legacy`, `shadow`, `sharded` | `legacy`     |
+| `FRONTEND_GATE_SHARD_COUNT`      | `1`, `2`, `4`                 | `1`          |
+
+`legacy` keeps the original serial gate authoritative. `shadow` runs that
+serial gate and the parallel lint, typecheck, production-build, inventory, and
+Jest shard jobs against the same SHA, but only the serial outcome controls the
+train. `sharded` makes the parallel aggregate authoritative. Jest continues to
+use `--runInBand --bail=0` inside every deterministic Jest `--shard=N/M`; the
+matrix has `fail-fast: false` and no automatic retry. Returning to
+`legacy`/one shard is the no-code rollback.
+
+Each validation job detaches the exact base SHA, installs frozen dependencies
+through `./bin/6529`, and proves that source files were not mutated. Gate and
+reporting tooling is copied to runner temporary storage from the exact workflow
+commit, so a workflow dispatched from pinned `main` can validate an older base
+without substituting that base's control-plane policy. The fingerprint covers
+the workflow and this tooling at the workflow SHA, plus the Jest configuration,
+package manager, lockfile, and approved runner at the base SHA. Changing any
+covered policy invalidates older evidence.
+
+Every shard uploads bounded JSON counts, timing, its planned manifest, its
+executed-file manifest, exact shard coordinates, and failing suite/test
+identities. The fail-closed aggregate requires every selected job to succeed,
+requires every expected Jest file in exactly one shard, compares each shard's
+plan to execution, and rejects missing, duplicate, unexpected, malformed,
+cancelled, or failed evidence. Artifacts are retained for 14 days and never
+contain raw logs or failure messages. Dependency-store caching is intentionally
+deferred: the measured frozen install is small compared with Jest, and neither
+`node_modules` nor validation output may be cached as gate evidence.
+
+The pre-acceleration reference run was
+[frontend Actions run 29816499825](https://github.com/6529-Collections/6529seize-frontend/actions/runs/29816499825):
+
+| Phase                    | Reference result                        |
+| ------------------------ | --------------------------------------- |
+| frozen install           | about 28 seconds                        |
+| lint                     | about 181 seconds                       |
+| typecheck                | about 57 seconds                        |
+| Jest                     | 2,033 suites / 12,025 tests / 1,511 sec |
+| production build         | about 452 seconds                       |
+| complete serial workflow | about 38.3 minutes                      |
+
+Exact-SHA evidence reuse is separately controlled on the backend worker:
+
+| Worker setting                            | Safe default |
+| ----------------------------------------- | ------------ |
+| `RELEASE_BUS_BASE_EVIDENCE_REUSE_SHADOW`  | `false`      |
+| `RELEASE_BUS_BASE_EVIDENCE_REUSE`         | `false`      |
+| `RELEASE_BUS_BASE_EVIDENCE_MAX_AGE_HOURS` | `24`         |
+
+An operator may also select **Fresh base canary required** on a frontend
+candidate. A reusable success must match repository, exact base SHA,
+`orchestration` environment, complete fingerprint and workflow provenance,
+Node/package-manager contract, structured artifact digest, successful shard
+coordinates/counts, and effective expiry. The newest result for that exact
+contract wins, so a newer failure blocks an older success. Reuse never covers
+candidate composition, preflight, deployment, or E2E. A hit writes durable
+`BASE_CANARY_EVIDENCE_REUSED` evidence with the source train, run, artifact,
+creation, and expiry, then advances within that worker cycle. Shadow lookup
+writes `BASE_CANARY_EVIDENCE_WOULD_REUSE` but still dispatches a fresh gate.
+
+Rollout is ordered and reversible: deploy the additive candidate column first;
+deploy the API/worker with both reuse flags false; merge the frontend workflow
+with `legacy`/one shard; collect serial-versus-sharded equivalence in `shadow`;
+promote `sharded` only after exact outcomes and all counts agree; enable reuse
+shadow and inspect real decisions; then enable reuse with the 24-hour TTL.
+Disable reuse independently or return the frontend to `legacy`/one shard before
+considering a code rollback.
+
 Frontend workflows report lint, typecheck, unit-test, and build outcomes as
 separate structured stages. Jest JSON is reduced to bounded repository-relative
 suite names and exact failing test names; failure messages and raw output are

--- a/ops/docs/developer/deployment-bus-process.md
+++ b/ops/docs/developer/deployment-bus-process.md
@@ -71,7 +71,8 @@ When the table selects a bus route, use the Release Bus panel at
 2. Resolve and review its exact 40-character head SHA.
 3. Declare cross-repository candidate dependencies. Backend candidates also
    declare allowlisted deploy units and ordering edges.
-4. Mark that exact SHA ready for staging.
+4. If this frontend candidate must not reuse an exact-base success, select
+   **Fresh base canary required**, then mark the exact SHA ready for staging.
 5. Wait for the bus to compose, deploy, and validate the staging train.
 6. After the same candidate shows `STAGING_VALIDATED`, separately mark it ready
    for production.
@@ -178,6 +179,12 @@ It then:
   backend-only train by using the currently deployed staging frontend;
 - records workflow, SHA, artifact, service, and E2E evidence;
 - fast-forwards `1a-staging` only after all required validation passes.
+
+A reused base-canary result is visible as reused evidence, with a link to the
+original train and Actions run. It proves only the unchanged pre-existing base
+under the same gate fingerprint. Candidate composition, preflight, deployment,
+and E2E still run fresh. The operator force-fresh choice is immutable after
+readiness; cancel and resubmit the candidate to change it.
 
 Backend units declared `production-only` in the deploy registry are built and
 tested during preflight but are not runtime-deployed to staging. Their staging

--- a/scripts/release-bus-frontend-gate.sh
+++ b/scripts/release-bus-frontend-gate.sh
@@ -5,17 +5,140 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SEIZE_BIN="${RELEASE_BUS_6529_BIN:-./bin/6529}"
+EVIDENCE_TOOL="$SCRIPT_DIR/release-bus-gate-evidence.cjs"
 
 cd "$REPO_ROOT"
 
 run_unit_tests() {
-  "$SEIZE_BIN" run test:no-coverage --runInBand "$@"
+  "$SEIZE_BIN" run test:no-coverage --runInBand --bail=0 "$@"
 }
 
 run_validation() {
   "$SEIZE_BIN" run lint
   "$SEIZE_BIN" run typecheck:ci
   run_unit_tests
+}
+
+now_ms() {
+  node -e 'process.stdout.write(String(Date.now()))'
+}
+
+record_phase_result() {
+  local source="$1"
+  local phase="$2"
+  local status="$3"
+  local duration_ms="$4"
+  local exit_code="$5"
+  local output_dir="$6"
+  node "$EVIDENCE_TOOL" phase \
+    --source "$source" \
+    --name "$phase" \
+    --status "$status" \
+    --duration-ms "$duration_ms" \
+    --exit-code "$exit_code" \
+    --output "$output_dir/phase-$phase.json"
+}
+
+run_recorded_phase() {
+  local source="$1"
+  local phase="$2"
+  local output_dir="$3"
+  shift 3
+  local started_at
+  local completed_at
+  local exit_code
+  local status
+  started_at="$(now_ms)"
+  set +e
+  "$@"
+  exit_code=$?
+  set -e
+  completed_at="$(now_ms)"
+  if [ "$exit_code" -eq 0 ]; then status=SUCCEEDED; else status=FAILED; fi
+  record_phase_result \
+    "$source" "$phase" "$status" "$((completed_at - started_at))" \
+    "$exit_code" "$output_dir"
+  return "$exit_code"
+}
+
+record_skipped_phase() {
+  record_phase_result "$1" "$2" SKIPPED 0 0 "$3"
+}
+
+capture_manifest() {
+  local source="$1"
+  local scope="$2"
+  local shard_index="$3"
+  local shard_count="$4"
+  local output_dir="$5"
+  local raw_file="$output_dir/manifest-$scope-$shard_index-of-$shard_count.raw"
+  local json_file="$output_dir/manifest-$scope-$shard_index-of-$shard_count.json"
+  if [ "$scope" = all ]; then
+    run_unit_tests --listTests > "$raw_file"
+    node "$EVIDENCE_TOOL" manifest \
+      --source "$source" --scope all --repo-root "$REPO_ROOT" \
+      --raw "$raw_file" --output "$json_file"
+  else
+    run_unit_tests --listTests --shard="$shard_index/$shard_count" > "$raw_file"
+    node "$EVIDENCE_TOOL" manifest \
+      --source "$source" --scope shard --repo-root "$REPO_ROOT" \
+      --shard-index "$shard_index" --shard-count "$shard_count" \
+      --raw "$raw_file" --output "$json_file"
+  fi
+}
+
+run_recorded_jest() {
+  local source="$1"
+  local shard_index="$2"
+  local shard_count="$3"
+  local output_dir="$4"
+  local manifest="$output_dir/manifest-shard-$shard_index-of-$shard_count.json"
+  local results="$output_dir/jest-results-$shard_index-of-$shard_count.json"
+  local summary="$output_dir/jest-shard-$shard_index-of-$shard_count.json"
+  local started_at
+  local completed_at
+  local exit_code
+  capture_manifest "$source" shard "$shard_index" "$shard_count" "$output_dir"
+  started_at="$(now_ms)"
+  set +e
+  run_unit_tests \
+    --shard="$shard_index/$shard_count" \
+    --json \
+    --outputFile="$results"
+  exit_code=$?
+  set -e
+  completed_at="$(now_ms)"
+  node "$EVIDENCE_TOOL" jest \
+    --source "$source" \
+    --repo-root "$REPO_ROOT" \
+    --results "$results" \
+    --manifest "$manifest" \
+    --shard-index "$shard_index" \
+    --shard-count "$shard_count" \
+    --duration-ms "$((completed_at - started_at))" \
+    --exit-code "$exit_code" \
+    --output "$summary"
+  return "$exit_code"
+}
+
+run_serial_evidence_gate() {
+  local output_dir="$1"
+  mkdir -p "$output_dir"
+  if ! run_recorded_phase legacy lint "$output_dir" "$SEIZE_BIN" run lint; then
+    record_skipped_phase legacy typecheck "$output_dir"
+    record_skipped_phase legacy build "$output_dir"
+    return 1
+  fi
+  if ! run_recorded_phase legacy typecheck "$output_dir" "$SEIZE_BIN" run typecheck:ci; then
+    record_skipped_phase legacy build "$output_dir"
+    return 1
+  fi
+  capture_manifest legacy all 1 1 "$output_dir"
+  if ! run_recorded_jest legacy 1 1 "$output_dir"; then
+    record_skipped_phase legacy build "$output_dir"
+    return 1
+  fi
+  run_recorded_phase legacy build "$output_dir" "$SEIZE_BIN" run build
 }
 
 case "${1:-full}" in
@@ -29,8 +152,43 @@ case "${1:-full}" in
     run_validation
     "$SEIZE_BIN" run build
     ;;
+  phase)
+    if [ "$#" -ne 3 ] || ! [[ "$2" =~ ^(lint|typecheck|build)$ ]]; then
+      echo "Usage: scripts/release-bus-frontend-gate.sh phase [lint|typecheck|build] OUTPUT_DIR" >&2
+      exit 2
+    fi
+    mkdir -p "$3"
+    case "$2" in
+      lint) run_recorded_phase parallel lint "$3" "$SEIZE_BIN" run lint ;;
+      typecheck) run_recorded_phase parallel typecheck "$3" "$SEIZE_BIN" run typecheck:ci ;;
+      build) run_recorded_phase parallel build "$3" "$SEIZE_BIN" run build ;;
+    esac
+    ;;
+  inventory)
+    if [ "$#" -ne 2 ]; then
+      echo "Usage: scripts/release-bus-frontend-gate.sh inventory OUTPUT_DIR" >&2
+      exit 2
+    fi
+    mkdir -p "$2"
+    capture_manifest parallel all 1 1 "$2"
+    ;;
+  jest)
+    if [ "$#" -ne 4 ]; then
+      echo "Usage: scripts/release-bus-frontend-gate.sh jest SHARD_INDEX SHARD_COUNT OUTPUT_DIR" >&2
+      exit 2
+    fi
+    mkdir -p "$4"
+    run_recorded_jest parallel "$2" "$3" "$4"
+    ;;
+  serial)
+    if [ "$#" -ne 2 ]; then
+      echo "Usage: scripts/release-bus-frontend-gate.sh serial OUTPUT_DIR" >&2
+      exit 2
+    fi
+    run_serial_evidence_gate "$2"
+    ;;
   *)
-    echo "Usage: scripts/release-bus-frontend-gate.sh [contract|validate|full]" >&2
+    echo "Usage: scripts/release-bus-frontend-gate.sh [contract|validate|full|phase|inventory|jest|serial]" >&2
     exit 2
     ;;
 esac

--- a/scripts/release-bus-frontend-gate.sh
+++ b/scripts/release-bus-frontend-gate.sh
@@ -94,11 +94,15 @@ run_recorded_jest() {
   local shard_count="$3"
   local output_dir="$4"
   local manifest="$output_dir/manifest-shard-$shard_index-of-$shard_count.json"
-  local results="$output_dir/jest-results-$shard_index-of-$shard_count.json"
+  local raw_dir
+  local results
   local summary="$output_dir/jest-shard-$shard_index-of-$shard_count.json"
   local started_at
   local completed_at
   local exit_code
+  local summary_exit_code
+  raw_dir="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/release-bus-jest-raw.XXXXXX")"
+  results="$raw_dir/jest-results.json"
   capture_manifest "$source" shard "$shard_index" "$shard_count" "$output_dir"
   started_at="$(now_ms)"
   set +e
@@ -109,6 +113,7 @@ run_recorded_jest() {
   exit_code=$?
   set -e
   completed_at="$(now_ms)"
+  set +e
   node "$EVIDENCE_TOOL" jest \
     --source "$source" \
     --repo-root "$REPO_ROOT" \
@@ -119,6 +124,11 @@ run_recorded_jest() {
     --duration-ms "$((completed_at - started_at))" \
     --exit-code "$exit_code" \
     --output "$summary"
+  summary_exit_code=$?
+  set -e
+  rm -f -- "$results"
+  rmdir -- "$raw_dir"
+  if [ "$summary_exit_code" -ne 0 ]; then return "$summary_exit_code"; fi
   return "$exit_code"
 }
 

--- a/scripts/release-bus-frontend-gate.sh
+++ b/scripts/release-bus-frontend-gate.sh
@@ -3,7 +3,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="${RELEASE_BUS_REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+REPO_ROOT="$(cd "$REPO_ROOT" && pwd)"
 SEIZE_BIN="${RELEASE_BUS_6529_BIN:-./bin/6529}"
 EVIDENCE_TOOL="$SCRIPT_DIR/release-bus-gate-evidence.cjs"
 
@@ -143,7 +144,11 @@ run_serial_evidence_gate() {
 
 case "${1:-full}" in
   contract)
-    run_unit_tests --runTestsByPath __tests__/scripts/release-bus-frontend-gate.test.ts
+    run_unit_tests --runTestsByPath \
+      __tests__/scripts/release-bus-frontend-gate.test.ts \
+      __tests__/scripts/release-bus-gate-evidence.test.ts \
+      __tests__/scripts/release-bus-jest-reporting.test.ts \
+      __tests__/scripts/release-bus-shard-injection.test.ts
     ;;
   validate)
     run_validation

--- a/scripts/release-bus-frontend-gate.sh
+++ b/scripts/release-bus-frontend-gate.sh
@@ -7,8 +7,28 @@ REPO_ROOT="${RELEASE_BUS_REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 REPO_ROOT="$(cd "$REPO_ROOT" && pwd)"
 SEIZE_BIN="${RELEASE_BUS_6529_BIN:-./bin/6529}"
 EVIDENCE_TOOL="$SCRIPT_DIR/release-bus-gate-evidence.cjs"
+EVIDENCE_IDENTITY_ARGS=()
 
 cd "$REPO_ROOT"
+
+set_evidence_identity_args() {
+  : "${RELEASE_BUS_BASE_SHA:?RELEASE_BUS_BASE_SHA is required}"
+  : "${RELEASE_BUS_EVIDENCE_ENVIRONMENT:?RELEASE_BUS_EVIDENCE_ENVIRONMENT is required}"
+  : "${RELEASE_BUS_GATE_FINGERPRINT:?RELEASE_BUS_GATE_FINGERPRINT is required}"
+  : "${RELEASE_BUS_WORKFLOW_SHA:?RELEASE_BUS_WORKFLOW_SHA is required}"
+  : "${RELEASE_BUS_WORKFLOW_DIGEST:?RELEASE_BUS_WORKFLOW_DIGEST is required}"
+  : "${RELEASE_BUS_NODE_VERSION:?RELEASE_BUS_NODE_VERSION is required}"
+  : "${RELEASE_BUS_PACKAGE_MANAGER:?RELEASE_BUS_PACKAGE_MANAGER is required}"
+  EVIDENCE_IDENTITY_ARGS=(
+    --base-sha "$RELEASE_BUS_BASE_SHA"
+    --environment "$RELEASE_BUS_EVIDENCE_ENVIRONMENT"
+    --gate-fingerprint "$RELEASE_BUS_GATE_FINGERPRINT"
+    --workflow-sha "$RELEASE_BUS_WORKFLOW_SHA"
+    --workflow-digest "$RELEASE_BUS_WORKFLOW_DIGEST"
+    --node-version "$RELEASE_BUS_NODE_VERSION"
+    --package-manager "$RELEASE_BUS_PACKAGE_MANAGER"
+  )
+}
 
 run_unit_tests() {
   "$SEIZE_BIN" run test:no-coverage --runInBand --bail=0 "$@"
@@ -37,6 +57,7 @@ record_phase_result() {
     --status "$status" \
     --duration-ms "$duration_ms" \
     --exit-code "$exit_code" \
+    "${EVIDENCE_IDENTITY_ARGS[@]}" \
     --output "$output_dir/phase-$phase.json"
 }
 
@@ -78,12 +99,14 @@ capture_manifest() {
     run_unit_tests --listTests > "$raw_file"
     node "$EVIDENCE_TOOL" manifest \
       --source "$source" --scope all --repo-root "$REPO_ROOT" \
+      "${EVIDENCE_IDENTITY_ARGS[@]}" \
       --raw "$raw_file" --output "$json_file"
   else
     run_unit_tests --listTests --shard="$shard_index/$shard_count" > "$raw_file"
     node "$EVIDENCE_TOOL" manifest \
       --source "$source" --scope shard --repo-root "$REPO_ROOT" \
       --shard-index "$shard_index" --shard-count "$shard_count" \
+      "${EVIDENCE_IDENTITY_ARGS[@]}" \
       --raw "$raw_file" --output "$json_file"
   fi
 }
@@ -123,6 +146,7 @@ run_recorded_jest() {
     --shard-count "$shard_count" \
     --duration-ms "$((completed_at - started_at))" \
     --exit-code "$exit_code" \
+    "${EVIDENCE_IDENTITY_ARGS[@]}" \
     --output "$summary"
   summary_exit_code=$?
   set -e
@@ -172,6 +196,7 @@ case "${1:-full}" in
       echo "Usage: scripts/release-bus-frontend-gate.sh phase [lint|typecheck|build] OUTPUT_DIR" >&2
       exit 2
     fi
+    set_evidence_identity_args
     mkdir -p "$3"
     case "$2" in
       lint) run_recorded_phase parallel lint "$3" "$SEIZE_BIN" run lint ;;
@@ -184,6 +209,7 @@ case "${1:-full}" in
       echo "Usage: scripts/release-bus-frontend-gate.sh inventory OUTPUT_DIR" >&2
       exit 2
     fi
+    set_evidence_identity_args
     mkdir -p "$2"
     capture_manifest parallel all 1 1 "$2"
     ;;
@@ -192,6 +218,7 @@ case "${1:-full}" in
       echo "Usage: scripts/release-bus-frontend-gate.sh jest SHARD_INDEX SHARD_COUNT OUTPUT_DIR" >&2
       exit 2
     fi
+    set_evidence_identity_args
     mkdir -p "$4"
     run_recorded_jest parallel "$2" "$3" "$4"
     ;;
@@ -200,6 +227,7 @@ case "${1:-full}" in
       echo "Usage: scripts/release-bus-frontend-gate.sh serial OUTPUT_DIR" >&2
       exit 2
     fi
+    set_evidence_identity_args
     run_serial_evidence_gate "$2"
     ;;
   *)

--- a/scripts/release-bus-gate-evidence.cjs
+++ b/scripts/release-bus-gate-evidence.cjs
@@ -16,6 +16,16 @@ const STATUSES = new Set([
 ]);
 const MAX_FAILURES = 100;
 const MAX_TEXT_LENGTH = 500;
+const EVIDENCE_IDENTITY_FIELDS = [
+  "base_sha",
+  "environment",
+  "gate_fingerprint",
+  "workflow_sha",
+  "workflow_digest",
+  "node_version",
+  "package_manager",
+];
+const EVIDENCE_RECORD_KINDS = new Set(["manifest", "phase", "jest_shard"]);
 const FRONTEND_GATE_WORKFLOW = ".github/workflows/release-bus-base-canary.yml";
 const FRONTEND_GATE_BASE_FILES = [
   "bin/6529",
@@ -125,8 +135,7 @@ function frontendGateContract({
   const packageManager = packageJson?.packageManager;
   if (
     typeof packageManager !== "string" ||
-    packageManager.length < 1 ||
-    packageManager.length > 128
+    !/^pnpm@[A-Za-z0-9.+-]{1,122}$/.test(packageManager)
   ) {
     throw new Error("Invalid package-manager contract");
   }
@@ -203,6 +212,58 @@ function contractFromRepository(args) {
   });
 }
 
+function validateEvidenceIdentity(identity) {
+  if (!identity || typeof identity !== "object" || Array.isArray(identity)) {
+    throw new Error("Evidence identity is missing");
+  }
+  if (!/^[a-f0-9]{40}$/.test(String(identity.base_sha ?? ""))) {
+    throw new Error("Evidence identity has an invalid base SHA");
+  }
+  if (identity.environment !== "orchestration") {
+    throw new Error("Evidence identity has an invalid environment");
+  }
+  if (!/^[a-f0-9]{64}$/.test(String(identity.gate_fingerprint ?? ""))) {
+    throw new Error("Evidence identity has an invalid gate fingerprint");
+  }
+  if (!/^[a-f0-9]{40}$/.test(String(identity.workflow_sha ?? ""))) {
+    throw new Error("Evidence identity has an invalid workflow SHA");
+  }
+  if (!/^[a-f0-9]{64}$/.test(String(identity.workflow_digest ?? ""))) {
+    throw new Error("Evidence identity has an invalid workflow digest");
+  }
+  if (identity.node_version !== "22") {
+    throw new Error("Evidence identity has an invalid Node contract");
+  }
+  if (
+    !/^pnpm@[A-Za-z0-9.+-]{1,122}$/.test(String(identity.package_manager ?? ""))
+  ) {
+    throw new Error(
+      "Evidence identity has an invalid package-manager contract"
+    );
+  }
+  return Object.fromEntries(
+    EVIDENCE_IDENTITY_FIELDS.map((field) => [field, identity[field]])
+  );
+}
+
+function evidenceIdentityFromArgs(args) {
+  return validateEvidenceIdentity({
+    base_sha: required(args, "base-sha"),
+    environment: required(args, "environment"),
+    gate_fingerprint: required(args, "gate-fingerprint"),
+    workflow_sha: required(args, "workflow-sha"),
+    workflow_digest: required(args, "workflow-digest"),
+    node_version: required(args, "node-version"),
+    package_manager: required(args, "package-manager"),
+  });
+}
+
+function sameEvidenceIdentity(record, identity) {
+  return EVIDENCE_IDENTITY_FIELDS.every(
+    (field) => record?.[field] === identity[field]
+  );
+}
+
 function relativeTestPath(testPath, repoRoot) {
   const relative = path.relative(repoRoot, testPath).split(path.sep).join("/");
   if (!relative || relative === ".." || relative.startsWith("../")) {
@@ -225,12 +286,13 @@ function manifestFromRaw(raw, repoRoot) {
   return stableSort(unique);
 }
 
-function phaseRecord({ name, status, durationMs, exitCode, source }) {
+function phaseRecord({ name, status, durationMs, exitCode, source, identity }) {
   if (!PHASES.includes(name)) throw new Error("Invalid phase name");
   if (!STATUSES.has(status)) throw new Error("Invalid phase status");
   return {
     schema_version: 1,
     kind: "phase",
+    ...(identity ? validateEvidenceIdentity(identity) : {}),
     source,
     name,
     status,
@@ -268,6 +330,7 @@ function jestRecord({
   durationMs,
   exitCode,
   source,
+  identity,
 }) {
   if (!ALLOWED_SHARD_COUNTS.has(shardCount)) {
     throw new Error("Unsupported shard count");
@@ -288,6 +351,7 @@ function jestRecord({
   return {
     schema_version: 1,
     kind: "jest_shard",
+    ...(identity ? validateEvidenceIdentity(identity) : {}),
     source,
     shard_index: shardIndex,
     shard_count: shardCount,
@@ -395,7 +459,13 @@ function uniqueByName(records, kind, source) {
   );
 }
 
-function buildGateSummary({ records, source, shardCount, jobResults }) {
+function buildGateSummary({
+  records,
+  source,
+  shardCount,
+  jobResults,
+  identity,
+}) {
   const globalManifests = uniqueByName(records, "manifest", source).filter(
     (record) => record.scope === "all"
   );
@@ -456,6 +526,17 @@ function buildGateSummary({ records, source, shardCount, jobResults }) {
     (_, index) => `${index + 1}/${shardCount}`
   );
   const errors = [];
+  const sourceEvidence = records.filter(
+    (record) =>
+      record.source === source && EVIDENCE_RECORD_KINDS.has(record.kind)
+  );
+  if (
+    identity &&
+    (sourceEvidence.length === 0 ||
+      sourceEvidence.some((record) => !sameEvidenceIdentity(record, identity)))
+  ) {
+    errors.push("evidence identity is missing or mismatched");
+  }
   if (globalManifests.length !== 1)
     errors.push("expected exactly one global Jest manifest");
   if (shardManifests.length !== shardCount)
@@ -573,6 +654,7 @@ function finalSummary({ args, records, jobResults }) {
   const shardCount = integer(required(args, "shard-count"), "shard-count", 1);
   if (!ALLOWED_SHARD_COUNTS.has(shardCount))
     throw new Error("Unsupported shard count");
+  const identity = evidenceIdentityFromArgs(args);
   const legacy =
     mode === "sharded"
       ? null
@@ -581,6 +663,7 @@ function finalSummary({ args, records, jobResults }) {
           source: "legacy",
           shardCount: 1,
           jobResults: { legacy: jobResults.legacy },
+          identity,
         });
   const sharded =
     mode === "legacy"
@@ -596,6 +679,7 @@ function finalSummary({ args, records, jobResults }) {
             inventory: jobResults.inventory,
             jest: jobResults.jest,
           },
+          identity,
         });
   const authoritative = mode === "sharded" ? sharded : legacy;
   const equivalent =
@@ -617,13 +701,7 @@ function finalSummary({ args, records, jobResults }) {
     status: authoritative?.status ?? "FAILED",
     gate_mode: mode,
     fresh_or_reused: "fresh",
-    base_sha: required(args, "base-sha"),
-    environment: required(args, "environment"),
-    gate_fingerprint: safeText(required(args, "gate-fingerprint"), 128),
-    workflow_sha: required(args, "workflow-sha"),
-    workflow_digest: safeText(required(args, "workflow-digest"), 128),
-    node_version: safeText(required(args, "node-version"), 50),
-    package_manager: safeText(required(args, "package-manager"), 100),
+    ...identity,
     shard_count: mode === "sharded" ? shardCount : 1,
     phases: authoritative?.phases ?? [],
     phase_durations_ms: Object.fromEntries(
@@ -650,6 +728,11 @@ function finalSummary({ args, records, jobResults }) {
             all_counts_equal: sameCounts(legacy.counts, sharded.counts),
             serial_totals: legacy.counts,
             sharded_totals: sharded.counts,
+            sharded_phase_durations_ms: Object.fromEntries(
+              sharded.phases.map((phase) => [phase.name, phase.duration_ms])
+            ),
+            sharded_shards: sharded.shards,
+            sharded_shard_imbalance_ms: sharded.shard_imbalance_ms,
           }
         : null,
     run_url: runUrl,
@@ -688,6 +771,7 @@ function run(command, args) {
     const value = {
       schema_version: 1,
       kind: "manifest",
+      ...evidenceIdentityFromArgs(args),
       source,
       scope,
       shard_index:
@@ -714,6 +798,7 @@ function run(command, args) {
         durationMs: integer(required(args, "duration-ms"), "duration-ms"),
         exitCode: integer(required(args, "exit-code"), "exit-code"),
         source: required(args, "source"),
+        identity: evidenceIdentityFromArgs(args),
       })
     );
     return;
@@ -734,6 +819,7 @@ function run(command, args) {
         durationMs: integer(required(args, "duration-ms"), "duration-ms"),
         exitCode: integer(required(args, "exit-code"), "exit-code"),
         source: required(args, "source"),
+        identity: evidenceIdentityFromArgs(args),
       })
     );
     return;

--- a/scripts/release-bus-gate-evidence.cjs
+++ b/scripts/release-bus-gate-evidence.cjs
@@ -588,6 +588,13 @@ function buildGateSummary({
     errors.push("one or more required phases failed");
   }
   const counts = sumCounts(shards);
+  if (
+    counts.pending_test_suites > 0 ||
+    counts.pending_tests > 0 ||
+    counts.todo_tests > 0
+  ) {
+    errors.push("Jest reported skipped or todo tests");
+  }
   const shardDurations = shards
     .map((shard) => Number(shard.duration_ms ?? 0))
     .filter((duration) => duration >= 0);

--- a/scripts/release-bus-gate-evidence.cjs
+++ b/scripts/release-bus-gate-evidence.cjs
@@ -701,7 +701,10 @@ function finalSummary({ args, records, jobResults }) {
           records,
           source: "legacy",
           shardCount: 1,
-          jobResults: { legacy: jobResults.legacy },
+          jobResults: {
+            legacy: jobResults.legacy,
+            source_mutation: jobResults.source_mutation,
+          },
           identity,
         });
   const sharded =
@@ -717,6 +720,7 @@ function finalSummary({ args, records, jobResults }) {
             build: jobResults.build,
             inventory: jobResults.inventory,
             jest: jobResults.jest,
+            source_mutation: jobResults.source_mutation,
           },
           identity,
         });

--- a/scripts/release-bus-gate-evidence.cjs
+++ b/scripts/release-bus-gate-evidence.cjs
@@ -1,0 +1,562 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ALLOWED_SHARD_COUNTS = new Set([1, 2, 4]);
+const PHASES = ["lint", "typecheck", "unit_tests", "build"];
+const STATUSES = new Set(["PENDING", "RUNNING", "SUCCEEDED", "FAILED", "SKIPPED"]);
+const MAX_FAILURES = 100;
+const MAX_TEXT_LENGTH = 500;
+
+function parseArgs(values) {
+  const result = {};
+  for (let index = 0; index < values.length; index += 1) {
+    const value = values[index];
+    if (!value.startsWith("--")) throw new Error(`Unexpected argument: ${value}`);
+    const name = value.slice(2);
+    const next = values[index + 1];
+    if (next === undefined || next.startsWith("--")) {
+      result[name] = "true";
+      continue;
+    }
+    result[name] = next;
+    index += 1;
+  }
+  return result;
+}
+
+function required(args, name) {
+  const value = args[name];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Missing --${name}`);
+  }
+  return value;
+}
+
+function integer(value, name, minimum = 0) {
+  if (!/^[0-9]+$/.test(value)) throw new Error(`Invalid --${name}`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum) {
+    throw new Error(`Invalid --${name}`);
+  }
+  return parsed;
+}
+
+function safeText(value, maximum = MAX_TEXT_LENGTH) {
+  return String(value ?? "")
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maximum);
+}
+
+function stableSort(values) {
+  return [...values].sort((left, right) => {
+    if (left < right) return -1;
+    if (left > right) return 1;
+    return 0;
+  });
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function relativeTestPath(testPath, repoRoot) {
+  const relative = path.relative(repoRoot, testPath).split(path.sep).join("/");
+  if (!relative || relative === ".." || relative.startsWith("../")) {
+    throw new Error("Jest returned a test path outside the repository");
+  }
+  return safeText(relative);
+}
+
+function manifestFromRaw(raw, repoRoot) {
+  const prefix = `${path.resolve(repoRoot)}${path.sep}`;
+  const files = raw
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith(prefix))
+    .map((line) => relativeTestPath(line, repoRoot));
+  const unique = new Set(files);
+  if (unique.size !== files.length) {
+    throw new Error("Jest test-file inventory contains duplicates");
+  }
+  return stableSort(unique);
+}
+
+function phaseRecord({ name, status, durationMs, exitCode, source }) {
+  if (!PHASES.includes(name)) throw new Error("Invalid phase name");
+  if (!STATUSES.has(status)) throw new Error("Invalid phase status");
+  return {
+    schema_version: 1,
+    kind: "phase",
+    source,
+    name,
+    status,
+    duration_ms: durationMs,
+    exit_code: exitCode
+  };
+}
+
+function failingTests(result, repoRoot) {
+  const failures = [];
+  for (const suite of result.testResults ?? []) {
+    const suitePath = relativeTestPath(suite.name, repoRoot);
+    for (const assertion of suite.assertionResults ?? []) {
+      if (assertion.status !== "failed") continue;
+      failures.push({
+        suite: suitePath,
+        test: safeText(
+          [...(assertion.ancestorTitles ?? []), assertion.title]
+            .map((item) => safeText(item, 200))
+            .filter(Boolean)
+            .join(" > ")
+        )
+      });
+    }
+  }
+  return failures.slice(0, MAX_FAILURES);
+}
+
+function jestRecord({
+  result,
+  manifest,
+  repoRoot,
+  shardIndex,
+  shardCount,
+  durationMs,
+  exitCode,
+  source
+}) {
+  if (!ALLOWED_SHARD_COUNTS.has(shardCount)) {
+    throw new Error("Unsupported shard count");
+  }
+  if (shardIndex < 1 || shardIndex > shardCount) {
+    throw new Error("Invalid shard index");
+  }
+  const executedFiles = stableSort(
+    (result.testResults ?? []).map((suite) => relativeTestPath(suite.name, repoRoot))
+  );
+  const failingSuitePaths = stableSort(
+    (result.testResults ?? [])
+      .filter((suite) => suite.status === "failed")
+      .map((suite) => relativeTestPath(suite.name, repoRoot))
+  ).slice(0, MAX_FAILURES);
+  return {
+    schema_version: 1,
+    kind: "jest_shard",
+    source,
+    shard_index: shardIndex,
+    shard_count: shardCount,
+    status: exitCode === 0 && result.success ? "SUCCEEDED" : "FAILED",
+    duration_ms: durationMs,
+    exit_code: exitCode,
+    planned_test_files: manifest.files,
+    executed_test_files: executedFiles,
+    counts: {
+      test_files: executedFiles.length,
+      test_suites: Number(result.numTotalTestSuites ?? 0),
+      passed_test_suites: Number(result.numPassedTestSuites ?? 0),
+      failed_test_suites: Number(result.numFailedTestSuites ?? 0),
+      pending_test_suites: Number(result.numPendingTestSuites ?? 0),
+      tests: Number(result.numTotalTests ?? 0),
+      passed_tests: Number(result.numPassedTests ?? 0),
+      failed_tests: Number(result.numFailedTests ?? 0),
+      pending_tests: Number(result.numPendingTests ?? 0),
+      todo_tests: Number(result.numTodoTests ?? 0)
+    },
+    failing_suites: failingSuitePaths,
+    failing_tests: failingTests(result, repoRoot)
+  };
+}
+
+function recursiveJsonFiles(root) {
+  if (!fs.existsSync(root)) return [];
+  const result = [];
+  const visit = (directory) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const absolute = path.join(directory, entry.name);
+      if (entry.isDirectory()) visit(absolute);
+      else if (entry.isFile() && entry.name.endsWith(".json")) result.push(absolute);
+    }
+  };
+  visit(root);
+  return stableSort(result);
+}
+
+function loadEvidence(root) {
+  const records = [];
+  for (const file of recursiveJsonFiles(root)) {
+    try {
+      const value = readJson(file);
+      if (value && typeof value === "object" && typeof value.kind === "string") {
+        records.push(value);
+      }
+    } catch {
+      records.push({ kind: "malformed", file: safeText(path.basename(file)) });
+    }
+  }
+  return records;
+}
+
+function sumCounts(shards) {
+  const fields = [
+    "test_files",
+    "test_suites",
+    "passed_test_suites",
+    "failed_test_suites",
+    "pending_test_suites",
+    "tests",
+    "passed_tests",
+    "failed_tests",
+    "pending_tests",
+    "todo_tests"
+  ];
+  return Object.fromEntries(
+    fields.map((field) => [
+      field,
+      shards.reduce((total, shard) => total + Number(shard.counts?.[field] ?? 0), 0)
+    ])
+  );
+}
+
+function duplicateValues(values) {
+  const counts = new Map();
+  for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1);
+  return stableSort(
+    [...counts.entries()].filter(([, count]) => count > 1).map(([value]) => value)
+  );
+}
+
+function sameValues(left, right) {
+  return JSON.stringify(stableSort(left)) === JSON.stringify(stableSort(right));
+}
+
+function uniqueByName(records, kind, source) {
+  return records.filter((record) => record.kind === kind && record.source === source);
+}
+
+function buildGateSummary({ records, source, shardCount, jobResults }) {
+  const globalManifests = uniqueByName(records, "manifest", source).filter(
+    (record) => record.scope === "all"
+  );
+  const shardManifests = uniqueByName(records, "manifest", source).filter(
+    (record) => record.scope === "shard"
+  );
+  const shards = uniqueByName(records, "jest_shard", source);
+  const phases = PHASES.map((name) => {
+    const matches = uniqueByName(records, "phase", source).filter(
+      (record) => record.name === name
+    );
+    if (name === "unit_tests") {
+      const duration = shards.length
+        ? Math.max(...shards.map((shard) => Number(shard.duration_ms ?? 0)))
+        : 0;
+      return {
+        name,
+        status:
+          shards.length === shardCount && shards.every((shard) => shard.status === "SUCCEEDED")
+            ? "SUCCEEDED"
+            : "FAILED",
+        duration_ms: duration
+      };
+    }
+    if (matches.length !== 1) return { name, status: "FAILED", duration_ms: 0 };
+    return {
+      name,
+      status: matches[0].status,
+      duration_ms: Number(matches[0].duration_ms ?? 0)
+    };
+  });
+  const expected = globalManifests.length === 1 ? globalManifests[0].files : [];
+  const planned = shardManifests.flatMap((manifest) => manifest.files ?? []);
+  const executed = shards.flatMap((shard) => shard.executed_test_files ?? []);
+  const plannedSet = new Set(planned);
+  const executedSet = new Set(executed);
+  const expectedSet = new Set(expected);
+  const missingFiles = stableSort(expected.filter((file) => !executedSet.has(file)));
+  const unexpectedFiles = stableSort(executed.filter((file) => !expectedSet.has(file)));
+  const duplicateFiles = duplicateValues(executed);
+  const plannedMissing = stableSort(expected.filter((file) => !plannedSet.has(file)));
+  const plannedUnexpected = stableSort(planned.filter((file) => !expectedSet.has(file)));
+  const plannedDuplicates = duplicateValues(planned);
+  const shardCoordinates = stableSort(
+    shards.map((shard) => `${shard.shard_index}/${shard.shard_count}`)
+  );
+  const expectedCoordinates = Array.from(
+    { length: shardCount },
+    (_, index) => `${index + 1}/${shardCount}`
+  );
+  const errors = [];
+  if (globalManifests.length !== 1) errors.push("expected exactly one global Jest manifest");
+  if (shardManifests.length !== shardCount) errors.push("missing shard plan manifest");
+  if (shards.length !== shardCount) errors.push("missing shard result");
+  if (JSON.stringify(shardCoordinates) !== JSON.stringify(expectedCoordinates)) {
+    errors.push("invalid shard coordinates");
+  }
+  if (missingFiles.length > 0) errors.push("expected Jest files were not executed");
+  if (unexpectedFiles.length > 0) errors.push("unexpected Jest files were executed");
+  if (duplicateFiles.length > 0) errors.push("Jest files executed more than once");
+  if (plannedMissing.length > 0 || plannedDuplicates.length > 0) {
+    errors.push("Jest shard plans are incomplete or overlapping");
+  }
+  if (plannedUnexpected.length > 0) {
+    errors.push("Jest shard plans contain unexpected files");
+  }
+  for (const shard of shards) {
+    const matchingManifests = shardManifests.filter(
+      (manifest) =>
+        manifest.shard_index === shard.shard_index &&
+        manifest.shard_count === shard.shard_count
+    );
+    if (
+      matchingManifests.length !== 1 ||
+      !sameValues(
+        matchingManifests[0]?.files ?? [],
+        shard.executed_test_files ?? []
+      )
+    ) {
+      errors.push(
+        `Jest shard ${safeText(shard.shard_index, 10)}/${safeText(shard.shard_count, 10)} did not execute its exact plan`
+      );
+    }
+  }
+  if (records.some((record) => record.kind === "malformed")) errors.push("malformed evidence");
+  for (const [job, result] of Object.entries(jobResults)) {
+    if (result !== "success" && result !== "skipped") {
+      errors.push(`${safeText(job, 80)} job did not succeed`);
+    }
+  }
+  if (phases.some((phase) => phase.status !== "SUCCEEDED")) {
+    errors.push("one or more required phases failed");
+  }
+  const counts = sumCounts(shards);
+  const shardDurations = shards
+    .map((shard) => Number(shard.duration_ms ?? 0))
+    .filter((duration) => duration >= 0);
+  const maximumShardDuration = shardDurations.length ? Math.max(...shardDurations) : 0;
+  const minimumShardDuration = shardDurations.length ? Math.min(...shardDurations) : 0;
+  return {
+    status: errors.length === 0 ? "SUCCEEDED" : "FAILED",
+    phases,
+    counts,
+    shards: stableSort(
+      shards.map((shard) => `${String(shard.shard_index).padStart(2, "0")}:${JSON.stringify({
+        index: shard.shard_index,
+        count: shard.shard_count,
+        status: shard.status,
+        duration_ms: shard.duration_ms,
+        counts: shard.counts
+      })}`)
+    ).map((value) => JSON.parse(value.slice(value.indexOf(":") + 1))),
+    shard_imbalance_ms: maximumShardDuration - minimumShardDuration,
+    missing_files: missingFiles.slice(0, MAX_FAILURES),
+    duplicate_files: duplicateFiles.slice(0, MAX_FAILURES),
+    unexpected_files: unexpectedFiles.slice(0, MAX_FAILURES),
+    failing_suites: stableSort(shards.flatMap((shard) => shard.failing_suites ?? [])).slice(
+      0,
+      MAX_FAILURES
+    ),
+    failing_tests: shards.flatMap((shard) => shard.failing_tests ?? []).slice(0, MAX_FAILURES),
+    errors: errors.map((error) => safeText(error, 200)).slice(0, 50)
+  };
+}
+
+function jobLinks(jobsFile) {
+  if (!jobsFile || !fs.existsSync(jobsFile)) return [];
+  try {
+    const jobs = readJson(jobsFile).jobs ?? [];
+    return jobs
+      .filter(
+        (job) =>
+          typeof job.name === "string" &&
+          /^https:\/\/github\.com\/6529-Collections\/6529seize-frontend\/actions\/runs\/\d+\/job\/\d+$/.test(
+            job.html_url ?? ""
+          )
+      )
+      .map((job) => ({ name: safeText(job.name, 120), url: job.html_url }))
+      .slice(0, 100);
+  } catch {
+    return [];
+  }
+}
+
+function finalSummary({ args, records, jobResults }) {
+  const mode = required(args, "mode");
+  if (!new Set(["legacy", "shadow", "sharded"]).has(mode)) {
+    throw new Error("Invalid gate mode");
+  }
+  const shardCount = integer(required(args, "shard-count"), "shard-count", 1);
+  if (!ALLOWED_SHARD_COUNTS.has(shardCount)) throw new Error("Unsupported shard count");
+  const legacy = mode === "sharded" ? null : buildGateSummary({
+    records,
+    source: "legacy",
+    shardCount: 1,
+    jobResults: { legacy: jobResults.legacy }
+  });
+  const sharded = mode === "legacy" ? null : buildGateSummary({
+    records,
+    source: "parallel",
+    shardCount,
+    jobResults: {
+      lint: jobResults.lint,
+      typecheck: jobResults.typecheck,
+      build: jobResults.build,
+      inventory: jobResults.inventory,
+      jest: jobResults.jest
+    }
+  });
+  const authoritative = mode === "sharded" ? sharded : legacy;
+  const equivalent =
+    mode === "shadow"
+      ? legacy.status === sharded.status &&
+        legacy.counts.tests === sharded.counts.tests &&
+        legacy.counts.test_suites === sharded.counts.test_suites &&
+        legacy.counts.test_files === sharded.counts.test_files
+      : null;
+  const runUrl = required(args, "run-url");
+  if (!/^https:\/\/github\.com\/6529-Collections\/6529seize-frontend\/actions\/runs\/\d+$/.test(runUrl)) {
+    throw new Error("Invalid run URL");
+  }
+  return {
+    schema_version: 1,
+    kind: "base_canary_summary",
+    status: authoritative?.status ?? "FAILED",
+    gate_mode: mode,
+    fresh_or_reused: "fresh",
+    base_sha: required(args, "base-sha"),
+    environment: required(args, "environment"),
+    gate_fingerprint: safeText(required(args, "gate-fingerprint"), 128),
+    workflow_sha: required(args, "workflow-sha"),
+    workflow_digest: safeText(required(args, "workflow-digest"), 128),
+    node_version: safeText(required(args, "node-version"), 50),
+    package_manager: safeText(required(args, "package-manager"), 100),
+    shard_count: mode === "sharded" ? shardCount : 1,
+    phases: authoritative?.phases ?? [],
+    phase_durations_ms: Object.fromEntries(
+      (authoritative?.phases ?? []).map((phase) => [phase.name, phase.duration_ms])
+    ),
+    totals: authoritative?.counts ?? sumCounts([]),
+    shards: authoritative?.shards ?? [],
+    shard_imbalance_ms: authoritative?.shard_imbalance_ms ?? 0,
+    missing_files: authoritative?.missing_files ?? [],
+    duplicate_files: authoritative?.duplicate_files ?? [],
+    unexpected_files: authoritative?.unexpected_files ?? [],
+    failing_suites: authoritative?.failing_suites ?? [],
+    failing_tests: authoritative?.failing_tests ?? [],
+    errors: authoritative?.errors ?? ["authoritative evidence missing"],
+    equivalence:
+      mode === "shadow"
+        ? {
+            equivalent,
+            serial_status: legacy.status,
+            sharded_status: sharded.status,
+            serial_totals: legacy.counts,
+            sharded_totals: sharded.counts
+          }
+        : null,
+    run_url: runUrl,
+    job_links: jobLinks(args["jobs-file"]),
+    summary_artifact_name: safeText(required(args, "artifact-name"), 200)
+  };
+}
+
+function run(command, args) {
+  if (command === "matrix") {
+    const count = integer(required(args, "shard-count"), "shard-count", 1);
+    if (!ALLOWED_SHARD_COUNTS.has(count)) throw new Error("Unsupported shard count");
+    process.stdout.write(
+      `${JSON.stringify({ include: Array.from({ length: count }, (_, index) => ({
+        index: index + 1,
+        total: count
+      })) })}\n`
+    );
+    return;
+  }
+  if (command === "manifest") {
+    const repoRoot = path.resolve(required(args, "repo-root"));
+    const files = manifestFromRaw(fs.readFileSync(required(args, "raw"), "utf8"), repoRoot);
+    const scope = required(args, "scope");
+    const source = required(args, "source");
+    const value = {
+      schema_version: 1,
+      kind: "manifest",
+      source,
+      scope,
+      shard_index: scope === "shard" ? integer(required(args, "shard-index"), "shard-index", 1) : null,
+      shard_count: scope === "shard" ? integer(required(args, "shard-count"), "shard-count", 1) : null,
+      files
+    };
+    if (files.length === 0) throw new Error("Jest test-file inventory is empty");
+    writeJson(required(args, "output"), value);
+    return;
+  }
+  if (command === "phase") {
+    writeJson(
+      required(args, "output"),
+      phaseRecord({
+        name: required(args, "name"),
+        status: required(args, "status"),
+        durationMs: integer(required(args, "duration-ms"), "duration-ms"),
+        exitCode: integer(required(args, "exit-code"), "exit-code"),
+        source: required(args, "source")
+      })
+    );
+    return;
+  }
+  if (command === "jest") {
+    const repoRoot = path.resolve(required(args, "repo-root"));
+    const resultsFile = required(args, "results");
+    writeJson(
+      required(args, "output"),
+      jestRecord({
+        result: fs.existsSync(resultsFile)
+          ? readJson(resultsFile)
+          : { success: false, testResults: [] },
+        manifest: readJson(required(args, "manifest")),
+        repoRoot,
+        shardIndex: integer(required(args, "shard-index"), "shard-index", 1),
+        shardCount: integer(required(args, "shard-count"), "shard-count", 1),
+        durationMs: integer(required(args, "duration-ms"), "duration-ms"),
+        exitCode: integer(required(args, "exit-code"), "exit-code"),
+        source: required(args, "source")
+      })
+    );
+    return;
+  }
+  if (command === "aggregate") {
+    const records = loadEvidence(required(args, "evidence-root"));
+    const jobResults = readJson(required(args, "job-results"));
+    const summary = finalSummary({ args, records, jobResults });
+    writeJson(required(args, "output"), summary);
+    if (summary.status !== "SUCCEEDED") process.exitCode = 1;
+    return;
+  }
+  throw new Error(`Unknown command: ${command}`);
+}
+
+module.exports = {
+  buildGateSummary,
+  finalSummary,
+  jestRecord,
+  manifestFromRaw,
+  phaseRecord,
+  safeText
+};
+
+if (require.main === module) {
+  try {
+    const [command, ...values] = process.argv.slice(2);
+    if (!command) throw new Error("A command is required");
+    run(command, parseArgs(values));
+  } catch (error) {
+    process.stderr.write(`${safeText(error instanceof Error ? error.message : error, 300)}\n`);
+    process.exitCode = 2;
+  }
+}

--- a/scripts/release-bus-gate-evidence.cjs
+++ b/scripts/release-bus-gate-evidence.cjs
@@ -2,6 +2,8 @@
 
 const fs = require("node:fs");
 const path = require("node:path");
+const { createHash } = require("node:crypto");
+const { execFileSync } = require("node:child_process");
 
 const ALLOWED_SHARD_COUNTS = new Set([1, 2, 4]);
 const PHASES = ["lint", "typecheck", "unit_tests", "build"];
@@ -14,6 +16,19 @@ const STATUSES = new Set([
 ]);
 const MAX_FAILURES = 100;
 const MAX_TEXT_LENGTH = 500;
+const FRONTEND_GATE_WORKFLOW = ".github/workflows/release-bus-base-canary.yml";
+const FRONTEND_GATE_BASE_FILES = [
+  "bin/6529",
+  "jest.config.js",
+  "jest.setup.js",
+  "package.json",
+  "pnpm-lock.yaml",
+];
+const FRONTEND_GATE_TOOLING_FILES = [
+  "scripts/release-bus-frontend-gate.sh",
+  "scripts/release-bus-gate-evidence.cjs",
+  "scripts/release-bus-report-progress.mjs",
+];
 
 function parseArgs(values) {
   const result = {};
@@ -73,6 +88,119 @@ function readJson(file) {
 function writeJson(file, value) {
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function frontendGateContract({
+  baseSha,
+  workflowSha,
+  baseFileContents,
+  workflowFileContents,
+  gateMode,
+  shardCount,
+}) {
+  if (!/^[a-f0-9]{40}$/.test(baseSha)) throw new Error("Invalid base SHA");
+  if (!/^[a-f0-9]{40}$/.test(workflowSha))
+    throw new Error("Invalid workflow SHA");
+  if (!new Set(["legacy", "shadow", "sharded"]).has(gateMode))
+    throw new Error("Invalid gate mode");
+  if (!ALLOWED_SHARD_COUNTS.has(shardCount))
+    throw new Error("Unsupported shard count");
+  const workflowFiles = [
+    FRONTEND_GATE_WORKFLOW,
+    ...FRONTEND_GATE_TOOLING_FILES,
+  ];
+  for (const file of FRONTEND_GATE_BASE_FILES) {
+    if (typeof baseFileContents[file] !== "string")
+      throw new Error(`Missing base contract file ${file}`);
+  }
+  for (const file of workflowFiles) {
+    if (typeof workflowFileContents[file] !== "string")
+      throw new Error(`Missing workflow contract file ${file}`);
+  }
+  const packageJson = JSON.parse(baseFileContents["package.json"]);
+  const packageManager = packageJson?.packageManager;
+  if (
+    typeof packageManager !== "string" ||
+    packageManager.length < 1 ||
+    packageManager.length > 128
+  ) {
+    throw new Error("Invalid package-manager contract");
+  }
+  const componentDigests = Object.fromEntries([
+    ...FRONTEND_GATE_BASE_FILES.map((file) => [
+      file,
+      sha256(baseFileContents[file]),
+    ]),
+    ...workflowFiles.map((file) => [file, sha256(workflowFileContents[file])]),
+  ]);
+  const workflowDigest = componentDigests[FRONTEND_GATE_WORKFLOW];
+  const fingerprint = sha256(
+    JSON.stringify({
+      schema_version: 1,
+      repository: "frontend",
+      environment: "orchestration",
+      base_sha: baseSha,
+      workflow_sha: workflowSha,
+      workflow_digest: workflowDigest,
+      node_version: "22",
+      package_manager: packageManager,
+      gate_mode: gateMode,
+      shard_count: shardCount,
+      component_digests: componentDigests,
+    })
+  );
+  return {
+    schema_version: 1,
+    repository: "frontend",
+    environment: "orchestration",
+    base_sha: baseSha,
+    gate_fingerprint: fingerprint,
+    workflow_sha: workflowSha,
+    workflow_digest: workflowDigest,
+    node_version: "22",
+    package_manager: packageManager,
+    gate_mode: gateMode,
+    shard_count: shardCount,
+    component_digests: componentDigests,
+  };
+}
+
+function contractFromRepository(args) {
+  const repoRoot = path.resolve(required(args, "repo-root"));
+  const baseSha = required(args, "base-sha");
+  const workflowSha = required(args, "workflow-sha");
+  const head = execFileSync("git", ["-C", repoRoot, "rev-parse", "HEAD"], {
+    encoding: "utf8",
+  }).trim();
+  if (head !== baseSha)
+    throw new Error("Base checkout does not match base SHA");
+  const baseFileContents = Object.fromEntries(
+    FRONTEND_GATE_BASE_FILES.map((file) => [
+      file,
+      fs.readFileSync(path.join(repoRoot, file), "utf8"),
+    ])
+  );
+  const workflowFileContents = Object.fromEntries(
+    [FRONTEND_GATE_WORKFLOW, ...FRONTEND_GATE_TOOLING_FILES].map((file) => [
+      file,
+      execFileSync("git", ["-C", repoRoot, "show", `${workflowSha}:${file}`], {
+        encoding: "utf8",
+        maxBuffer: 2 * 1024 * 1024,
+      }),
+    ])
+  );
+  return frontendGateContract({
+    baseSha,
+    workflowSha,
+    baseFileContents,
+    workflowFileContents,
+    gateMode: required(args, "mode"),
+    shardCount: integer(required(args, "shard-count"), "shard-count", 1),
+  });
 }
 
 function relativeTestPath(testPath, repoRoot) {
@@ -531,6 +659,10 @@ function finalSummary({ args, records, jobResults }) {
 }
 
 function run(command, args) {
+  if (command === "fingerprint") {
+    writeJson(required(args, "output"), contractFromRepository(args));
+    return;
+  }
   if (command === "matrix") {
     const count = integer(required(args, "shard-count"), "shard-count", 1);
     if (!ALLOWED_SHARD_COUNTS.has(count))
@@ -620,6 +752,7 @@ function run(command, args) {
 module.exports = {
   buildGateSummary,
   finalSummary,
+  frontendGateContract,
   jestRecord,
   manifestFromRaw,
   phaseRecord,

--- a/scripts/release-bus-gate-evidence.cjs
+++ b/scripts/release-bus-gate-evidence.cjs
@@ -75,6 +75,12 @@ function integer(value, name, minimum = 0) {
   return parsed;
 }
 
+function digest(args, name) {
+  const value = required(args, name);
+  if (!/^[a-f0-9]{64}$/.test(value)) throw new Error(`Invalid --${name}`);
+  return value;
+}
+
 function safeText(value, maximum = MAX_TEXT_LENGTH) {
   return String(value ?? "")
     .replace(/[\u0000-\u001f\u007f]/g, " ")
@@ -111,6 +117,7 @@ function frontendGateContract({
   workflowFileContents,
   gateMode,
   shardCount,
+  nodeVersion = "22",
 }) {
   if (!/^[a-f0-9]{40}$/.test(baseSha)) throw new Error("Invalid base SHA");
   if (!/^[a-f0-9]{40}$/.test(workflowSha))
@@ -119,6 +126,8 @@ function frontendGateContract({
     throw new Error("Invalid gate mode");
   if (!ALLOWED_SHARD_COUNTS.has(shardCount))
     throw new Error("Unsupported shard count");
+  if (!/^[1-9][0-9]{0,2}$/.test(nodeVersion))
+    throw new Error("Invalid Node version");
   const workflowFiles = [
     FRONTEND_GATE_WORKFLOW,
     ...FRONTEND_GATE_TOOLING_FILES,
@@ -147,6 +156,18 @@ function frontendGateContract({
     ...workflowFiles.map((file) => [file, sha256(workflowFileContents[file])]),
   ]);
   const workflowDigest = componentDigests[FRONTEND_GATE_WORKFLOW];
+  const behaviorDigest = sha256(
+    JSON.stringify({
+      schema_version: 1,
+      repository: "frontend",
+      environment: "orchestration",
+      node_version: nodeVersion,
+      package_manager: packageManager,
+      gate_mode: gateMode,
+      shard_count: shardCount,
+      component_digests: componentDigests,
+    })
+  );
   const fingerprint = sha256(
     JSON.stringify({
       schema_version: 1,
@@ -155,7 +176,7 @@ function frontendGateContract({
       base_sha: baseSha,
       workflow_sha: workflowSha,
       workflow_digest: workflowDigest,
-      node_version: "22",
+      node_version: nodeVersion,
       package_manager: packageManager,
       gate_mode: gateMode,
       shard_count: shardCount,
@@ -167,10 +188,11 @@ function frontendGateContract({
     repository: "frontend",
     environment: "orchestration",
     base_sha: baseSha,
+    behavior_digest: behaviorDigest,
     gate_fingerprint: fingerprint,
     workflow_sha: workflowSha,
     workflow_digest: workflowDigest,
-    node_version: "22",
+    node_version: nodeVersion,
     package_manager: packageManager,
     gate_mode: gateMode,
     shard_count: shardCount,
@@ -709,6 +731,7 @@ function finalSummary({ args, records, jobResults }) {
     gate_mode: mode,
     fresh_or_reused: "fresh",
     ...identity,
+    behavior_digest: digest(args, "behavior-digest"),
     shard_count: mode === "sharded" ? shardCount : 1,
     phases: authoritative?.phases ?? [],
     phase_durations_ms: Object.fromEntries(

--- a/scripts/release-bus-gate-evidence.cjs
+++ b/scripts/release-bus-gate-evidence.cjs
@@ -5,7 +5,13 @@ const path = require("node:path");
 
 const ALLOWED_SHARD_COUNTS = new Set([1, 2, 4]);
 const PHASES = ["lint", "typecheck", "unit_tests", "build"];
-const STATUSES = new Set(["PENDING", "RUNNING", "SUCCEEDED", "FAILED", "SKIPPED"]);
+const STATUSES = new Set([
+  "PENDING",
+  "RUNNING",
+  "SUCCEEDED",
+  "FAILED",
+  "SKIPPED",
+]);
 const MAX_FAILURES = 100;
 const MAX_TEXT_LENGTH = 500;
 
@@ -13,7 +19,8 @@ function parseArgs(values) {
   const result = {};
   for (let index = 0; index < values.length; index += 1) {
     const value = values[index];
-    if (!value.startsWith("--")) throw new Error(`Unexpected argument: ${value}`);
+    if (!value.startsWith("--"))
+      throw new Error(`Unexpected argument: ${value}`);
     const name = value.slice(2);
     const next = values[index + 1];
     if (next === undefined || next.startsWith("--")) {
@@ -100,7 +107,7 @@ function phaseRecord({ name, status, durationMs, exitCode, source }) {
     name,
     status,
     duration_ms: durationMs,
-    exit_code: exitCode
+    exit_code: exitCode,
   };
 }
 
@@ -117,7 +124,7 @@ function failingTests(result, repoRoot) {
             .map((item) => safeText(item, 200))
             .filter(Boolean)
             .join(" > ")
-        )
+        ),
       });
     }
   }
@@ -132,7 +139,7 @@ function jestRecord({
   shardCount,
   durationMs,
   exitCode,
-  source
+  source,
 }) {
   if (!ALLOWED_SHARD_COUNTS.has(shardCount)) {
     throw new Error("Unsupported shard count");
@@ -141,7 +148,9 @@ function jestRecord({
     throw new Error("Invalid shard index");
   }
   const executedFiles = stableSort(
-    (result.testResults ?? []).map((suite) => relativeTestPath(suite.name, repoRoot))
+    (result.testResults ?? []).map((suite) =>
+      relativeTestPath(suite.name, repoRoot)
+    )
   );
   const failingSuitePaths = stableSort(
     (result.testResults ?? [])
@@ -169,10 +178,10 @@ function jestRecord({
       passed_tests: Number(result.numPassedTests ?? 0),
       failed_tests: Number(result.numFailedTests ?? 0),
       pending_tests: Number(result.numPendingTests ?? 0),
-      todo_tests: Number(result.numTodoTests ?? 0)
+      todo_tests: Number(result.numTodoTests ?? 0),
     },
     failing_suites: failingSuitePaths,
-    failing_tests: failingTests(result, repoRoot)
+    failing_tests: failingTests(result, repoRoot),
   };
 }
 
@@ -183,7 +192,8 @@ function recursiveJsonFiles(root) {
     for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
       const absolute = path.join(directory, entry.name);
       if (entry.isDirectory()) visit(absolute);
-      else if (entry.isFile() && entry.name.endsWith(".json")) result.push(absolute);
+      else if (entry.isFile() && entry.name.endsWith(".json"))
+        result.push(absolute);
     }
   };
   visit(root);
@@ -195,7 +205,11 @@ function loadEvidence(root) {
   for (const file of recursiveJsonFiles(root)) {
     try {
       const value = readJson(file);
-      if (value && typeof value === "object" && typeof value.kind === "string") {
+      if (
+        value &&
+        typeof value === "object" &&
+        typeof value.kind === "string"
+      ) {
         records.push(value);
       }
     } catch {
@@ -216,12 +230,15 @@ function sumCounts(shards) {
     "passed_tests",
     "failed_tests",
     "pending_tests",
-    "todo_tests"
+    "todo_tests",
   ];
   return Object.fromEntries(
     fields.map((field) => [
       field,
-      shards.reduce((total, shard) => total + Number(shard.counts?.[field] ?? 0), 0)
+      shards.reduce(
+        (total, shard) => total + Number(shard.counts?.[field] ?? 0),
+        0
+      ),
     ])
   );
 }
@@ -230,7 +247,9 @@ function duplicateValues(values) {
   const counts = new Map();
   for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1);
   return stableSort(
-    [...counts.entries()].filter(([, count]) => count > 1).map(([value]) => value)
+    [...counts.entries()]
+      .filter(([, count]) => count > 1)
+      .map(([value]) => value)
   );
 }
 
@@ -238,8 +257,14 @@ function sameValues(left, right) {
   return JSON.stringify(stableSort(left)) === JSON.stringify(stableSort(right));
 }
 
+function sameCounts(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
 function uniqueByName(records, kind, source) {
-  return records.filter((record) => record.kind === kind && record.source === source);
+  return records.filter(
+    (record) => record.kind === kind && record.source === source
+  );
 }
 
 function buildGateSummary({ records, source, shardCount, jobResults }) {
@@ -261,17 +286,18 @@ function buildGateSummary({ records, source, shardCount, jobResults }) {
       return {
         name,
         status:
-          shards.length === shardCount && shards.every((shard) => shard.status === "SUCCEEDED")
+          shards.length === shardCount &&
+          shards.every((shard) => shard.status === "SUCCEEDED")
             ? "SUCCEEDED"
             : "FAILED",
-        duration_ms: duration
+        duration_ms: duration,
       };
     }
     if (matches.length !== 1) return { name, status: "FAILED", duration_ms: 0 };
     return {
       name,
       status: matches[0].status,
-      duration_ms: Number(matches[0].duration_ms ?? 0)
+      duration_ms: Number(matches[0].duration_ms ?? 0),
     };
   });
   const expected = globalManifests.length === 1 ? globalManifests[0].files : [];
@@ -280,11 +306,19 @@ function buildGateSummary({ records, source, shardCount, jobResults }) {
   const plannedSet = new Set(planned);
   const executedSet = new Set(executed);
   const expectedSet = new Set(expected);
-  const missingFiles = stableSort(expected.filter((file) => !executedSet.has(file)));
-  const unexpectedFiles = stableSort(executed.filter((file) => !expectedSet.has(file)));
+  const missingFiles = stableSort(
+    expected.filter((file) => !executedSet.has(file))
+  );
+  const unexpectedFiles = stableSort(
+    executed.filter((file) => !expectedSet.has(file))
+  );
   const duplicateFiles = duplicateValues(executed);
-  const plannedMissing = stableSort(expected.filter((file) => !plannedSet.has(file)));
-  const plannedUnexpected = stableSort(planned.filter((file) => !expectedSet.has(file)));
+  const plannedMissing = stableSort(
+    expected.filter((file) => !plannedSet.has(file))
+  );
+  const plannedUnexpected = stableSort(
+    planned.filter((file) => !expectedSet.has(file))
+  );
   const plannedDuplicates = duplicateValues(planned);
   const shardCoordinates = stableSort(
     shards.map((shard) => `${shard.shard_index}/${shard.shard_count}`)
@@ -294,15 +328,22 @@ function buildGateSummary({ records, source, shardCount, jobResults }) {
     (_, index) => `${index + 1}/${shardCount}`
   );
   const errors = [];
-  if (globalManifests.length !== 1) errors.push("expected exactly one global Jest manifest");
-  if (shardManifests.length !== shardCount) errors.push("missing shard plan manifest");
+  if (globalManifests.length !== 1)
+    errors.push("expected exactly one global Jest manifest");
+  if (shardManifests.length !== shardCount)
+    errors.push("missing shard plan manifest");
   if (shards.length !== shardCount) errors.push("missing shard result");
-  if (JSON.stringify(shardCoordinates) !== JSON.stringify(expectedCoordinates)) {
+  if (
+    JSON.stringify(shardCoordinates) !== JSON.stringify(expectedCoordinates)
+  ) {
     errors.push("invalid shard coordinates");
   }
-  if (missingFiles.length > 0) errors.push("expected Jest files were not executed");
-  if (unexpectedFiles.length > 0) errors.push("unexpected Jest files were executed");
-  if (duplicateFiles.length > 0) errors.push("Jest files executed more than once");
+  if (missingFiles.length > 0)
+    errors.push("expected Jest files were not executed");
+  if (unexpectedFiles.length > 0)
+    errors.push("unexpected Jest files were executed");
+  if (duplicateFiles.length > 0)
+    errors.push("Jest files executed more than once");
   if (plannedMissing.length > 0 || plannedDuplicates.length > 0) {
     errors.push("Jest shard plans are incomplete or overlapping");
   }
@@ -327,7 +368,8 @@ function buildGateSummary({ records, source, shardCount, jobResults }) {
       );
     }
   }
-  if (records.some((record) => record.kind === "malformed")) errors.push("malformed evidence");
+  if (records.some((record) => record.kind === "malformed"))
+    errors.push("malformed evidence");
   for (const [job, result] of Object.entries(jobResults)) {
     if (result !== "success" && result !== "skipped") {
       errors.push(`${safeText(job, 80)} job did not succeed`);
@@ -340,31 +382,39 @@ function buildGateSummary({ records, source, shardCount, jobResults }) {
   const shardDurations = shards
     .map((shard) => Number(shard.duration_ms ?? 0))
     .filter((duration) => duration >= 0);
-  const maximumShardDuration = shardDurations.length ? Math.max(...shardDurations) : 0;
-  const minimumShardDuration = shardDurations.length ? Math.min(...shardDurations) : 0;
+  const maximumShardDuration = shardDurations.length
+    ? Math.max(...shardDurations)
+    : 0;
+  const minimumShardDuration = shardDurations.length
+    ? Math.min(...shardDurations)
+    : 0;
   return {
     status: errors.length === 0 ? "SUCCEEDED" : "FAILED",
     phases,
     counts,
     shards: stableSort(
-      shards.map((shard) => `${String(shard.shard_index).padStart(2, "0")}:${JSON.stringify({
-        index: shard.shard_index,
-        count: shard.shard_count,
-        status: shard.status,
-        duration_ms: shard.duration_ms,
-        counts: shard.counts
-      })}`)
+      shards.map(
+        (shard) =>
+          `${String(shard.shard_index).padStart(2, "0")}:${JSON.stringify({
+            index: shard.shard_index,
+            count: shard.shard_count,
+            status: shard.status,
+            duration_ms: shard.duration_ms,
+            counts: shard.counts,
+          })}`
+      )
     ).map((value) => JSON.parse(value.slice(value.indexOf(":") + 1))),
     shard_imbalance_ms: maximumShardDuration - minimumShardDuration,
     missing_files: missingFiles.slice(0, MAX_FAILURES),
     duplicate_files: duplicateFiles.slice(0, MAX_FAILURES),
     unexpected_files: unexpectedFiles.slice(0, MAX_FAILURES),
-    failing_suites: stableSort(shards.flatMap((shard) => shard.failing_suites ?? [])).slice(
-      0,
-      MAX_FAILURES
-    ),
-    failing_tests: shards.flatMap((shard) => shard.failing_tests ?? []).slice(0, MAX_FAILURES),
-    errors: errors.map((error) => safeText(error, 200)).slice(0, 50)
+    failing_suites: stableSort(
+      shards.flatMap((shard) => shard.failing_suites ?? [])
+    ).slice(0, MAX_FAILURES),
+    failing_tests: shards
+      .flatMap((shard) => shard.failing_tests ?? [])
+      .slice(0, MAX_FAILURES),
+    errors: errors.map((error) => safeText(error, 200)).slice(0, 50),
   };
 }
 
@@ -393,35 +443,44 @@ function finalSummary({ args, records, jobResults }) {
     throw new Error("Invalid gate mode");
   }
   const shardCount = integer(required(args, "shard-count"), "shard-count", 1);
-  if (!ALLOWED_SHARD_COUNTS.has(shardCount)) throw new Error("Unsupported shard count");
-  const legacy = mode === "sharded" ? null : buildGateSummary({
-    records,
-    source: "legacy",
-    shardCount: 1,
-    jobResults: { legacy: jobResults.legacy }
-  });
-  const sharded = mode === "legacy" ? null : buildGateSummary({
-    records,
-    source: "parallel",
-    shardCount,
-    jobResults: {
-      lint: jobResults.lint,
-      typecheck: jobResults.typecheck,
-      build: jobResults.build,
-      inventory: jobResults.inventory,
-      jest: jobResults.jest
-    }
-  });
+  if (!ALLOWED_SHARD_COUNTS.has(shardCount))
+    throw new Error("Unsupported shard count");
+  const legacy =
+    mode === "sharded"
+      ? null
+      : buildGateSummary({
+          records,
+          source: "legacy",
+          shardCount: 1,
+          jobResults: { legacy: jobResults.legacy },
+        });
+  const sharded =
+    mode === "legacy"
+      ? null
+      : buildGateSummary({
+          records,
+          source: "parallel",
+          shardCount,
+          jobResults: {
+            lint: jobResults.lint,
+            typecheck: jobResults.typecheck,
+            build: jobResults.build,
+            inventory: jobResults.inventory,
+            jest: jobResults.jest,
+          },
+        });
   const authoritative = mode === "sharded" ? sharded : legacy;
   const equivalent =
     mode === "shadow"
       ? legacy.status === sharded.status &&
-        legacy.counts.tests === sharded.counts.tests &&
-        legacy.counts.test_suites === sharded.counts.test_suites &&
-        legacy.counts.test_files === sharded.counts.test_files
+        sameCounts(legacy.counts, sharded.counts)
       : null;
   const runUrl = required(args, "run-url");
-  if (!/^https:\/\/github\.com\/6529-Collections\/6529seize-frontend\/actions\/runs\/\d+$/.test(runUrl)) {
+  if (
+    !/^https:\/\/github\.com\/6529-Collections\/6529seize-frontend\/actions\/runs\/\d+$/.test(
+      runUrl
+    )
+  ) {
     throw new Error("Invalid run URL");
   }
   return {
@@ -440,7 +499,10 @@ function finalSummary({ args, records, jobResults }) {
     shard_count: mode === "sharded" ? shardCount : 1,
     phases: authoritative?.phases ?? [],
     phase_durations_ms: Object.fromEntries(
-      (authoritative?.phases ?? []).map((phase) => [phase.name, phase.duration_ms])
+      (authoritative?.phases ?? []).map((phase) => [
+        phase.name,
+        phase.duration_ms,
+      ])
     ),
     totals: authoritative?.counts ?? sumCounts([]),
     shards: authoritative?.shards ?? [],
@@ -457,31 +519,38 @@ function finalSummary({ args, records, jobResults }) {
             equivalent,
             serial_status: legacy.status,
             sharded_status: sharded.status,
+            all_counts_equal: sameCounts(legacy.counts, sharded.counts),
             serial_totals: legacy.counts,
-            sharded_totals: sharded.counts
+            sharded_totals: sharded.counts,
           }
         : null,
     run_url: runUrl,
     job_links: jobLinks(args["jobs-file"]),
-    summary_artifact_name: safeText(required(args, "artifact-name"), 200)
+    summary_artifact_name: safeText(required(args, "artifact-name"), 200),
   };
 }
 
 function run(command, args) {
   if (command === "matrix") {
     const count = integer(required(args, "shard-count"), "shard-count", 1);
-    if (!ALLOWED_SHARD_COUNTS.has(count)) throw new Error("Unsupported shard count");
+    if (!ALLOWED_SHARD_COUNTS.has(count))
+      throw new Error("Unsupported shard count");
     process.stdout.write(
-      `${JSON.stringify({ include: Array.from({ length: count }, (_, index) => ({
-        index: index + 1,
-        total: count
-      })) })}\n`
+      `${JSON.stringify({
+        include: Array.from({ length: count }, (_, index) => ({
+          index: index + 1,
+          total: count,
+        })),
+      })}\n`
     );
     return;
   }
   if (command === "manifest") {
     const repoRoot = path.resolve(required(args, "repo-root"));
-    const files = manifestFromRaw(fs.readFileSync(required(args, "raw"), "utf8"), repoRoot);
+    const files = manifestFromRaw(
+      fs.readFileSync(required(args, "raw"), "utf8"),
+      repoRoot
+    );
     const scope = required(args, "scope");
     const source = required(args, "source");
     const value = {
@@ -489,11 +558,18 @@ function run(command, args) {
       kind: "manifest",
       source,
       scope,
-      shard_index: scope === "shard" ? integer(required(args, "shard-index"), "shard-index", 1) : null,
-      shard_count: scope === "shard" ? integer(required(args, "shard-count"), "shard-count", 1) : null,
-      files
+      shard_index:
+        scope === "shard"
+          ? integer(required(args, "shard-index"), "shard-index", 1)
+          : null,
+      shard_count:
+        scope === "shard"
+          ? integer(required(args, "shard-count"), "shard-count", 1)
+          : null,
+      files,
     };
-    if (files.length === 0) throw new Error("Jest test-file inventory is empty");
+    if (files.length === 0)
+      throw new Error("Jest test-file inventory is empty");
     writeJson(required(args, "output"), value);
     return;
   }
@@ -505,7 +581,7 @@ function run(command, args) {
         status: required(args, "status"),
         durationMs: integer(required(args, "duration-ms"), "duration-ms"),
         exitCode: integer(required(args, "exit-code"), "exit-code"),
-        source: required(args, "source")
+        source: required(args, "source"),
       })
     );
     return;
@@ -525,7 +601,7 @@ function run(command, args) {
         shardCount: integer(required(args, "shard-count"), "shard-count", 1),
         durationMs: integer(required(args, "duration-ms"), "duration-ms"),
         exitCode: integer(required(args, "exit-code"), "exit-code"),
-        source: required(args, "source")
+        source: required(args, "source"),
       })
     );
     return;
@@ -547,7 +623,7 @@ module.exports = {
   jestRecord,
   manifestFromRaw,
   phaseRecord,
-  safeText
+  safeText,
 };
 
 if (require.main === module) {
@@ -556,7 +632,9 @@ if (require.main === module) {
     if (!command) throw new Error("A command is required");
     run(command, parseArgs(values));
   } catch (error) {
-    process.stderr.write(`${safeText(error instanceof Error ? error.message : error, 300)}\n`);
+    process.stderr.write(
+      `${safeText(error instanceof Error ? error.message : error, 300)}\n`
+    );
     process.exitCode = 2;
   }
 }

--- a/scripts/release-bus-report-progress.mjs
+++ b/scripts/release-bus-report-progress.mjs
@@ -6,6 +6,8 @@ const STAGES = ["lint", "typecheck", "unit_tests", "build"];
 const MAX_SUITES = 50;
 const MAX_TESTS = 100;
 const MAX_TEXT = 500;
+const MAX_FILES = 200;
+const MAX_DURATION_MS = 24 * 60 * 60 * 1000;
 const OUTCOME_STATUS = {
   success: "SUCCEEDED",
   failure: "FAILED",
@@ -71,7 +73,207 @@ function readJestSummary() {
   }
 }
 
+function safeDuration(value) {
+  if (!Number.isInteger(value) || value < 0 || value > MAX_DURATION_MS) {
+    throw new Error("Release Bus summary contains an invalid duration");
+  }
+  return value;
+}
+
+function strictCount(value, maximum) {
+  if (!Number.isInteger(value) || value < 0 || value > maximum) {
+    throw new Error("Release Bus summary contains an invalid count");
+  }
+  return value;
+}
+
+function safePath(value) {
+  const text = safeText(value);
+  const allowed =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._/@+-";
+  const segments = text?.split("/") ?? [];
+  if (
+    !text ||
+    text.length > MAX_TEXT ||
+    text.startsWith("/") ||
+    segments.some(
+      (segment) => !segment || segment === "." || segment === ".."
+    ) ||
+    Array.from(text).some((character) => !allowed.includes(character))
+  ) {
+    throw new Error("Release Bus summary contains an invalid path");
+  }
+  return text;
+}
+
+function safePathList(value) {
+  if (!Array.isArray(value) || value.length > MAX_FILES) {
+    throw new Error("Release Bus summary contains an invalid path list");
+  }
+  const paths = value.map(safePath);
+  if (new Set(paths).size !== paths.length) {
+    throw new Error("Release Bus summary path list contains duplicates");
+  }
+  return paths;
+}
+
+function isVersionedAggregate(value) {
+  return (
+    /^[a-f0-9]{40}$/.test(String(value?.base_sha ?? "")) &&
+    value?.environment === "orchestration" &&
+    /^[a-f0-9]{64}$/.test(String(value?.gate_fingerprint ?? "")) &&
+    /^[a-f0-9]{40}$/.test(String(value?.workflow_sha ?? "")) &&
+    /^[a-f0-9]{64}$/.test(String(value?.workflow_digest ?? "")) &&
+    typeof value?.node_version === "string" &&
+    value.node_version.length > 0 &&
+    value.node_version.length <= 64 &&
+    typeof value?.package_manager === "string" &&
+    value.package_manager.length > 0 &&
+    value.package_manager.length <= 128 &&
+    ["legacy", "shadow", "sharded"].includes(value?.gate_mode)
+  );
+}
+
+function projectAggregateProgress(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Release Bus aggregate summary is invalid");
+  }
+  const status = value.status === "SUCCEEDED" ? "SUCCEEDED" : "FAILED";
+  const phases = Array.isArray(value.phases) ? value.phases : [];
+  const stages = STAGES.map((name) => {
+    const phase = phases.find((item) => item?.name === name);
+    const phaseStatus = [
+      "PENDING",
+      "RUNNING",
+      "SUCCEEDED",
+      "FAILED",
+      "SKIPPED",
+    ].includes(phase?.status)
+      ? phase.status
+      : "FAILED";
+    return { name, status: phaseStatus };
+  });
+  const totals = value.totals ?? {};
+  const jest = projectJestSummary({
+    num_failed_test_suites: totals.failed_test_suites,
+    num_failed_tests: totals.failed_tests,
+    failing_suites: value.failing_suites,
+    failing_tests: value.failing_tests,
+  });
+  if (!isVersionedAggregate(value)) {
+    return { status, stages, jest, summary: null };
+  }
+  const artifactDigest = String(
+    process.env.RELEASE_BUS_SUMMARY_ARTIFACT_DIGEST ?? ""
+  ).replace(/^sha256:/, "");
+  if (!/^[a-f0-9]{64}$/.test(artifactDigest)) {
+    throw new Error("Release Bus summary artifact digest is invalid");
+  }
+  const phaseDurations = Object.fromEntries(
+    STAGES.map((name) => [name, safeDuration(value.phase_durations_ms?.[name])])
+  );
+  const durationValues = Object.values(phaseDurations);
+  const totalDuration =
+    value.gate_mode === "sharded"
+      ? Math.max(...durationValues)
+      : durationValues.reduce((total, duration) => total + duration, 0);
+  const shardCount = strictCount(value.shard_count, 256);
+  if (![1, 2, 4].includes(shardCount)) {
+    throw new Error("Release Bus shard count is invalid");
+  }
+  if (!Array.isArray(value.shards) || value.shards.length !== shardCount) {
+    throw new Error("Release Bus shard summary is incomplete");
+  }
+  const shards = value.shards.map((shard) => {
+    const index = strictCount(shard?.index, 255);
+    const count = strictCount(shard?.count, 256);
+    if (index < 1 || index > shardCount || count !== shardCount) {
+      throw new Error("Release Bus shard coordinate is invalid");
+    }
+    return {
+      index,
+      count,
+      coordinate: `${index}/${count}`,
+      status: ["PENDING", "RUNNING", "SUCCEEDED", "FAILED", "SKIPPED"].includes(
+        shard?.status
+      )
+        ? shard.status
+        : "FAILED",
+      duration_ms: safeDuration(shard?.duration_ms),
+      files: strictCount(shard?.counts?.test_files, 10_000_000),
+      test_suites: strictCount(shard?.counts?.test_suites, 10_000_000),
+      tests: strictCount(shard?.counts?.tests, 10_000_000),
+      failed_test_suites: strictCount(
+        shard?.counts?.failed_test_suites,
+        10_000_000
+      ),
+      failed_tests: strictCount(shard?.counts?.failed_tests, 10_000_000),
+    };
+  });
+  if (new Set(shards.map((shard) => shard.index)).size !== shardCount) {
+    throw new Error("Release Bus shard coordinates contain duplicates");
+  }
+  return {
+    status,
+    stages,
+    jest,
+    summary: {
+      base_sha: value.base_sha,
+      environment: value.environment,
+      gate_fingerprint: value.gate_fingerprint,
+      workflow_sha: value.workflow_sha,
+      workflow_digest: value.workflow_digest,
+      node_version: safeText(value.node_version),
+      package_manager: safeText(value.package_manager),
+      shard_count: shardCount,
+      summary_artifact_name: safePath(value.summary_artifact_name),
+      summary_artifact_digest: artifactDigest,
+      phase_durations_ms: {
+        ...phaseDurations,
+        total: safeDuration(totalDuration),
+      },
+      totals: {
+        files: strictCount(totals.test_files, 10_000_000),
+        test_suites: strictCount(totals.test_suites, 10_000_000),
+        tests: strictCount(totals.tests, 10_000_000),
+        failed_test_suites: strictCount(totals.failed_test_suites, 10_000_000),
+        failed_tests: strictCount(totals.failed_tests, 10_000_000),
+        skipped_tests: strictCount(
+          strictCount(totals.pending_tests, 10_000_000) +
+            strictCount(totals.todo_tests, 10_000_000),
+          10_000_000
+        ),
+      },
+      fresh_or_reused: "fresh",
+      shards,
+      missing_files: safePathList(value.missing_files),
+      duplicate_files: safePathList(value.duplicate_files),
+    },
+  };
+}
+
+function readAggregateProgress() {
+  const filename = process.env.RELEASE_BUS_AGGREGATE_SUMMARY;
+  if (!filename) return null;
+  if (!fs.existsSync(filename)) {
+    throw new Error("Release Bus aggregate summary is missing");
+  }
+  return projectAggregateProgress(
+    JSON.parse(fs.readFileSync(filename, "utf8"))
+  );
+}
+
 export function buildProgressPayload() {
+  const aggregate = readAggregateProgress();
+  if (aggregate) {
+    return {
+      train_id: process.env.RELEASE_BUS_TRAIN_ID,
+      operation_key: process.env.RELEASE_BUS_OPERATION_KEY,
+      workflow_run_id: process.env.GITHUB_RUN_ID,
+      phase: "complete",
+      ...aggregate,
+    };
+  }
   const stages =
     process.env.RELEASE_BUS_REPORT_INCLUDE_STAGES === "false"
       ? []


### PR DESCRIPTION
## Issue
- Frontend base-canary validation was a 38-minute serial critical path, while exact-SHA evidence and failure attribution had to remain fail-closed.

## Fix
- Split lint, typecheck, production build, complete Jest inventory, and deterministic Jest shards into parallel jobs with one fail-closed aggregate.
- Preserve exact workflow/source SHA provenance, content-addressed behavior identity, structured sanitized evidence, and no OpenAI dependency.

## Changes
- Use Jest `--shard=N/M --maxWorkers=2 --bail=0` with `fail-fast: false` and no validation retry or `--runInBand`.
- Prove every expected Jest file executes exactly once; reject missing, duplicate, unexpected, skipped, todo, failed, cancelled, or source-mutating results.
- Retain independently reversible `FRONTEND_GATE_SHARD_COUNT=1|2|4` and `RELEASE_BUS_FRONTEND_GATE_MODE=legacy|shadow|sharded` controls.
- Reconcile the bounded authorization transport helper from current main: 10-second connect, 30-second request, six same-payload attempts for ambiguous transport/408/429/5xx only.

## Validation
- Exact signed/DCO head: `ec9778811a1d8648257ea113aaa1987f06df5aea`; merge parents `5a118aeb78c324cdfe2ac66f31b9ac08fb6d4193` and main `24fa1dece50b226c9fb0e131b1c03c7a2dde0fad`.
- Staging train `d09a9f56-5668-43bf-a5fa-66a8936c3657` completed with composed frontend `0b949b4c9f88d87c7d55bc5c49b08959982347c3`; preflight, deploy, exact live version, and E2E succeeded.
- Exact integrated-head behavior digest `42b46aa01f3eab5a0c30d75e4e1b444112280cb6f81fae3f6b4736277f7d1d84`; workflow digest `7848d7fdd38d616dead13726a9ae65081bf883ce8e3b28750a6c2ce527a11de5`.
- Clean proof [29884080438](https://github.com/6529-Collections/6529seize-frontend/actions/runs/29884080438): 2,041 files/suites and 12,075 tests, all passed; zero pending/todo/missing/duplicate/unexpected/errors; summary artifact digest `sha256:2047893f841224320baae445cba30eeb73d2780a7065cd141a087ad9c3e2619e`.
- Injected proof [29884081334](https://github.com/6529-Collections/6529seize-frontend/actions/runs/29884081334): only final shard and aggregate failed; full inventory/counts remained exact; summary artifact digest `sha256:ac77be73416ac7ea0c091cb62c01731b508b33a88b80abdb7a98344006e2c18a`.
- Local shell syntax, contract 29/29, lint:changed, typecheck:changed, and diff checks passed.

## Risk
- Level: Medium. This changes a release-control workflow, but the deployed worker inputs and authorization payload are unchanged and the exact candidate was staged successfully.
- Rollback: set one shard or legacy mode without redeployment; code rollback remains available.

## Review Notes
- Review the aggregate failure conditions, exact immutable workflow-tool staging, source-mutation checks, and bounded authorization retry semantics.