### PR TITLE
Fix Release Bus staging artifact endpoint

### DIFF
--- a/.github/workflows/release-bus-deploy-staging.yml
+++ b/.github/workflows/release-bus-deploy-staging.yml
@@ -23,6 +23,7 @@ concurrency:
 env:
   AWS_REGION: ${{ vars.STAGING_AWS_REGION || 'eu-west-1' }}
   ARTIFACT_BUCKET: ${{ vars.RELEASE_BUS_ARTIFACT_BUCKET || 'seize-web' }}
+  ARTIFACT_BUCKET_REGION: ${{ vars.RELEASE_BUS_ARTIFACT_BUCKET_REGION || 'us-east-1' }}
   STAGING_REPO_DIR: ${{ vars.STAGING_REPO_DIR || '/home/ubuntu/6529seize-frontend' }}
   STAGING_RUN_AS: ${{ vars.STAGING_RUN_AS || 'ubuntu' }}
 
@@ -121,10 +122,14 @@ jobs:
           [[ "$TRAIN_ID" =~ ^[A-Za-z0-9._-]{1,100}$ ]]
           [[ "$TRAIN_REVISION" =~ ^[1-9][0-9]{0,8}$ ]]
           [[ "$PACKAGE_DIGEST" =~ ^[a-f0-9]{64}$ ]]
+          [[ "$ARTIFACT_BUCKET_REGION" =~ ^[a-z]{2}(-gov)?-[a-z]+-[1-9][0-9]*$ ]]
           object_key="release-bus/${TRAIN_ID}/r${TRAIN_REVISION}/staging/frontend/${EXPECTED_SHA}.zip"
           aws s3 cp release-bus-artifact/target/package.zip "s3://${ARTIFACT_BUCKET}/${object_key}" \
+            --region "$ARTIFACT_BUCKET_REGION" \
             --metadata "sha256=${PACKAGE_DIGEST},source-sha=${EXPECTED_SHA}"
-          url="$(aws s3 presign "s3://${ARTIFACT_BUCKET}/${object_key}" --expires-in 7200)"
+          url="$(aws s3 presign "s3://${ARTIFACT_BUCKET}/${object_key}" \
+            --region "$ARTIFACT_BUCKET_REGION" \
+            --expires-in 7200)"
           echo "url=$url" >> "$GITHUB_OUTPUT"
       - name: Deploy immutable bundle through SSM
         id: send-command
@@ -151,7 +156,11 @@ jobs:
           current_link="$release_root/current"
           previous_target="$(readlink "$current_link" 2>/dev/null || true)"
           install -d -o "$RUN_AS" -g "$RUN_AS" "$release_dir"
-          curl --fail --silent --show-error --location "$ARTIFACT_URL" -o "$release_dir/package.zip"
+          http_status="$(curl --silent --show-error --proto '=https' \
+            --output "$release_dir/package.zip" \
+            --write-out '%{http_code}' \
+            "$ARTIFACT_URL")"
+          test "$http_status" = 200
           echo "$EXPECTED_DIGEST  $release_dir/package.zip" | sha256sum -c -
           rm -rf "$release_dir/app"
           install -d -o "$RUN_AS" -g "$RUN_AS" "$release_dir/app"

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -78,6 +78,40 @@ describe("release bus immutable frontend artifact", () => {
   });
 });
 
+describe("release bus staging artifact transfer", () => {
+  const deployWorkflow = YAML.parse(
+    fs.readFileSync(
+      path.join(
+        process.cwd(),
+        ".github/workflows/release-bus-deploy-staging.yml"
+      ),
+      "utf8"
+    )
+  );
+
+  it("uses the bucket region and rejects redirect bodies before activation", () => {
+    const stageStep = deployWorkflow.jobs.deploy.steps.find(
+      (step: { name?: string }) =>
+        step.name === "Stage artifact for the managed instance"
+    );
+    const deployStep = deployWorkflow.jobs.deploy.steps.find(
+      (step: { name?: string }) =>
+        step.name === "Deploy immutable bundle through SSM"
+    );
+
+    expect(deployWorkflow.env.ARTIFACT_BUCKET_REGION).toContain("us-east-1");
+    expect(
+      stageStep.run.match(/--region "\$ARTIFACT_BUCKET_REGION"/g)
+    ).toHaveLength(2);
+    expect(deployStep.run).not.toContain("curl --fail");
+    expect(deployStep.run).toContain("--write-out '%{http_code}'");
+    expect(deployStep.run).toContain('test "$http_status" = 200');
+    expect(deployStep.run.indexOf('test "$http_status" = 200')).toBeLessThan(
+      deployStep.run.indexOf("sha256sum -c -")
+    );
+  });
+});
+
 function releaseArtifact(uri, metadata) {
   return {
     uri,


### PR DESCRIPTION
## What changed

- bind Release Bus staging artifact upload and presigning to the configured artifact-bucket region (`us-east-1` by default)
- require the managed-instance download to return HTTP 200 before the existing SHA-256 check and before any activation step
- add a workflow contract test for region binding and fail-closed ordering

## Root cause

Staging train `9f8e5f8b-c82c-42f4-9af3-01e3da24967a` generated a presigned URL against the `eu-west-1` endpoint for the `seize-web` bucket, which is in `us-east-1`. The managed instance saved a 455-byte `PermanentRedirect` XML response. The existing digest guard correctly stopped before unzip, symlink, or PM2 activation.

## Validation

- `jest __tests__/scripts/deployment-bus.test.ts --runInBand` — 49/49 passed
- Prettier check — passed
- ESLint — passed
- read-only live transfer probe on the staging instance downloaded 84,338,781 bytes with SHA-256 `b6e16be9550af2f6cefed8738076f629aa80b0166834569fbfb234ff0df530d4`, exactly matching the immutable S3 object
- commit is signed and DCO-signed-off

No application or staging ref change is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved staging deployments by ensuring artifact uploads and downloads use the configured bucket region.
  - Added explicit HTTP status validation before deployment artifacts are processed, preventing incomplete or unsuccessful downloads from continuing.

- **Tests**
  - Added automated checks to verify regional artifact handling and download status validation in staging deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->