### PR TITLE
Bootstrap sharded frontend base canary

### DIFF
--- a/.github/workflows/release-bus-base-canary.yml
+++ b/.github/workflows/release-bus-base-canary.yml
@@ -8,6 +8,24 @@ on:
       operation_key: { type: string, required: true }
       base_sha: { type: string, required: true }
       expected_sha: { type: string, required: true }
+      gate_contract: { type: string, required: false, default: "" }
+      validation_only: { type: boolean, required: false, default: false }
+      validation_gate_mode:
+        {
+          type: choice,
+          required: false,
+          default: "shadow",
+          options: [shadow, sharded],
+        }
+      validation_shard_count:
+        {
+          type: choice,
+          required: false,
+          default: "4",
+          options: ["1", "2", "4"],
+        }
+      validation_inject_failure:
+        { type: boolean, required: false, default: false }
 
 permissions: {}
 
@@ -17,16 +35,30 @@ jobs:
   authorize:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    outputs:
+      gate_mode: ${{ steps.inputs.outputs.gate_mode }}
+      shard_count: ${{ steps.inputs.outputs.shard_count }}
+      shard_matrix: ${{ steps.inputs.outputs.shard_matrix }}
+      gate_fingerprint: ${{ steps.fingerprint.outputs.gate_fingerprint }}
+      behavior_digest: ${{ steps.fingerprint.outputs.behavior_digest }}
+      workflow_sha: ${{ steps.fingerprint.outputs.workflow_sha }}
+      workflow_digest: ${{ steps.fingerprint.outputs.workflow_digest }}
+      evidence_environment: ${{ steps.fingerprint.outputs.evidence_environment }}
+      package_manager: ${{ steps.fingerprint.outputs.package_manager }}
     steps:
-      - name: Validate and authorize immutable inputs
+      - name: Validate immutable inputs
+        id: inputs
         env:
           BASE_SHA: ${{ inputs.base_sha }}
           EXPECTED_SHA: ${{ inputs.expected_sha }}
+          GATE_CONTRACT_INPUT: ${{ inputs.gate_contract }}
           OPERATION_KEY: ${{ inputs.operation_key }}
-          RELEASE_BUS_API_URL: ${{ vars.RELEASE_BUS_API_URL }}
-          RELEASE_BUS_WORKFLOW_AUTH_TOKEN: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
           TRAIN_ID: ${{ inputs.release_train_id }}
           TRAIN_REVISION: ${{ inputs.release_train_revision }}
+          VALIDATION_GATE_MODE: ${{ inputs.validation_gate_mode }}
+          VALIDATION_INJECT_FAILURE: ${{ inputs.validation_inject_failure }}
+          VALIDATION_ONLY: ${{ inputs.validation_only }}
+          VALIDATION_SHARD_COUNT: ${{ inputs.validation_shard_count }}
         run: |
           set -euo pipefail
           [[ "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]]
@@ -34,21 +66,49 @@ jobs:
           [[ "$TRAIN_ID" =~ ^[A-Za-z0-9._-]{1,100}$ ]]
           [[ "$TRAIN_REVISION" =~ ^[1-9][0-9]{0,8}$ ]]
           [[ "$OPERATION_KEY" =~ ^[A-Za-z0-9:._-]{1,180}$ ]]
-          payload="$(jq -n --arg train_id "$TRAIN_ID" --arg operation_key "$OPERATION_KEY" --arg workflow_run_id "$GITHUB_RUN_ID" --arg expected_sha "$EXPECTED_SHA" '{train_id:$train_id,operation_key:$operation_key,workflow_run_id:$workflow_run_id,artifact_run_id:null,repository:"frontend",environment:"orchestration",service:null,expected_sha:$expected_sha,artifact_digest:null}')"
-          curl --fail-with-body --silent --show-error \
-            -H "Authorization: Bearer $RELEASE_BUS_WORKFLOW_AUTH_TOKEN" \
-            -H 'Content-Type: application/json' \
-            --data "$payload" \
-            "$RELEASE_BUS_API_URL/deploy/release-bus/authorize"
-
-  gate:
-    needs: authorize
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    permissions:
-      contents: read
-    steps:
-      - name: Check out exact frontend base
+          [[ "$VALIDATION_INJECT_FAILURE" =~ ^(true|false)$ ]]
+          if [ "$VALIDATION_INJECT_FAILURE" = true ]; then
+            test "$VALIDATION_ONLY" = true
+          fi
+          if [ "$VALIDATION_ONLY" = true ]; then
+            test -z "$GATE_CONTRACT_INPUT"
+            GATE_MODE="$VALIDATION_GATE_MODE"
+            FRONTEND_GATE_SHARD_COUNT="$VALIDATION_SHARD_COUNT"
+          elif [ -n "$GATE_CONTRACT_INPUT" ]; then
+            test "${#GATE_CONTRACT_INPUT}" -le 10000
+            jq -e \
+              --arg base_sha "$BASE_SHA" \
+              --arg workflow_sha "$GITHUB_SHA" \
+              'type == "object" and
+               .schema_version == 1 and
+               .repository == "frontend" and
+               .environment == "orchestration" and
+               .base_sha == $base_sha and
+               .workflow_sha == $workflow_sha and
+               .node_version == "22" and
+               (.gate_mode | IN("legacy", "shadow", "sharded")) and
+               (.shard_count | IN(1, 2, 4))' \
+              <<< "$GATE_CONTRACT_INPUT" >/dev/null
+            GATE_MODE="$(jq -r '.gate_mode' <<< "$GATE_CONTRACT_INPUT")"
+            FRONTEND_GATE_SHARD_COUNT="$(jq -r '.shard_count' <<< "$GATE_CONTRACT_INPUT")"
+          else
+            GATE_MODE="${{ vars.RELEASE_BUS_FRONTEND_GATE_MODE || 'legacy' }}"
+            FRONTEND_GATE_SHARD_COUNT="${{ vars.FRONTEND_GATE_SHARD_COUNT || '1' }}"
+          fi
+          [[ "$GATE_MODE" =~ ^(legacy|shadow|sharded)$ ]]
+          [[ "$FRONTEND_GATE_SHARD_COUNT" =~ ^(1|2|4)$ ]]
+          case "$FRONTEND_GATE_SHARD_COUNT" in
+            1) shard_matrix='{"include":[{"index":1,"total":1}]}' ;;
+            2) shard_matrix='{"include":[{"index":1,"total":2},{"index":2,"total":2}]}' ;;
+            4) shard_matrix='{"include":[{"index":1,"total":4},{"index":2,"total":4},{"index":3,"total":4},{"index":4,"total":4}]}' ;;
+          esac
+          {
+            echo "gate_mode=$GATE_MODE"
+            echo "shard_count=$FRONTEND_GATE_SHARD_COUNT"
+            echo "shard_matrix=$shard_matrix"
+          } >> "$GITHUB_OUTPUT"
+      - &checkout
+        name: Check out exact frontend base
         env:
           BASE_SHA: ${{ inputs.base_sha }}
         run: |
@@ -59,23 +119,137 @@ jobs:
           git fetch --no-tags origin "$BASE_SHA"
           git checkout --detach "$BASE_SHA"
           test "$(git rev-parse HEAD)" = "$BASE_SHA"
-      - name: Install Node.js
+      - &setup-node
+        name: Install Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with: { node-version: "22" }
-      - name: Activate pinned pnpm
+      - name: Derive and verify immutable gate fingerprint
+        id: fingerprint
+        env:
+          BASE_SHA: ${{ inputs.base_sha }}
+          GATE_CONTRACT_INPUT: ${{ inputs.gate_contract }}
+          GATE_MODE: ${{ steps.inputs.outputs.gate_mode }}
+          SHARD_COUNT: ${{ steps.inputs.outputs.shard_count }}
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$WORKFLOW_SHA" =~ ^[a-f0-9]{40}$ ]]
+          git cat-file -e "$WORKFLOW_SHA^{commit}" 2>/dev/null || \
+            git fetch --no-tags origin "$WORKFLOW_SHA"
+          evidence_tool="$RUNNER_TEMP/release-bus-gate-evidence.cjs"
+          contract="$RUNNER_TEMP/release-bus-gate-contract.json"
+          git show "$WORKFLOW_SHA:scripts/release-bus-gate-evidence.cjs" > "$evidence_tool"
+          node "$evidence_tool" fingerprint \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --base-sha "$BASE_SHA" \
+            --workflow-sha "$WORKFLOW_SHA" \
+            --mode "$GATE_MODE" \
+            --shard-count "$SHARD_COUNT" \
+            --output "$contract"
+          gate_fingerprint="$(jq -r '.gate_fingerprint' "$contract")"
+          behavior_digest="$(jq -r '.behavior_digest' "$contract")"
+          workflow_digest="$(jq -r '.workflow_digest' "$contract")"
+          package_manager="$(jq -r '.package_manager' "$contract")"
+          if [ -n "$GATE_CONTRACT_INPUT" ]; then
+            test "$(jq -r '.gate_fingerprint' <<< "$GATE_CONTRACT_INPUT")" = "$gate_fingerprint"
+            test "$(jq -r '.workflow_digest' <<< "$GATE_CONTRACT_INPUT")" = "$workflow_digest"
+            test "$(jq -r '.package_manager' <<< "$GATE_CONTRACT_INPUT")" = "$package_manager"
+          fi
+          {
+            echo "gate_fingerprint=$gate_fingerprint"
+            echo "behavior_digest=$behavior_digest"
+            echo "workflow_sha=$WORKFLOW_SHA"
+            echo "workflow_digest=$workflow_digest"
+            echo "evidence_environment=orchestration"
+            echo "package_manager=$package_manager"
+          } >> "$GITHUB_OUTPUT"
+      - name: Authorize Release Bus operation
+        if: inputs.validation_only != true
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          OPERATION_KEY: ${{ inputs.operation_key }}
+          RELEASE_BUS_API_URL: ${{ vars.RELEASE_BUS_API_URL }}
+          RELEASE_BUS_WORKFLOW_AUTH_TOKEN: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
+          TRAIN_ID: ${{ inputs.release_train_id }}
+        run: |
+          set -euo pipefail
+          payload="$(jq -n --arg train_id "$TRAIN_ID" --arg operation_key "$OPERATION_KEY" --arg workflow_run_id "$GITHUB_RUN_ID" --arg expected_sha "$EXPECTED_SHA" '{train_id:$train_id,operation_key:$operation_key,workflow_run_id:$workflow_run_id,artifact_run_id:null,repository:"frontend",environment:"orchestration",service:null,expected_sha:$expected_sha,artifact_digest:null}')"
+          curl --fail-with-body --silent --show-error \
+            -H "Authorization: Bearer $RELEASE_BUS_WORKFLOW_AUTH_TOKEN" \
+            -H 'Content-Type: application/json' \
+            --data "$payload" \
+            "$RELEASE_BUS_API_URL/deploy/release-bus/authorize"
+      - name: Verify authorization did not mutate source
+        run: test -z "$(git status --porcelain --untracked-files=all)"
+
+  legacy:
+    if: needs.authorize.outputs.gate_mode != 'sharded'
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - *checkout
+      - &stage-tooling
+        name: Stage immutable gate tooling
+        env:
+          BASE_SHA: ${{ inputs.base_sha }}
+          EVIDENCE_ENVIRONMENT: ${{ needs.authorize.outputs.evidence_environment }}
+          GATE_FINGERPRINT: ${{ needs.authorize.outputs.gate_fingerprint }}
+          PACKAGE_MANAGER: ${{ needs.authorize.outputs.package_manager }}
+          WORKFLOW_SHA: ${{ needs.authorize.outputs.workflow_sha }}
+          WORKFLOW_DIGEST: ${{ needs.authorize.outputs.workflow_digest }}
+        run: |
+          set -euo pipefail
+          [[ "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]]
+          test "$EVIDENCE_ENVIRONMENT" = orchestration
+          [[ "$GATE_FINGERPRINT" =~ ^[a-f0-9]{64}$ ]]
+          [[ "$PACKAGE_MANAGER" =~ ^pnpm@[A-Za-z0-9.+-]{1,122}$ ]]
+          [[ "$WORKFLOW_SHA" =~ ^[a-f0-9]{40}$ ]]
+          [[ "$WORKFLOW_DIGEST" =~ ^[a-f0-9]{64}$ ]]
+          git cat-file -e "$WORKFLOW_SHA^{commit}" 2>/dev/null || \
+            git fetch --no-tags origin "$WORKFLOW_SHA"
+          tooling="$RUNNER_TEMP/release-bus-tooling/scripts"
+          mkdir -p "$tooling"
+          for file in \
+            scripts/release-bus-frontend-gate.sh \
+            scripts/release-bus-gate-evidence.cjs
+          do
+            git show "$WORKFLOW_SHA:$file" > "$RUNNER_TEMP/release-bus-tooling/$file"
+          done
+          chmod +x "$tooling/release-bus-frontend-gate.sh"
+          {
+            echo "RELEASE_BUS_GATE_TOOL=$tooling/release-bus-frontend-gate.sh"
+            echo "RELEASE_BUS_EVIDENCE_TOOL=$tooling/release-bus-gate-evidence.cjs"
+            echo "RELEASE_BUS_BASE_SHA=$BASE_SHA"
+            echo "RELEASE_BUS_EVIDENCE_ENVIRONMENT=$EVIDENCE_ENVIRONMENT"
+            echo "RELEASE_BUS_GATE_FINGERPRINT=$GATE_FINGERPRINT"
+            echo "RELEASE_BUS_WORKFLOW_SHA=$WORKFLOW_SHA"
+            echo "RELEASE_BUS_WORKFLOW_DIGEST=$WORKFLOW_DIGEST"
+            echo "RELEASE_BUS_NODE_VERSION=22"
+            echo "RELEASE_BUS_PACKAGE_MANAGER=$PACKAGE_MANAGER"
+          } >> "$GITHUB_ENV"
+      - *setup-node
+      - &activate-pnpm
+        name: Activate pinned pnpm
         run: |
           corepack enable pnpm
           corepack prepare "$(node -p 'require("./package.json").packageManager')" --activate
-      - name: Install Socket Firewall
+      - &socket-firewall
+        name: Install Socket Firewall
         id: socket-firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
         with: { mode: firewall }
-      - name: Install frozen dependencies
+      - &install
+        name: Install frozen dependencies
         env:
           SFW_BIN: ${{ steps.socket-firewall.outputs.firewall-path-binary }}
         run: ./bin/6529 install:frozen
-      - name: Run exact-base Release Bus gate
-        env:
+      - name: Run authoritative serial gate
+        id: gate
+        continue-on-error: true
+        env: &build-env
           NODE_ENV: production
           API_ENDPOINT: https://api.staging.6529.io
           WS_ENDPOINT: wss://ws.staging.6529.io
@@ -97,6 +271,321 @@ jobs:
           ASSETS_FROM_S3: "false"
           SENTRY_AUTH_TOKEN: ""
           SENTRY_DSN: ""
-        run: ./scripts/release-bus-frontend-gate.sh full
-      - name: Verify gate did not mutate source
-        run: git diff --exit-code
+        run: RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE" "$RELEASE_BUS_GATE_TOOL" serial "$RUNNER_TEMP/release-bus-evidence"
+      - &source-mutation
+        name: Verify gate did not mutate source
+        id: source-mutation
+        if: always()
+        run: test -z "$(git status --porcelain --untracked-files=all)"
+      - name: Upload serial evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-bus-base-canary-legacy-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-evidence/*.json
+          if-no-files-found: error
+          retention-days: 14
+      - name: Return authoritative serial result
+        if: always()
+        env:
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+          MUTATION_OUTCOME: ${{ steps.source-mutation.outcome }}
+        run: test "$GATE_OUTCOME" = success -a "$MUTATION_OUTCOME" = success
+
+  lint:
+    if: needs.authorize.outputs.gate_mode != 'legacy'
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - *checkout
+      - *stage-tooling
+      - *setup-node
+      - *activate-pnpm
+      - *socket-firewall
+      - *install
+      - name: Run lint
+        id: gate
+        continue-on-error: true
+        run: RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE" "$RELEASE_BUS_GATE_TOOL" phase lint "$RUNNER_TEMP/release-bus-evidence"
+      - *source-mutation
+      - name: Upload lint evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-bus-base-canary-lint-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-evidence/*.json
+          if-no-files-found: error
+          retention-days: 14
+      - name: Return lint result
+        if: always()
+        env:
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+          MUTATION_OUTCOME: ${{ steps.source-mutation.outcome }}
+        run: test "$GATE_OUTCOME" = success -a "$MUTATION_OUTCOME" = success
+
+  typecheck:
+    if: needs.authorize.outputs.gate_mode != 'legacy'
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - *checkout
+      - *stage-tooling
+      - *setup-node
+      - *activate-pnpm
+      - *socket-firewall
+      - *install
+      - name: Run typecheck
+        id: gate
+        continue-on-error: true
+        run: RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE" "$RELEASE_BUS_GATE_TOOL" phase typecheck "$RUNNER_TEMP/release-bus-evidence"
+      - *source-mutation
+      - name: Upload typecheck evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-bus-base-canary-typecheck-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-evidence/*.json
+          if-no-files-found: error
+          retention-days: 14
+      - name: Return typecheck result
+        if: always()
+        env:
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+          MUTATION_OUTCOME: ${{ steps.source-mutation.outcome }}
+        run: test "$GATE_OUTCOME" = success -a "$MUTATION_OUTCOME" = success
+
+  production-build:
+    if: needs.authorize.outputs.gate_mode != 'legacy'
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - *checkout
+      - *stage-tooling
+      - *setup-node
+      - *activate-pnpm
+      - *socket-firewall
+      - *install
+      - name: Run production build
+        id: gate
+        continue-on-error: true
+        env: *build-env
+        run: RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE" "$RELEASE_BUS_GATE_TOOL" phase build "$RUNNER_TEMP/release-bus-evidence"
+      - *source-mutation
+      - name: Upload build evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-bus-base-canary-build-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-evidence/*.json
+          if-no-files-found: error
+          retention-days: 14
+      - name: Return build result
+        if: always()
+        env:
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+          MUTATION_OUTCOME: ${{ steps.source-mutation.outcome }}
+        run: test "$GATE_OUTCOME" = success -a "$MUTATION_OUTCOME" = success
+
+  jest-inventory:
+    if: needs.authorize.outputs.gate_mode != 'legacy'
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - *checkout
+      - *stage-tooling
+      - *setup-node
+      - *activate-pnpm
+      - *socket-firewall
+      - *install
+      - name: Capture complete Jest inventory
+        id: gate
+        continue-on-error: true
+        run: RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE" "$RELEASE_BUS_GATE_TOOL" inventory "$RUNNER_TEMP/release-bus-evidence"
+      - *source-mutation
+      - name: Upload complete Jest inventory
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-bus-base-canary-inventory-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-evidence/*.json
+          if-no-files-found: error
+          retention-days: 14
+      - name: Return inventory result
+        if: always()
+        env:
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+          MUTATION_OUTCOME: ${{ steps.source-mutation.outcome }}
+        run: test "$GATE_OUTCOME" = success -a "$MUTATION_OUTCOME" = success
+
+  jest:
+    if: needs.authorize.outputs.gate_mode != 'legacy'
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.authorize.outputs.shard_matrix) }}
+    name: Jest shard ${{ matrix.index }}/${{ matrix.total }}
+    steps:
+      - *checkout
+      - *stage-tooling
+      - *setup-node
+      - *activate-pnpm
+      - *socket-firewall
+      - *install
+      - name: Run complete deterministic Jest shard
+        id: gate
+        continue-on-error: true
+        env:
+          RELEASE_BUS_INJECT_SHARD_FAILURE: ${{ inputs.validation_inject_failure && '1' || '0' }}
+        run: RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE" "$RELEASE_BUS_GATE_TOOL" jest "${{ matrix.index }}" "${{ matrix.total }}" "$RUNNER_TEMP/release-bus-evidence"
+      - *source-mutation
+      - name: Upload sanitized shard evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-bus-base-canary-jest-${{ matrix.index }}-of-${{ matrix.total }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-evidence/*.json
+          if-no-files-found: error
+          retention-days: 14
+      - name: Return first-run shard result
+        if: always()
+        env:
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+          MUTATION_OUTCOME: ${{ steps.source-mutation.outcome }}
+        run: test "$GATE_OUTCOME" = success -a "$MUTATION_OUTCOME" = success
+
+  aggregate:
+    if: always() && needs.authorize.result == 'success'
+    needs:
+      [
+        authorize,
+        legacy,
+        lint,
+        typecheck,
+        production-build,
+        jest-inventory,
+        jest,
+      ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - *checkout
+      - *stage-tooling
+      - *setup-node
+      - *activate-pnpm
+      - *socket-firewall
+      - *install
+      - name: Download all gate evidence
+        id: evidence-download
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: release-bus-base-canary-*-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-evidence
+      - name: Capture public job links
+        if: always()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          curl --fail-with-body --silent --show-error \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs?filter=latest&per_page=100" \
+            > "$RUNNER_TEMP/release-bus-jobs.json"
+      - name: Aggregate fail-closed evidence
+        id: aggregate
+        if: always()
+        continue-on-error: true
+        env:
+          BASE_SHA: ${{ inputs.base_sha }}
+          BUILD_RESULT: ${{ needs.production-build.result }}
+          INVENTORY_RESULT: ${{ needs.jest-inventory.result }}
+          JEST_RESULT: ${{ needs.jest.result }}
+          LEGACY_RESULT: ${{ needs.legacy.result }}
+          LINT_RESULT: ${{ needs.lint.result }}
+          PASSED_GATE_FINGERPRINT: ${{ needs.authorize.outputs.gate_fingerprint }}
+          PASSED_BEHAVIOR_DIGEST: ${{ needs.authorize.outputs.behavior_digest }}
+          PASSED_PACKAGE_MANAGER: ${{ needs.authorize.outputs.package_manager }}
+          PASSED_WORKFLOW_DIGEST: ${{ needs.authorize.outputs.workflow_digest }}
+          TYPECHECK_RESULT: ${{ needs.typecheck.result }}
+        run: |
+          set -euo pipefail
+          [[ "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]]
+          contract="$RUNNER_TEMP/release-bus-gate-contract.json"
+          node "$RELEASE_BUS_EVIDENCE_TOOL" fingerprint \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --base-sha "$BASE_SHA" \
+            --workflow-sha "${{ needs.authorize.outputs.workflow_sha }}" \
+            --mode "${{ needs.authorize.outputs.gate_mode }}" \
+            --shard-count "${{ needs.authorize.outputs.shard_count }}" \
+            --output "$contract"
+          gate_fingerprint="$(jq -r '.gate_fingerprint' "$contract")"
+          behavior_digest="$(jq -r '.behavior_digest' "$contract")"
+          workflow_digest="$(jq -r '.workflow_digest' "$contract")"
+          package_manager="$(jq -r '.package_manager' "$contract")"
+          test "$PASSED_GATE_FINGERPRINT" = "$gate_fingerprint"
+          test "$PASSED_BEHAVIOR_DIGEST" = "$behavior_digest"
+          test "$PASSED_WORKFLOW_DIGEST" = "$workflow_digest"
+          test "$PASSED_PACKAGE_MANAGER" = "$package_manager"
+          jq -n \
+            --arg legacy "$LEGACY_RESULT" \
+            --arg lint "$LINT_RESULT" \
+            --arg typecheck "$TYPECHECK_RESULT" \
+            --arg build "$BUILD_RESULT" \
+            --arg inventory "$INVENTORY_RESULT" \
+            --arg jest "$JEST_RESULT" \
+            '{legacy:$legacy,lint:$lint,typecheck:$typecheck,build:$build,inventory:$inventory,jest:$jest}' \
+            > "$RUNNER_TEMP/release-bus-job-results.json"
+          node "$RELEASE_BUS_EVIDENCE_TOOL" aggregate \
+            --mode "${{ needs.authorize.outputs.gate_mode }}" \
+            --shard-count "${{ needs.authorize.outputs.shard_count }}" \
+            --evidence-root "$RUNNER_TEMP/release-bus-evidence" \
+            --job-results "$RUNNER_TEMP/release-bus-job-results.json" \
+            --base-sha "$BASE_SHA" \
+            --environment "${{ needs.authorize.outputs.evidence_environment }}" \
+            --gate-fingerprint "$gate_fingerprint" \
+            --behavior-digest "$behavior_digest" \
+            --workflow-sha "${{ needs.authorize.outputs.workflow_sha }}" \
+            --workflow-digest "$workflow_digest" \
+            --node-version "22" \
+            --package-manager "$package_manager" \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --jobs-file "$RUNNER_TEMP/release-bus-jobs.json" \
+            --artifact-name "release-bus-base-canary-summary-$GITHUB_RUN_ID" \
+            --output "$RUNNER_TEMP/release-bus-base-canary-summary.json"
+      - name: Upload deterministic aggregate summary
+        id: summary-artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-bus-base-canary-summary-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-base-canary-summary.json
+          if-no-files-found: error
+          retention-days: 14
+      - *source-mutation
+      - name: Return aggregate result
+        if: always()
+        env:
+          AGGREGATE_OUTCOME: ${{ steps.aggregate.outcome }}
+          MUTATION_OUTCOME: ${{ steps.source-mutation.outcome }}
+        run: test "$AGGREGATE_OUTCOME" = success -a "$MUTATION_OUTCOME" = success

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
+import { parse as parseYaml } from "yaml";
 
 const read = (relativePath: string) =>
   fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
@@ -13,9 +14,52 @@ describe("Release Bus frontend gate contract", () => {
   const canary = read(".github/workflows/release-bus-base-canary.yml");
   const appPrCi = read(".github/workflows/app-pr-ci.yml");
 
+  type WorkflowStep = {
+    env?: Record<string, string>;
+    name?: string;
+    run?: string;
+  };
+
+  const canaryWorkflow = parseYaml(canary) as {
+    on?: {
+      workflow_dispatch?: {
+        inputs?: Record<string, { required?: boolean }>;
+      };
+    };
+    jobs?: Record<string, { steps?: WorkflowStep[] }>;
+  };
+
+  it("keeps deployed worker dispatch and authorization backward compatible", () => {
+    const inputs = canaryWorkflow.on?.workflow_dispatch?.inputs ?? {};
+    expect(
+      Object.entries(inputs)
+        .filter(([, contract]) => contract.required === true)
+        .map(([name]) => name)
+        .sort()
+    ).toEqual(
+      [
+        "base_sha",
+        "expected_sha",
+        "operation_key",
+        "release_train_id",
+        "release_train_revision",
+      ].sort()
+    );
+    expect(inputs.gate_contract?.required).toBe(false);
+    expect(inputs.validation_only?.required).toBe(false);
+    expect(canary).toContain(
+      '\'{train_id:$train_id,operation_key:$operation_key,workflow_run_id:$workflow_run_id,artifact_run_id:null,repository:"frontend",environment:"orchestration",service:null,expected_sha:$expected_sha,artifact_digest:null}\''
+    );
+    expect(canary).toContain(
+      "$RELEASE_BUS_API_URL/deploy/release-bus/authorize"
+    );
+    expect(canary).not.toContain("/deploy/release-bus/report-progress");
+    expect(canary).not.toContain("release-bus-report-progress.mjs");
+  });
+
   it("owns the only Release Bus Jest invocation", () => {
     expect(gate).toContain(
-      '"$SEIZE_BIN" run test:no-coverage --runInBand "$@"'
+      '"$SEIZE_BIN" run test:no-coverage --runInBand --bail=0 "$@"'
     );
     expect(gate).not.toContain("test:no-coverage -- --runInBand");
 
@@ -52,9 +96,66 @@ describe("Release Bus frontend gate contract", () => {
         "run",
         "test:no-coverage",
         "--runInBand",
+        "--bail=0",
         "--runTestsByPath",
         "__tests__/scripts/release-bus-frontend-gate.test.ts",
+        "__tests__/scripts/release-bus-gate-evidence.test.ts",
+        "__tests__/scripts/release-bus-shard-injection.test.ts",
       ]);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("binds immutable identity to emitted phase evidence", () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "release-bus-evidence-")
+    );
+    const runner = path.join(tempDir, "fake-6529");
+    const outputDir = path.join(tempDir, "evidence");
+    const identity = {
+      RELEASE_BUS_BASE_SHA: "a".repeat(40),
+      RELEASE_BUS_EVIDENCE_ENVIRONMENT: "orchestration",
+      RELEASE_BUS_GATE_FINGERPRINT: "b".repeat(64),
+      RELEASE_BUS_WORKFLOW_SHA: "c".repeat(40),
+      RELEASE_BUS_WORKFLOW_DIGEST: "d".repeat(64),
+      RELEASE_BUS_NODE_VERSION: "22",
+      RELEASE_BUS_PACKAGE_MANAGER: "pnpm@10.14.0",
+    };
+    try {
+      fs.writeFileSync(runner, "#!/usr/bin/env bash\nexit 0\n");
+      fs.chmodSync(runner, 0o755);
+
+      execFileSync(
+        "bash",
+        ["scripts/release-bus-frontend-gate.sh", "phase", "lint", outputDir],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...process.env,
+            ...identity,
+            RELEASE_BUS_6529_BIN: runner,
+          },
+        }
+      );
+
+      expect(
+        JSON.parse(
+          fs.readFileSync(path.join(outputDir, "phase-lint.json"), "utf8")
+        )
+      ).toMatchObject({
+        kind: "phase",
+        source: "parallel",
+        name: "lint",
+        status: "SUCCEEDED",
+        base_sha: identity.RELEASE_BUS_BASE_SHA,
+        environment: identity.RELEASE_BUS_EVIDENCE_ENVIRONMENT,
+        gate_fingerprint: identity.RELEASE_BUS_GATE_FINGERPRINT,
+        workflow_sha: identity.RELEASE_BUS_WORKFLOW_SHA,
+        workflow_digest: identity.RELEASE_BUS_WORKFLOW_DIGEST,
+        node_version: identity.RELEASE_BUS_NODE_VERSION,
+        package_manager: identity.RELEASE_BUS_PACKAGE_MANAGER,
+      });
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
@@ -65,9 +166,89 @@ describe("Release Bus frontend gate contract", () => {
       "./scripts/release-bus-frontend-gate.sh validate"
     );
     expect(isolation).toContain("./scripts/release-bus-frontend-gate.sh full");
-    expect(canary).toContain("./scripts/release-bus-frontend-gate.sh full");
+    expect(canary).toContain('"$RELEASE_BUS_GATE_TOOL" serial');
+    expect(canary).toContain('"$RELEASE_BUS_GATE_TOOL" phase lint');
+    expect(canary).toContain('"$RELEASE_BUS_GATE_TOOL" phase typecheck');
+    expect(canary).toContain('"$RELEASE_BUS_GATE_TOOL" phase build');
+    expect(canary).toContain('"$RELEASE_BUS_GATE_TOOL" jest');
     expect(canary).toContain('git fetch --no-tags origin "$BASE_SHA"');
+    expect(canary).toContain('git show "$WORKFLOW_SHA:$file"');
+    expect(canary).toContain("Derive and verify immutable gate fingerprint");
+    expect(canary).toContain("RELEASE_BUS_GATE_FINGERPRINT=$GATE_FINGERPRINT");
+    expect(canary).toContain("behavior_digest");
+    expect(canary).toContain('--behavior-digest "$behavior_digest"');
+    expect(canary).not.toContain("gate_fingerprint=unversioned");
+    expect(canary).toContain('RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE"');
     expect(canary).not.toContain("ref: ${{ inputs.base_sha }}");
+  });
+
+  it("passes untrusted workflow inputs through the environment before shell use", () => {
+    const steps = Object.values(canaryWorkflow.jobs ?? {}).flatMap(
+      (job) => job.steps ?? []
+    );
+    for (const step of steps) {
+      expect(step.run ?? "").not.toMatch(/\$\{\{\s*inputs\./);
+    }
+
+    const aggregate = steps.find(
+      (step) => step.name === "Aggregate fail-closed evidence"
+    );
+    expect(aggregate?.env?.BASE_SHA).toBe("${{ inputs.base_sha }}");
+    expect(aggregate?.run).toContain('[[ "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]]');
+    expect(aggregate?.run?.match(/--base-sha "\$BASE_SHA"/g)).toHaveLength(2);
+
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "release-bus-input-")
+    );
+    const marker = path.join(tempDir, "shell-interpolation-ran");
+    const validator = path.join(tempDir, "validate-base-sha");
+    const maliciousBaseSha = `$(touch ${marker})`;
+    try {
+      fs.writeFileSync(
+        validator,
+        '#!/usr/bin/env bash\nset -euo pipefail\n[[ "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]]\n'
+      );
+      fs.chmodSync(validator, 0o755);
+      expect(() =>
+        execFileSync(validator, [], {
+          env: { ...process.env, BASE_SHA: maliciousBaseSha },
+          stdio: "ignore",
+        })
+      ).toThrow();
+      expect(fs.existsSync(marker)).toBe(false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps all required phases and deterministic shard controls", () => {
+    for (const phase of ["lint", "typecheck", "unit_tests", "build"]) {
+      expect(gate).toContain(phase);
+    }
+    expect(gate).toContain('--shard="$shard_index/$shard_count"');
+    expect(gate).toContain("--bail=0");
+    expect(gate).toContain('raw_dir="$(mktemp -d');
+    expect(gate).toContain('results="$raw_dir/jest-results.json"');
+    expect(gate).not.toContain('results="$output_dir/jest-results');
+    for (const identityFlag of [
+      "--base-sha",
+      "--environment",
+      "--gate-fingerprint",
+      "--workflow-sha",
+      "--workflow-digest",
+      "--node-version",
+      "--package-manager",
+    ]) {
+      expect(gate).toContain(identityFlag);
+    }
+    expect(canary).toContain("fail-fast: false");
+    expect(canary).toContain("FRONTEND_GATE_SHARD_COUNT");
+    expect(canary).toContain("RELEASE_BUS_FRONTEND_GATE_MODE");
+    expect(canary).toContain("validation_only");
+    expect(canary).toContain("inputs.validation_only != true");
+    expect(canary).toContain("validation_inject_failure");
+    expect(canary).toContain('test "$VALIDATION_ONLY" = true');
+    expect(canary).toContain("RELEASE_BUS_INJECT_SHARD_FAILURE");
   });
 
   it("executes its argument-forwarding contract in ordinary PR CI", () => {

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -59,8 +59,9 @@ describe("Release Bus frontend gate contract", () => {
 
   it("owns the only Release Bus Jest invocation", () => {
     expect(gate).toContain(
-      '"$SEIZE_BIN" run test:no-coverage --runInBand --bail=0 "$@"'
+      '"$SEIZE_BIN" run test:no-coverage --maxWorkers=2 --bail=0 "$@"'
     );
+    expect(gate).not.toContain("--runInBand");
     expect(gate).not.toContain("test:no-coverage -- --runInBand");
 
     for (const workflow of [preflight, isolation, canary]) {
@@ -95,7 +96,7 @@ describe("Release Bus frontend gate contract", () => {
       expect(fs.readFileSync(argumentLog, "utf8").trim().split("\n")).toEqual([
         "run",
         "test:no-coverage",
-        "--runInBand",
+        "--maxWorkers=2",
         "--bail=0",
         "--runTestsByPath",
         "__tests__/scripts/release-bus-frontend-gate.test.ts",

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -101,7 +101,6 @@ describe("Release Bus frontend gate contract", () => {
         "--runTestsByPath",
         "__tests__/scripts/release-bus-frontend-gate.test.ts",
         "__tests__/scripts/release-bus-gate-evidence.test.ts",
-        "__tests__/scripts/release-bus-shard-injection.test.ts",
       ]);
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
@@ -250,6 +249,11 @@ describe("Release Bus frontend gate contract", () => {
     expect(canary).toContain("validation_inject_failure");
     expect(canary).toContain('test "$VALIDATION_ONLY" = true');
     expect(canary).toContain("RELEASE_BUS_INJECT_SHARD_FAILURE");
+    expect(gate).toContain("manifest-error");
+    expect(gate).toContain("injected_failure=1");
+    expect(gate).toContain('[ "$shard_index" -eq "$shard_count" ]');
+    expect(gate).toContain('--injected-failure "$injected_failure"');
+    expect(gate).not.toContain("release-bus-shard-injection.test.ts");
   });
 
   it("executes its argument-forwarding contract in ordinary PR CI", () => {

--- a/__tests__/scripts/release-bus-gate-evidence.test.ts
+++ b/__tests__/scripts/release-bus-gate-evidence.test.ts
@@ -1,0 +1,648 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const {
+  buildGateSummary,
+  finalSummary,
+  frontendGateContract,
+  jestRecord,
+  manifestFromRaw,
+  phaseRecord,
+  safeText,
+}: {
+  buildGateSummary: (input: Record<string, unknown>) => Record<string, any>;
+  finalSummary: (input: Record<string, unknown>) => Record<string, any>;
+  frontendGateContract: (input: Record<string, unknown>) => Record<string, any>;
+  jestRecord: (input: Record<string, unknown>) => Record<string, any>;
+  manifestFromRaw: (raw: string, root: string) => string[];
+  phaseRecord: (input: Record<string, unknown>) => Record<string, any>;
+  safeText: (value: unknown, maximum?: number) => string;
+} = require("../../scripts/release-bus-gate-evidence.cjs");
+
+describe("Release Bus gate evidence", () => {
+  const evidenceIdentity = {
+    base_sha: "a".repeat(40),
+    environment: "orchestration",
+    gate_fingerprint: "b".repeat(64),
+    workflow_sha: "c".repeat(40),
+    workflow_digest: "d".repeat(64),
+    node_version: "22",
+    package_manager: "pnpm@10.14.0",
+  };
+
+  it("fingerprints base policy and pinned workflow tooling deterministically", () => {
+    const baseFileContents = {
+      "bin/6529": "runner",
+      "jest.config.js": "config",
+      "jest.setup.js": "setup",
+      "package.json": JSON.stringify({ packageManager: "pnpm@10.14.0" }),
+      "pnpm-lock.yaml": "lockfile",
+    };
+    const workflowFileContents = {
+      ".github/workflows/release-bus-base-canary.yml": "workflow",
+      "scripts/release-bus-frontend-gate.sh": "gate",
+      "scripts/release-bus-gate-evidence.cjs": "evidence",
+    };
+    const input = {
+      baseSha: "a".repeat(40),
+      workflowSha: "b".repeat(40),
+      baseFileContents,
+      workflowFileContents,
+      gateMode: "sharded",
+      shardCount: 4,
+    };
+
+    const baseline = frontendGateContract(input);
+    expect(frontendGateContract(input)).toEqual(baseline);
+    expect(baseline).toMatchObject({
+      behavior_digest:
+        "7efb9837a165c888eb262499d267efb6cc642405d3462ae768944ada88148490",
+      gate_fingerprint:
+        "2891de0c74bdd9a075d09f23ef160fbe9313f798d62fcfc5eb60d31e5070b14e",
+      workflow_digest:
+        "da7f739f627198465eeab537a6f7a435dc4a0c332f9e4a8462293eb3f4ab7ee0",
+    });
+    expect(
+      frontendGateContract({
+        ...input,
+        baseFileContents: { ...baseFileContents, "jest.config.js": "changed" },
+      }).gate_fingerprint
+    ).not.toBe(baseline.gate_fingerprint);
+    expect(
+      frontendGateContract({
+        ...input,
+        baseSha: "c".repeat(40),
+        workflowSha: "d".repeat(40),
+      }).behavior_digest
+    ).toBe(baseline.behavior_digest);
+    for (const file of Object.keys(baseFileContents)) {
+      const changedContents =
+        file === "package.json"
+          ? JSON.stringify({ packageManager: "pnpm@10.15.0" })
+          : `${baseFileContents[file]} changed`;
+      expect(
+        frontendGateContract({
+          ...input,
+          baseFileContents: {
+            ...baseFileContents,
+            [file]: changedContents,
+          },
+        }).behavior_digest
+      ).not.toBe(baseline.behavior_digest);
+    }
+    for (const file of Object.keys(workflowFileContents)) {
+      expect(
+        frontendGateContract({
+          ...input,
+          workflowFileContents: {
+            ...workflowFileContents,
+            [file]: `${workflowFileContents[file]} changed`,
+          },
+        }).behavior_digest
+      ).not.toBe(baseline.behavior_digest);
+    }
+    expect(
+      frontendGateContract({ ...input, shardCount: 2 }).behavior_digest
+    ).not.toBe(baseline.behavior_digest);
+    expect(
+      frontendGateContract({ ...input, gateMode: "shadow" }).behavior_digest
+    ).not.toBe(baseline.behavior_digest);
+    expect(
+      frontendGateContract({ ...input, nodeVersion: "24" }).behavior_digest
+    ).not.toBe(baseline.behavior_digest);
+    expect(
+      frontendGateContract({
+        ...input,
+        workflowFileContents: {
+          ...workflowFileContents,
+          "scripts/release-bus-gate-evidence.cjs": "changed",
+        },
+      }).gate_fingerprint
+    ).not.toBe(baseline.gate_fingerprint);
+    expect(() =>
+      frontendGateContract({
+        ...input,
+        baseFileContents: {
+          ...baseFileContents,
+          "package.json": JSON.stringify({ packageManager: "pnpm@10\nunsafe" }),
+        },
+      })
+    ).toThrow("Invalid package-manager contract");
+  });
+
+  it("normalizes an exact repository-local test inventory", () => {
+    const root = path.join(os.tmpdir(), "release-bus-evidence-root");
+    const raw = [
+      "pnpm wrapper output",
+      path.join(root, "__tests__/b.test.ts"),
+      path.join(root, "__tests__/a.test.ts"),
+    ].join("\n");
+
+    expect(manifestFromRaw(raw, root)).toEqual([
+      "__tests__/a.test.ts",
+      "__tests__/b.test.ts",
+    ]);
+  });
+
+  it("sanitizes bounded operator-facing strings", () => {
+    expect(safeText("failed\n\u0000suite", 20)).toBe("failed suite");
+    expect(safeText("x".repeat(50), 10)).toHaveLength(10);
+  });
+
+  it("proves every expected Jest file executed exactly once and required jobs cannot skip", () => {
+    const root = path.join(os.tmpdir(), "release-bus-evidence-root");
+    const files = ["__tests__/a.test.ts", "__tests__/b.test.ts"];
+    const records = [
+      {
+        kind: "manifest",
+        ...evidenceIdentity,
+        source: "parallel",
+        scope: "all",
+        files,
+      },
+      ...files.map((file, index) => ({
+        kind: "manifest",
+        ...evidenceIdentity,
+        source: "parallel",
+        scope: "shard",
+        shard_index: index + 1,
+        shard_count: 2,
+        files: [file],
+      })),
+      ...files.map((file, index) =>
+        jestRecord({
+          result: {
+            success: true,
+            numTotalTestSuites: 1,
+            numPassedTestSuites: 1,
+            numFailedTestSuites: 0,
+            numTotalTests: 2,
+            numPassedTests: 2,
+            numFailedTests: 0,
+            testResults: [
+              {
+                name: path.join(root, file),
+                status: "passed",
+                assertionResults: [],
+              },
+            ],
+          },
+          manifest: { files: [file] },
+          repoRoot: root,
+          shardIndex: index + 1,
+          shardCount: 2,
+          durationMs: 10 + index,
+          exitCode: 0,
+          source: "parallel",
+          identity: evidenceIdentity,
+        })
+      ),
+      ...["lint", "typecheck", "build"].map((name) =>
+        phaseRecord({
+          name,
+          status: "SUCCEEDED",
+          durationMs: 10,
+          exitCode: 0,
+          source: "parallel",
+          identity: evidenceIdentity,
+        })
+      ),
+    ];
+
+    const summary = buildGateSummary({
+      records,
+      source: "parallel",
+      shardCount: 2,
+      jobResults: {
+        lint: "success",
+        typecheck: "success",
+        build: "success",
+        inventory: "success",
+        jest: "success",
+      },
+      identity: evidenceIdentity,
+    });
+
+    expect(summary).toMatchObject({
+      status: "SUCCEEDED",
+      counts: { test_files: 2, test_suites: 2, tests: 4 },
+      missing_files: [],
+      duplicate_files: [],
+    });
+
+    for (const requiredJob of ["lint", "typecheck", "jest"] as const) {
+      const evidenceWithoutSkippedJob = records.filter((record) =>
+        requiredJob === "jest"
+          ? record.kind !== "jest_shard"
+          : !(record.kind === "phase" && record.name === requiredJob)
+      );
+      expect(
+        buildGateSummary({
+          records: evidenceWithoutSkippedJob,
+          source: "parallel",
+          shardCount: 2,
+          jobResults: {
+            lint: requiredJob === "lint" ? "skipped" : "success",
+            typecheck: requiredJob === "typecheck" ? "skipped" : "success",
+            build: "success",
+            inventory: "success",
+            jest: requiredJob === "jest" ? "skipped" : "success",
+          },
+          identity: evidenceIdentity,
+        })
+      ).toMatchObject({ status: "FAILED" });
+    }
+
+    const mismatched = records.map((record) =>
+      record.kind === "jest_shard"
+        ? { ...record, gate_fingerprint: "e".repeat(64) }
+        : record
+    );
+    expect(
+      buildGateSummary({
+        records: mismatched,
+        source: "parallel",
+        shardCount: 2,
+        jobResults: {
+          lint: "success",
+          typecheck: "success",
+          build: "success",
+          inventory: "success",
+          jest: "success",
+        },
+        identity: evidenceIdentity,
+      })
+    ).toMatchObject({
+      status: "FAILED",
+      errors: expect.arrayContaining([
+        "evidence identity is missing or mismatched",
+      ]),
+    });
+  });
+
+  it("fails closed for a duplicate, omitted, or failed shard", () => {
+    const records = [
+      {
+        kind: "manifest",
+        source: "parallel",
+        scope: "all",
+        files: ["a.test.ts", "b.test.ts"],
+      },
+      {
+        kind: "manifest",
+        source: "parallel",
+        scope: "shard",
+        files: ["a.test.ts"],
+      },
+      {
+        kind: "jest_shard",
+        source: "parallel",
+        shard_index: 1,
+        shard_count: 2,
+        status: "FAILED",
+        duration_ms: 1,
+        counts: {},
+        executed_test_files: ["a.test.ts", "a.test.ts"],
+      },
+    ];
+
+    const summary = buildGateSummary({
+      records,
+      source: "parallel",
+      shardCount: 2,
+      jobResults: { jest: "failure" },
+    });
+
+    expect(summary.status).toBe("FAILED");
+    expect(summary.missing_files).toContain("b.test.ts");
+    expect(summary.duplicate_files).toContain("a.test.ts");
+  });
+
+  it("fails closed when Jest reports a skipped or todo test", () => {
+    const records = [
+      {
+        kind: "manifest",
+        source: "parallel",
+        scope: "all",
+        files: ["a.test.ts"],
+      },
+      {
+        kind: "manifest",
+        source: "parallel",
+        scope: "shard",
+        shard_index: 1,
+        shard_count: 1,
+        files: ["a.test.ts"],
+      },
+      {
+        kind: "jest_shard",
+        source: "parallel",
+        shard_index: 1,
+        shard_count: 1,
+        status: "SUCCEEDED",
+        duration_ms: 1,
+        counts: {
+          test_files: 1,
+          test_suites: 1,
+          passed_test_suites: 1,
+          failed_test_suites: 0,
+          pending_test_suites: 0,
+          tests: 2,
+          passed_tests: 1,
+          failed_tests: 0,
+          pending_tests: 1,
+          todo_tests: 0,
+        },
+        executed_test_files: ["a.test.ts"],
+      },
+      ...["lint", "typecheck", "build"].map((name) =>
+        phaseRecord({
+          name,
+          status: "SUCCEEDED",
+          durationMs: 1,
+          exitCode: 0,
+          source: "parallel",
+        })
+      ),
+    ];
+
+    expect(
+      buildGateSummary({
+        records,
+        source: "parallel",
+        shardCount: 1,
+        jobResults: { jest: "success" },
+      })
+    ).toMatchObject({
+      status: "FAILED",
+      errors: expect.arrayContaining(["Jest reported skipped or todo tests"]),
+    });
+  });
+
+  it("fails when an individual shard does not execute its exact plan", () => {
+    const records = [
+      {
+        kind: "manifest",
+        source: "parallel",
+        scope: "all",
+        files: ["a.test.ts", "b.test.ts"],
+      },
+      {
+        kind: "manifest",
+        source: "parallel",
+        scope: "shard",
+        shard_index: 1,
+        shard_count: 2,
+        files: ["a.test.ts"],
+      },
+      {
+        kind: "manifest",
+        source: "parallel",
+        scope: "shard",
+        shard_index: 2,
+        shard_count: 2,
+        files: ["b.test.ts"],
+      },
+      {
+        kind: "jest_shard",
+        source: "parallel",
+        shard_index: 1,
+        shard_count: 2,
+        status: "SUCCEEDED",
+        duration_ms: 1,
+        counts: {},
+        executed_test_files: ["b.test.ts"],
+      },
+      {
+        kind: "jest_shard",
+        source: "parallel",
+        shard_index: 2,
+        shard_count: 2,
+        status: "SUCCEEDED",
+        duration_ms: 1,
+        counts: {},
+        executed_test_files: ["a.test.ts"],
+      },
+    ];
+
+    const summary = buildGateSummary({
+      records,
+      source: "parallel",
+      shardCount: 2,
+      jobResults: { jest: "success" },
+    });
+
+    expect(summary.status).toBe("FAILED");
+    expect(summary.errors).toContain(
+      "Jest shard 1/2 did not execute its exact plan"
+    );
+    expect(summary.errors).toContain(
+      "Jest shard 2/2 did not execute its exact plan"
+    );
+  });
+
+  it("attributes a deliberate first-run failure to its exact shard", () => {
+    const files = Array.from({ length: 4 }, (_, index) => `${index}.test.ts`);
+    const records = [
+      {
+        kind: "manifest",
+        source: "parallel",
+        scope: "all",
+        files,
+      },
+      ...files.map((file, index) => ({
+        kind: "manifest",
+        source: "parallel",
+        scope: "shard",
+        shard_index: index + 1,
+        shard_count: 4,
+        files: [file],
+      })),
+      ...files.map((file, index) => ({
+        kind: "jest_shard",
+        source: "parallel",
+        shard_index: index + 1,
+        shard_count: 4,
+        status: index === 2 ? "FAILED" : "SUCCEEDED",
+        duration_ms: 10,
+        counts: {
+          test_files: 1,
+          test_suites: 1,
+          passed_test_suites: index === 2 ? 0 : 1,
+          failed_test_suites: index === 2 ? 1 : 0,
+          pending_test_suites: 0,
+          tests: 1,
+          passed_tests: index === 2 ? 0 : 1,
+          failed_tests: index === 2 ? 1 : 0,
+          pending_tests: 0,
+          todo_tests: 0,
+        },
+        executed_test_files: [file],
+        failing_suites: index === 2 ? [file] : [],
+        failing_tests:
+          index === 2 ? [{ suite: file, test: "deliberate failure" }] : [],
+      })),
+      ...["lint", "typecheck", "build"].map((name) =>
+        phaseRecord({
+          name,
+          status: "SUCCEEDED",
+          durationMs: 1,
+          exitCode: 0,
+          source: "parallel",
+        })
+      ),
+    ];
+
+    const summary = buildGateSummary({
+      records,
+      source: "parallel",
+      shardCount: 4,
+      jobResults: { jest: "failure" },
+    });
+
+    expect(summary).toMatchObject({
+      status: "FAILED",
+      shards: expect.arrayContaining([
+        expect.objectContaining({ index: 3, status: "FAILED" }),
+      ]),
+      failing_suites: ["2.test.ts"],
+      failing_tests: [{ suite: "2.test.ts", test: "deliberate failure" }],
+    });
+  });
+
+  it("keeps serial authoritative in shadow mode and records equivalence", () => {
+    const evidenceRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "release-bus-final-summary-")
+    );
+    const jobsFile = path.join(evidenceRoot, "jobs.json");
+    fs.writeFileSync(jobsFile, JSON.stringify({ jobs: [] }));
+    const records: Array<Record<string, unknown>> = [];
+    for (const source of ["legacy", "parallel"] as const) {
+      records.push({
+        kind: "manifest",
+        ...evidenceIdentity,
+        source,
+        scope: "all",
+        files: ["a.test.ts"],
+      });
+      records.push({
+        kind: "manifest",
+        ...evidenceIdentity,
+        source,
+        scope: "shard",
+        shard_index: 1,
+        shard_count: 1,
+        files: ["a.test.ts"],
+      });
+      records.push({
+        kind: "jest_shard",
+        ...evidenceIdentity,
+        source,
+        shard_index: 1,
+        shard_count: 1,
+        status: "SUCCEEDED",
+        duration_ms: 1,
+        counts: {
+          test_files: 1,
+          test_suites: 1,
+          passed_test_suites: 1,
+          failed_test_suites: 0,
+          pending_test_suites: 0,
+          tests: 2,
+          passed_tests: 2,
+          failed_tests: 0,
+          pending_tests: 0,
+          todo_tests: 0,
+        },
+        executed_test_files: ["a.test.ts"],
+      });
+      for (const name of ["lint", "typecheck", "build"]) {
+        records.push(
+          phaseRecord({
+            name,
+            status: "SUCCEEDED",
+            durationMs: 1,
+            exitCode: 0,
+            source,
+            identity: evidenceIdentity,
+          })
+        );
+      }
+    }
+
+    const summary = finalSummary({
+      args: {
+        mode: "shadow",
+        "shard-count": "1",
+        "run-url":
+          "https://github.com/6529-Collections/6529seize-frontend/actions/runs/123",
+        "base-sha": evidenceIdentity.base_sha,
+        environment: evidenceIdentity.environment,
+        "gate-fingerprint": evidenceIdentity.gate_fingerprint,
+        "behavior-digest": "e".repeat(64),
+        "workflow-sha": evidenceIdentity.workflow_sha,
+        "workflow-digest": evidenceIdentity.workflow_digest,
+        "node-version": evidenceIdentity.node_version,
+        "package-manager": evidenceIdentity.package_manager,
+        "artifact-name": "release-bus-base-canary-summary-123",
+        "jobs-file": jobsFile,
+      },
+      records,
+      jobResults: {
+        legacy: "success",
+        lint: "success",
+        typecheck: "success",
+        build: "success",
+        inventory: "success",
+        jest: "success",
+      },
+    });
+
+    expect(summary).toMatchObject({
+      status: "SUCCEEDED",
+      gate_mode: "shadow",
+      equivalence: {
+        equivalent: true,
+        sharded_phase_durations_ms: {
+          lint: 1,
+          typecheck: 1,
+          unit_tests: 1,
+          build: 1,
+        },
+        sharded_shards: [
+          expect.objectContaining({ index: 1, count: 1, duration_ms: 1 }),
+        ],
+      },
+    });
+
+    const skippedLegacy = finalSummary({
+      args: {
+        mode: "shadow",
+        "shard-count": "1",
+        "run-url":
+          "https://github.com/6529-Collections/6529seize-frontend/actions/runs/123",
+        "base-sha": evidenceIdentity.base_sha,
+        environment: evidenceIdentity.environment,
+        "gate-fingerprint": evidenceIdentity.gate_fingerprint,
+        "behavior-digest": "e".repeat(64),
+        "workflow-sha": evidenceIdentity.workflow_sha,
+        "workflow-digest": evidenceIdentity.workflow_digest,
+        "node-version": evidenceIdentity.node_version,
+        "package-manager": evidenceIdentity.package_manager,
+        "artifact-name": "release-bus-base-canary-summary-123",
+        "jobs-file": jobsFile,
+      },
+      records: records.filter((record) => record.source !== "legacy"),
+      jobResults: {
+        legacy: "skipped",
+        lint: "success",
+        typecheck: "success",
+        build: "success",
+        inventory: "success",
+        jest: "success",
+      },
+    });
+    expect(skippedLegacy.status).toBe("FAILED");
+  });
+});

--- a/__tests__/scripts/release-bus-gate-evidence.test.ts
+++ b/__tests__/scripts/release-bus-gate-evidence.test.ts
@@ -279,6 +279,86 @@ describe("Release Bus gate evidence", () => {
         "evidence identity is missing or mismatched",
       ]),
     });
+
+    expect(
+      buildGateSummary({
+        records: [
+          ...records,
+          {
+            kind: "manifest_error",
+            ...evidenceIdentity,
+            source: "parallel",
+            scope: "shard",
+            shard_index: 1,
+            shard_count: 2,
+            exit_code: 2,
+            error: "Jest manifest command failed",
+          },
+        ],
+        source: "parallel",
+        shardCount: 2,
+        jobResults: {
+          lint: "success",
+          typecheck: "success",
+          build: "success",
+          inventory: "success",
+          jest: "failure",
+        },
+        identity: evidenceIdentity,
+      })
+    ).toMatchObject({
+      status: "FAILED",
+      errors: expect.arrayContaining(["Jest manifest capture failed"]),
+    });
+  });
+
+  it("records a direct deliberate gate failure without falsifying Jest counts", () => {
+    const root = path.join(os.tmpdir(), "release-bus-injected-failure-root");
+    const record = jestRecord({
+      result: {
+        success: true,
+        numTotalTestSuites: 1,
+        numPassedTestSuites: 1,
+        numFailedTestSuites: 0,
+        numPendingTestSuites: 0,
+        numTotalTests: 3,
+        numPassedTests: 3,
+        numFailedTests: 0,
+        numPendingTests: 0,
+        numTodoTests: 0,
+        testResults: [
+          {
+            name: path.join(root, "__tests__/a.test.ts"),
+            status: "passed",
+            assertionResults: [],
+          },
+        ],
+      },
+      manifest: { files: ["__tests__/a.test.ts"] },
+      repoRoot: root,
+      shardIndex: 2,
+      shardCount: 2,
+      durationMs: 10,
+      exitCode: 86,
+      source: "parallel",
+      identity: evidenceIdentity,
+      injectedFailure: true,
+    });
+
+    expect(record).toMatchObject({
+      status: "FAILED",
+      exit_code: 86,
+      injected_failure: true,
+      counts: {
+        test_files: 1,
+        test_suites: 1,
+        passed_test_suites: 1,
+        failed_test_suites: 0,
+        tests: 3,
+        passed_tests: 3,
+        failed_tests: 0,
+      },
+    });
   });
 
   it("fails closed for a duplicate, omitted, or failed shard", () => {

--- a/__tests__/scripts/release-bus-shard-injection.test.ts
+++ b/__tests__/scripts/release-bus-shard-injection.test.ts
@@ -1,5 +1,0 @@
-describe("Release Bus shard failure injection fixture", () => {
-  it("fails only when deliberate validation injection is enabled", () => {
-    expect(process.env.RELEASE_BUS_INJECT_SHARD_FAILURE).not.toBe("1");
-  });
-});

--- a/__tests__/scripts/release-bus-shard-injection.test.ts
+++ b/__tests__/scripts/release-bus-shard-injection.test.ts
@@ -1,0 +1,5 @@
+describe("Release Bus shard failure injection fixture", () => {
+  it("fails only when deliberate validation injection is enabled", () => {
+    expect(process.env.RELEASE_BUS_INJECT_SHARD_FAILURE).not.toBe("1");
+  });
+});

--- a/scripts/release-bus-frontend-gate.sh
+++ b/scripts/release-bus-frontend-gate.sh
@@ -95,14 +95,35 @@ capture_manifest() {
   local output_dir="$5"
   local raw_file="$output_dir/manifest-$scope-$shard_index-of-$shard_count.raw"
   local json_file="$output_dir/manifest-$scope-$shard_index-of-$shard_count.json"
+  local exit_code
+  set +e
   if [ "$scope" = all ]; then
     run_unit_tests --listTests > "$raw_file"
+    exit_code=$?
+    set -e
+    if [ "$exit_code" -ne 0 ]; then
+      node "$EVIDENCE_TOOL" manifest-error \
+        --source "$source" --scope all --exit-code "$exit_code" \
+        "${EVIDENCE_IDENTITY_ARGS[@]}" \
+        --output "$output_dir/manifest-error-all.json"
+      return "$exit_code"
+    fi
     node "$EVIDENCE_TOOL" manifest \
       --source "$source" --scope all --repo-root "$REPO_ROOT" \
       "${EVIDENCE_IDENTITY_ARGS[@]}" \
       --raw "$raw_file" --output "$json_file"
   else
     run_unit_tests --listTests --shard="$shard_index/$shard_count" > "$raw_file"
+    exit_code=$?
+    set -e
+    if [ "$exit_code" -ne 0 ]; then
+      node "$EVIDENCE_TOOL" manifest-error \
+        --source "$source" --scope shard \
+        --shard-index "$shard_index" --shard-count "$shard_count" \
+        --exit-code "$exit_code" "${EVIDENCE_IDENTITY_ARGS[@]}" \
+        --output "$output_dir/manifest-error-shard-$shard_index-of-$shard_count.json"
+      return "$exit_code"
+    fi
     node "$EVIDENCE_TOOL" manifest \
       --source "$source" --scope shard --repo-root "$REPO_ROOT" \
       --shard-index "$shard_index" --shard-count "$shard_count" \
@@ -123,6 +144,7 @@ run_recorded_jest() {
   local started_at
   local completed_at
   local exit_code
+  local injected_failure=0
   local summary_exit_code
   raw_dir="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/release-bus-jest-raw.XXXXXX")"
   results="$raw_dir/jest-results.json"
@@ -135,6 +157,11 @@ run_recorded_jest() {
     --outputFile="$results"
   exit_code=$?
   set -e
+  if [ "${RELEASE_BUS_INJECT_SHARD_FAILURE:-0}" = 1 ] && \
+    [ "$shard_index" -eq "$shard_count" ]; then
+    injected_failure=1
+    if [ "$exit_code" -eq 0 ]; then exit_code=86; fi
+  fi
   completed_at="$(now_ms)"
   set +e
   node "$EVIDENCE_TOOL" jest \
@@ -146,6 +173,7 @@ run_recorded_jest() {
     --shard-count "$shard_count" \
     --duration-ms "$((completed_at - started_at))" \
     --exit-code "$exit_code" \
+    --injected-failure "$injected_failure" \
     "${EVIDENCE_IDENTITY_ARGS[@]}" \
     --output "$summary"
   summary_exit_code=$?
@@ -180,8 +208,7 @@ case "${1:-full}" in
   contract)
     run_unit_tests --runTestsByPath \
       __tests__/scripts/release-bus-frontend-gate.test.ts \
-      __tests__/scripts/release-bus-gate-evidence.test.ts \
-      __tests__/scripts/release-bus-shard-injection.test.ts
+      __tests__/scripts/release-bus-gate-evidence.test.ts
     ;;
   validate)
     run_validation

--- a/scripts/release-bus-frontend-gate.sh
+++ b/scripts/release-bus-frontend-gate.sh
@@ -3,13 +3,35 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="${RELEASE_BUS_REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+REPO_ROOT="$(cd "$REPO_ROOT" && pwd)"
 SEIZE_BIN="${RELEASE_BUS_6529_BIN:-./bin/6529}"
+EVIDENCE_TOOL="$SCRIPT_DIR/release-bus-gate-evidence.cjs"
+EVIDENCE_IDENTITY_ARGS=()
 
 cd "$REPO_ROOT"
 
+set_evidence_identity_args() {
+  : "${RELEASE_BUS_BASE_SHA:?RELEASE_BUS_BASE_SHA is required}"
+  : "${RELEASE_BUS_EVIDENCE_ENVIRONMENT:?RELEASE_BUS_EVIDENCE_ENVIRONMENT is required}"
+  : "${RELEASE_BUS_GATE_FINGERPRINT:?RELEASE_BUS_GATE_FINGERPRINT is required}"
+  : "${RELEASE_BUS_WORKFLOW_SHA:?RELEASE_BUS_WORKFLOW_SHA is required}"
+  : "${RELEASE_BUS_WORKFLOW_DIGEST:?RELEASE_BUS_WORKFLOW_DIGEST is required}"
+  : "${RELEASE_BUS_NODE_VERSION:?RELEASE_BUS_NODE_VERSION is required}"
+  : "${RELEASE_BUS_PACKAGE_MANAGER:?RELEASE_BUS_PACKAGE_MANAGER is required}"
+  EVIDENCE_IDENTITY_ARGS=(
+    --base-sha "$RELEASE_BUS_BASE_SHA"
+    --environment "$RELEASE_BUS_EVIDENCE_ENVIRONMENT"
+    --gate-fingerprint "$RELEASE_BUS_GATE_FINGERPRINT"
+    --workflow-sha "$RELEASE_BUS_WORKFLOW_SHA"
+    --workflow-digest "$RELEASE_BUS_WORKFLOW_DIGEST"
+    --node-version "$RELEASE_BUS_NODE_VERSION"
+    --package-manager "$RELEASE_BUS_PACKAGE_MANAGER"
+  )
+}
+
 run_unit_tests() {
-  "$SEIZE_BIN" run test:no-coverage --runInBand "$@"
+  "$SEIZE_BIN" run test:no-coverage --runInBand --bail=0 "$@"
 }
 
 run_validation() {
@@ -18,9 +40,148 @@ run_validation() {
   run_unit_tests
 }
 
+now_ms() {
+  node -e 'process.stdout.write(String(Date.now()))'
+}
+
+record_phase_result() {
+  local source="$1"
+  local phase="$2"
+  local status="$3"
+  local duration_ms="$4"
+  local exit_code="$5"
+  local output_dir="$6"
+  node "$EVIDENCE_TOOL" phase \
+    --source "$source" \
+    --name "$phase" \
+    --status "$status" \
+    --duration-ms "$duration_ms" \
+    --exit-code "$exit_code" \
+    "${EVIDENCE_IDENTITY_ARGS[@]}" \
+    --output "$output_dir/phase-$phase.json"
+}
+
+run_recorded_phase() {
+  local source="$1"
+  local phase="$2"
+  local output_dir="$3"
+  shift 3
+  local started_at
+  local completed_at
+  local exit_code
+  local status
+  started_at="$(now_ms)"
+  set +e
+  "$@"
+  exit_code=$?
+  set -e
+  completed_at="$(now_ms)"
+  if [ "$exit_code" -eq 0 ]; then status=SUCCEEDED; else status=FAILED; fi
+  record_phase_result \
+    "$source" "$phase" "$status" "$((completed_at - started_at))" \
+    "$exit_code" "$output_dir"
+  return "$exit_code"
+}
+
+record_skipped_phase() {
+  record_phase_result "$1" "$2" SKIPPED 0 0 "$3"
+}
+
+capture_manifest() {
+  local source="$1"
+  local scope="$2"
+  local shard_index="$3"
+  local shard_count="$4"
+  local output_dir="$5"
+  local raw_file="$output_dir/manifest-$scope-$shard_index-of-$shard_count.raw"
+  local json_file="$output_dir/manifest-$scope-$shard_index-of-$shard_count.json"
+  if [ "$scope" = all ]; then
+    run_unit_tests --listTests > "$raw_file"
+    node "$EVIDENCE_TOOL" manifest \
+      --source "$source" --scope all --repo-root "$REPO_ROOT" \
+      "${EVIDENCE_IDENTITY_ARGS[@]}" \
+      --raw "$raw_file" --output "$json_file"
+  else
+    run_unit_tests --listTests --shard="$shard_index/$shard_count" > "$raw_file"
+    node "$EVIDENCE_TOOL" manifest \
+      --source "$source" --scope shard --repo-root "$REPO_ROOT" \
+      --shard-index "$shard_index" --shard-count "$shard_count" \
+      "${EVIDENCE_IDENTITY_ARGS[@]}" \
+      --raw "$raw_file" --output "$json_file"
+  fi
+}
+
+run_recorded_jest() {
+  local source="$1"
+  local shard_index="$2"
+  local shard_count="$3"
+  local output_dir="$4"
+  local manifest="$output_dir/manifest-shard-$shard_index-of-$shard_count.json"
+  local raw_dir
+  local results
+  local summary="$output_dir/jest-shard-$shard_index-of-$shard_count.json"
+  local started_at
+  local completed_at
+  local exit_code
+  local summary_exit_code
+  raw_dir="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/release-bus-jest-raw.XXXXXX")"
+  results="$raw_dir/jest-results.json"
+  capture_manifest "$source" shard "$shard_index" "$shard_count" "$output_dir"
+  started_at="$(now_ms)"
+  set +e
+  run_unit_tests \
+    --shard="$shard_index/$shard_count" \
+    --json \
+    --outputFile="$results"
+  exit_code=$?
+  set -e
+  completed_at="$(now_ms)"
+  set +e
+  node "$EVIDENCE_TOOL" jest \
+    --source "$source" \
+    --repo-root "$REPO_ROOT" \
+    --results "$results" \
+    --manifest "$manifest" \
+    --shard-index "$shard_index" \
+    --shard-count "$shard_count" \
+    --duration-ms "$((completed_at - started_at))" \
+    --exit-code "$exit_code" \
+    "${EVIDENCE_IDENTITY_ARGS[@]}" \
+    --output "$summary"
+  summary_exit_code=$?
+  set -e
+  rm -f -- "$results"
+  rmdir -- "$raw_dir"
+  if [ "$summary_exit_code" -ne 0 ]; then return "$summary_exit_code"; fi
+  return "$exit_code"
+}
+
+run_serial_evidence_gate() {
+  local output_dir="$1"
+  mkdir -p "$output_dir"
+  if ! run_recorded_phase legacy lint "$output_dir" "$SEIZE_BIN" run lint; then
+    record_skipped_phase legacy typecheck "$output_dir"
+    record_skipped_phase legacy build "$output_dir"
+    return 1
+  fi
+  if ! run_recorded_phase legacy typecheck "$output_dir" "$SEIZE_BIN" run typecheck:ci; then
+    record_skipped_phase legacy build "$output_dir"
+    return 1
+  fi
+  capture_manifest legacy all 1 1 "$output_dir"
+  if ! run_recorded_jest legacy 1 1 "$output_dir"; then
+    record_skipped_phase legacy build "$output_dir"
+    return 1
+  fi
+  run_recorded_phase legacy build "$output_dir" "$SEIZE_BIN" run build
+}
+
 case "${1:-full}" in
   contract)
-    run_unit_tests --runTestsByPath __tests__/scripts/release-bus-frontend-gate.test.ts
+    run_unit_tests --runTestsByPath \
+      __tests__/scripts/release-bus-frontend-gate.test.ts \
+      __tests__/scripts/release-bus-gate-evidence.test.ts \
+      __tests__/scripts/release-bus-shard-injection.test.ts
     ;;
   validate)
     run_validation
@@ -29,8 +190,47 @@ case "${1:-full}" in
     run_validation
     "$SEIZE_BIN" run build
     ;;
+  phase)
+    if [ "$#" -ne 3 ] || ! [[ "$2" =~ ^(lint|typecheck|build)$ ]]; then
+      echo "Usage: scripts/release-bus-frontend-gate.sh phase [lint|typecheck|build] OUTPUT_DIR" >&2
+      exit 2
+    fi
+    set_evidence_identity_args
+    mkdir -p "$3"
+    case "$2" in
+      lint) run_recorded_phase parallel lint "$3" "$SEIZE_BIN" run lint ;;
+      typecheck) run_recorded_phase parallel typecheck "$3" "$SEIZE_BIN" run typecheck:ci ;;
+      build) run_recorded_phase parallel build "$3" "$SEIZE_BIN" run build ;;
+    esac
+    ;;
+  inventory)
+    if [ "$#" -ne 2 ]; then
+      echo "Usage: scripts/release-bus-frontend-gate.sh inventory OUTPUT_DIR" >&2
+      exit 2
+    fi
+    set_evidence_identity_args
+    mkdir -p "$2"
+    capture_manifest parallel all 1 1 "$2"
+    ;;
+  jest)
+    if [ "$#" -ne 4 ]; then
+      echo "Usage: scripts/release-bus-frontend-gate.sh jest SHARD_INDEX SHARD_COUNT OUTPUT_DIR" >&2
+      exit 2
+    fi
+    set_evidence_identity_args
+    mkdir -p "$4"
+    run_recorded_jest parallel "$2" "$3" "$4"
+    ;;
+  serial)
+    if [ "$#" -ne 2 ]; then
+      echo "Usage: scripts/release-bus-frontend-gate.sh serial OUTPUT_DIR" >&2
+      exit 2
+    fi
+    set_evidence_identity_args
+    run_serial_evidence_gate "$2"
+    ;;
   *)
-    echo "Usage: scripts/release-bus-frontend-gate.sh [contract|validate|full]" >&2
+    echo "Usage: scripts/release-bus-frontend-gate.sh [contract|validate|full|phase|inventory|jest|serial]" >&2
     exit 2
     ;;
 esac

--- a/scripts/release-bus-frontend-gate.sh
+++ b/scripts/release-bus-frontend-gate.sh
@@ -31,7 +31,7 @@ set_evidence_identity_args() {
 }
 
 run_unit_tests() {
-  "$SEIZE_BIN" run test:no-coverage --runInBand --bail=0 "$@"
+  "$SEIZE_BIN" run test:no-coverage --maxWorkers=2 --bail=0 "$@"
 }
 
 run_validation() {

--- a/scripts/release-bus-gate-evidence.cjs
+++ b/scripts/release-bus-gate-evidence.cjs
@@ -25,7 +25,12 @@ const EVIDENCE_IDENTITY_FIELDS = [
   "node_version",
   "package_manager",
 ];
-const EVIDENCE_RECORD_KINDS = new Set(["manifest", "phase", "jest_shard"]);
+const EVIDENCE_RECORD_KINDS = new Set([
+  "manifest",
+  "manifest_error",
+  "phase",
+  "jest_shard",
+]);
 const FRONTEND_GATE_WORKFLOW = ".github/workflows/release-bus-base-canary.yml";
 const FRONTEND_GATE_BASE_FILES = [
   "bin/6529",
@@ -352,6 +357,7 @@ function jestRecord({
   exitCode,
   source,
   identity,
+  injectedFailure = false,
 }) {
   if (!ALLOWED_SHARD_COUNTS.has(shardCount)) {
     throw new Error("Unsupported shard count");
@@ -377,6 +383,7 @@ function jestRecord({
     shard_index: shardIndex,
     shard_count: shardCount,
     status: exitCode === 0 && result.success ? "SUCCEEDED" : "FAILED",
+    injected_failure: injectedFailure,
     duration_ms: durationMs,
     exit_code: exitCode,
     planned_test_files: manifest.files,
@@ -600,6 +607,8 @@ function buildGateSummary({
   }
   if (records.some((record) => record.kind === "malformed"))
     errors.push("malformed evidence");
+  if (sourceEvidence.some((record) => record.kind === "manifest_error"))
+    errors.push("Jest manifest capture failed");
   for (const [job, result] of Object.entries(jobResults)) {
     if (result !== "success" && result !== "skipped") {
       errors.push(`${safeText(job, 80)} job did not succeed`);
@@ -636,6 +645,7 @@ function buildGateSummary({
             index: shard.shard_index,
             count: shard.shard_count,
             status: shard.status,
+            injected_failure: shard.injected_failure === true,
             duration_ms: shard.duration_ms,
             counts: shard.counts,
           })}`
@@ -818,6 +828,29 @@ function run(command, args) {
     writeJson(required(args, "output"), value);
     return;
   }
+  if (command === "manifest-error") {
+    const scope = required(args, "scope");
+    if (!new Set(["all", "shard"]).has(scope))
+      throw new Error("Invalid manifest-error scope");
+    writeJson(required(args, "output"), {
+      schema_version: 1,
+      kind: "manifest_error",
+      ...evidenceIdentityFromArgs(args),
+      source: required(args, "source"),
+      scope,
+      shard_index:
+        scope === "shard"
+          ? integer(required(args, "shard-index"), "shard-index", 1)
+          : null,
+      shard_count:
+        scope === "shard"
+          ? integer(required(args, "shard-count"), "shard-count", 1)
+          : null,
+      exit_code: integer(required(args, "exit-code"), "exit-code", 1),
+      error: "Jest manifest command failed",
+    });
+    return;
+  }
   if (command === "phase") {
     writeJson(
       required(args, "output"),
@@ -835,6 +868,11 @@ function run(command, args) {
   if (command === "jest") {
     const repoRoot = path.resolve(required(args, "repo-root"));
     const resultsFile = required(args, "results");
+    const injectedFailure = integer(
+      required(args, "injected-failure"),
+      "injected-failure"
+    );
+    if (injectedFailure > 1) throw new Error("Invalid --injected-failure");
     writeJson(
       required(args, "output"),
       jestRecord({
@@ -849,6 +887,7 @@ function run(command, args) {
         exitCode: integer(required(args, "exit-code"), "exit-code"),
         source: required(args, "source"),
         identity: evidenceIdentityFromArgs(args),
+        injectedFailure: injectedFailure === 1,
       })
     );
     return;

--- a/scripts/release-bus-gate-evidence.cjs
+++ b/scripts/release-bus-gate-evidence.cjs
@@ -1,0 +1,888 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { createHash } = require("node:crypto");
+const { execFileSync } = require("node:child_process");
+
+const ALLOWED_SHARD_COUNTS = new Set([1, 2, 4]);
+const PHASES = ["lint", "typecheck", "unit_tests", "build"];
+const STATUSES = new Set([
+  "PENDING",
+  "RUNNING",
+  "SUCCEEDED",
+  "FAILED",
+  "SKIPPED",
+]);
+const MAX_FAILURES = 100;
+const MAX_TEXT_LENGTH = 500;
+const EVIDENCE_IDENTITY_FIELDS = [
+  "base_sha",
+  "environment",
+  "gate_fingerprint",
+  "workflow_sha",
+  "workflow_digest",
+  "node_version",
+  "package_manager",
+];
+const EVIDENCE_RECORD_KINDS = new Set(["manifest", "phase", "jest_shard"]);
+const FRONTEND_GATE_WORKFLOW = ".github/workflows/release-bus-base-canary.yml";
+const FRONTEND_GATE_BASE_FILES = [
+  "bin/6529",
+  "jest.config.js",
+  "jest.setup.js",
+  "package.json",
+  "pnpm-lock.yaml",
+];
+const FRONTEND_GATE_TOOLING_FILES = [
+  "scripts/release-bus-frontend-gate.sh",
+  "scripts/release-bus-gate-evidence.cjs",
+];
+
+function parseArgs(values) {
+  const result = {};
+  for (let index = 0; index < values.length; index += 1) {
+    const value = values[index];
+    if (!value.startsWith("--"))
+      throw new Error(`Unexpected argument: ${value}`);
+    const name = value.slice(2);
+    const next = values[index + 1];
+    if (next === undefined || next.startsWith("--")) {
+      result[name] = "true";
+      continue;
+    }
+    result[name] = next;
+    index += 1;
+  }
+  return result;
+}
+
+function required(args, name) {
+  const value = args[name];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Missing --${name}`);
+  }
+  return value;
+}
+
+function integer(value, name, minimum = 0) {
+  if (!/^[0-9]+$/.test(value)) throw new Error(`Invalid --${name}`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum) {
+    throw new Error(`Invalid --${name}`);
+  }
+  return parsed;
+}
+
+function digest(args, name) {
+  const value = required(args, name);
+  if (!/^[a-f0-9]{64}$/.test(value)) throw new Error(`Invalid --${name}`);
+  return value;
+}
+
+function safeText(value, maximum = MAX_TEXT_LENGTH) {
+  return String(value ?? "")
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maximum);
+}
+
+function stableSort(values) {
+  return [...values].sort((left, right) => {
+    if (left < right) return -1;
+    if (left > right) return 1;
+    return 0;
+  });
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function frontendGateContract({
+  baseSha,
+  workflowSha,
+  baseFileContents,
+  workflowFileContents,
+  gateMode,
+  shardCount,
+  nodeVersion = "22",
+}) {
+  if (!/^[a-f0-9]{40}$/.test(baseSha)) throw new Error("Invalid base SHA");
+  if (!/^[a-f0-9]{40}$/.test(workflowSha))
+    throw new Error("Invalid workflow SHA");
+  if (!new Set(["legacy", "shadow", "sharded"]).has(gateMode))
+    throw new Error("Invalid gate mode");
+  if (!ALLOWED_SHARD_COUNTS.has(shardCount))
+    throw new Error("Unsupported shard count");
+  if (!/^[1-9][0-9]{0,2}$/.test(nodeVersion))
+    throw new Error("Invalid Node version");
+  const workflowFiles = [
+    FRONTEND_GATE_WORKFLOW,
+    ...FRONTEND_GATE_TOOLING_FILES,
+  ];
+  for (const file of FRONTEND_GATE_BASE_FILES) {
+    if (typeof baseFileContents[file] !== "string")
+      throw new Error(`Missing base contract file ${file}`);
+  }
+  for (const file of workflowFiles) {
+    if (typeof workflowFileContents[file] !== "string")
+      throw new Error(`Missing workflow contract file ${file}`);
+  }
+  const packageJson = JSON.parse(baseFileContents["package.json"]);
+  const packageManager = packageJson?.packageManager;
+  if (
+    typeof packageManager !== "string" ||
+    !/^pnpm@[A-Za-z0-9.+-]{1,122}$/.test(packageManager)
+  ) {
+    throw new Error("Invalid package-manager contract");
+  }
+  const componentDigests = Object.fromEntries([
+    ...FRONTEND_GATE_BASE_FILES.map((file) => [
+      file,
+      sha256(baseFileContents[file]),
+    ]),
+    ...workflowFiles.map((file) => [file, sha256(workflowFileContents[file])]),
+  ]);
+  const workflowDigest = componentDigests[FRONTEND_GATE_WORKFLOW];
+  const behaviorDigest = sha256(
+    JSON.stringify({
+      schema_version: 1,
+      repository: "frontend",
+      environment: "orchestration",
+      node_version: nodeVersion,
+      package_manager: packageManager,
+      gate_mode: gateMode,
+      shard_count: shardCount,
+      component_digests: componentDigests,
+    })
+  );
+  const fingerprint = sha256(
+    JSON.stringify({
+      schema_version: 1,
+      repository: "frontend",
+      environment: "orchestration",
+      base_sha: baseSha,
+      workflow_sha: workflowSha,
+      workflow_digest: workflowDigest,
+      node_version: nodeVersion,
+      package_manager: packageManager,
+      gate_mode: gateMode,
+      shard_count: shardCount,
+      component_digests: componentDigests,
+    })
+  );
+  return {
+    schema_version: 1,
+    repository: "frontend",
+    environment: "orchestration",
+    base_sha: baseSha,
+    behavior_digest: behaviorDigest,
+    gate_fingerprint: fingerprint,
+    workflow_sha: workflowSha,
+    workflow_digest: workflowDigest,
+    node_version: nodeVersion,
+    package_manager: packageManager,
+    gate_mode: gateMode,
+    shard_count: shardCount,
+    component_digests: componentDigests,
+  };
+}
+
+function contractFromRepository(args) {
+  const repoRoot = path.resolve(required(args, "repo-root"));
+  const baseSha = required(args, "base-sha");
+  const workflowSha = required(args, "workflow-sha");
+  const head = execFileSync("git", ["-C", repoRoot, "rev-parse", "HEAD"], {
+    encoding: "utf8",
+  }).trim();
+  if (head !== baseSha)
+    throw new Error("Base checkout does not match base SHA");
+  const baseFileContents = Object.fromEntries(
+    FRONTEND_GATE_BASE_FILES.map((file) => [
+      file,
+      fs.readFileSync(path.join(repoRoot, file), "utf8"),
+    ])
+  );
+  const workflowFileContents = Object.fromEntries(
+    [FRONTEND_GATE_WORKFLOW, ...FRONTEND_GATE_TOOLING_FILES].map((file) => [
+      file,
+      execFileSync("git", ["-C", repoRoot, "show", `${workflowSha}:${file}`], {
+        encoding: "utf8",
+        maxBuffer: 2 * 1024 * 1024,
+      }),
+    ])
+  );
+  return frontendGateContract({
+    baseSha,
+    workflowSha,
+    baseFileContents,
+    workflowFileContents,
+    gateMode: required(args, "mode"),
+    shardCount: integer(required(args, "shard-count"), "shard-count", 1),
+  });
+}
+
+function validateEvidenceIdentity(identity) {
+  if (!identity || typeof identity !== "object" || Array.isArray(identity)) {
+    throw new Error("Evidence identity is missing");
+  }
+  if (!/^[a-f0-9]{40}$/.test(String(identity.base_sha ?? ""))) {
+    throw new Error("Evidence identity has an invalid base SHA");
+  }
+  if (identity.environment !== "orchestration") {
+    throw new Error("Evidence identity has an invalid environment");
+  }
+  if (!/^[a-f0-9]{64}$/.test(String(identity.gate_fingerprint ?? ""))) {
+    throw new Error("Evidence identity has an invalid gate fingerprint");
+  }
+  if (!/^[a-f0-9]{40}$/.test(String(identity.workflow_sha ?? ""))) {
+    throw new Error("Evidence identity has an invalid workflow SHA");
+  }
+  if (!/^[a-f0-9]{64}$/.test(String(identity.workflow_digest ?? ""))) {
+    throw new Error("Evidence identity has an invalid workflow digest");
+  }
+  if (identity.node_version !== "22") {
+    throw new Error("Evidence identity has an invalid Node contract");
+  }
+  if (
+    !/^pnpm@[A-Za-z0-9.+-]{1,122}$/.test(String(identity.package_manager ?? ""))
+  ) {
+    throw new Error(
+      "Evidence identity has an invalid package-manager contract"
+    );
+  }
+  return Object.fromEntries(
+    EVIDENCE_IDENTITY_FIELDS.map((field) => [field, identity[field]])
+  );
+}
+
+function evidenceIdentityFromArgs(args) {
+  return validateEvidenceIdentity({
+    base_sha: required(args, "base-sha"),
+    environment: required(args, "environment"),
+    gate_fingerprint: required(args, "gate-fingerprint"),
+    workflow_sha: required(args, "workflow-sha"),
+    workflow_digest: required(args, "workflow-digest"),
+    node_version: required(args, "node-version"),
+    package_manager: required(args, "package-manager"),
+  });
+}
+
+function sameEvidenceIdentity(record, identity) {
+  return EVIDENCE_IDENTITY_FIELDS.every(
+    (field) => record?.[field] === identity[field]
+  );
+}
+
+function relativeTestPath(testPath, repoRoot) {
+  const relative = path.relative(repoRoot, testPath).split(path.sep).join("/");
+  if (!relative || relative === ".." || relative.startsWith("../")) {
+    throw new Error("Jest returned a test path outside the repository");
+  }
+  return safeText(relative);
+}
+
+function manifestFromRaw(raw, repoRoot) {
+  const prefix = `${path.resolve(repoRoot)}${path.sep}`;
+  const files = raw
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith(prefix))
+    .map((line) => relativeTestPath(line, repoRoot));
+  const unique = new Set(files);
+  if (unique.size !== files.length) {
+    throw new Error("Jest test-file inventory contains duplicates");
+  }
+  return stableSort(unique);
+}
+
+function phaseRecord({ name, status, durationMs, exitCode, source, identity }) {
+  if (!PHASES.includes(name)) throw new Error("Invalid phase name");
+  if (!STATUSES.has(status)) throw new Error("Invalid phase status");
+  return {
+    schema_version: 1,
+    kind: "phase",
+    ...(identity ? validateEvidenceIdentity(identity) : {}),
+    source,
+    name,
+    status,
+    duration_ms: durationMs,
+    exit_code: exitCode,
+  };
+}
+
+function failingTests(result, repoRoot) {
+  const failures = [];
+  for (const suite of result.testResults ?? []) {
+    const suitePath = relativeTestPath(suite.name, repoRoot);
+    for (const assertion of suite.assertionResults ?? []) {
+      if (assertion.status !== "failed") continue;
+      failures.push({
+        suite: suitePath,
+        test: safeText(
+          [...(assertion.ancestorTitles ?? []), assertion.title]
+            .map((item) => safeText(item, 200))
+            .filter(Boolean)
+            .join(" > ")
+        ),
+      });
+    }
+  }
+  return failures.slice(0, MAX_FAILURES);
+}
+
+function jestRecord({
+  result,
+  manifest,
+  repoRoot,
+  shardIndex,
+  shardCount,
+  durationMs,
+  exitCode,
+  source,
+  identity,
+}) {
+  if (!ALLOWED_SHARD_COUNTS.has(shardCount)) {
+    throw new Error("Unsupported shard count");
+  }
+  if (shardIndex < 1 || shardIndex > shardCount) {
+    throw new Error("Invalid shard index");
+  }
+  const executedFiles = stableSort(
+    (result.testResults ?? []).map((suite) =>
+      relativeTestPath(suite.name, repoRoot)
+    )
+  );
+  const failingSuitePaths = stableSort(
+    (result.testResults ?? [])
+      .filter((suite) => suite.status === "failed")
+      .map((suite) => relativeTestPath(suite.name, repoRoot))
+  ).slice(0, MAX_FAILURES);
+  return {
+    schema_version: 1,
+    kind: "jest_shard",
+    ...(identity ? validateEvidenceIdentity(identity) : {}),
+    source,
+    shard_index: shardIndex,
+    shard_count: shardCount,
+    status: exitCode === 0 && result.success ? "SUCCEEDED" : "FAILED",
+    duration_ms: durationMs,
+    exit_code: exitCode,
+    planned_test_files: manifest.files,
+    executed_test_files: executedFiles,
+    counts: {
+      test_files: executedFiles.length,
+      test_suites: Number(result.numTotalTestSuites ?? 0),
+      passed_test_suites: Number(result.numPassedTestSuites ?? 0),
+      failed_test_suites: Number(result.numFailedTestSuites ?? 0),
+      pending_test_suites: Number(result.numPendingTestSuites ?? 0),
+      tests: Number(result.numTotalTests ?? 0),
+      passed_tests: Number(result.numPassedTests ?? 0),
+      failed_tests: Number(result.numFailedTests ?? 0),
+      pending_tests: Number(result.numPendingTests ?? 0),
+      todo_tests: Number(result.numTodoTests ?? 0),
+    },
+    failing_suites: failingSuitePaths,
+    failing_tests: failingTests(result, repoRoot),
+  };
+}
+
+function recursiveJsonFiles(root) {
+  if (!fs.existsSync(root)) return [];
+  const result = [];
+  const visit = (directory) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const absolute = path.join(directory, entry.name);
+      if (entry.isDirectory()) visit(absolute);
+      else if (entry.isFile() && entry.name.endsWith(".json"))
+        result.push(absolute);
+    }
+  };
+  visit(root);
+  return stableSort(result);
+}
+
+function loadEvidence(root) {
+  const records = [];
+  for (const file of recursiveJsonFiles(root)) {
+    try {
+      const value = readJson(file);
+      if (
+        value &&
+        typeof value === "object" &&
+        typeof value.kind === "string"
+      ) {
+        records.push(value);
+      }
+    } catch {
+      records.push({ kind: "malformed", file: safeText(path.basename(file)) });
+    }
+  }
+  return records;
+}
+
+function sumCounts(shards) {
+  const fields = [
+    "test_files",
+    "test_suites",
+    "passed_test_suites",
+    "failed_test_suites",
+    "pending_test_suites",
+    "tests",
+    "passed_tests",
+    "failed_tests",
+    "pending_tests",
+    "todo_tests",
+  ];
+  return Object.fromEntries(
+    fields.map((field) => [
+      field,
+      shards.reduce(
+        (total, shard) => total + Number(shard.counts?.[field] ?? 0),
+        0
+      ),
+    ])
+  );
+}
+
+function duplicateValues(values) {
+  const counts = new Map();
+  for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1);
+  return stableSort(
+    [...counts.entries()]
+      .filter(([, count]) => count > 1)
+      .map(([value]) => value)
+  );
+}
+
+function sameValues(left, right) {
+  return JSON.stringify(stableSort(left)) === JSON.stringify(stableSort(right));
+}
+
+function sameCounts(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function uniqueByName(records, kind, source) {
+  return records.filter(
+    (record) => record.kind === kind && record.source === source
+  );
+}
+
+function buildGateSummary({
+  records,
+  source,
+  shardCount,
+  jobResults,
+  identity,
+}) {
+  const globalManifests = uniqueByName(records, "manifest", source).filter(
+    (record) => record.scope === "all"
+  );
+  const shardManifests = uniqueByName(records, "manifest", source).filter(
+    (record) => record.scope === "shard"
+  );
+  const shards = uniqueByName(records, "jest_shard", source);
+  const phases = PHASES.map((name) => {
+    const matches = uniqueByName(records, "phase", source).filter(
+      (record) => record.name === name
+    );
+    if (name === "unit_tests") {
+      const duration = shards.length
+        ? Math.max(...shards.map((shard) => Number(shard.duration_ms ?? 0)))
+        : 0;
+      return {
+        name,
+        status:
+          shards.length === shardCount &&
+          shards.every((shard) => shard.status === "SUCCEEDED")
+            ? "SUCCEEDED"
+            : "FAILED",
+        duration_ms: duration,
+      };
+    }
+    if (matches.length !== 1) return { name, status: "FAILED", duration_ms: 0 };
+    return {
+      name,
+      status: matches[0].status,
+      duration_ms: Number(matches[0].duration_ms ?? 0),
+    };
+  });
+  const expected = globalManifests.length === 1 ? globalManifests[0].files : [];
+  const planned = shardManifests.flatMap((manifest) => manifest.files ?? []);
+  const executed = shards.flatMap((shard) => shard.executed_test_files ?? []);
+  const plannedSet = new Set(planned);
+  const executedSet = new Set(executed);
+  const expectedSet = new Set(expected);
+  const missingFiles = stableSort(
+    expected.filter((file) => !executedSet.has(file))
+  );
+  const unexpectedFiles = stableSort(
+    executed.filter((file) => !expectedSet.has(file))
+  );
+  const duplicateFiles = duplicateValues(executed);
+  const plannedMissing = stableSort(
+    expected.filter((file) => !plannedSet.has(file))
+  );
+  const plannedUnexpected = stableSort(
+    planned.filter((file) => !expectedSet.has(file))
+  );
+  const plannedDuplicates = duplicateValues(planned);
+  const shardCoordinates = stableSort(
+    shards.map((shard) => `${shard.shard_index}/${shard.shard_count}`)
+  );
+  const expectedCoordinates = Array.from(
+    { length: shardCount },
+    (_, index) => `${index + 1}/${shardCount}`
+  );
+  const errors = [];
+  const sourceEvidence = records.filter(
+    (record) =>
+      record.source === source && EVIDENCE_RECORD_KINDS.has(record.kind)
+  );
+  if (
+    identity &&
+    (sourceEvidence.length === 0 ||
+      sourceEvidence.some((record) => !sameEvidenceIdentity(record, identity)))
+  ) {
+    errors.push("evidence identity is missing or mismatched");
+  }
+  if (globalManifests.length !== 1)
+    errors.push("expected exactly one global Jest manifest");
+  if (shardManifests.length !== shardCount)
+    errors.push("missing shard plan manifest");
+  if (shards.length !== shardCount) errors.push("missing shard result");
+  if (
+    JSON.stringify(shardCoordinates) !== JSON.stringify(expectedCoordinates)
+  ) {
+    errors.push("invalid shard coordinates");
+  }
+  if (missingFiles.length > 0)
+    errors.push("expected Jest files were not executed");
+  if (unexpectedFiles.length > 0)
+    errors.push("unexpected Jest files were executed");
+  if (duplicateFiles.length > 0)
+    errors.push("Jest files executed more than once");
+  if (plannedMissing.length > 0 || plannedDuplicates.length > 0) {
+    errors.push("Jest shard plans are incomplete or overlapping");
+  }
+  if (plannedUnexpected.length > 0) {
+    errors.push("Jest shard plans contain unexpected files");
+  }
+  for (const shard of shards) {
+    const matchingManifests = shardManifests.filter(
+      (manifest) =>
+        manifest.shard_index === shard.shard_index &&
+        manifest.shard_count === shard.shard_count
+    );
+    if (
+      matchingManifests.length !== 1 ||
+      !sameValues(
+        matchingManifests[0]?.files ?? [],
+        shard.executed_test_files ?? []
+      )
+    ) {
+      errors.push(
+        `Jest shard ${safeText(shard.shard_index, 10)}/${safeText(shard.shard_count, 10)} did not execute its exact plan`
+      );
+    }
+  }
+  if (records.some((record) => record.kind === "malformed"))
+    errors.push("malformed evidence");
+  for (const [job, result] of Object.entries(jobResults)) {
+    if (result !== "success" && result !== "skipped") {
+      errors.push(`${safeText(job, 80)} job did not succeed`);
+    }
+  }
+  if (phases.some((phase) => phase.status !== "SUCCEEDED")) {
+    errors.push("one or more required phases failed");
+  }
+  const counts = sumCounts(shards);
+  if (
+    counts.pending_test_suites > 0 ||
+    counts.pending_tests > 0 ||
+    counts.todo_tests > 0
+  ) {
+    errors.push("Jest reported skipped or todo tests");
+  }
+  const shardDurations = shards
+    .map((shard) => Number(shard.duration_ms ?? 0))
+    .filter((duration) => duration >= 0);
+  const maximumShardDuration = shardDurations.length
+    ? Math.max(...shardDurations)
+    : 0;
+  const minimumShardDuration = shardDurations.length
+    ? Math.min(...shardDurations)
+    : 0;
+  return {
+    status: errors.length === 0 ? "SUCCEEDED" : "FAILED",
+    phases,
+    counts,
+    shards: stableSort(
+      shards.map(
+        (shard) =>
+          `${String(shard.shard_index).padStart(2, "0")}:${JSON.stringify({
+            index: shard.shard_index,
+            count: shard.shard_count,
+            status: shard.status,
+            duration_ms: shard.duration_ms,
+            counts: shard.counts,
+          })}`
+      )
+    ).map((value) => JSON.parse(value.slice(value.indexOf(":") + 1))),
+    shard_imbalance_ms: maximumShardDuration - minimumShardDuration,
+    missing_files: missingFiles.slice(0, MAX_FAILURES),
+    duplicate_files: duplicateFiles.slice(0, MAX_FAILURES),
+    unexpected_files: unexpectedFiles.slice(0, MAX_FAILURES),
+    failing_suites: stableSort(
+      shards.flatMap((shard) => shard.failing_suites ?? [])
+    ).slice(0, MAX_FAILURES),
+    failing_tests: shards
+      .flatMap((shard) => shard.failing_tests ?? [])
+      .slice(0, MAX_FAILURES),
+    errors: errors.map((error) => safeText(error, 200)).slice(0, 50),
+  };
+}
+
+function jobLinks(jobsFile) {
+  if (!jobsFile || !fs.existsSync(jobsFile)) return [];
+  try {
+    const jobs = readJson(jobsFile).jobs ?? [];
+    return jobs
+      .filter(
+        (job) =>
+          typeof job.name === "string" &&
+          /^https:\/\/github\.com\/6529-Collections\/6529seize-frontend\/actions\/runs\/\d+\/job\/\d+$/.test(
+            job.html_url ?? ""
+          )
+      )
+      .map((job) => ({ name: safeText(job.name, 120), url: job.html_url }))
+      .slice(0, 100);
+  } catch {
+    return [];
+  }
+}
+
+function finalSummary({ args, records, jobResults }) {
+  const mode = required(args, "mode");
+  if (!new Set(["legacy", "shadow", "sharded"]).has(mode)) {
+    throw new Error("Invalid gate mode");
+  }
+  const shardCount = integer(required(args, "shard-count"), "shard-count", 1);
+  if (!ALLOWED_SHARD_COUNTS.has(shardCount))
+    throw new Error("Unsupported shard count");
+  const identity = evidenceIdentityFromArgs(args);
+  const legacy =
+    mode === "sharded"
+      ? null
+      : buildGateSummary({
+          records,
+          source: "legacy",
+          shardCount: 1,
+          jobResults: { legacy: jobResults.legacy },
+          identity,
+        });
+  const sharded =
+    mode === "legacy"
+      ? null
+      : buildGateSummary({
+          records,
+          source: "parallel",
+          shardCount,
+          jobResults: {
+            lint: jobResults.lint,
+            typecheck: jobResults.typecheck,
+            build: jobResults.build,
+            inventory: jobResults.inventory,
+            jest: jobResults.jest,
+          },
+          identity,
+        });
+  const authoritative = mode === "sharded" ? sharded : legacy;
+  const equivalent =
+    mode === "shadow"
+      ? legacy.status === sharded.status &&
+        sameCounts(legacy.counts, sharded.counts)
+      : null;
+  const runUrl = required(args, "run-url");
+  if (
+    !/^https:\/\/github\.com\/6529-Collections\/6529seize-frontend\/actions\/runs\/\d+$/.test(
+      runUrl
+    )
+  ) {
+    throw new Error("Invalid run URL");
+  }
+  return {
+    schema_version: 1,
+    kind: "base_canary_summary",
+    status: authoritative?.status ?? "FAILED",
+    gate_mode: mode,
+    fresh_or_reused: "fresh",
+    ...identity,
+    behavior_digest: digest(args, "behavior-digest"),
+    shard_count: mode === "sharded" ? shardCount : 1,
+    phases: authoritative?.phases ?? [],
+    phase_durations_ms: Object.fromEntries(
+      (authoritative?.phases ?? []).map((phase) => [
+        phase.name,
+        phase.duration_ms,
+      ])
+    ),
+    totals: authoritative?.counts ?? sumCounts([]),
+    shards: authoritative?.shards ?? [],
+    shard_imbalance_ms: authoritative?.shard_imbalance_ms ?? 0,
+    missing_files: authoritative?.missing_files ?? [],
+    duplicate_files: authoritative?.duplicate_files ?? [],
+    unexpected_files: authoritative?.unexpected_files ?? [],
+    failing_suites: authoritative?.failing_suites ?? [],
+    failing_tests: authoritative?.failing_tests ?? [],
+    errors: authoritative?.errors ?? ["authoritative evidence missing"],
+    equivalence:
+      mode === "shadow"
+        ? {
+            equivalent,
+            serial_status: legacy.status,
+            sharded_status: sharded.status,
+            all_counts_equal: sameCounts(legacy.counts, sharded.counts),
+            serial_totals: legacy.counts,
+            sharded_totals: sharded.counts,
+            sharded_phase_durations_ms: Object.fromEntries(
+              sharded.phases.map((phase) => [phase.name, phase.duration_ms])
+            ),
+            sharded_shards: sharded.shards,
+            sharded_shard_imbalance_ms: sharded.shard_imbalance_ms,
+          }
+        : null,
+    run_url: runUrl,
+    job_links: jobLinks(args["jobs-file"]),
+    summary_artifact_name: safeText(required(args, "artifact-name"), 200),
+  };
+}
+
+function run(command, args) {
+  if (command === "fingerprint") {
+    writeJson(required(args, "output"), contractFromRepository(args));
+    return;
+  }
+  if (command === "matrix") {
+    const count = integer(required(args, "shard-count"), "shard-count", 1);
+    if (!ALLOWED_SHARD_COUNTS.has(count))
+      throw new Error("Unsupported shard count");
+    process.stdout.write(
+      `${JSON.stringify({
+        include: Array.from({ length: count }, (_, index) => ({
+          index: index + 1,
+          total: count,
+        })),
+      })}\n`
+    );
+    return;
+  }
+  if (command === "manifest") {
+    const repoRoot = path.resolve(required(args, "repo-root"));
+    const files = manifestFromRaw(
+      fs.readFileSync(required(args, "raw"), "utf8"),
+      repoRoot
+    );
+    const scope = required(args, "scope");
+    const source = required(args, "source");
+    const value = {
+      schema_version: 1,
+      kind: "manifest",
+      ...evidenceIdentityFromArgs(args),
+      source,
+      scope,
+      shard_index:
+        scope === "shard"
+          ? integer(required(args, "shard-index"), "shard-index", 1)
+          : null,
+      shard_count:
+        scope === "shard"
+          ? integer(required(args, "shard-count"), "shard-count", 1)
+          : null,
+      files,
+    };
+    if (files.length === 0)
+      throw new Error("Jest test-file inventory is empty");
+    writeJson(required(args, "output"), value);
+    return;
+  }
+  if (command === "phase") {
+    writeJson(
+      required(args, "output"),
+      phaseRecord({
+        name: required(args, "name"),
+        status: required(args, "status"),
+        durationMs: integer(required(args, "duration-ms"), "duration-ms"),
+        exitCode: integer(required(args, "exit-code"), "exit-code"),
+        source: required(args, "source"),
+        identity: evidenceIdentityFromArgs(args),
+      })
+    );
+    return;
+  }
+  if (command === "jest") {
+    const repoRoot = path.resolve(required(args, "repo-root"));
+    const resultsFile = required(args, "results");
+    writeJson(
+      required(args, "output"),
+      jestRecord({
+        result: fs.existsSync(resultsFile)
+          ? readJson(resultsFile)
+          : { success: false, testResults: [] },
+        manifest: readJson(required(args, "manifest")),
+        repoRoot,
+        shardIndex: integer(required(args, "shard-index"), "shard-index", 1),
+        shardCount: integer(required(args, "shard-count"), "shard-count", 1),
+        durationMs: integer(required(args, "duration-ms"), "duration-ms"),
+        exitCode: integer(required(args, "exit-code"), "exit-code"),
+        source: required(args, "source"),
+        identity: evidenceIdentityFromArgs(args),
+      })
+    );
+    return;
+  }
+  if (command === "aggregate") {
+    const records = loadEvidence(required(args, "evidence-root"));
+    const jobResults = readJson(required(args, "job-results"));
+    const summary = finalSummary({ args, records, jobResults });
+    writeJson(required(args, "output"), summary);
+    if (summary.status !== "SUCCEEDED") process.exitCode = 1;
+    return;
+  }
+  throw new Error(`Unknown command: ${command}`);
+}
+
+module.exports = {
+  buildGateSummary,
+  finalSummary,
+  frontendGateContract,
+  jestRecord,
+  manifestFromRaw,
+  phaseRecord,
+  safeText,
+};
+
+if (require.main === module) {
+  try {
+    const [command, ...values] = process.argv.slice(2);
+    if (!command) throw new Error("A command is required");
+    run(command, parseArgs(values));
+  } catch (error) {
+    process.stderr.write(
+      `${safeText(error instanceof Error ? error.message : error, 300)}\n`
+    );
+    process.exitCode = 2;
+  }
+}


### PR DESCRIPTION
## Issue
- The legacy frontend base canary serializes lint, typecheck, the complete Jest suite, and build, keeping staging recovery on a ~24–38 minute critical path.
- This bootstrap must accelerate only future base-canary dispatches without changing the active train’s preflight, isolation, deploy, API, or worker behavior.

## Fix
- Add a fail-closed parallel base-canary workflow with independently reversible legacy/sharded mode and 1/2/4 deterministic Jest shards.
- Bind behavioral equivalence to a complete content digest while retaining exact base/workflow SHAs as provenance.

## Changes
- Replace only `release-bus-base-canary.yml`.
- Add the immutable gate/evidence tool and focused contract, completeness, and deliberate-shard-failure tests.
- Keep deployed worker dispatch inputs and authorization payload/path unchanged; all new validation inputs are optional.
- Deliberately omit progress-reporting and backend evidence-reuse dependencies for compatibility with the currently deployed API.
- Do not modify preflight, isolation, deploy, app-PR CI, docs, or application code.

## Validation
- `./scripts/release-bus-frontend-gate.sh contract` — 18/18 tests passed.
- Prettier, `bash -n`, YAML parse, GPG/DCO, and `git diff --check` passed.
- Exact sharded-2 behavior digest on main base: `a250052ffd790d79e487bf38a97877e5bfd759c5fb69a37f0bdf70cf7819afd6`.
- One validation-only sharded-2 full-inventory Actions proof will be attached before merge.

## Risk
- Level: Medium. The changed workflow gates all future frontend trains, but defaults remain `legacy` with one shard and merging does not deploy the application.
- Rollback: set `RELEASE_BUS_FRONTEND_GATE_MODE=legacy` and `FRONTEND_GATE_SHARD_COUNT=1`; code rollback is a revert to main SHA `c507e5e2c389a984731478035678f89f9cbfc11d`.

## Review Notes
- Verify exact manifest partition/completeness, aggregate failure on any failed/cancelled/skipped required job, immutable SHA/tooling staging, minimal permissions, and the absence of active-train workflow overlap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable release-gate modes, validation-only runs, shard counts, and failure injection.
  * Added parallel lint, type-check, build, test-inventory, and sharded test execution.
  * Added deterministic evidence collection, fingerprint validation, phase reporting, and aggregate release summaries.
  * Added links to relevant workflow jobs in aggregated results.

* **Bug Fixes**
  * Improved fail-closed validation for missing, duplicate, skipped, or unexpected test shards and phases.

* **Tests**
  * Expanded coverage for workflow inputs, evidence identity, deterministic sharding, failure handling, and summary generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->