### PR TITLE
Fix Release Bus staging PM2 migration

### DIFF
--- a/.github/workflows/release-bus-deploy-staging.yml
+++ b/.github/workflows/release-bus-deploy-staging.yml
@@ -154,7 +154,101 @@ jobs:
           release_root="$REPO_DIR/.release-bus"
           release_dir="$release_root/releases/$EXPECTED_SHA"
           current_link="$release_root/current"
-          previous_target="$(readlink "$current_link" 2>/dev/null || true)"
+          previous_target="$(readlink -f "$current_link" 2>/dev/null || true)"
+          pm2_json="$(sudo -H -u "$RUN_AS" pm2 jlist)"
+          process_count="$(jq '[.[] | select(.name == "6529seize")] | length' <<<"$pm2_json")"
+          process_kind=''
+          if [ "$process_count" -eq 0 ]; then
+            process_kind='absent'
+          elif [ "$process_count" -eq 1 ]; then
+            process_shape="$(jq -c '[.[] | select(.name == "6529seize")][0] | {
+              exec_mode: .pm2_env.exec_mode,
+              pm_exec_path: .pm2_env.pm_exec_path,
+              pm_cwd: .pm2_env.pm_cwd,
+              args: .pm2_env.args
+            }' <<<"$pm2_json")"
+            if jq -e --arg repo_dir "$REPO_DIR" '
+              .exec_mode == "fork_mode" and
+              .pm_exec_path == "/usr/bin/bash" and
+              .pm_cwd == $repo_dir and
+              .args == ["-lc", ("cd \"" + $repo_dir + "\" && ./bin/6529 run start:standalone")]
+            ' <<<"$process_shape" >/dev/null; then
+              # One historical staging process predates the immutable release layout.
+              # Only this exact tuple may take the one-time replacement path below.
+              process_kind='legacy'
+            elif [ -n "$previous_target" ] && jq -e \
+              --arg release_root "$release_root" \
+              --arg previous_target "$previous_target" '
+              .exec_mode == "cluster_mode" and
+              (.args == null or .args == []) and
+              (.pm_cwd == ($release_root + "/current") or .pm_cwd == $previous_target) and
+              (.pm_exec_path == ($release_root + "/current/server.js") or
+                .pm_exec_path == ($previous_target + "/server.js"))
+            ' <<<"$process_shape" >/dev/null; then
+              process_kind='managed'
+            else
+              echo 'Refusing to replace an unrecognized 6529seize PM2 process.' >&2
+              exit 1
+            fi
+          else
+            echo 'Refusing to deploy with duplicate 6529seize PM2 processes.' >&2
+            exit 1
+          fi
+
+          restore_previous_link() {
+            if [ -n "$previous_target" ]; then
+              ln -sfn "$previous_target" "$current_link"
+            else
+              rm -f "$current_link"
+            fi
+          }
+
+          wait_for_exact_local_version() {
+            for attempt in {1..24}; do
+              response="$(curl --fail --silent --show-error --max-time 10 \
+                http://127.0.0.1:3001/api/version 2>/dev/null || true)"
+              actual_version="$(jq -r '
+                select(.stale == false) |
+                .version | select(type == "string" and test("^[a-f0-9]{40}$"))
+              ' <<<"$response" 2>/dev/null || true)"
+              if [ "$actual_version" = "$EXPECTED_SHA" ]; then
+                return 0
+              fi
+              sleep 5
+            done
+            return 1
+          }
+
+          restore_legacy_process() {
+            sudo -H -u "$RUN_AS" pm2 delete 6529seize >/dev/null 2>&1 || true
+            restore_previous_link
+            sudo -H -u "$RUN_AS" pm2 start bash --name=6529seize -- \
+              -lc "cd \"$REPO_DIR\" && ./bin/6529 run start:standalone"
+            for attempt in {1..24}; do
+              if curl --fail --silent --show-error --max-time 10 \
+                http://127.0.0.1:3001/api/version | jq -e '
+                  .stale == false and
+                  (.version | type == "string" and test("^[a-f0-9]{40}$"))
+                ' >/dev/null 2>&1; then
+                sudo -H -u "$RUN_AS" pm2 save
+                return 0
+              fi
+              sleep 5
+            done
+            return 1
+          }
+
+          rollback_managed_process() {
+            restore_previous_link
+            if [ -n "$previous_target" ]; then
+              sudo -H -u "$RUN_AS" pm2 startOrReload \
+                "$release_root/ecosystem.config.cjs" --only 6529seize --update-env
+            else
+              sudo -H -u "$RUN_AS" pm2 delete 6529seize >/dev/null 2>&1 || true
+            fi
+            sudo -H -u "$RUN_AS" pm2 save
+          }
+
           install -d -o "$RUN_AS" -g "$RUN_AS" "$release_dir"
           http_status="$(curl --silent --show-error --proto '=https' \
             --output "$release_dir/package.zip" \
@@ -181,18 +275,43 @@ jobs:
           };
           PM2_CONFIG
           chown "$RUN_AS:$RUN_AS" "$release_root/ecosystem.config.cjs"
-          if ! sudo -H -u "$RUN_AS" pm2 startOrReload "$release_root/ecosystem.config.cjs" --only 6529seize --update-env; then
-            if [ -n "$previous_target" ]; then
-              ln -sfn "$previous_target" "$current_link"
-              if ! sudo -H -u "$RUN_AS" pm2 startOrReload "$release_root/ecosystem.config.cjs" --only 6529seize --update-env; then
+
+          if [ "$process_kind" = legacy ]; then
+            # Future managed releases stay on startOrReload. This bounded replacement
+            # is reserved for migrating the exact legacy fork detected above.
+            sudo -H -u "$RUN_AS" pm2 delete 6529seize
+            if ! sudo -H -u "$RUN_AS" pm2 start \
+              "$release_root/ecosystem.config.cjs" --only 6529seize; then
+              if ! restore_legacy_process; then
+                echo 'CRITICAL: staging migration and legacy rollback both failed.' >&2
+                exit 2
+              fi
+              echo 'Staging migration failed; the known legacy process was restored.' >&2
+              exit 1
+            fi
+          else
+            if ! sudo -H -u "$RUN_AS" pm2 startOrReload \
+              "$release_root/ecosystem.config.cjs" --only 6529seize --update-env; then
+              if ! rollback_managed_process; then
                 echo 'CRITICAL: staging deploy and rollback reload both failed.' >&2
                 exit 2
               fi
-            else
-              rm -f "$current_link"
-              sudo -H -u "$RUN_AS" pm2 delete 6529seize || true
-              echo 'Staging deploy failed and no prior release exists to restore.' >&2
+              echo 'Staging deploy failed; the prior managed release was restored.' >&2
+              exit 1
             fi
+          fi
+
+          if ! wait_for_exact_local_version; then
+            if [ "$process_kind" = legacy ]; then
+              if ! restore_legacy_process; then
+                echo 'CRITICAL: exact-version check and legacy rollback both failed.' >&2
+                exit 2
+              fi
+            elif ! rollback_managed_process; then
+              echo 'CRITICAL: exact-version check and managed rollback both failed.' >&2
+              exit 2
+            fi
+            echo 'Instance-local exact-version verification failed; the prior process was restored.' >&2
             exit 1
           fi
           sudo -H -u "$RUN_AS" pm2 save

--- a/.github/workflows/release-bus-deploy-staging.yml
+++ b/.github/workflows/release-bus-deploy-staging.yml
@@ -197,56 +197,69 @@ jobs:
 
           restore_previous_link() {
             if [ -n "$previous_target" ]; then
-              ln -sfn "$previous_target" "$current_link"
+              ln -sfn "$previous_target" "$current_link" || return 1
             else
-              rm -f "$current_link"
+              rm -f "$current_link" || return 1
             fi
           }
 
-          wait_for_exact_local_version() {
+          read_local_version() {
+            response="$(curl --fail --silent --show-error --max-time 10 \
+              http://127.0.0.1:3001/api/version 2>/dev/null || true)"
+            jq -r '
+              select(.stale == false) |
+              .version | select(type == "string" and test("^[a-f0-9]{40}$"))
+            ' <<<"$response" 2>/dev/null || true
+          }
+
+          wait_for_local_version() {
+            target_version="$1"
             for attempt in {1..24}; do
-              response="$(curl --fail --silent --show-error --max-time 10 \
-                http://127.0.0.1:3001/api/version 2>/dev/null || true)"
-              actual_version="$(jq -r '
-                select(.stale == false) |
-                .version | select(type == "string" and test("^[a-f0-9]{40}$"))
-              ' <<<"$response" 2>/dev/null || true)"
-              if [ "$actual_version" = "$EXPECTED_SHA" ]; then
+              actual_version="$(read_local_version)"
+              if [ "$actual_version" = "$target_version" ]; then
                 return 0
               fi
-              sleep 5
+              sleep 5 || return 1
             done
             return 1
           }
 
-          restore_legacy_process() {
+          delete_6529_process() {
             sudo -H -u "$RUN_AS" pm2 delete 6529seize >/dev/null 2>&1 || true
-            restore_previous_link
+            remaining_count="$(sudo -H -u "$RUN_AS" pm2 jlist | \
+              jq '[.[] | select(.name == "6529seize")] | length')" || return 1
+            [ "$remaining_count" -eq 0 ] || return 1
+          }
+
+          previous_local_version=''
+          if [ "$process_kind" != absent ]; then
+            previous_local_version="$(read_local_version)"
+            [[ "$previous_local_version" =~ ^[a-f0-9]{40}$ ]] || {
+              echo 'Refusing to deploy without an exact healthy pre-mutation local version.' >&2
+              exit 1
+            }
+          fi
+
+          restore_legacy_process() {
+            delete_6529_process || return 1
+            restore_previous_link || return 1
             sudo -H -u "$RUN_AS" pm2 start bash --name=6529seize -- \
-              -lc "cd \"$REPO_DIR\" && ./bin/6529 run start:standalone"
-            for attempt in {1..24}; do
-              if curl --fail --silent --show-error --max-time 10 \
-                http://127.0.0.1:3001/api/version | jq -e '
-                  .stale == false and
-                  (.version | type == "string" and test("^[a-f0-9]{40}$"))
-                ' >/dev/null 2>&1; then
-                sudo -H -u "$RUN_AS" pm2 save
-                return 0
-              fi
-              sleep 5
-            done
-            return 1
+              -lc "cd \"$REPO_DIR\" && ./bin/6529 run start:standalone" || return 1
+            wait_for_local_version "$previous_local_version" || return 1
+            sudo -H -u "$RUN_AS" pm2 save || return 1
           }
 
           rollback_managed_process() {
-            restore_previous_link
+            restore_previous_link || return 1
             if [ -n "$previous_target" ]; then
               sudo -H -u "$RUN_AS" pm2 startOrReload \
-                "$release_root/ecosystem.config.cjs" --only 6529seize --update-env
+                "$release_root/ecosystem.config.cjs" \
+                --only 6529seize --update-env || return 1
+              wait_for_local_version "$previous_local_version" || return 1
             else
-              sudo -H -u "$RUN_AS" pm2 delete 6529seize >/dev/null 2>&1 || true
+              delete_6529_process || return 1
             fi
-            sudo -H -u "$RUN_AS" pm2 save
+            sudo -H -u "$RUN_AS" pm2 save || return 1
           }
 
           install -d -o "$RUN_AS" -g "$RUN_AS" "$release_dir"
@@ -279,7 +292,10 @@ jobs:
           if [ "$process_kind" = legacy ]; then
             # Future managed releases stay on startOrReload. This bounded replacement
             # is reserved for migrating the exact legacy fork detected above.
-            sudo -H -u "$RUN_AS" pm2 delete 6529seize
+            if ! delete_6529_process; then
+              echo 'Refusing to migrate because the legacy process could not be removed.' >&2
+              exit 1
+            fi
             if ! sudo -H -u "$RUN_AS" pm2 start \
               "$release_root/ecosystem.config.cjs" --only 6529seize; then
               if ! restore_legacy_process; then
@@ -301,7 +317,7 @@ jobs:
             fi
           fi
 
-          if ! wait_for_exact_local_version; then
+          if ! wait_for_local_version "$EXPECTED_SHA"; then
             if [ "$process_kind" = legacy ]; then
               if ! restore_legacy_process; then
                 echo 'CRITICAL: exact-version check and legacy rollback both failed.' >&2

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -138,11 +138,21 @@ describe("release bus staging artifact transfer", () => {
     );
     expect(script).toContain("process_kind='legacy'");
     expect(script).toContain("restore_legacy_process");
-    expect(script).toContain("wait_for_exact_local_version");
-    expect(script).toContain("http://127.0.0.1:3001/api/version");
-    expect(script.indexOf("wait_for_exact_local_version")).toBeLessThan(
-      script.lastIndexOf("pm2 save")
+    expect(script).toContain("delete_6529_process || return 1");
+    expect(script).toContain("restore_previous_link || return 1");
+    expect(script).toContain("--update-env || return 1");
+    expect(script).toContain("pm2 save || return 1");
+    expect(script).toContain(
+      'wait_for_local_version "$previous_local_version" || return 1'
     );
+    expect(script).toContain('wait_for_local_version "$EXPECTED_SHA"');
+    expect(script).toContain(
+      "Refusing to deploy without an exact healthy pre-mutation local version."
+    );
+    expect(script).toContain("http://127.0.0.1:3001/api/version");
+    expect(
+      script.lastIndexOf('wait_for_local_version "$EXPECTED_SHA"')
+    ).toBeLessThan(script.lastIndexOf("pm2 save"));
   });
 });
 

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -103,11 +103,45 @@ describe("release bus staging artifact transfer", () => {
     expect(
       stageStep.run.match(/--region "\$ARTIFACT_BUCKET_REGION"/g)
     ).toHaveLength(2);
-    expect(deployStep.run).not.toContain("curl --fail");
+    const artifactTransfer = deployStep.run.slice(
+      deployStep.run.indexOf('http_status="$(curl'),
+      deployStep.run.indexOf('test "$http_status" = 200')
+    );
+    expect(artifactTransfer).not.toContain("curl --fail");
     expect(deployStep.run).toContain("--write-out '%{http_code}'");
     expect(deployStep.run).toContain('test "$http_status" = 200');
     expect(deployStep.run.indexOf('test "$http_status" = 200')).toBeLessThan(
       deployStep.run.indexOf("sha256sum -c -")
+    );
+  });
+
+  it("migrates only the exact legacy PM2 process and verifies locally", () => {
+    const deployStep = deployWorkflow.jobs.deploy.steps.find(
+      (step: { name?: string }) =>
+        step.name === "Deploy immutable bundle through SSM"
+    );
+    const script = deployStep.run;
+
+    expect(script).toContain(
+      'process_count="$(jq \'[.[] | select(.name == "6529seize")] | length\''
+    );
+    expect(script).toContain('.pm_exec_path == "/usr/bin/bash"');
+    expect(script).toContain(".pm_cwd == $repo_dir");
+    expect(script).toContain(
+      '.args == ["-lc", ("cd \\\"" + $repo_dir + "\\\" && ./bin/6529 run start:standalone")]'
+    );
+    expect(script).toContain(
+      "Refusing to replace an unrecognized 6529seize PM2 process."
+    );
+    expect(script).toContain(
+      "Refusing to deploy with duplicate 6529seize PM2 processes."
+    );
+    expect(script).toContain("process_kind='legacy'");
+    expect(script).toContain("restore_legacy_process");
+    expect(script).toContain("wait_for_exact_local_version");
+    expect(script).toContain("http://127.0.0.1:3001/api/version");
+    expect(script.indexOf("wait_for_exact_local_version")).toBeLessThan(
+      script.lastIndexOf("pm2 save")
     );
   });
 });


### PR DESCRIPTION
## Issue
- Release Bus staging deploy run 29869706687 transferred and verified the immutable artifact, but `pm2 startOrReload` matched the historical fork-mode process and retained its legacy command/cwd. The public version therefore stayed on the prior SHA.

## Fix
- Classify the existing `6529seize` PM2 process before activation.
- Permit the one-time replacement only for the exact known legacy tuple; reject duplicates and all unknown shapes.
- Keep normal managed deployments on cluster-mode `startOrReload`.
- Verify the exact SHA on the instance before SSM may report success, with deterministic legacy/managed rollback paths.

## Changes
- Harden `.github/workflows/release-bus-deploy-staging.yml`.
- Extend the workflow contract test for exact tuple binding, fail-closed behavior, rollback, and local version verification.

## Validation
- 50/50 deployment-bus tests passed.
- Embedded SSM shell passed `bash -n`; workflow YAML parsed in the contract test.
- `lint:changed`, `typecheck:changed`, formatting, and `git diff --check` passed.
- Read-only SSM evidence: current symlink points to the new release, while the active PM2 definition remains the exact legacy fork tuple and `/api/version` remains the prior SHA.

## Risk
- Level: Medium.
- Why: staging process-manager migration. The exact historical tuple requires one bounded restart; this is not represented as zero downtime. All later managed releases retain PM2 cluster reload behavior.
- Rollback: restore the exact legacy command and require a healthy local version before returning failure; unknown/duplicate process shapes fail before replacement.

## Review Notes
- Focus on the strict legacy tuple, rollback branches, and ordering of instance-local exact-version verification before SSM success.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staging deployment reliability when handling existing, legacy, or managed service processes.
  * Added safer rollback behavior when deployments or version verification fail.
  * Deployments now verify that the running service matches the expected release before completing.
  * Improved artifact transfer handling for HTTP redirects and successful responses.

* **Tests**
  * Added coverage for legacy process migration, duplicate or unknown process detection, rollback flows, and deployment verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->