### PR TITLE
Harden Release Bus authorization transport

### DIFF
--- a/.github/workflows/app-pr-ci.yml
+++ b/.github/workflows/app-pr-ci.yml
@@ -242,10 +242,13 @@ jobs:
           set -euo pipefail
           if git diff --quiet "origin/${BASE_REF}...HEAD" -- \
             .github/workflows/release-bus-*.yml \
+            scripts/release-bus-authorize-operation.sh \
             scripts/release-bus-frontend-gate.sh \
+            scripts/release-bus-gate-evidence.cjs \
             scripts/release-bus-summarize-jest.mjs \
             scripts/release-bus-report-progress.mjs \
             __tests__/scripts/release-bus-frontend-gate.test.ts \
+            __tests__/scripts/release-bus-gate-evidence.test.ts \
             __tests__/scripts/release-bus-jest-reporting.test.ts; then
             echo "Release Bus gate files are unchanged."
             exit 0

--- a/.github/workflows/release-bus-base-canary.yml
+++ b/.github/workflows/release-bus-base-canary.yml
@@ -34,7 +34,7 @@ run-name: Canary frontend base ${{ inputs.base_sha }} [${{ inputs.operation_key 
 jobs:
   authorize:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     outputs:
       gate_mode: ${{ steps.inputs.outputs.gate_mode }}
       shard_count: ${{ steps.inputs.outputs.shard_count }}
@@ -171,14 +171,14 @@ jobs:
           RELEASE_BUS_API_URL: ${{ vars.RELEASE_BUS_API_URL }}
           RELEASE_BUS_WORKFLOW_AUTH_TOKEN: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
           TRAIN_ID: ${{ inputs.release_train_id }}
+          WORKFLOW_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           payload="$(jq -n --arg train_id "$TRAIN_ID" --arg operation_key "$OPERATION_KEY" --arg workflow_run_id "$GITHUB_RUN_ID" --arg expected_sha "$EXPECTED_SHA" '{train_id:$train_id,operation_key:$operation_key,workflow_run_id:$workflow_run_id,artifact_run_id:null,repository:"frontend",environment:"orchestration",service:null,expected_sha:$expected_sha,artifact_digest:null}')"
-          curl --fail-with-body --silent --show-error \
-            -H "Authorization: Bearer $RELEASE_BUS_WORKFLOW_AUTH_TOKEN" \
-            -H 'Content-Type: application/json' \
-            --data "$payload" \
-            "$RELEASE_BUS_API_URL/deploy/release-bus/authorize"
+          authorize_tool="$RUNNER_TEMP/release-bus-authorize-operation.sh"
+          git show "$WORKFLOW_SHA:scripts/release-bus-authorize-operation.sh" > "$authorize_tool"
+          chmod 700 "$authorize_tool"
+          "$authorize_tool" "$payload"
       - name: Verify authorization did not mutate source
         run: test -z "$(git status --porcelain --untracked-files=all)"
 

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -12,6 +12,7 @@ describe("Release Bus frontend gate contract", () => {
   const preflight = read(".github/workflows/release-bus-preflight.yml");
   const isolation = read(".github/workflows/release-bus-isolate-candidate.yml");
   const canary = read(".github/workflows/release-bus-base-canary.yml");
+  const authorization = read("scripts/release-bus-authorize-operation.sh");
   const appPrCi = read(".github/workflows/app-pr-ci.yml");
 
   type WorkflowStep = {
@@ -26,7 +27,10 @@ describe("Release Bus frontend gate contract", () => {
         inputs?: Record<string, { required?: boolean }>;
       };
     };
-    jobs?: Record<string, { steps?: WorkflowStep[] }>;
+    jobs?: Record<
+      string,
+      { steps?: WorkflowStep[]; "timeout-minutes"?: number }
+    >;
   };
 
   it("keeps deployed worker dispatch and authorization backward compatible", () => {
@@ -50,11 +54,89 @@ describe("Release Bus frontend gate contract", () => {
     expect(canary).toContain(
       '\'{train_id:$train_id,operation_key:$operation_key,workflow_run_id:$workflow_run_id,artifact_run_id:null,repository:"frontend",environment:"orchestration",service:null,expected_sha:$expected_sha,artifact_digest:null}\''
     );
-    expect(canary).toContain(
-      "$RELEASE_BUS_API_URL/deploy/release-bus/authorize"
+    expect(authorization).toContain(
+      '"$api_url/deploy/release-bus/authorize"'
     );
     expect(canary).not.toContain("/deploy/release-bus/report-progress");
     expect(canary).not.toContain("release-bus-report-progress.mjs");
+  });
+
+  it("bounds and retries an ambiguous authorization transport failure", () => {
+    expect(canaryWorkflow.jobs?.authorize?.["timeout-minutes"]).toBe(10);
+    expect(canary).toContain(
+      'git show "$WORKFLOW_SHA:scripts/release-bus-authorize-operation.sh"'
+    );
+
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "release-bus-authorize-")
+    );
+    const attemptFile = path.join(tempDir, "attempts.txt");
+    try {
+      fs.writeFileSync(
+        path.join(tempDir, "curl"),
+        `#!/usr/bin/env bash\ncount=0\nif [ -f "$RELEASE_BUS_ATTEMPT_FILE" ]; then count="$(cat "$RELEASE_BUS_ATTEMPT_FILE")"; fi\ncount=$((count + 1))\nprintf '%s' "$count" > "$RELEASE_BUS_ATTEMPT_FILE"\nif [ "$count" -eq 1 ]; then exit 28; fi\nprintf '200'\n`
+      );
+      fs.writeFileSync(path.join(tempDir, "sleep"), "#!/usr/bin/env bash\n");
+      fs.chmodSync(path.join(tempDir, "curl"), 0o755);
+      fs.chmodSync(path.join(tempDir, "sleep"), 0o755);
+
+      execFileSync(
+        "bash",
+        ["scripts/release-bus-authorize-operation.sh", '{"operation":"same"}'],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...process.env,
+            PATH: `${tempDir}:${process.env.PATH}`,
+            RELEASE_BUS_API_URL: "https://api.example.test",
+            RELEASE_BUS_ATTEMPT_FILE: attemptFile,
+            RELEASE_BUS_WORKFLOW_AUTH_TOKEN: "test-token",
+          },
+        }
+      );
+
+      expect(fs.readFileSync(attemptFile, "utf8")).toBe("2");
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not retry a deterministic authorization rejection", () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "release-bus-authorize-reject-")
+    );
+    const attemptFile = path.join(tempDir, "attempts.txt");
+    try {
+      fs.writeFileSync(
+        path.join(tempDir, "curl"),
+        `#!/usr/bin/env bash\nprintf '1' > "$RELEASE_BUS_ATTEMPT_FILE"\nprintf '409'\n`
+      );
+      fs.chmodSync(path.join(tempDir, "curl"), 0o755);
+
+      expect(() =>
+        execFileSync(
+          "bash",
+          [
+            "scripts/release-bus-authorize-operation.sh",
+            '{"operation":"same"}',
+          ],
+          {
+            cwd: process.cwd(),
+            env: {
+              ...process.env,
+              PATH: `${tempDir}:${process.env.PATH}`,
+              RELEASE_BUS_API_URL: "https://api.example.test",
+              RELEASE_BUS_ATTEMPT_FILE: attemptFile,
+              RELEASE_BUS_WORKFLOW_AUTH_TOKEN: "test-token",
+            },
+            stdio: "pipe",
+          }
+        )
+      ).toThrow();
+      expect(fs.readFileSync(attemptFile, "utf8")).toBe("1");
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("owns the only Release Bus Jest invocation", () => {
@@ -259,6 +341,11 @@ describe("Release Bus frontend gate contract", () => {
   it("executes its argument-forwarding contract in ordinary PR CI", () => {
     expect(appPrCi).toContain(
       "./scripts/release-bus-frontend-gate.sh contract"
+    );
+    expect(appPrCi).toContain("scripts/release-bus-authorize-operation.sh");
+    expect(appPrCi).toContain("scripts/release-bus-gate-evidence.cjs");
+    expect(appPrCi).toContain(
+      "__tests__/scripts/release-bus-gate-evidence.test.ts"
     );
   });
 });

--- a/__tests__/scripts/release-bus-gate-evidence.test.ts
+++ b/__tests__/scripts/release-bus-gate-evidence.test.ts
@@ -41,6 +41,7 @@ describe("Release Bus gate evidence", () => {
     };
     const workflowFileContents = {
       ".github/workflows/release-bus-base-canary.yml": "workflow",
+      "scripts/release-bus-authorize-operation.sh": "authorize",
       "scripts/release-bus-frontend-gate.sh": "gate",
       "scripts/release-bus-gate-evidence.cjs": "evidence",
     };
@@ -57,9 +58,9 @@ describe("Release Bus gate evidence", () => {
     expect(frontendGateContract(input)).toEqual(baseline);
     expect(baseline).toMatchObject({
       behavior_digest:
-        "7efb9837a165c888eb262499d267efb6cc642405d3462ae768944ada88148490",
+        "9602c7d472e4cbb9dbb5f69c196d25f0ef4746739d199ab93449b5fc951ff089",
       gate_fingerprint:
-        "2891de0c74bdd9a075d09f23ef160fbe9313f798d62fcfc5eb60d31e5070b14e",
+        "b51976f92bcc5a34a9fabae337a08935a52424a8c29c48e3fbe7d773eac8e805",
       workflow_digest:
         "da7f739f627198465eeab537a6f7a435dc4a0c332f9e4a8462293eb3f4ab7ee0",
     });

--- a/scripts/release-bus-authorize-operation.sh
+++ b/scripts/release-bus-authorize-operation.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+payload="${1:-}"
+api_url="${RELEASE_BUS_API_URL:-}"
+auth_token="${RELEASE_BUS_WORKFLOW_AUTH_TOKEN:-}"
+
+test -n "$payload"
+jq -e 'type == "object"' <<< "$payload" >/dev/null
+[[ "$api_url" =~ ^https://[A-Za-z0-9] ]]
+test -n "$auth_token"
+
+api_url="${api_url%/}"
+response_file="$(mktemp)"
+trap 'rm -f "$response_file"' EXIT
+
+max_attempts=6
+for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+  http_status=""
+  curl_status=0
+  if http_status="$(curl --silent --show-error \
+    --proto '=https' \
+    --connect-timeout 10 \
+    --max-time 30 \
+    --output "$response_file" \
+    --write-out '%{http_code}' \
+    -H "Authorization: Bearer $auth_token" \
+    -H 'Content-Type: application/json' \
+    --data-binary "$payload" \
+    "$api_url/deploy/release-bus/authorize")"; then
+    curl_status=0
+  else
+    curl_status=$?
+  fi
+
+  if [ "$curl_status" -eq 0 ] && [[ "$http_status" =~ ^2[0-9]{2}$ ]]; then
+    exit 0
+  fi
+
+  retryable=false
+  if [ "$curl_status" -ne 0 ]; then
+    retryable=true
+  elif [[ "$http_status" =~ ^5[0-9]{2}$ ]] ||
+    [ "$http_status" = 408 ] || [ "$http_status" = 429 ]; then
+    retryable=true
+  fi
+
+  if [ "$retryable" != true ]; then
+    echo "Release Bus authorization was rejected with HTTP ${http_status:-unknown}; not retrying." >&2
+    exit 1
+  fi
+  if [ "$attempt" -eq "$max_attempts" ]; then
+    echo "Release Bus authorization transport failed after $max_attempts bounded attempts." >&2
+    exit 1
+  fi
+
+  echo "Release Bus authorization transport attempt $attempt failed; retrying the same operation/run binding." >&2
+  sleep 5
+done

--- a/scripts/release-bus-gate-evidence.cjs
+++ b/scripts/release-bus-gate-evidence.cjs
@@ -40,6 +40,7 @@ const FRONTEND_GATE_BASE_FILES = [
   "pnpm-lock.yaml",
 ];
 const FRONTEND_GATE_TOOLING_FILES = [
+  "scripts/release-bus-authorize-operation.sh",
   "scripts/release-bus-frontend-gate.sh",
   "scripts/release-bus-gate-evidence.cjs",
 ];


### PR DESCRIPTION
## What changed

- bound Release Bus authorization connects to 10 seconds and each request to 30 seconds
- retry the exact same operation/run payload for curl transport failures and HTTP 408, 429, or 5xx responses, with six bounded attempts
- fail immediately on deterministic non-retryable HTTP responses and never print response bodies
- load the authorization helper from the exact workflow SHA
- include the helper in the content-addressed gate behavior/fingerprint contract and app PR CI trigger set

## Root cause

Base-canary run 29879179838 never reached the production `seizeAPI` Lambda. The unbounded curl remained hung until the authorize job's five-minute timeout cancelled the run, before any candidate gate or staging mutation.

## Validation

- Release Bus gate contract: 20/20 tests
- changed lint: pass
- changed typecheck: pass
- YAML parse, shell syntax, and `git diff --check`: pass
- signed commit with DCO sign-off

This workflow/tooling-only merge does not deploy the application. STAGING remains paused until the exact replacement release set is rechecked.
