### PR TITLE
Shard frontend Release Bus preflight validation

### DIFF
--- a/.github/workflows/app-pr-ci.yml
+++ b/.github/workflows/app-pr-ci.yml
@@ -250,11 +250,13 @@ jobs:
             scripts/release-bus-authorize-operation.sh \
             scripts/release-bus-frontend-gate.sh \
             scripts/release-bus-gate-evidence.cjs \
+            scripts/release-bus-preflight-evidence.cjs \
             scripts/release-bus-summarize-jest.mjs \
             scripts/release-bus-report-progress.mjs \
             __tests__/scripts/release-bus-frontend-gate.test.ts \
             __tests__/scripts/release-bus-gate-evidence.test.ts \
             __tests__/scripts/release-bus-jest-reporting.test.ts \
+            __tests__/scripts/release-bus-preflight-evidence.test.ts \
             __tests__/scripts/release-bus-shard-injection.test.ts; then
             echo "Release Bus gate files are unchanged."
             exit 0

--- a/.github/workflows/release-bus-preflight.yml
+++ b/.github/workflows/release-bus-preflight.yml
@@ -11,6 +11,16 @@ on:
       release_branch: { type: string, required: true }
       deploy_units: { type: string, required: true }
       expected_sha: { type: string, required: true }
+      validation_only: { type: boolean, required: false, default: false }
+      validation_shard_count:
+        {
+          type: choice,
+          required: false,
+          default: "2",
+          options: ["1", "2", "4"],
+        }
+      validation_inject_failure:
+        { type: boolean, required: false, default: false }
 
 permissions: {}
 
@@ -19,17 +29,31 @@ run-name: Preflight frontend train ${{ inputs.release_train_id }} [${{ inputs.op
 jobs:
   authorize:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      shard_count: ${{ steps.inputs.outputs.shard_count }}
+      shard_matrix: ${{ steps.inputs.outputs.shard_matrix }}
+      gate_fingerprint: ${{ steps.fingerprint.outputs.gate_fingerprint }}
+      behavior_digest: ${{ steps.fingerprint.outputs.behavior_digest }}
+      workflow_sha: ${{ steps.fingerprint.outputs.workflow_sha }}
+      workflow_digest: ${{ steps.fingerprint.outputs.workflow_digest }}
+      package_manager: ${{ steps.fingerprint.outputs.package_manager }}
+    permissions:
+      contents: read
     steps:
-      - name: Validate and authorize immutable inputs
+      - name: Validate immutable inputs
+        id: inputs
         env:
           EXPECTED_SHA: ${{ inputs.expected_sha }}
           OPERATION_KEY: ${{ inputs.operation_key }}
+          PREFLIGHT_SHARD_COUNT: ${{ vars.FRONTEND_PREFLIGHT_SHARD_COUNT || '2' }}
           RELEASE_BRANCH: ${{ inputs.release_branch }}
-          RELEASE_BUS_API_URL: ${{ vars.RELEASE_BUS_API_URL }}
-          RELEASE_BUS_WORKFLOW_AUTH_TOKEN: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
           TARGET_LANE: ${{ inputs.target_lane }}
           TRAIN_ID: ${{ inputs.release_train_id }}
           TRAIN_REVISION: ${{ inputs.release_train_revision }}
+          VALIDATION_INJECT_FAILURE: ${{ inputs.validation_inject_failure }}
+          VALIDATION_ONLY: ${{ inputs.validation_only }}
+          VALIDATION_SHARD_COUNT: ${{ inputs.validation_shard_count }}
         run: |
           set -euo pipefail
           [[ "$EXPECTED_SHA" =~ ^[a-f0-9]{40}$ ]]
@@ -38,26 +62,25 @@ jobs:
           [[ "$OPERATION_KEY" =~ ^[A-Za-z0-9:._-]{1,180}$ ]]
           [[ "$TARGET_LANE" =~ ^(STAGING|PRODUCTION)$ ]]
           [[ "$RELEASE_BRANCH" =~ ^release-bus/(staging|production)-train-[A-Za-z0-9._-]+$ ]]
-          payload="$(jq -n --arg train_id "$TRAIN_ID" --arg operation_key "$OPERATION_KEY" --arg workflow_run_id "$GITHUB_RUN_ID" --arg expected_sha "$EXPECTED_SHA" '{train_id:$train_id,operation_key:$operation_key,workflow_run_id:$workflow_run_id,artifact_run_id:null,repository:"frontend",environment:"orchestration",service:null,expected_sha:$expected_sha,artifact_digest:null}')"
-          curl --fail-with-body --silent --show-error \
-            -H "Authorization: Bearer $RELEASE_BUS_WORKFLOW_AUTH_TOKEN" \
-            -H 'Content-Type: application/json' \
-            --data "$payload" \
-            "$RELEASE_BUS_API_URL/deploy/release-bus/authorize"
-  build:
-    needs: authorize
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: true
-      matrix:
-        environment: ${{ fromJSON(inputs.target_lane == 'PRODUCTION' && '["staging","production"]' || '["staging"]') }}
-    env:
-      SOURCE_SHA: ${{ inputs.expected_sha }}
-    steps:
-      - name: Check out exact train SHA
+          [[ "$VALIDATION_INJECT_FAILURE" =~ ^(true|false)$ ]]
+          if [ "$VALIDATION_INJECT_FAILURE" = true ]; then
+            test "$VALIDATION_ONLY" = true
+          fi
+          if [ "$VALIDATION_ONLY" = true ]; then
+            PREFLIGHT_SHARD_COUNT="$VALIDATION_SHARD_COUNT"
+          fi
+          [[ "$PREFLIGHT_SHARD_COUNT" =~ ^(1|2|4)$ ]]
+          case "$PREFLIGHT_SHARD_COUNT" in
+            1) shard_matrix='{"include":[{"index":1,"total":1}]}' ;;
+            2) shard_matrix='{"include":[{"index":1,"total":2},{"index":2,"total":2}]}' ;;
+            4) shard_matrix='{"include":[{"index":1,"total":4},{"index":2,"total":4},{"index":3,"total":4},{"index":4,"total":4}]}' ;;
+          esac
+          {
+            echo "shard_count=$PREFLIGHT_SHARD_COUNT"
+            echo "shard_matrix=$shard_matrix"
+          } >> "$GITHUB_OUTPUT"
+      - &checkout
+        name: Check out exact train SHA
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.expected_sha }}
@@ -67,35 +90,277 @@ jobs:
         env:
           EXPECTED_SHA: ${{ inputs.expected_sha }}
         run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
-      - name: Install Node.js
+      - &setup-node
+        name: Install Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with: { node-version: "22" }
-      - name: Activate pinned pnpm
+      - name: Derive deterministic preflight fingerprint
+        id: fingerprint
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          SHARD_COUNT: ${{ steps.inputs.outputs.shard_count }}
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$WORKFLOW_SHA" =~ ^[a-f0-9]{40}$ ]]
+          git cat-file -e "$WORKFLOW_SHA^{commit}" 2>/dev/null || \
+            git fetch --no-tags origin "$WORKFLOW_SHA"
+          evidence_dir="$RUNNER_TEMP/release-bus-preflight-fingerprint"
+          evidence_tool="$evidence_dir/release-bus-preflight-evidence.cjs"
+          contract="$RUNNER_TEMP/release-bus-preflight-contract.json"
+          mkdir -p "$evidence_dir"
+          git show "$WORKFLOW_SHA:scripts/release-bus-preflight-evidence.cjs" > "$evidence_tool"
+          git show "$WORKFLOW_SHA:scripts/release-bus-gate-evidence.cjs" > "$evidence_dir/release-bus-gate-evidence.cjs"
+          node "$evidence_tool" fingerprint \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --source-sha "$EXPECTED_SHA" \
+            --workflow-sha "$WORKFLOW_SHA" \
+            --shard-count "$SHARD_COUNT" \
+            --output "$contract"
+          {
+            echo "gate_fingerprint=$(jq -r '.gate_fingerprint' "$contract")"
+            echo "behavior_digest=$(jq -r '.behavior_digest' "$contract")"
+            echo "workflow_sha=$WORKFLOW_SHA"
+            echo "workflow_digest=$(jq -r '.workflow_digest' "$contract")"
+            echo "package_manager=$(jq -r '.package_manager' "$contract")"
+          } >> "$GITHUB_OUTPUT"
+      - name: Authorize Release Bus operation
+        if: inputs.validation_only != true
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          OPERATION_KEY: ${{ inputs.operation_key }}
+          RELEASE_BUS_API_URL: ${{ vars.RELEASE_BUS_API_URL }}
+          RELEASE_BUS_WORKFLOW_AUTH_TOKEN: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
+          TRAIN_ID: ${{ inputs.release_train_id }}
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          payload="$(jq -n --arg train_id "$TRAIN_ID" --arg operation_key "$OPERATION_KEY" --arg workflow_run_id "$GITHUB_RUN_ID" --arg expected_sha "$EXPECTED_SHA" '{train_id:$train_id,operation_key:$operation_key,workflow_run_id:$workflow_run_id,artifact_run_id:null,repository:"frontend",environment:"orchestration",service:null,expected_sha:$expected_sha,artifact_digest:null}')"
+          authorize_tool="$RUNNER_TEMP/release-bus-authorize-operation.sh"
+          git show "$WORKFLOW_SHA:scripts/release-bus-authorize-operation.sh" > "$authorize_tool"
+          chmod 700 "$authorize_tool"
+          "$authorize_tool" "$payload"
+      - name: Verify authorization did not mutate source
+        run: test -z "$(git status --porcelain --untracked-files=all)"
+
+  lint:
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - *checkout
+      - &stage-tooling
+        name: Stage immutable preflight tooling
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          GATE_FINGERPRINT: ${{ needs.authorize.outputs.gate_fingerprint }}
+          PACKAGE_MANAGER: ${{ needs.authorize.outputs.package_manager }}
+          WORKFLOW_SHA: ${{ needs.authorize.outputs.workflow_sha }}
+          WORKFLOW_DIGEST: ${{ needs.authorize.outputs.workflow_digest }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+          [[ "$GATE_FINGERPRINT" =~ ^[a-f0-9]{64}$ ]]
+          [[ "$PACKAGE_MANAGER" =~ ^pnpm@[A-Za-z0-9.+-]{1,122}$ ]]
+          [[ "$WORKFLOW_SHA" =~ ^[a-f0-9]{40}$ ]]
+          [[ "$WORKFLOW_DIGEST" =~ ^[a-f0-9]{64}$ ]]
+          git cat-file -e "$WORKFLOW_SHA^{commit}" 2>/dev/null || \
+            git fetch --no-tags origin "$WORKFLOW_SHA"
+          tooling="$RUNNER_TEMP/release-bus-tooling/scripts"
+          mkdir -p "$tooling"
+          for file in \
+            scripts/release-bus-frontend-gate.sh \
+            scripts/release-bus-gate-evidence.cjs \
+            scripts/release-bus-preflight-evidence.cjs \
+            scripts/release-bus-report-progress.mjs
+          do
+            git show "$WORKFLOW_SHA:$file" > "$RUNNER_TEMP/release-bus-tooling/$file"
+          done
+          chmod +x "$tooling/release-bus-frontend-gate.sh"
+          {
+            echo "RELEASE_BUS_GATE_TOOL=$tooling/release-bus-frontend-gate.sh"
+            echo "RELEASE_BUS_EVIDENCE_TOOL=$tooling/release-bus-gate-evidence.cjs"
+            echo "RELEASE_BUS_PREFLIGHT_EVIDENCE_TOOL=$tooling/release-bus-preflight-evidence.cjs"
+            echo "RELEASE_BUS_REPORT_TOOL=$tooling/release-bus-report-progress.mjs"
+            echo "RELEASE_BUS_BASE_SHA=$EXPECTED_SHA"
+            echo "RELEASE_BUS_EVIDENCE_ENVIRONMENT=orchestration"
+            echo "RELEASE_BUS_GATE_FINGERPRINT=$GATE_FINGERPRINT"
+            echo "RELEASE_BUS_WORKFLOW_SHA=$WORKFLOW_SHA"
+            echo "RELEASE_BUS_WORKFLOW_DIGEST=$WORKFLOW_DIGEST"
+            echo "RELEASE_BUS_NODE_VERSION=22"
+            echo "RELEASE_BUS_PACKAGE_MANAGER=$PACKAGE_MANAGER"
+          } >> "$GITHUB_ENV"
+      - *setup-node
+      - &activate-pnpm
+        name: Activate pinned pnpm
         run: |
           corepack enable pnpm
           corepack prepare "$(node -p 'require("./package.json").packageManager')" --activate
-      - name: Install Socket Firewall
+      - &socket-firewall
+        name: Install Socket Firewall
         id: socket-firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
         with: { mode: firewall }
-      - name: Install frozen dependencies
+      - &install
+        name: Install frozen dependencies
         env:
           SFW_BIN: ${{ steps.socket-firewall.outputs.firewall-path-binary }}
         run: ./bin/6529 install:frozen
-      - name: Run exact train validation gate
-        id: validation
-        if: matrix.environment == 'staging'
-        run: ./scripts/release-bus-frontend-gate.sh validate
-      - name: Typecheck production artifact source
-        id: typecheck_production
-        if: matrix.environment == 'production'
-        run: ./bin/6529 run typecheck:ci
-      - name: Verify validation did not mutate source
-        run: git diff --exit-code
+      - name: Run lint
+        id: gate
+        continue-on-error: true
+        run: RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE" "$RELEASE_BUS_GATE_TOOL" phase lint "$RUNNER_TEMP/release-bus-evidence"
+      - &source-mutation
+        name: Verify gate did not mutate source
+        id: source-mutation
+        if: always()
+        run: test -z "$(git status --porcelain --untracked-files=all)"
+      - name: Upload lint evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-bus-preflight-evidence-lint-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-evidence/*.json
+          if-no-files-found: error
+          retention-days: 14
+      - name: Return lint result
+        if: always()
+        env:
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+          MUTATION_OUTCOME: ${{ steps.source-mutation.outcome }}
+        run: test "$GATE_OUTCOME" = success -a "$MUTATION_OUTCOME" = success
+
+  typecheck:
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - *checkout
+      - *stage-tooling
+      - *setup-node
+      - *activate-pnpm
+      - *socket-firewall
+      - *install
+      - name: Run typecheck
+        id: gate
+        continue-on-error: true
+        run: RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE" "$RELEASE_BUS_GATE_TOOL" phase typecheck "$RUNNER_TEMP/release-bus-evidence"
+      - *source-mutation
+      - name: Upload typecheck evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-bus-preflight-evidence-typecheck-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-evidence/*.json
+          if-no-files-found: error
+          retention-days: 14
+      - name: Return typecheck result
+        if: always()
+        env:
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+          MUTATION_OUTCOME: ${{ steps.source-mutation.outcome }}
+        run: test "$GATE_OUTCOME" = success -a "$MUTATION_OUTCOME" = success
+
+  jest-inventory:
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - *checkout
+      - *stage-tooling
+      - *setup-node
+      - *activate-pnpm
+      - *socket-firewall
+      - *install
+      - name: Capture complete Jest inventory
+        id: gate
+        continue-on-error: true
+        run: RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE" "$RELEASE_BUS_GATE_TOOL" inventory "$RUNNER_TEMP/release-bus-evidence"
+      - *source-mutation
+      - name: Upload complete Jest inventory
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-bus-preflight-evidence-inventory-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-evidence/*.json
+          if-no-files-found: error
+          retention-days: 14
+      - name: Return inventory result
+        if: always()
+        env:
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+          MUTATION_OUTCOME: ${{ steps.source-mutation.outcome }}
+        run: test "$GATE_OUTCOME" = success -a "$MUTATION_OUTCOME" = success
+
+  jest:
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.authorize.outputs.shard_matrix) }}
+    name: Jest shard ${{ matrix.index }}/${{ matrix.total }}
+    steps:
+      - *checkout
+      - *stage-tooling
+      - *setup-node
+      - *activate-pnpm
+      - *socket-firewall
+      - *install
+      - name: Run complete deterministic Jest shard
+        id: gate
+        continue-on-error: true
+        env:
+          RELEASE_BUS_INJECT_SHARD_FAILURE: ${{ inputs.validation_inject_failure && '1' || '0' }}
+        run: RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE" "$RELEASE_BUS_GATE_TOOL" jest "${{ matrix.index }}" "${{ matrix.total }}" "$RUNNER_TEMP/release-bus-evidence"
+      - *source-mutation
+      - name: Upload sanitized shard evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-bus-preflight-evidence-jest-${{ matrix.index }}-of-${{ matrix.total }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-evidence/*.json
+          if-no-files-found: error
+          retention-days: 14
+      - name: Return first-run shard result
+        if: always()
+        env:
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+          MUTATION_OUTCOME: ${{ steps.source-mutation.outcome }}
+        run: test "$GATE_OUTCOME" = success -a "$MUTATION_OUTCOME" = success
+
+  build:
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: ${{ fromJSON(inputs.target_lane == 'PRODUCTION' && '["staging","production"]' || '["staging"]') }}
+    env:
+      SOURCE_SHA: ${{ inputs.expected_sha }}
+    steps:
+      - *checkout
+      - *stage-tooling
+      - *setup-node
+      - *activate-pnpm
+      - *socket-firewall
+      - *install
       - name: Capture build timestamp
         run: printf 'VERSION_BUILD_TIMESTAMP=%s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_ENV"
       - name: Build immutable application
-        id: build
+        id: gate
+        continue-on-error: true
         env:
           BUILD_ENVIRONMENT: ${{ matrix.environment }}
           NODE_ENV: production
@@ -120,14 +385,20 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
+          set -euo pipefail
           if [ "$BUILD_ENVIRONMENT" = production ]; then
             export ANNOUNCED_VERSION_ENDPOINT='https://dnclu2fna0b2b.cloudfront.net/web_build/current-production-version.json'
+            ./bin/6529 run build
           else
             unset ANNOUNCED_VERSION_ENDPOINT
+            RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE" "$RELEASE_BUS_GATE_TOOL" phase build "$RUNNER_TEMP/release-bus-evidence"
           fi
-          ./bin/6529 run build
-      - name: Report structured preflight result
+      - name: Verify build did not mutate source
+        id: source-mutation
         if: always()
+        run: git diff --exit-code
+      - name: Report structured preflight result
+        if: always() && inputs.validation_only != true
         continue-on-error: true
         env:
           RELEASE_BUS_API_URL: ${{ vars.RELEASE_BUS_API_URL }}
@@ -136,10 +407,10 @@ jobs:
           RELEASE_BUS_OPERATION_KEY: ${{ inputs.operation_key }}
           RELEASE_BUS_REPORT_PHASE: build
           RELEASE_BUS_JOB_STATUS: ${{ job.status }}
-          RELEASE_BUS_GATE_TYPECHECK_OUTCOME: ${{ steps.typecheck_production.outcome }}
-          RELEASE_BUS_GATE_BUILD_OUTCOME: ${{ steps.build.outcome }}
-        run: node scripts/release-bus-report-progress.mjs
+          RELEASE_BUS_GATE_BUILD_OUTCOME: ${{ steps.gate.outcome }}
+        run: node "$RELEASE_BUS_REPORT_TOOL"
       - name: Package immutable bundle
+        if: steps.gate.outcome == 'success' && steps.source-mutation.outcome == 'success'
         env:
           BUILD_ENVIRONMENT: ${{ matrix.environment }}
           EXPECTED_SHA: ${{ inputs.expected_sha }}
@@ -163,6 +434,7 @@ jobs:
           jq -n --arg train_id "$TRAIN_ID" --arg source_sha "$EXPECTED_SHA" --arg environment "$BUILD_ENVIRONMENT" '{train_id:$train_id,source_sha:$source_sha,environment:$environment}' > release-bus-artifact/manifest.json
           (cd release-bus-artifact && find . -type f ! -path ./SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)
       - name: Upload immutable frontend artifact
+        if: steps.gate.outcome == 'success' && steps.source-mutation.outcome == 'success'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-bus-frontend-${{ inputs.release_train_id }}-r${{ inputs.release_train_revision }}-${{ matrix.environment }}
@@ -170,3 +442,125 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
           retention-days: 90
+      - name: Upload build evidence
+        if: always() && matrix.environment == 'staging'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-bus-preflight-evidence-build-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-evidence/*.json
+          if-no-files-found: error
+          retention-days: 14
+      - name: Return build result
+        if: always()
+        env:
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+          MUTATION_OUTCOME: ${{ steps.source-mutation.outcome }}
+        run: test "$GATE_OUTCOME" = success -a "$MUTATION_OUTCOME" = success
+
+  aggregate:
+    if: always() && needs.authorize.result == 'success'
+    needs: [authorize, lint, typecheck, jest-inventory, jest, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - *checkout
+      - *stage-tooling
+      - *setup-node
+      - name: Download all preflight evidence
+        id: evidence-download
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: release-bus-preflight-evidence-*-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-evidence
+      - name: Capture public job links
+        if: always()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          curl --fail-with-body --silent --show-error \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs?filter=latest&per_page=100" \
+            > "$RUNNER_TEMP/release-bus-jobs.json"
+      - *source-mutation
+      - name: Aggregate fail-closed preflight evidence
+        id: aggregate
+        if: always()
+        continue-on-error: true
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+          INVENTORY_RESULT: ${{ needs.jest-inventory.result }}
+          JEST_RESULT: ${{ needs.jest.result }}
+          LINT_RESULT: ${{ needs.lint.result }}
+          MUTATION_RESULT: ${{ steps.source-mutation.outcome }}
+          PASSED_BEHAVIOR_DIGEST: ${{ needs.authorize.outputs.behavior_digest }}
+          PASSED_GATE_FINGERPRINT: ${{ needs.authorize.outputs.gate_fingerprint }}
+          PASSED_PACKAGE_MANAGER: ${{ needs.authorize.outputs.package_manager }}
+          PASSED_WORKFLOW_DIGEST: ${{ needs.authorize.outputs.workflow_digest }}
+          SOURCE_SHA: ${{ inputs.expected_sha }}
+          TARGET_LANE: ${{ inputs.target_lane }}
+          TYPECHECK_RESULT: ${{ needs.typecheck.result }}
+          WORKFLOW_SHA: ${{ needs.authorize.outputs.workflow_sha }}
+        run: |
+          set -euo pipefail
+          contract="$RUNNER_TEMP/release-bus-preflight-contract.json"
+          node "$RELEASE_BUS_PREFLIGHT_EVIDENCE_TOOL" fingerprint \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --source-sha "$SOURCE_SHA" \
+            --workflow-sha "$WORKFLOW_SHA" \
+            --shard-count "${{ needs.authorize.outputs.shard_count }}" \
+            --output "$contract"
+          gate_fingerprint="$(jq -r '.gate_fingerprint' "$contract")"
+          behavior_digest="$(jq -r '.behavior_digest' "$contract")"
+          workflow_digest="$(jq -r '.workflow_digest' "$contract")"
+          package_manager="$(jq -r '.package_manager' "$contract")"
+          test "$PASSED_GATE_FINGERPRINT" = "$gate_fingerprint"
+          test "$PASSED_BEHAVIOR_DIGEST" = "$behavior_digest"
+          test "$PASSED_WORKFLOW_DIGEST" = "$workflow_digest"
+          test "$PASSED_PACKAGE_MANAGER" = "$package_manager"
+          jq -n \
+            --arg lint "$LINT_RESULT" \
+            --arg typecheck "$TYPECHECK_RESULT" \
+            --arg build "$BUILD_RESULT" \
+            --arg inventory "$INVENTORY_RESULT" \
+            --arg jest "$JEST_RESULT" \
+            --arg source_mutation "$MUTATION_RESULT" \
+            '{lint:$lint,typecheck:$typecheck,build:$build,inventory:$inventory,jest:$jest,source_mutation:$source_mutation}' \
+            > "$RUNNER_TEMP/release-bus-job-results.json"
+          node "$RELEASE_BUS_PREFLIGHT_EVIDENCE_TOOL" aggregate \
+            --shard-count "${{ needs.authorize.outputs.shard_count }}" \
+            --evidence-root "$RUNNER_TEMP/release-bus-evidence" \
+            --job-results "$RUNNER_TEMP/release-bus-job-results.json" \
+            --source-sha "$SOURCE_SHA" \
+            --environment orchestration \
+            --gate-fingerprint "$gate_fingerprint" \
+            --behavior-digest "$behavior_digest" \
+            --workflow-sha "$WORKFLOW_SHA" \
+            --workflow-digest "$workflow_digest" \
+            --node-version 22 \
+            --package-manager "$package_manager" \
+            --target-lane "$TARGET_LANE" \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --jobs-file "$RUNNER_TEMP/release-bus-jobs.json" \
+            --artifact-name "release-bus-preflight-summary-$GITHUB_RUN_ID" \
+            --output "$RUNNER_TEMP/release-bus-preflight-summary.json"
+      - name: Upload deterministic preflight summary
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-bus-preflight-summary-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-preflight-summary.json
+          if-no-files-found: error
+          retention-days: 14
+      - name: Return aggregate result
+        if: always()
+        env:
+          AGGREGATE_OUTCOME: ${{ steps.aggregate.outcome }}
+          MUTATION_OUTCOME: ${{ steps.source-mutation.outcome }}
+        run: test "$AGGREGATE_OUTCOME" = success -a "$MUTATION_OUTCOME" = success

--- a/.github/workflows/release-bus-preflight.yml
+++ b/.github/workflows/release-bus-preflight.yml
@@ -33,6 +33,7 @@ jobs:
     outputs:
       shard_count: ${{ steps.inputs.outputs.shard_count }}
       shard_matrix: ${{ steps.inputs.outputs.shard_matrix }}
+      inject_failure: ${{ steps.inputs.outputs.inject_failure }}
       gate_fingerprint: ${{ steps.fingerprint.outputs.gate_fingerprint }}
       behavior_digest: ${{ steps.fingerprint.outputs.behavior_digest }}
       workflow_sha: ${{ steps.fingerprint.outputs.workflow_sha }}
@@ -78,6 +79,7 @@ jobs:
           {
             echo "shard_count=$PREFLIGHT_SHARD_COUNT"
             echo "shard_matrix=$shard_matrix"
+            echo "inject_failure=$VALIDATION_INJECT_FAILURE"
           } >> "$GITHUB_OUTPUT"
       - &checkout
         name: Check out exact train SHA
@@ -319,7 +321,7 @@ jobs:
         id: gate
         continue-on-error: true
         env:
-          RELEASE_BUS_INJECT_SHARD_FAILURE: ${{ inputs.validation_inject_failure && '1' || '0' }}
+          RELEASE_BUS_INJECT_SHARD_FAILURE: ${{ needs.authorize.outputs.inject_failure == 'true' && '1' || '0' }}
         run: RELEASE_BUS_REPO_ROOT="$GITHUB_WORKSPACE" "$RELEASE_BUS_GATE_TOOL" jest "${{ matrix.index }}" "${{ matrix.total }}" "$RUNNER_TEMP/release-bus-evidence"
       - *source-mutation
       - name: Upload sanitized shard evidence

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -43,6 +43,7 @@ describe("Release Bus frontend gate contract", () => {
       string,
       {
         needs?: string[] | string;
+        outputs?: Record<string, string>;
         steps?: WorkflowStep[];
         strategy?: { "fail-fast"?: boolean };
         "timeout-minutes"?: number;
@@ -447,6 +448,9 @@ describe("Release Bus frontend gate contract", () => {
     expect(preflightWorkflow.jobs?.authorize?.["timeout-minutes"]).toBe(10);
     expect(preflightWorkflow.jobs?.jest?.strategy?.["fail-fast"]).toBe(false);
     expect(preflightWorkflow.jobs?.build?.strategy?.["fail-fast"]).toBe(false);
+    expect(preflightWorkflow.jobs?.authorize?.outputs).toMatchObject({
+      inject_failure: "${{ steps.inputs.outputs.inject_failure }}",
+    });
     expect(preflightWorkflow.jobs?.aggregate?.needs).toEqual([
       "authorize",
       "lint",
@@ -465,6 +469,13 @@ describe("Release Bus frontend gate contract", () => {
     const aggregate = steps.find(
       (step) => step.name === "Aggregate fail-closed preflight evidence"
     );
+    const jestGate = preflightWorkflow.jobs?.jest?.steps?.find(
+      (step) => step.name === "Run complete deterministic Jest shard"
+    );
+    expect(jestGate?.env).toMatchObject({
+      RELEASE_BUS_INJECT_SHARD_FAILURE:
+        "${{ needs.authorize.outputs.inject_failure == 'true' && '1' || '0' }}",
+    });
     expect(aggregate?.env).toMatchObject({
       BUILD_RESULT: "${{ needs.build.result }}",
       INVENTORY_RESULT: "${{ needs.jest-inventory.result }}",
@@ -479,6 +490,9 @@ describe("Release Bus frontend gate contract", () => {
       'test "$PASSED_BEHAVIOR_DIGEST" = "$behavior_digest"'
     );
     expect(preflight).toContain('test "$VALIDATION_ONLY" = true');
+    expect(preflight).toContain(
+      'echo "inject_failure=$VALIDATION_INJECT_FAILURE"'
+    );
     expect(preflight).toContain(
       'git show "$WORKFLOW_SHA:scripts/release-bus-authorize-operation.sh"'
     );

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -33,6 +33,22 @@ describe("Release Bus frontend gate contract", () => {
       { steps?: WorkflowStep[]; "timeout-minutes"?: number }
     >;
   };
+  const preflightWorkflow = parseYaml(preflight) as {
+    on?: {
+      workflow_dispatch?: {
+        inputs?: Record<string, { required?: boolean }>;
+      };
+    };
+    jobs?: Record<
+      string,
+      {
+        needs?: string[] | string;
+        steps?: WorkflowStep[];
+        strategy?: { "fail-fast"?: boolean };
+        "timeout-minutes"?: number;
+      }
+    >;
+  };
 
   it("keeps deployed worker dispatch and authorization backward compatible", () => {
     const inputs = canaryWorkflow.on?.workflow_dispatch?.inputs ?? {};
@@ -55,9 +71,7 @@ describe("Release Bus frontend gate contract", () => {
     expect(canary).toContain(
       '\'{train_id:$train_id,operation_key:$operation_key,workflow_run_id:$workflow_run_id,artifact_run_id:null,repository:"frontend",environment:"orchestration",service:null,expected_sha:$expected_sha,artifact_digest:null}\''
     );
-    expect(authorization).toContain(
-      '"$api_url/deploy/release-bus/authorize"'
-    );
+    expect(authorization).toContain('"$api_url/deploy/release-bus/authorize"');
     expect(canary).toContain("release-bus-report-progress.mjs");
     expect(canary).toContain("Report sanitized terminal evidence");
     expect(reporter).toContain("/deploy/release-bus/report-progress");
@@ -198,6 +212,7 @@ describe("Release Bus frontend gate contract", () => {
         "__tests__/scripts/release-bus-frontend-gate.test.ts",
         "__tests__/scripts/release-bus-gate-evidence.test.ts",
         "__tests__/scripts/release-bus-jest-reporting.test.ts",
+        "__tests__/scripts/release-bus-preflight-evidence.test.ts",
       ]);
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
@@ -259,9 +274,11 @@ describe("Release Bus frontend gate contract", () => {
   });
 
   it("is shared by preflight, isolation, and exact-base canary", () => {
-    expect(preflight).toContain(
-      "./scripts/release-bus-frontend-gate.sh validate"
-    );
+    expect(preflight).toContain('"$RELEASE_BUS_GATE_TOOL" phase lint');
+    expect(preflight).toContain('"$RELEASE_BUS_GATE_TOOL" phase typecheck');
+    expect(preflight).toContain('"$RELEASE_BUS_GATE_TOOL" phase build');
+    expect(preflight).toContain('"$RELEASE_BUS_GATE_TOOL" inventory');
+    expect(preflight).toContain('"$RELEASE_BUS_GATE_TOOL" jest');
     expect(isolation).toContain("./scripts/release-bus-frontend-gate.sh full");
     expect(canary).toContain('"$RELEASE_BUS_GATE_TOOL" serial');
     expect(canary).toContain('"$RELEASE_BUS_GATE_TOOL" phase lint');
@@ -373,6 +390,13 @@ describe("Release Bus frontend gate contract", () => {
       expect(gate).toContain(identityFlag);
     }
     expect(canary).toContain("fail-fast: false");
+    expect(preflight).toContain("fail-fast: false");
+    expect(preflight).toContain("FRONTEND_PREFLIGHT_SHARD_COUNT");
+    expect(preflight).toContain("validation_shard_count");
+    expect(preflight).toContain("validation_inject_failure");
+    expect(preflight).toContain("RELEASE_BUS_INJECT_SHARD_FAILURE");
+    expect(preflight).toContain("Aggregate fail-closed preflight evidence");
+    expect(preflight).toContain("release-bus-preflight-evidence.cjs");
     expect(canary).toContain("FRONTEND_GATE_SHARD_COUNT");
     expect(canary).toContain("RELEASE_BUS_FRONTEND_GATE_MODE");
     expect(canary).toContain("validation_only");
@@ -393,8 +417,70 @@ describe("Release Bus frontend gate contract", () => {
     );
     expect(appPrCi).toContain("scripts/release-bus-authorize-operation.sh");
     expect(appPrCi).toContain("scripts/release-bus-gate-evidence.cjs");
+    expect(appPrCi).toContain("scripts/release-bus-preflight-evidence.cjs");
     expect(appPrCi).toContain(
       "__tests__/scripts/release-bus-gate-evidence.test.ts"
+    );
+  });
+
+  it("keeps preflight dispatch backward compatible and fail-closed", () => {
+    const inputs = preflightWorkflow.on?.workflow_dispatch?.inputs ?? {};
+    expect(
+      Object.entries(inputs)
+        .filter(([, contract]) => contract.required === true)
+        .map(([name]) => name)
+        .sort()
+    ).toEqual(
+      [
+        "release_train_id",
+        "release_train_revision",
+        "operation_key",
+        "target_lane",
+        "release_branch",
+        "deploy_units",
+        "expected_sha",
+      ].sort()
+    );
+    expect(inputs.validation_only?.required).toBe(false);
+    expect(inputs.validation_shard_count?.required).toBe(false);
+    expect(inputs.validation_inject_failure?.required).toBe(false);
+    expect(preflightWorkflow.jobs?.authorize?.["timeout-minutes"]).toBe(10);
+    expect(preflightWorkflow.jobs?.jest?.strategy?.["fail-fast"]).toBe(false);
+    expect(preflightWorkflow.jobs?.build?.strategy?.["fail-fast"]).toBe(false);
+    expect(preflightWorkflow.jobs?.aggregate?.needs).toEqual([
+      "authorize",
+      "lint",
+      "typecheck",
+      "jest-inventory",
+      "jest",
+      "build",
+    ]);
+
+    const steps = Object.values(preflightWorkflow.jobs ?? {}).flatMap(
+      (job) => job.steps ?? []
+    );
+    for (const step of steps) {
+      expect(step.run ?? "").not.toMatch(/\$\{\{\s*inputs\./);
+    }
+    const aggregate = steps.find(
+      (step) => step.name === "Aggregate fail-closed preflight evidence"
+    );
+    expect(aggregate?.env).toMatchObject({
+      BUILD_RESULT: "${{ needs.build.result }}",
+      INVENTORY_RESULT: "${{ needs.jest-inventory.result }}",
+      JEST_RESULT: "${{ needs.jest.result }}",
+      LINT_RESULT: "${{ needs.lint.result }}",
+      TYPECHECK_RESULT: "${{ needs.typecheck.result }}",
+    });
+    expect(aggregate?.run).toContain(
+      '--arg source_mutation "$MUTATION_RESULT"'
+    );
+    expect(aggregate?.run).toContain(
+      'test "$PASSED_BEHAVIOR_DIGEST" = "$behavior_digest"'
+    );
+    expect(preflight).toContain('test "$VALIDATION_ONLY" = true');
+    expect(preflight).toContain(
+      'git show "$WORKFLOW_SHA:scripts/release-bus-authorize-operation.sh"'
     );
   });
 });

--- a/__tests__/scripts/release-bus-gate-evidence.test.ts
+++ b/__tests__/scripts/release-bus-gate-evidence.test.ts
@@ -234,6 +234,28 @@ describe("Release Bus gate evidence", () => {
       duplicate_files: [],
     });
 
+    for (const result of ["failure", "cancelled", "skipped", ""] as const) {
+      expect(
+        buildGateSummary({
+          records,
+          source: "parallel",
+          shardCount: 2,
+          jobResults: {
+            lint: "success",
+            typecheck: "success",
+            build: "success",
+            inventory: "success",
+            jest: result,
+            source_mutation: "success",
+          },
+          identity: evidenceIdentity,
+        })
+      ).toMatchObject({
+        status: "FAILED",
+        errors: expect.arrayContaining(["jest job did not succeed"]),
+      });
+    }
+
     for (const requiredJob of ["lint", "typecheck", "jest"] as const) {
       const evidenceWithoutSkippedJob = records.filter((record) =>
         requiredJob === "jest"

--- a/__tests__/scripts/release-bus-jest-reporting.test.ts
+++ b/__tests__/scripts/release-bus-jest-reporting.test.ts
@@ -471,8 +471,8 @@ describe("Release Bus structured Jest reporting", () => {
 
     expect(preflightReport).toEqual(
       expect.objectContaining({
-        if: "always()",
-        run: "node scripts/release-bus-report-progress.mjs",
+        if: "always() && inputs.validation_only != true",
+        run: 'node "$RELEASE_BUS_REPORT_TOOL"',
       })
     );
     expect(isolationReport).toEqual(
@@ -493,6 +493,9 @@ describe("Release Bus structured Jest reporting", () => {
     );
     expect(gateContract?.run).toContain(
       "scripts/release-bus-summarize-jest.mjs"
+    );
+    expect(gateContract?.run).toContain(
+      "scripts/release-bus-preflight-evidence.cjs"
     );
     expect(gateContract?.run).toContain(
       "__tests__/scripts/release-bus-jest-reporting.test.ts"

--- a/__tests__/scripts/release-bus-preflight-evidence.test.ts
+++ b/__tests__/scripts/release-bus-preflight-evidence.test.ts
@@ -89,5 +89,11 @@ describe("Release Bus preflight evidence", () => {
     expect(() => preflightContract({ ...input, maxWorkers: 3 })).toThrow(
       "Invalid Jest worker contract"
     );
+    expect(() =>
+      preflightContract({
+        ...input,
+        baseFileContents: { ...baseFileContents, "package.json": "{" },
+      })
+    ).toThrow("Invalid package-manager contract");
   });
 });

--- a/__tests__/scripts/release-bus-preflight-evidence.test.ts
+++ b/__tests__/scripts/release-bus-preflight-evidence.test.ts
@@ -1,0 +1,93 @@
+const {
+  preflightContract,
+}: {
+  preflightContract: (input: Record<string, unknown>) => Record<string, any>;
+} = require("../../scripts/release-bus-preflight-evidence.cjs");
+
+describe("Release Bus preflight evidence", () => {
+  const baseFileContents = {
+    "bin/6529": "runner",
+    "jest.config.js": "config",
+    "jest.setup.js": "setup",
+    "package.json": JSON.stringify({ packageManager: "pnpm@10.14.0" }),
+    "pnpm-lock.yaml": "lockfile",
+  };
+  const workflowFileContents = {
+    ".github/workflows/release-bus-preflight.yml": "workflow",
+    "scripts/release-bus-authorize-operation.sh": "authorize",
+    "scripts/release-bus-frontend-gate.sh": "gate",
+    "scripts/release-bus-gate-evidence.cjs": "gate evidence",
+    "scripts/release-bus-preflight-evidence.cjs": "preflight evidence",
+    "scripts/release-bus-report-progress.mjs": "reporter",
+  };
+  const input = {
+    sourceSha: "a".repeat(40),
+    workflowSha: "b".repeat(40),
+    baseFileContents,
+    workflowFileContents,
+    shardCount: 2,
+  };
+
+  it("keys behavioral continuity on every executable contract byte", () => {
+    const baseline = preflightContract(input);
+    expect(preflightContract(input)).toEqual(baseline);
+    expect(baseline).toMatchObject({
+      kind: "frontend_preflight_contract",
+      node_version: "22",
+      package_manager: "pnpm@10.14.0",
+      shard_count: 2,
+      max_workers: 2,
+    });
+
+    for (const file of Object.keys(baseFileContents)) {
+      const changedContents =
+        file === "package.json"
+          ? JSON.stringify({ packageManager: "pnpm@10.15.0" })
+          : `${baseFileContents[file as keyof typeof baseFileContents]} changed`;
+      const changed = preflightContract({
+        ...input,
+        baseFileContents: {
+          ...baseFileContents,
+          [file]: changedContents,
+        },
+      });
+      expect(changed.behavior_digest).not.toBe(baseline.behavior_digest);
+      expect(changed.gate_fingerprint).not.toBe(baseline.gate_fingerprint);
+    }
+    for (const file of Object.keys(workflowFileContents)) {
+      const changed = preflightContract({
+        ...input,
+        workflowFileContents: {
+          ...workflowFileContents,
+          [file]: `${workflowFileContents[file as keyof typeof workflowFileContents]} changed`,
+        },
+      });
+      expect(changed.behavior_digest).not.toBe(baseline.behavior_digest);
+      expect(changed.gate_fingerprint).not.toBe(baseline.gate_fingerprint);
+    }
+  });
+
+  it("separates behavioral identity from commit ancestry and exact source identity", () => {
+    const baseline = preflightContract(input);
+    const moved = preflightContract({
+      ...input,
+      sourceSha: "c".repeat(40),
+      workflowSha: "d".repeat(40),
+    });
+    expect(moved.behavior_digest).toBe(baseline.behavior_digest);
+    expect(moved.gate_fingerprint).not.toBe(baseline.gate_fingerprint);
+
+    const resharded = preflightContract({ ...input, shardCount: 4 });
+    expect(resharded.behavior_digest).not.toBe(baseline.behavior_digest);
+    expect(resharded.gate_fingerprint).not.toBe(baseline.gate_fingerprint);
+  });
+
+  it("fail-closes unsupported shard and worker contracts", () => {
+    expect(() => preflightContract({ ...input, shardCount: 3 })).toThrow(
+      "Unsupported shard count"
+    );
+    expect(() => preflightContract({ ...input, maxWorkers: 3 })).toThrow(
+      "Invalid Jest worker contract"
+    );
+  });
+});

--- a/ops/docs/developer/deployment-bus-automation.md
+++ b/ops/docs/developer/deployment-bus-automation.md
@@ -209,6 +209,26 @@ shadow and inspect real decisions; then enable reuse with the 24-hour TTL.
 Disable reuse independently or return the frontend to `legacy`/one shard before
 considering a code rollback.
 
+Candidate preflight uses the same fail-closed Jest inventory model without
+sharing the base-canary reuse identity. Lint, typecheck, the complete Jest
+inventory, deterministic Jest shards, and immutable staging/production builds
+run as independent jobs. The final preflight aggregate requires every job to
+succeed and proves every expected test file executed exactly once, with no
+missing, duplicate, unexpected, skipped, todo, or rerun-masked tests. Jest runs
+with `--maxWorkers=2 --bail=0`; Release Bus full, isolation, base, and preflight
+execution never uses `--runInBand`.
+
+`FRONTEND_PREFLIGHT_SHARD_COUNT` accepts `1`, `2`, or `4` and defaults to `2`.
+Setting it to `1` is the no-deploy rollback for shard fan-out while retaining
+bounded Jest workers and complete inventory enforcement. The preflight
+fingerprint covers the exact candidate lockfile/Jest/runtime contract and the
+workflow, action pins, authorization helper, gate, evidence, and reporting
+tooling from the pinned workflow commit. Its content-addressed
+`behavior_digest` permits continuity across ancestry-only changes; any covered
+byte, runtime, worker, or shard-count change invalidates continuity. Workflow
+and candidate SHAs remain exact provenance and are never replaced by the
+content digest.
+
 Frontend workflows report lint, typecheck, unit-test, and build outcomes as
 separate structured stages. Jest JSON is reduced to bounded repository-relative
 suite names and exact failing test names; failure messages and raw output are

--- a/ops/docs/developer/deployment-bus-process.md
+++ b/ops/docs/developer/deployment-bus-process.md
@@ -172,7 +172,9 @@ It then:
 - runs the shared frontend validation/build gate against the exact fresh
   `1a-staging` base before composing any frontend candidate, so a broken base or
   control-plane command cannot be blamed on candidate code;
-- runs immutable preflight builds;
+- runs parallel fail-closed frontend preflight lint, typecheck, complete Jest
+  inventory/shards, and immutable builds, with an independently reversible
+  `1|2|4` shard count and bounded Jest workers;
 - deploys backend units in service-DAG order;
 - deploys frontend after backend succeeds;
 - runs the existing staging E2E packs against the exact train, including for a

--- a/scripts/release-bus-frontend-gate.sh
+++ b/scripts/release-bus-frontend-gate.sh
@@ -209,7 +209,8 @@ case "${1:-full}" in
     run_unit_tests --runTestsByPath \
       __tests__/scripts/release-bus-frontend-gate.test.ts \
       __tests__/scripts/release-bus-gate-evidence.test.ts \
-      __tests__/scripts/release-bus-jest-reporting.test.ts
+      __tests__/scripts/release-bus-jest-reporting.test.ts \
+      __tests__/scripts/release-bus-preflight-evidence.test.ts
     ;;
   validate)
     run_validation

--- a/scripts/release-bus-gate-evidence.cjs
+++ b/scripts/release-bus-gate-evidence.cjs
@@ -612,7 +612,7 @@ function buildGateSummary({
   if (sourceEvidence.some((record) => record.kind === "manifest_error"))
     errors.push("Jest manifest capture failed");
   for (const [job, result] of Object.entries(jobResults)) {
-    if (result !== "success" && result !== "skipped") {
+    if (result !== "success") {
       errors.push(`${safeText(job, 80)} job did not succeed`);
     }
   }

--- a/scripts/release-bus-preflight-evidence.cjs
+++ b/scripts/release-bus-preflight-evidence.cjs
@@ -69,7 +69,7 @@ function preflightContract({
 }) {
   validateSha(sourceSha, "source");
   validateSha(workflowSha, "workflow");
-  if (!ALLOWED_SHARD_COUNTS.has(shardCount)) {
+  if (!Number.isInteger(shardCount) || !ALLOWED_SHARD_COUNTS.has(shardCount)) {
     throw new Error("Unsupported shard count");
   }
   if (nodeVersion !== "22") throw new Error("Invalid Node version");
@@ -85,9 +85,14 @@ function preflightContract({
       throw new Error(`Missing preflight workflow file ${file}`);
     }
   }
-  const packageManager = JSON.parse(
-    baseFileContents["package.json"]
-  )?.packageManager;
+  let packageManager;
+  try {
+    packageManager = JSON.parse(
+      baseFileContents["package.json"]
+    )?.packageManager;
+  } catch {
+    throw new Error("Invalid package-manager contract");
+  }
   if (
     typeof packageManager !== "string" ||
     !/^pnpm@[A-Za-z0-9.+-]{1,122}$/.test(packageManager)

--- a/scripts/release-bus-preflight-evidence.cjs
+++ b/scripts/release-bus-preflight-evidence.cjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+
+const { createHash } = require("node:crypto");
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { finalSummary, safeText } = require("./release-bus-gate-evidence.cjs");
+
+const ALLOWED_SHARD_COUNTS = new Set([1, 2, 4]);
+const PREFLIGHT_WORKFLOW = ".github/workflows/release-bus-preflight.yml";
+const PREFLIGHT_BASE_FILES = [
+  "bin/6529",
+  "jest.config.js",
+  "jest.setup.js",
+  "package.json",
+  "pnpm-lock.yaml",
+];
+const PREFLIGHT_TOOLING_FILES = [
+  "scripts/release-bus-authorize-operation.sh",
+  "scripts/release-bus-frontend-gate.sh",
+  "scripts/release-bus-gate-evidence.cjs",
+  "scripts/release-bus-preflight-evidence.cjs",
+  "scripts/release-bus-report-progress.mjs",
+];
+
+function parseArgs(values) {
+  const args = {};
+  for (let index = 0; index < values.length; index += 2) {
+    const key = values[index];
+    const value = values[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      throw new Error("Arguments must be --key value pairs");
+    }
+    args[key.slice(2)] = value;
+  }
+  return args;
+}
+
+function required(args, name) {
+  const value = args[name];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Missing --${name}`);
+  }
+  return value;
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function validateSha(value, label) {
+  if (!/^[a-f0-9]{40}$/.test(value)) throw new Error(`Invalid ${label} SHA`);
+}
+
+function preflightContract({
+  sourceSha,
+  workflowSha,
+  baseFileContents,
+  workflowFileContents,
+  shardCount,
+  nodeVersion = "22",
+  maxWorkers = 2,
+}) {
+  validateSha(sourceSha, "source");
+  validateSha(workflowSha, "workflow");
+  if (!ALLOWED_SHARD_COUNTS.has(shardCount)) {
+    throw new Error("Unsupported shard count");
+  }
+  if (nodeVersion !== "22") throw new Error("Invalid Node version");
+  if (maxWorkers !== 2) throw new Error("Invalid Jest worker contract");
+  for (const file of PREFLIGHT_BASE_FILES) {
+    if (typeof baseFileContents[file] !== "string") {
+      throw new Error(`Missing preflight base file ${file}`);
+    }
+  }
+  const workflowFiles = [PREFLIGHT_WORKFLOW, ...PREFLIGHT_TOOLING_FILES];
+  for (const file of workflowFiles) {
+    if (typeof workflowFileContents[file] !== "string") {
+      throw new Error(`Missing preflight workflow file ${file}`);
+    }
+  }
+  const packageManager = JSON.parse(
+    baseFileContents["package.json"]
+  )?.packageManager;
+  if (
+    typeof packageManager !== "string" ||
+    !/^pnpm@[A-Za-z0-9.+-]{1,122}$/.test(packageManager)
+  ) {
+    throw new Error("Invalid package-manager contract");
+  }
+  const componentDigests = Object.fromEntries([
+    ...PREFLIGHT_BASE_FILES.map((file) => [
+      file,
+      sha256(baseFileContents[file]),
+    ]),
+    ...workflowFiles.map((file) => [file, sha256(workflowFileContents[file])]),
+  ]);
+  const workflowDigest = componentDigests[PREFLIGHT_WORKFLOW];
+  const behaviorDigest = sha256(
+    JSON.stringify({
+      schema_version: 1,
+      kind: "frontend_preflight_contract",
+      repository: "frontend",
+      environment: "orchestration",
+      node_version: nodeVersion,
+      package_manager: packageManager,
+      shard_count: shardCount,
+      max_workers: maxWorkers,
+      component_digests: componentDigests,
+    })
+  );
+  const gateFingerprint = sha256(
+    JSON.stringify({
+      schema_version: 1,
+      source_sha: sourceSha,
+      workflow_sha: workflowSha,
+      behavior_digest: behaviorDigest,
+    })
+  );
+  return {
+    schema_version: 1,
+    kind: "frontend_preflight_contract",
+    repository: "frontend",
+    environment: "orchestration",
+    source_sha: sourceSha,
+    behavior_digest: behaviorDigest,
+    gate_fingerprint: gateFingerprint,
+    workflow_sha: workflowSha,
+    workflow_digest: workflowDigest,
+    node_version: nodeVersion,
+    package_manager: packageManager,
+    shard_count: shardCount,
+    max_workers: maxWorkers,
+    component_digests: componentDigests,
+  };
+}
+
+function contractFromRepository(args) {
+  const repoRoot = path.resolve(required(args, "repo-root"));
+  const sourceSha = required(args, "source-sha");
+  const workflowSha = required(args, "workflow-sha");
+  const shardCount = Number(required(args, "shard-count"));
+  const head = execFileSync("git", ["-C", repoRoot, "rev-parse", "HEAD"], {
+    encoding: "utf8",
+  }).trim();
+  if (head !== sourceSha) throw new Error("Source checkout does not match SHA");
+  const baseFileContents = Object.fromEntries(
+    PREFLIGHT_BASE_FILES.map((file) => [
+      file,
+      fs.readFileSync(path.join(repoRoot, file), "utf8"),
+    ])
+  );
+  const workflowFileContents = Object.fromEntries(
+    [PREFLIGHT_WORKFLOW, ...PREFLIGHT_TOOLING_FILES].map((file) => [
+      file,
+      execFileSync("git", ["-C", repoRoot, "show", `${workflowSha}:${file}`], {
+        encoding: "utf8",
+        maxBuffer: 2 * 1024 * 1024,
+      }),
+    ])
+  );
+  return preflightContract({
+    sourceSha,
+    workflowSha,
+    baseFileContents,
+    workflowFileContents,
+    shardCount,
+  });
+}
+
+function recursiveJsonFiles(root) {
+  if (!fs.existsSync(root)) return [];
+  const files = [];
+  const visit = (directory) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const absolute = path.join(directory, entry.name);
+      if (entry.isDirectory()) visit(absolute);
+      else if (entry.isFile() && entry.name.endsWith(".json")) {
+        files.push(absolute);
+      }
+    }
+  };
+  visit(root);
+  return files.sort();
+}
+
+function loadEvidence(root) {
+  return recursiveJsonFiles(root).map((file) => {
+    try {
+      return JSON.parse(fs.readFileSync(file, "utf8"));
+    } catch {
+      return { kind: "malformed", file: safeText(path.basename(file)) };
+    }
+  });
+}
+
+function aggregate(args) {
+  const targetLane = required(args, "target-lane");
+  if (!new Set(["STAGING", "PRODUCTION"]).has(targetLane)) {
+    throw new Error("Invalid target lane");
+  }
+  const records = loadEvidence(required(args, "evidence-root"));
+  const jobResults = JSON.parse(
+    fs.readFileSync(required(args, "job-results"), "utf8")
+  );
+  const summary = finalSummary({
+    args: {
+      ...args,
+      mode: "sharded",
+      "base-sha": required(args, "source-sha"),
+    },
+    records,
+    jobResults,
+  });
+  return {
+    ...summary,
+    kind: "frontend_preflight_summary",
+    target_lane: targetLane,
+    build_environments:
+      targetLane === "PRODUCTION" ? ["production", "staging"] : ["staging"],
+  };
+}
+
+function run(command, args) {
+  if (command === "fingerprint") {
+    writeJson(required(args, "output"), contractFromRepository(args));
+    return;
+  }
+  if (command === "aggregate") {
+    const summary = aggregate(args);
+    writeJson(required(args, "output"), summary);
+    if (summary.status !== "SUCCEEDED") process.exitCode = 1;
+    return;
+  }
+  throw new Error(`Unknown command: ${command}`);
+}
+
+module.exports = { preflightContract };
+
+if (require.main === module) {
+  try {
+    const [command, ...values] = process.argv.slice(2);
+    if (!command) throw new Error("A command is required");
+    run(command, parseArgs(values));
+  } catch (error) {
+    process.stderr.write(
+      `${safeText(error instanceof Error ? error.message : error, 300)}\n`
+    );
+    process.exitCode = 2;
+  }
+}


### PR DESCRIPTION
## Issue

The frontend candidate preflight still ran lint, typecheck, every Jest test, and build serially in one job. It lacked the base-canary gate’s deterministic shard manifests and fail-closed completeness aggregate.

## Fix

Run lint, typecheck, complete Jest inventory, deterministic Jest shards, and immutable environment builds in parallel, then require a single fail-closed aggregate before preflight can succeed.

## Changes

- Add configurable `FRONTEND_PREFLIGHT_SHARD_COUNT=1|2|4`, defaulting to two shards with one-shard rollback.
- Use `--maxWorkers=2 --bail=0` inside every shard; Release Bus full, isolation, base, and preflight execution contains no `--runInBand`.
- Prove every expected test file executes exactly once and reject missing, duplicate, unexpected, skipped, todo, failed, cancelled, or source-mutating results.
- Sanitize deliberate injection through the authorize output before its exact Jest consumer.
- Add one validation-only clean/injected proof mode without API, lane, ref, or deployment mutation.
- Fingerprint the exact candidate lockfile/Jest/runtime and pinned workflow/action/authorization/gate/evidence/reporting bytes.

## Validation

- Exact base: frontend main `5c95f6b588007204ff71e42bb48ab6368ef482b4`.
- Exact signed/DCO head: `f47bf07c085746a9ed53a3f313311216cb386cca`.
- Local gate contract 33/33; lint/typecheck/knip/YAML/Bash/Prettier/diff clean.
- Clean sharded2 proof: run https://github.com/6529-Collections/6529seize-frontend/actions/runs/29885912936, SUCCESS, artifact `sha256:db0a5bd9a459a75fc927cd50533ea6e471a0835ad97b939a5c30082d85a8ce4a`, summary SHA `232473dd...`; 2035/2035 files+suites, 12044/12044 tests, pending/todo/failed/missing/duplicate/unexpected all zero; shards 276973/334940ms.
- Injected proof: run https://github.com/6529-Collections/6529seize-frontend/actions/runs/29885913959, expected FAILED, artifact `sha256:e3b1b0005c9bef40a53ac216bd6464cd4f3d57e5b3eca39e07ce46215d5aa241`, summary SHA `aa63d54f...`; identical complete counts, only shard 2 failed with `injected_failure=true`, bounded aggregate errors, completeness arrays empty.
- Both bind fingerprint `c6b53889...`, behavior digest `64f1930f...`, workflow digest `faacf418...`, Node 22, pnpm 10.33.0, maxWorkers=2.

## Risk

Medium workflow-topology change, no application/runtime API change. Roll back instantly with `FRONTEND_PREFLIGHT_SHARD_COUNT=1`; revert the workflow commit if required. Bounded Jest concurrency stays enabled.