### PR TITLE
Harden Release Bus against CI install failures

### DIFF
--- a/.github/workflows/app-pr-ci.yml
+++ b/.github/workflows/app-pr-ci.yml
@@ -250,11 +250,13 @@ jobs:
             scripts/release-bus-authorize-operation.sh \
             scripts/release-bus-frontend-gate.sh \
             scripts/release-bus-gate-evidence.cjs \
+            scripts/release-bus-install-dependencies.cjs \
             scripts/release-bus-preflight-evidence.cjs \
             scripts/release-bus-summarize-jest.mjs \
             scripts/release-bus-report-progress.mjs \
             __tests__/scripts/release-bus-frontend-gate.test.ts \
             __tests__/scripts/release-bus-gate-evidence.test.ts \
+            __tests__/scripts/release-bus-install-dependencies.test.ts \
             __tests__/scripts/release-bus-jest-reporting.test.ts \
             __tests__/scripts/release-bus-preflight-evidence.test.ts \
             __tests__/scripts/release-bus-shard-injection.test.ts; then

--- a/.github/workflows/release-bus-base-canary.yml
+++ b/.github/workflows/release-bus-base-canary.yml
@@ -215,6 +215,7 @@ jobs:
           for file in \
             scripts/release-bus-frontend-gate.sh \
             scripts/release-bus-gate-evidence.cjs \
+            scripts/release-bus-install-dependencies.cjs \
             scripts/release-bus-report-progress.mjs
           do
             git show "$WORKFLOW_SHA:$file" > "$RUNNER_TEMP/release-bus-tooling/$file"
@@ -223,6 +224,7 @@ jobs:
           {
             echo "RELEASE_BUS_GATE_TOOL=$tooling/release-bus-frontend-gate.sh"
             echo "RELEASE_BUS_EVIDENCE_TOOL=$tooling/release-bus-gate-evidence.cjs"
+            echo "RELEASE_BUS_INSTALL_TOOL=$tooling/release-bus-install-dependencies.cjs"
             echo "RELEASE_BUS_REPORT_TOOL=$tooling/release-bus-report-progress.mjs"
             echo "RELEASE_BUS_BASE_SHA=$BASE_SHA"
             echo "RELEASE_BUS_EVIDENCE_ENVIRONMENT=$EVIDENCE_ENVIRONMENT"
@@ -241,13 +243,15 @@ jobs:
       - &socket-firewall
         name: Install Socket Firewall
         id: socket-firewall
+        continue-on-error: true
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
         with: { mode: firewall }
       - &install
-        name: Install frozen dependencies
+        name: Install and verify frozen dependencies
         env:
+          RELEASE_BUS_SOCKET_FIREWALL_OUTCOME: ${{ steps.socket-firewall.outcome }}
           SFW_BIN: ${{ steps.socket-firewall.outputs.firewall-path-binary }}
-        run: ./bin/6529 install:frozen
+        run: node "$RELEASE_BUS_INSTALL_TOOL"
       - name: Run authoritative serial gate
         id: gate
         continue-on-error: true
@@ -493,8 +497,6 @@ jobs:
       - *stage-tooling
       - *setup-node
       - *activate-pnpm
-      - *socket-firewall
-      - *install
       - name: Download all gate evidence
         id: evidence-download
         continue-on-error: true

--- a/.github/workflows/release-bus-preflight.yml
+++ b/.github/workflows/release-bus-preflight.yml
@@ -449,10 +449,10 @@ jobs:
           if-no-files-found: error
           retention-days: 90
       - name: Upload build evidence
-        if: always() && matrix.environment == 'staging'
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: release-bus-preflight-evidence-build-${{ github.run_id }}
+          name: release-bus-preflight-evidence-build-${{ matrix.environment }}-${{ github.run_id }}
           path: ${{ runner.temp }}/release-bus-evidence/*.json
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/release-bus-preflight.yml
+++ b/.github/workflows/release-bus-preflight.yml
@@ -355,6 +355,7 @@ jobs:
         environment: ${{ fromJSON(inputs.target_lane == 'PRODUCTION' && '["staging","production"]' || '["staging"]') }}
     env:
       SOURCE_SHA: ${{ inputs.expected_sha }}
+      RELEASE_BUS_INSTALL_EVIDENCE: ${{ runner.temp }}/release-bus-evidence/dependency-install-${{ matrix.environment }}.json
     steps:
       - *checkout
       - *stage-tooling

--- a/.github/workflows/release-bus-preflight.yml
+++ b/.github/workflows/release-bus-preflight.yml
@@ -175,6 +175,7 @@ jobs:
           for file in \
             scripts/release-bus-frontend-gate.sh \
             scripts/release-bus-gate-evidence.cjs \
+            scripts/release-bus-install-dependencies.cjs \
             scripts/release-bus-preflight-evidence.cjs \
             scripts/release-bus-report-progress.mjs
           do
@@ -184,6 +185,7 @@ jobs:
           {
             echo "RELEASE_BUS_GATE_TOOL=$tooling/release-bus-frontend-gate.sh"
             echo "RELEASE_BUS_EVIDENCE_TOOL=$tooling/release-bus-gate-evidence.cjs"
+            echo "RELEASE_BUS_INSTALL_TOOL=$tooling/release-bus-install-dependencies.cjs"
             echo "RELEASE_BUS_PREFLIGHT_EVIDENCE_TOOL=$tooling/release-bus-preflight-evidence.cjs"
             echo "RELEASE_BUS_REPORT_TOOL=$tooling/release-bus-report-progress.mjs"
             echo "RELEASE_BUS_BASE_SHA=$EXPECTED_SHA"
@@ -203,13 +205,15 @@ jobs:
       - &socket-firewall
         name: Install Socket Firewall
         id: socket-firewall
+        continue-on-error: true
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
         with: { mode: firewall }
       - &install
-        name: Install frozen dependencies
+        name: Install and verify frozen dependencies
         env:
+          RELEASE_BUS_SOCKET_FIREWALL_OUTCOME: ${{ steps.socket-firewall.outcome }}
           SFW_BIN: ${{ steps.socket-firewall.outputs.firewall-path-binary }}
-        run: ./bin/6529 install:frozen
+        run: node "$RELEASE_BUS_INSTALL_TOOL"
       - name: Run lint
         id: gate
         continue-on-error: true

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -42,6 +42,7 @@ describe("Release Bus frontend gate contract", () => {
     jobs?: Record<
       string,
       {
+        env?: Record<string, string>;
         needs?: string[] | string;
         outputs?: Record<string, string>;
         steps?: WorkflowStep[];
@@ -450,6 +451,10 @@ describe("Release Bus frontend gate contract", () => {
     expect(preflightWorkflow.jobs?.authorize?.["timeout-minutes"]).toBe(10);
     expect(preflightWorkflow.jobs?.jest?.strategy?.["fail-fast"]).toBe(false);
     expect(preflightWorkflow.jobs?.build?.strategy?.["fail-fast"]).toBe(false);
+    expect(preflightWorkflow.jobs?.build?.env).toMatchObject({
+      RELEASE_BUS_INSTALL_EVIDENCE:
+        "${{ runner.temp }}/release-bus-evidence/dependency-install-${{ matrix.environment }}.json",
+    });
     expect(preflightWorkflow.jobs?.authorize?.outputs).toMatchObject({
       inject_failure: "${{ steps.inputs.outputs.inject_failure }}",
     });

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -212,6 +212,7 @@ describe("Release Bus frontend gate contract", () => {
         "--runTestsByPath",
         "__tests__/scripts/release-bus-frontend-gate.test.ts",
         "__tests__/scripts/release-bus-gate-evidence.test.ts",
+        "__tests__/scripts/release-bus-install-dependencies.test.ts",
         "__tests__/scripts/release-bus-jest-reporting.test.ts",
         "__tests__/scripts/release-bus-preflight-evidence.test.ts",
       ]);
@@ -418,6 +419,7 @@ describe("Release Bus frontend gate contract", () => {
     );
     expect(appPrCi).toContain("scripts/release-bus-authorize-operation.sh");
     expect(appPrCi).toContain("scripts/release-bus-gate-evidence.cjs");
+    expect(appPrCi).toContain("scripts/release-bus-install-dependencies.cjs");
     expect(appPrCi).toContain("scripts/release-bus-preflight-evidence.cjs");
     expect(appPrCi).toContain(
       "__tests__/scripts/release-bus-gate-evidence.test.ts"

--- a/__tests__/scripts/release-bus-gate-evidence.test.ts
+++ b/__tests__/scripts/release-bus-gate-evidence.test.ts
@@ -44,6 +44,7 @@ describe("Release Bus gate evidence", () => {
       "scripts/release-bus-authorize-operation.sh": "authorize",
       "scripts/release-bus-frontend-gate.sh": "gate",
       "scripts/release-bus-gate-evidence.cjs": "evidence",
+      "scripts/release-bus-install-dependencies.cjs": "installer",
       "scripts/release-bus-report-progress.mjs": "reporter",
     };
     const input = {
@@ -59,9 +60,9 @@ describe("Release Bus gate evidence", () => {
     expect(frontendGateContract(input)).toEqual(baseline);
     expect(baseline).toMatchObject({
       behavior_digest:
-        "7fcd636de546cfc19c57db6f876b57c5157c264710c15848cf56bd2409f0ba68",
+        "c3ae3169f9e467e9c2b97e4202b7c9e2cb09a6efbbdd3070083196152f23c6ee",
       gate_fingerprint:
-        "04b7cea66d8075f2c1b8e246bb41ee0d86b7ecc284af42bbe4540de489ea7c6c",
+        "e125874c704b5ef9776819709444b938eeb9477315d15e1df92b25507b87386d",
       workflow_digest:
         "da7f739f627198465eeab537a6f7a435dc4a0c332f9e4a8462293eb3f4ab7ee0",
     });
@@ -229,9 +230,44 @@ describe("Release Bus gate evidence", () => {
 
     expect(summary).toMatchObject({
       status: "SUCCEEDED",
+      failure_class: null,
+      retryable: false,
       counts: { test_files: 2, test_suites: 2, tests: 4 },
       missing_files: [],
       duplicate_files: [],
+    });
+
+    expect(
+      buildGateSummary({
+        records: [
+          ...records,
+          {
+            schema_version: 1,
+            kind: "dependency_install",
+            source: "parallel",
+            ...evidenceIdentity,
+            status: "FAILED",
+            failure_class: "INFRASTRUCTURE_TRANSIENT",
+            failure_code: "DEPENDENCY_TRANSPORT_FAILURE",
+          },
+        ],
+        source: "parallel",
+        shardCount: 2,
+        jobResults: {
+          lint: "success",
+          typecheck: "success",
+          build: "failure",
+          inventory: "success",
+          jest: "success",
+          source_mutation: "success",
+        },
+        identity: evidenceIdentity,
+      })
+    ).toMatchObject({
+      status: "FAILED",
+      failure_class: "INFRASTRUCTURE_TRANSIENT",
+      failure_phase: "dependency_install",
+      retryable: true,
     });
 
     for (const result of ["failure", "cancelled", "skipped", ""] as const) {

--- a/__tests__/scripts/release-bus-gate-evidence.test.ts
+++ b/__tests__/scripts/release-bus-gate-evidence.test.ts
@@ -211,6 +211,16 @@ describe("Release Bus gate evidence", () => {
           identity: evidenceIdentity,
         })
       ),
+      ...["staging", "production"].map((buildEnvironment) => ({
+        schema_version: 1,
+        kind: "dependency_install",
+        source: "parallel",
+        ...evidenceIdentity,
+        build_environment: buildEnvironment,
+        status: "SUCCEEDED",
+        failure_class: null,
+        failure_code: null,
+      })),
     ];
 
     const summary = buildGateSummary({

--- a/__tests__/scripts/release-bus-install-dependencies.test.ts
+++ b/__tests__/scripts/release-bus-install-dependencies.test.ts
@@ -1,0 +1,202 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const {
+  classifyFailure,
+  installWithRetries,
+  verifyInstall,
+}: {
+  classifyFailure: (
+    result: Record<string, unknown>,
+    verification: Record<string, unknown>
+  ) => Record<string, string>;
+  installWithRetries: (options: Record<string, unknown>) => Promise<any>;
+  verifyInstall: (repoRoot: string) => Record<string, any>;
+} = require("../../scripts/release-bus-install-dependencies.cjs");
+
+const identityEnvironment = (runnerTemp: string) => ({
+  ...process.env,
+  GITHUB_JOB: "jest",
+  RELEASE_BUS_BASE_SHA: "a".repeat(40),
+  RELEASE_BUS_EVIDENCE_ENVIRONMENT: "orchestration",
+  RELEASE_BUS_GATE_FINGERPRINT: "b".repeat(64),
+  RELEASE_BUS_WORKFLOW_SHA: "c".repeat(40),
+  RELEASE_BUS_WORKFLOW_DIGEST: "d".repeat(64),
+  RELEASE_BUS_NODE_VERSION: "22",
+  RELEASE_BUS_PACKAGE_MANAGER: "pnpm@10.14.0",
+  RUNNER_TEMP: runnerTemp,
+});
+
+describe("Release Bus verified dependency installation", () => {
+  let repoRoot: string;
+
+  beforeEach(() => {
+    repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "release-bus-install-"));
+    fs.mkdirSync(path.join(repoRoot, "bin"));
+    fs.writeFileSync(path.join(repoRoot, "bin", "6529"), "#!/bin/sh\n");
+    fs.writeFileSync(
+      path.join(repoRoot, "package.json"),
+      JSON.stringify({
+        dependencies: { alpha: "1.0.0" },
+        devDependencies: { beta: "1.0.0" },
+      })
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it("treats a successful command with an incomplete tree as infrastructure", () => {
+    expect(
+      classifyFailure(
+        { status: 0, output: "", timedOut: false },
+        { complete: false }
+      )
+    ).toEqual({
+      failure_class: "INFRASTRUCTURE_TRANSIENT",
+      failure_code: "DEPENDENCY_INSTALL_INCOMPLETE",
+    });
+  });
+
+  it("cleans a partial install and retries the same frozen install", async () => {
+    let invocation = 0;
+    const evidence = await installWithRetries({
+      repoRoot,
+      environment: identityEnvironment(repoRoot),
+      maxAttempts: 2,
+      backoffMs: 0,
+      runInstall: jest.fn(async () => {
+        invocation += 1;
+        fs.mkdirSync(path.join(repoRoot, "node_modules"), { recursive: true });
+        return {
+          status: 0,
+          signal: null,
+          timedOut: false,
+          output: "Socket Firewall encountered an unexpected error",
+          durationMs: 1,
+        };
+      }),
+      verifyInstall: jest.fn(() => ({
+        complete: invocation === 2,
+        metadata_present: invocation === 2,
+        missing_dependencies: invocation === 2 ? [] : ["alpha"],
+        missing_binaries: [],
+      })),
+    });
+
+    expect(evidence).toMatchObject({
+      status: "SUCCEEDED",
+      failure_class: null,
+      recovered: true,
+    });
+    expect(evidence.attempts).toHaveLength(2);
+    expect(
+      JSON.parse(
+        fs.readFileSync(
+          path.join(
+            repoRoot,
+            "release-bus-evidence",
+            "dependency-install.json"
+          ),
+          "utf8"
+        )
+      )
+    ).toMatchObject({ status: "SUCCEEDED", recovered: true });
+  });
+
+  it("does not retry a deterministic frozen-lockfile failure", async () => {
+    const runInstall = jest.fn(async () => ({
+      status: 1,
+      signal: null,
+      timedOut: false,
+      output: "ERR_PNPM_OUTDATED_LOCKFILE",
+      durationMs: 1,
+    }));
+
+    await expect(
+      installWithRetries({
+        repoRoot,
+        environment: identityEnvironment(repoRoot),
+        maxAttempts: 3,
+        backoffMs: 0,
+        runInstall,
+      })
+    ).rejects.toThrow("DEPENDENCY_CONTRACT_INVALID");
+    expect(runInstall).toHaveBeenCalledTimes(1);
+    expect(
+      JSON.parse(
+        fs.readFileSync(
+          path.join(
+            repoRoot,
+            "release-bus-evidence",
+            "dependency-install.json"
+          ),
+          "utf8"
+        )
+      )
+    ).toMatchObject({
+      status: "FAILED",
+      failure_class: "SOURCE",
+      failure_code: "DEPENDENCY_CONTRACT_INVALID",
+    });
+  });
+
+  it("records a Socket Firewall setup failure before running package code", async () => {
+    const runInstall = jest.fn();
+    await expect(
+      installWithRetries({
+        repoRoot,
+        environment: {
+          ...identityEnvironment(repoRoot),
+          RELEASE_BUS_SOCKET_FIREWALL_OUTCOME: "failure",
+        },
+        runInstall,
+      })
+    ).rejects.toThrow("SOCKET_FIREWALL_SETUP_FAILED");
+    expect(runInstall).not.toHaveBeenCalled();
+    expect(
+      JSON.parse(
+        fs.readFileSync(
+          path.join(
+            repoRoot,
+            "release-bus-evidence",
+            "dependency-install.json"
+          ),
+          "utf8"
+        )
+      )
+    ).toMatchObject({
+      status: "FAILED",
+      failure_class: "INFRASTRUCTURE_TRANSIENT",
+      failure_code: "SOCKET_FIREWALL_SETUP_FAILED",
+    });
+  });
+
+  it("verifies direct packages, required binaries, and pnpm metadata", () => {
+    for (const dependency of ["alpha", "beta"]) {
+      fs.mkdirSync(path.join(repoRoot, "node_modules", dependency), {
+        recursive: true,
+      });
+      fs.writeFileSync(
+        path.join(repoRoot, "node_modules", dependency, "package.json"),
+        "{}"
+      );
+    }
+    fs.mkdirSync(path.join(repoRoot, "node_modules", ".bin"), {
+      recursive: true,
+    });
+    for (const binary of ["cross-env", "eslint", "jest", "next", "tsc"]) {
+      fs.writeFileSync(path.join(repoRoot, "node_modules", ".bin", binary), "");
+    }
+    fs.writeFileSync(path.join(repoRoot, "node_modules", ".modules.yaml"), "");
+
+    expect(verifyInstall(repoRoot)).toEqual({
+      complete: true,
+      metadata_present: true,
+      missing_dependencies: [],
+      missing_binaries: [],
+    });
+  });
+});

--- a/__tests__/scripts/release-bus-jest-reporting.test.ts
+++ b/__tests__/scripts/release-bus-jest-reporting.test.ts
@@ -311,6 +311,64 @@ describe("Release Bus structured Jest reporting", () => {
     });
   });
 
+  it("fails after three persistent server responses", () => {
+    const moduleUrl = pathToFileURL(
+      path.join(process.cwd(), "scripts/release-bus-report-progress.mjs")
+    ).href;
+    const source = `import { postProgress } from ${JSON.stringify(moduleUrl)};
+      let attempts = 0;
+      try {
+        await postProgress("https://api.example.test", "token", {operation:"same"}, {
+          fetchImpl: async () => { attempts += 1; return {ok:false,status:503}; },
+          sleep: async () => {},
+          timeoutMs: 10
+        });
+      } catch (error) {
+        process.stdout.write(JSON.stringify({attempts,message:error.message}));
+      }`;
+    const output = execFileSync(
+      process.execPath,
+      ["--input-type=module", "--eval", source],
+      { cwd: process.cwd() }
+    );
+
+    expect(JSON.parse(output.toString("utf8"))).toEqual({
+      attempts: 3,
+      message:
+        "Release Bus progress report failed after bounded transport retries (503)",
+    });
+  });
+
+  it.each([401, 600])(
+    "fails immediately for non-retryable HTTP status %s",
+    (status) => {
+      const moduleUrl = pathToFileURL(
+        path.join(process.cwd(), "scripts/release-bus-report-progress.mjs")
+      ).href;
+      const source = `import { postProgress } from ${JSON.stringify(moduleUrl)};
+        let attempts = 0;
+        try {
+          await postProgress("https://api.example.test", "token", {operation:"same"}, {
+            fetchImpl: async () => { attempts += 1; return {ok:false,status:${status}}; },
+            sleep: async () => {},
+            timeoutMs: 10
+          });
+        } catch (error) {
+          process.stdout.write(JSON.stringify({attempts,message:error.message}));
+        }`;
+      const output = execFileSync(
+        process.execPath,
+        ["--input-type=module", "--eval", source],
+        { cwd: process.cwd() }
+      );
+
+      expect(JSON.parse(output.toString("utf8"))).toEqual({
+        attempts: 1,
+        message: `Release Bus progress report failed (${status})`,
+      });
+    }
+  );
+
   it("projects a versioned aggregate into the strict reusable summary", () => {
     const tempDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "release-bus-aggregate-")

--- a/__tests__/scripts/release-bus-jest-reporting.test.ts
+++ b/__tests__/scripts/release-bus-jest-reporting.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { execFileSync, spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const YAML = require("yaml") as { parse: (text: string) => unknown };
@@ -275,6 +276,39 @@ describe("Release Bus structured Jest reporting", () => {
 
     expect(result.status).toBe(0);
     expect(result.stderr).toContain("not configured; skipping");
+  });
+
+  it("retries only transport and server failures with the exact payload", () => {
+    const moduleUrl = pathToFileURL(
+      path.join(process.cwd(), "scripts/release-bus-report-progress.mjs")
+    ).href;
+    const output = execFileSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "--eval",
+        `import { postProgress } from ${JSON.stringify(moduleUrl)};
+         let attempts = 0;
+         const bodies = [];
+         await postProgress("https://api.example.test", "token", {operation:"same"}, {
+           fetchImpl: async (_url, options) => {
+             attempts += 1;
+             bodies.push(options.body);
+             return {ok: attempts === 2, status: attempts === 2 ? 200 : 503};
+           },
+           sleep: async () => {},
+           timeoutMs: 10
+         });
+         process.stdout.write(JSON.stringify({attempts,bodies}));`,
+      ],
+      { cwd: process.cwd() }
+    );
+    const result = JSON.parse(output.toString("utf8"));
+
+    expect(result).toEqual({
+      attempts: 2,
+      bodies: ['{"operation":"same"}', '{"operation":"same"}'],
+    });
   });
 
   it("projects a versioned aggregate into the strict reusable summary", () => {

--- a/__tests__/scripts/release-bus-jest-reporting.test.ts
+++ b/__tests__/scripts/release-bus-jest-reporting.test.ts
@@ -60,13 +60,16 @@ describe("Release Bus structured Jest reporting", () => {
 
     for (const name of requiredJobs) {
       const steps = workflow.jobs?.[name]?.steps ?? [];
+      const expectedSteps = [
+        "Check out exact frontend base",
+        "Stage immutable gate tooling",
+        "Verify gate did not mutate source",
+      ];
+      if (name !== "aggregate") {
+        expectedSteps.push("Install and verify frozen dependencies");
+      }
       expect(steps.map((step) => step.name)).toEqual(
-        expect.arrayContaining([
-          "Check out exact frontend base",
-          "Stage immutable gate tooling",
-          "Install frozen dependencies",
-          "Verify gate did not mutate source",
-        ])
+        expect.arrayContaining(expectedSteps)
       );
     }
     expect(workflow.jobs?.jest?.strategy?.["fail-fast"]).toBe(false);
@@ -355,6 +358,9 @@ describe("Release Bus structured Jest reporting", () => {
 
       expect(payload).toMatchObject({
         status: "SUCCEEDED",
+        failure_class: null,
+        failure_phase: null,
+        retryable: false,
         summary: {
           base_sha: "a".repeat(40),
           shard_count: 1,

--- a/__tests__/scripts/release-bus-preflight-evidence.test.ts
+++ b/__tests__/scripts/release-bus-preflight-evidence.test.ts
@@ -17,6 +17,7 @@ describe("Release Bus preflight evidence", () => {
     "scripts/release-bus-authorize-operation.sh": "authorize",
     "scripts/release-bus-frontend-gate.sh": "gate",
     "scripts/release-bus-gate-evidence.cjs": "gate evidence",
+    "scripts/release-bus-install-dependencies.cjs": "installer",
     "scripts/release-bus-preflight-evidence.cjs": "preflight evidence",
     "scripts/release-bus-report-progress.mjs": "reporter",
   };

--- a/ops/docs/developer/deployment-bus-automation.md
+++ b/ops/docs/developer/deployment-bus-automation.md
@@ -117,9 +117,13 @@ merged unnoticed.
 Before composing a train that contains frontend work, the worker dispatches
 `release-bus-base-canary.yml` against the train's exact recorded frontend base
 SHA. The canary runs lint, typecheck, the complete Jest suite, and a production
-build. Failure requeues the train's candidates, pauses the lane, and records the
-exact Actions run as operator evidence; it never attributes the base failure to
-a candidate. Backend-only trains skip this frontend canary.
+build. A deterministic source/gate failure requeues the train's candidates,
+pauses the lane, and records the exact Actions run as operator evidence; it
+never attributes the base failure to a candidate. This pause also applies to an
+unclassified failure. A dependency-install failure explicitly classified as
+transient infrastructure keeps the candidates attached, keeps the lane
+running, and retries the same immutable operation. Backend-only trains skip
+this frontend canary.
 
 The frontend base canary has three independently selectable execution modes:
 
@@ -134,11 +138,19 @@ Jest shard jobs against the same SHA, but only the serial outcome controls the
 train. `sharded` makes the parallel aggregate authoritative. Every deterministic
 Jest `--shard=N/M` uses `--maxWorkers=2 --bail=0`, bounding memory and process
 fan-out without forcing serial execution. The matrix has `fail-fast: false` and
-no automatic retry. Returning to
+does not retry source gates. Only verified transient dependency infrastructure
+is retried. Returning to
 `legacy`/one shard is the no-code rollback.
 
 Each validation job detaches the exact base SHA, installs frozen dependencies
-through `./bin/6529`, and proves that source files were not mutated. Gate and
+through `./bin/6529`, verifies every direct package, required binary, and pnpm
+installation metadata, and proves that source files were not mutated. A
+Socket Firewall or package-transport failure, timeout, or false-success partial
+install is recorded as bounded `dependency_install` evidence. The job removes
+the partial `node_modules` tree and retries the exact frozen install up to three
+times; lockfile/contract failures are source failures and are never retried.
+The aggregate job uses staged built-in Node tooling and does not install
+dependencies, removing an unnecessary third-party failure point. Gate and
 reporting tooling is copied to runner temporary storage from the exact workflow
 commit, so a workflow dispatched from pinned `main` can validate an older base
 without substituting that base's control-plane policy. The fingerprint covers
@@ -462,9 +474,15 @@ are verified.
   irreversible operation.
 - A missed workflow response remains `AMBIGUOUS` until exact-run reconciliation
   proves its state.
+- A failed base-canary or preflight operation carrying authenticated
+  `INFRASTRUCTURE_TRANSIENT` dependency evidence is retried with a new exact
+  attempt key. The first retries are prompt; continued outages use bounded
+  5/10/15-minute backoff. The train remains visible as
+  `INFRASTRUCTURE_RETRY_BACKOFF`, candidates stay attached, and the lane is not
+  paused. Source and unknown failures retain fail-closed behavior.
 - The incident card distinguishes `PRE_EXISTING_BASE`,
   `DETERMINISTIC_CANDIDATE`, and train/environment failures. A pre-existing
-  base failure returns every candidate, quarantines none, applies
+  deterministic base failure returns every candidate, quarantines none, applies
   `BASE_FAILURE_NO_CANDIDATE_BLAMED`, pauses the lane, and records the exact
   recovery recommendation. Candidate quarantine is allowed only after
   deterministic isolation proves the candidate-owned failure.

--- a/ops/docs/developer/deployment-bus-automation.md
+++ b/ops/docs/developer/deployment-bus-automation.md
@@ -122,8 +122,11 @@ pauses the lane, and records the exact Actions run as operator evidence; it
 never attributes the base failure to a candidate. This pause also applies to an
 unclassified failure. A dependency-install failure explicitly classified as
 transient infrastructure keeps the candidates attached, keeps the lane
-running, and retries the same immutable operation. Backend-only trains skip
-this frontend canary.
+running, and retries the same immutable operation. A train gets at most five
+workflow attempts. If all five fail with authenticated transient-infrastructure
+evidence, the train ends, its candidates return to the queue, and the lane
+stays running so a later fresh train becomes the automatic recovery probe.
+Backend-only trains skip this frontend canary.
 
 The frontend base canary has three independently selectable execution modes:
 
@@ -477,9 +480,12 @@ are verified.
 - A failed base-canary or preflight operation carrying authenticated
   `INFRASTRUCTURE_TRANSIENT` dependency evidence is retried with a new exact
   attempt key. The first retries are prompt; continued outages use bounded
-  5/10/15-minute backoff. The train remains visible as
+  5/10-minute backoff. The train remains visible as
   `INFRASTRUCTURE_RETRY_BACKOFF`, candidates stay attached, and the lane is not
-  paused. Source and unknown failures retain fail-closed behavior.
+  paused. After five failed workflow attempts, the train terminates, candidates
+  are automatically requeued, and the lane remains running. This prevents a
+  permanent provider outage from monopolizing the train indefinitely. Source
+  and unknown failures retain fail-closed behavior.
 - The incident card distinguishes `PRE_EXISTING_BASE`,
   `DETERMINISTIC_CANDIDATE`, and train/environment failures. A pre-existing
   deterministic base failure returns every candidate, quarantines none, applies

--- a/ops/docs/developer/deployment-bus-process.md
+++ b/ops/docs/developer/deployment-bus-process.md
@@ -133,7 +133,10 @@ for staging SHA … Candidates have not been tested yet.” A verified transient
 dependency-infrastructure failure instead says that the same immutable
 operation will retry automatically. The candidates remain attached and
 STAGING remains running; initial retries are prompt and a continued outage uses
-bounded 5/10/15-minute backoff. A deterministic source failure still says:
+bounded 5/10-minute backoff. After five failed workflow attempts, the failed
+train becomes terminal and its immutable candidates are automatically returned
+to the still-running lane for a later fresh train. A deterministic source
+failure still says:
 “Existing staging base failed … No candidate was blamed. STAGING was paused.”
 It also lists the failed gate/job/step, exact failing Jest suite/test when
 reported, candidates returned or quarantined, and the recommended recovery.
@@ -260,8 +263,10 @@ publishes release notes nor invokes the legacy GelatoBot skill.
   frontend base SHA. A deterministic or unknown base-canary failure requeues
   every candidate and pauses the lane without quarantining a developer branch.
   Authenticated transient dependency-infrastructure evidence retries the exact
-  operation without pausing or detaching candidates. The same behavior applies
-  to frontend preflight infrastructure failures before candidate isolation.
+  operation without pausing or detaching candidates. Retries are capped at five
+  workflow attempts; exhaustion terminates only that train, requeues its
+  candidates, and leaves the lane running. The same behavior applies to
+  frontend preflight infrastructure failures before candidate isolation.
 - Ambiguous external calls are reconciled by exact operation key before any
   retry. A timeout is not treated as proof that an operation did not happen.
 - Before production mutation, an unexpected target-branch move safely cancels

--- a/ops/docs/developer/deployment-bus-process.md
+++ b/ops/docs/developer/deployment-bus-process.md
@@ -129,13 +129,17 @@ discovered, or no recent workflow progress. Do not retry while GitHub still
 shows a healthy active run.
 
 During a base canary, the incident card says: “Frontend base canary running
-for staging SHA … Candidates have not been tested yet.” If it fails, the card
-says: “Existing staging base failed … No candidate was blamed. STAGING was
-paused.” It also lists the failed gate/job/step, exact failing Jest suite/test
-when reported, candidates returned or quarantined, and the recommended
-recovery. For a base failure, repair and validate the existing staging base,
-deploy that isolated repair, verify it, and only then resume the lane. Do not
-change, cancel, or blame queued candidates to work around a base failure.
+for staging SHA … Candidates have not been tested yet.” A verified transient
+dependency-infrastructure failure instead says that the same immutable
+operation will retry automatically. The candidates remain attached and
+STAGING remains running; initial retries are prompt and a continued outage uses
+bounded 5/10/15-minute backoff. A deterministic source failure still says:
+“Existing staging base failed … No candidate was blamed. STAGING was paused.”
+It also lists the failed gate/job/step, exact failing Jest suite/test when
+reported, candidates returned or quarantined, and the recommended recovery.
+For a deterministic base failure, repair and validate the existing staging
+base, deploy that isolated repair, verify it, and only then resume the lane. Do
+not change, cancel, or blame queued candidates to work around a base failure.
 
 ## How a train departs
 
@@ -253,8 +257,11 @@ publishes release notes nor invokes the legacy GelatoBot skill.
   Release Bus gate. Pull-request CI executes the gate's regression contract
   whenever that gate or a Release Bus workflow changes. Before candidate
   composition, the bus also runs the full gate against the exact recorded
-  frontend base SHA. A base-canary failure requeues every candidate and pauses
-  the lane without quarantining a developer branch.
+  frontend base SHA. A deterministic or unknown base-canary failure requeues
+  every candidate and pauses the lane without quarantining a developer branch.
+  Authenticated transient dependency-infrastructure evidence retries the exact
+  operation without pausing or detaching candidates. The same behavior applies
+  to frontend preflight infrastructure failures before candidate isolation.
 - Ambiguous external calls are reconciled by exact operation key before any
   retry. A timeout is not treated as proof that an operation did not happen.
 - Before production mutation, an unexpected target-branch move safely cancels

--- a/scripts/release-bus-frontend-gate.sh
+++ b/scripts/release-bus-frontend-gate.sh
@@ -209,6 +209,7 @@ case "${1:-full}" in
     run_unit_tests --runTestsByPath \
       __tests__/scripts/release-bus-frontend-gate.test.ts \
       __tests__/scripts/release-bus-gate-evidence.test.ts \
+      __tests__/scripts/release-bus-install-dependencies.test.ts \
       __tests__/scripts/release-bus-jest-reporting.test.ts \
       __tests__/scripts/release-bus-preflight-evidence.test.ts
     ;;

--- a/scripts/release-bus-gate-evidence.cjs
+++ b/scripts/release-bus-gate-evidence.cjs
@@ -26,6 +26,7 @@ const EVIDENCE_IDENTITY_FIELDS = [
   "package_manager",
 ];
 const EVIDENCE_RECORD_KINDS = new Set([
+  "dependency_install",
   "manifest",
   "manifest_error",
   "phase",
@@ -43,6 +44,7 @@ const FRONTEND_GATE_TOOLING_FILES = [
   "scripts/release-bus-authorize-operation.sh",
   "scripts/release-bus-frontend-gate.sh",
   "scripts/release-bus-gate-evidence.cjs",
+  "scripts/release-bus-install-dependencies.cjs",
   "scripts/release-bus-report-progress.mjs",
 ];
 
@@ -560,6 +562,10 @@ function buildGateSummary({
     (record) =>
       record.source === source && EVIDENCE_RECORD_KINDS.has(record.kind)
   );
+  const failedDependencyInstall = sourceEvidence.find(
+    (record) =>
+      record.kind === "dependency_install" && record.status === "FAILED"
+  );
   if (
     identity &&
     (sourceEvidence.length === 0 ||
@@ -636,23 +642,49 @@ function buildGateSummary({
   const minimumShardDuration = shardDurations.length
     ? Math.min(...shardDurations)
     : 0;
+  const status = errors.length === 0 ? "SUCCEEDED" : "FAILED";
+  const failureClass =
+    status === "SUCCEEDED"
+      ? null
+      : failedDependencyInstall?.failure_class === "INFRASTRUCTURE_TRANSIENT"
+        ? "INFRASTRUCTURE_TRANSIENT"
+        : failedDependencyInstall?.failure_class === "SOURCE"
+          ? "SOURCE"
+          : failedDependencyInstall
+            ? "UNKNOWN"
+            : "SOURCE";
+  const shardSummaries = Array.from({ length: shardCount }, (_, offset) => {
+    const index = offset + 1;
+    const shard = shards.find(
+      (candidate) =>
+        candidate.shard_index === index && candidate.shard_count === shardCount
+    );
+    return shard
+      ? {
+          index: shard.shard_index,
+          count: shard.shard_count,
+          status: shard.status,
+          injected_failure: shard.injected_failure === true,
+          duration_ms: shard.duration_ms,
+          counts: shard.counts,
+        }
+      : {
+          index,
+          count: shardCount,
+          status: "FAILED",
+          injected_failure: false,
+          duration_ms: 0,
+          counts: sumCounts([]),
+        };
+  });
   return {
-    status: errors.length === 0 ? "SUCCEEDED" : "FAILED",
+    status,
+    failure_class: failureClass,
+    failure_phase: failedDependencyInstall ? "dependency_install" : "gate",
+    retryable: failureClass === "INFRASTRUCTURE_TRANSIENT",
     phases,
     counts,
-    shards: stableSort(
-      shards.map(
-        (shard) =>
-          `${String(shard.shard_index).padStart(2, "0")}:${JSON.stringify({
-            index: shard.shard_index,
-            count: shard.shard_count,
-            status: shard.status,
-            injected_failure: shard.injected_failure === true,
-            duration_ms: shard.duration_ms,
-            counts: shard.counts,
-          })}`
-      )
-    ).map((value) => JSON.parse(value.slice(value.indexOf(":") + 1))),
+    shards: shardSummaries,
     shard_imbalance_ms: maximumShardDuration - minimumShardDuration,
     missing_files: missingFiles.slice(0, MAX_FAILURES),
     duplicate_files: duplicateFiles.slice(0, MAX_FAILURES),
@@ -743,6 +775,15 @@ function finalSummary({ args, records, jobResults }) {
     schema_version: 1,
     kind: "base_canary_summary",
     status: authoritative?.status ?? "FAILED",
+    failure_class:
+      authoritative?.status === "SUCCEEDED"
+        ? null
+        : (authoritative?.failure_class ?? "UNKNOWN"),
+    failure_phase:
+      authoritative?.status === "SUCCEEDED"
+        ? null
+        : (authoritative?.failure_phase ?? "gate"),
+    retryable: authoritative?.retryable === true,
     gate_mode: mode,
     fresh_or_reused: "fresh",
     ...identity,

--- a/scripts/release-bus-install-dependencies.cjs
+++ b/scripts/release-bus-install-dependencies.cjs
@@ -1,0 +1,340 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+const MAX_CAPTURE_BYTES = 128 * 1024;
+const REQUIRED_BINARIES = ["cross-env", "eslint", "jest", "next", "tsc"];
+
+const INFRASTRUCTURE_PATTERNS = [
+  /Socket Firewall encountered an unexpected error/i,
+  /\bfetch failed\b/i,
+  /\bEAI_AGAIN\b/i,
+  /\bECONNRESET\b/i,
+  /\bECONNREFUSED\b/i,
+  /\bENETUNREACH\b/i,
+  /\bETIMEDOUT\b/i,
+  /\bERR_SOCKET_TIMEOUT\b/i,
+  /\bERR_PNPM_(?:FETCH|META_FETCH)[A-Z0-9_]*\b/i,
+  /SFW_BIN does not exist/i,
+  /Socket Firewall \(`sfw`\) is not installed/i,
+  /\b(?:HTTP|status(?: code)?)\s*5\d\d\b/i,
+];
+
+const SOURCE_PATTERNS = [
+  /\bERR_PNPM_OUTDATED_LOCKFILE\b/i,
+  /\bERR_PNPM_LOCKFILE_CONFIG_MISMATCH\b/i,
+  /\bERR_PNPM_PEER_DEP_ISSUES\b/i,
+  /frozen-lockfile[^\n]*out.of.date/i,
+];
+
+function boundedInteger(value, fallback, minimum, maximum) {
+  if (!/^[0-9]+$/.test(String(value ?? ""))) return fallback;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= minimum && parsed <= maximum
+    ? parsed
+    : fallback;
+}
+
+function appendCapture(current, chunk) {
+  const next = `${current}${chunk}`;
+  return next.length <= MAX_CAPTURE_BYTES
+    ? next
+    : next.slice(next.length - MAX_CAPTURE_BYTES);
+}
+
+function runInstall(command, args, options = {}) {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  return new Promise((resolve) => {
+    const startedAt = Date.now();
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env ?? process.env,
+      stdio: ["inherit", "pipe", "pipe"],
+    });
+    let output = "";
+    let timedOut = false;
+    let settled = false;
+    const capture = (target, chunk) => {
+      target.write(chunk);
+      output = appendCapture(output, chunk.toString("utf8"));
+    };
+    child.stdout.on("data", (chunk) => capture(process.stdout, chunk));
+    child.stderr.on("data", (chunk) => capture(process.stderr, chunk));
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), 5_000).unref();
+    }, timeoutMs);
+    child.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({
+        status: 1,
+        signal: null,
+        timedOut,
+        output: appendCapture(output, error.message),
+        durationMs: Date.now() - startedAt,
+      });
+    });
+    child.on("close", (status, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({
+        status: status ?? 1,
+        signal,
+        timedOut,
+        output,
+        durationMs: Date.now() - startedAt,
+      });
+    });
+  });
+}
+
+function dependencyPath(repoRoot, dependency) {
+  return path.join(repoRoot, "node_modules", ...dependency.split("/"));
+}
+
+function verifyInstall(repoRoot) {
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, "package.json"), "utf8")
+  );
+  const dependencies = Object.keys({
+    ...(packageJson.dependencies ?? {}),
+    ...(packageJson.devDependencies ?? {}),
+  });
+  const missingDependencies = dependencies.filter(
+    (dependency) =>
+      !fs.existsSync(
+        path.join(dependencyPath(repoRoot, dependency), "package.json")
+      )
+  );
+  const missingBinaries = REQUIRED_BINARIES.filter(
+    (binary) =>
+      !fs.existsSync(path.join(repoRoot, "node_modules", ".bin", binary))
+  );
+  const metadataPresent = fs.existsSync(
+    path.join(repoRoot, "node_modules", ".modules.yaml")
+  );
+  return {
+    complete:
+      metadataPresent &&
+      missingDependencies.length === 0 &&
+      missingBinaries.length === 0,
+    metadata_present: metadataPresent,
+    missing_dependencies: missingDependencies.slice(0, 50),
+    missing_binaries: missingBinaries,
+  };
+}
+
+function classifyFailure(result, verification) {
+  if (result.timedOut) {
+    return {
+      failure_class: "INFRASTRUCTURE_TRANSIENT",
+      failure_code: "DEPENDENCY_INSTALL_TIMEOUT",
+    };
+  }
+  if (result.status === 0 && !verification.complete) {
+    return {
+      failure_class: "INFRASTRUCTURE_TRANSIENT",
+      failure_code: "DEPENDENCY_INSTALL_INCOMPLETE",
+    };
+  }
+  if (SOURCE_PATTERNS.some((pattern) => pattern.test(result.output))) {
+    return {
+      failure_class: "SOURCE",
+      failure_code: "DEPENDENCY_CONTRACT_INVALID",
+    };
+  }
+  if (INFRASTRUCTURE_PATTERNS.some((pattern) => pattern.test(result.output))) {
+    return {
+      failure_class: "INFRASTRUCTURE_TRANSIENT",
+      failure_code: "DEPENDENCY_TRANSPORT_FAILURE",
+    };
+  }
+  return {
+    failure_class: "UNKNOWN",
+    failure_code: "DEPENDENCY_INSTALL_FAILED",
+  };
+}
+
+function evidenceIdentity(environment = process.env) {
+  return {
+    base_sha: environment.RELEASE_BUS_BASE_SHA,
+    environment: environment.RELEASE_BUS_EVIDENCE_ENVIRONMENT,
+    gate_fingerprint: environment.RELEASE_BUS_GATE_FINGERPRINT,
+    workflow_sha: environment.RELEASE_BUS_WORKFLOW_SHA,
+    workflow_digest: environment.RELEASE_BUS_WORKFLOW_DIGEST,
+    node_version: environment.RELEASE_BUS_NODE_VERSION,
+    package_manager: environment.RELEASE_BUS_PACKAGE_MANAGER,
+  };
+}
+
+function writeEvidence(filename, value) {
+  fs.mkdirSync(path.dirname(filename), { recursive: true });
+  fs.writeFileSync(filename, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function wait(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function installWithRetries(options = {}) {
+  const repoRoot = path.resolve(options.repoRoot ?? process.cwd());
+  const environment = options.environment ?? process.env;
+  const maxAttempts = boundedInteger(
+    options.maxAttempts ?? environment.RELEASE_BUS_INSTALL_MAX_ATTEMPTS,
+    DEFAULT_MAX_ATTEMPTS,
+    1,
+    5
+  );
+  const timeoutMs = boundedInteger(
+    options.timeoutMs ?? environment.RELEASE_BUS_INSTALL_TIMEOUT_MS,
+    DEFAULT_TIMEOUT_MS,
+    10_000,
+    15 * 60 * 1000
+  );
+  const baseBackoffMs = boundedInteger(
+    options.backoffMs ?? environment.RELEASE_BUS_INSTALL_BACKOFF_MS,
+    5_000,
+    0,
+    60_000
+  );
+  const evidenceFile =
+    options.evidenceFile ??
+    environment.RELEASE_BUS_INSTALL_EVIDENCE ??
+    path.join(
+      environment.RUNNER_TEMP ?? repoRoot,
+      "release-bus-evidence",
+      "dependency-install.json"
+    );
+  const command = options.command ?? path.join(repoRoot, "bin", "6529");
+  const args = options.args ?? ["install:frozen"];
+  const attempts = [];
+
+  if (
+    environment.RELEASE_BUS_SOCKET_FIREWALL_OUTCOME &&
+    environment.RELEASE_BUS_SOCKET_FIREWALL_OUTCOME !== "success"
+  ) {
+    const evidence = {
+      schema_version: 1,
+      kind: "dependency_install",
+      source: environment.GITHUB_JOB === "legacy" ? "legacy" : "parallel",
+      ...evidenceIdentity(environment),
+      status: "FAILED",
+      failure_class: "INFRASTRUCTURE_TRANSIENT",
+      failure_code: "SOCKET_FIREWALL_SETUP_FAILED",
+      recovered: false,
+      attempts: [],
+    };
+    writeEvidence(evidenceFile, evidence);
+    const error = new Error(
+      "Release Bus dependency installation failed (SOCKET_FIREWALL_SETUP_FAILED)"
+    );
+    error.evidence = evidence;
+    throw error;
+  }
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const result = await (options.runInstall ?? runInstall)(command, args, {
+      cwd: repoRoot,
+      env: environment,
+      timeoutMs,
+    });
+    const verification =
+      result.status === 0
+        ? (options.verifyInstall ?? verifyInstall)(repoRoot)
+        : {
+            complete: false,
+            metadata_present: false,
+            missing_dependencies: [],
+            missing_binaries: [],
+          };
+    if (result.status === 0 && verification.complete) {
+      attempts.push({
+        attempt,
+        status: "SUCCEEDED",
+        duration_ms: result.durationMs,
+      });
+      const evidence = {
+        schema_version: 1,
+        kind: "dependency_install",
+        source: environment.GITHUB_JOB === "legacy" ? "legacy" : "parallel",
+        ...evidenceIdentity(environment),
+        status: "SUCCEEDED",
+        failure_class: null,
+        failure_code: null,
+        recovered: attempt > 1,
+        attempts,
+      };
+      writeEvidence(evidenceFile, evidence);
+      return evidence;
+    }
+
+    const classification = classifyFailure(result, verification);
+    attempts.push({
+      attempt,
+      status: "FAILED",
+      duration_ms: result.durationMs,
+      timed_out: result.timedOut,
+      exit_code: result.status,
+      ...classification,
+      verification,
+    });
+    const retryable =
+      classification.failure_class === "INFRASTRUCTURE_TRANSIENT" &&
+      attempt < maxAttempts;
+    if (!retryable) {
+      const evidence = {
+        schema_version: 1,
+        kind: "dependency_install",
+        source: environment.GITHUB_JOB === "legacy" ? "legacy" : "parallel",
+        ...evidenceIdentity(environment),
+        status: "FAILED",
+        ...classification,
+        recovered: false,
+        attempts,
+      };
+      writeEvidence(evidenceFile, evidence);
+      const error = new Error(
+        `Release Bus dependency installation failed (${classification.failure_code})`
+      );
+      error.evidence = evidence;
+      throw error;
+    }
+
+    process.stderr.write(
+      `Transient dependency-install failure (${classification.failure_code}); retrying exact frozen install (${attempt + 1}/${maxAttempts}).\n`
+    );
+    fs.rmSync(path.join(repoRoot, "node_modules"), {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: 100,
+    });
+    await wait(baseBackoffMs * attempt);
+  }
+  throw new Error("Release Bus dependency installation exhausted unexpectedly");
+}
+
+async function main() {
+  try {
+    await installWithRetries();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : error}\n`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  classifyFailure,
+  installWithRetries,
+  verifyInstall,
+};
+
+if (require.main === module) void main();

--- a/scripts/release-bus-preflight-evidence.cjs
+++ b/scripts/release-bus-preflight-evidence.cjs
@@ -20,6 +20,7 @@ const PREFLIGHT_TOOLING_FILES = [
   "scripts/release-bus-authorize-operation.sh",
   "scripts/release-bus-frontend-gate.sh",
   "scripts/release-bus-gate-evidence.cjs",
+  "scripts/release-bus-install-dependencies.cjs",
   "scripts/release-bus-preflight-evidence.cjs",
   "scripts/release-bus-report-progress.mjs",
 ];

--- a/scripts/release-bus-report-progress.mjs
+++ b/scripts/release-bus-report-progress.mjs
@@ -14,6 +14,8 @@ const OUTCOME_STATUS = {
   cancelled: "FAILED",
   skipped: "SKIPPED",
 };
+const REPORT_MAX_ATTEMPTS = 3;
+const REPORT_TIMEOUT_MS = 15_000;
 
 function stageStatus(name) {
   const key = `RELEASE_BUS_GATE_${name.toUpperCase()}_OUTCOME`;
@@ -326,6 +328,62 @@ export function buildProgressPayload() {
   };
 }
 
+export async function postProgress(
+  apiUrl,
+  token,
+  payload,
+  {
+    fetchImpl = fetch,
+    sleep = (milliseconds) =>
+      new Promise((resolve) => setTimeout(resolve, milliseconds)),
+    timeoutMs = REPORT_TIMEOUT_MS,
+  } = {}
+) {
+  let lastStatus = null;
+  for (let attempt = 1; attempt <= REPORT_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await fetchImpl(
+        `${apiUrl.replace(/\/$/, "")}/deploy/release-bus/report-progress`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(payload),
+          signal: AbortSignal.timeout(timeoutMs),
+        }
+      );
+      if (response.ok) return;
+      lastStatus = response.status;
+      if (response.status < 500 || response.status > 599) {
+        throw new Error(
+          `Release Bus progress report failed (${response.status})`
+        );
+      }
+      if (attempt === REPORT_MAX_ATTEMPTS) {
+        throw new Error("Release Bus progress report retryable server failure");
+      }
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        /^Release Bus progress report failed \([1-4]\d\d\)$/.test(error.message)
+      ) {
+        throw error;
+      }
+      if (attempt === REPORT_MAX_ATTEMPTS) {
+        throw new Error(
+          `Release Bus progress report failed after bounded transport retries${lastStatus ? ` (${lastStatus})` : ""}`
+        );
+      }
+    }
+    process.stderr.write(
+      `Release Bus progress report transport attempt ${attempt} failed; retrying the same operation/run payload.\n`
+    );
+    await sleep(1_000 * attempt);
+  }
+}
+
 async function main() {
   const payload = buildProgressPayload();
   if (process.argv.includes("--payload-only")) {
@@ -343,20 +401,7 @@ async function main() {
   // Only the strict, bounded projection above is sent to the configured Release
   // Bus endpoint. Unknown fields, failure messages, and raw logs are discarded.
   // lgtm[js/file-access-to-http]
-  const response = await fetch(
-    `${apiUrl.replace(/\/$/, "")}/deploy/release-bus/report-progress`,
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(payload),
-    }
-  );
-  if (!response.ok) {
-    throw new Error(`Release Bus progress report failed (${response.status})`);
-  }
+  await postProgress(apiUrl, token, payload);
 }
 
 if (

--- a/scripts/release-bus-report-progress.mjs
+++ b/scripts/release-bus-report-progress.mjs
@@ -139,6 +139,20 @@ function projectAggregateProgress(value) {
     throw new Error("Release Bus aggregate summary is invalid");
   }
   const status = value.status === "SUCCEEDED" ? "SUCCEEDED" : "FAILED";
+  const failureClass =
+    status === "SUCCEEDED"
+      ? null
+      : ["SOURCE", "INFRASTRUCTURE_TRANSIENT", "UNKNOWN"].includes(
+            value.failure_class
+          )
+        ? value.failure_class
+        : "UNKNOWN";
+  const failurePhase =
+    status === "SUCCEEDED"
+      ? null
+      : ["dependency_install", "gate"].includes(value.failure_phase)
+        ? value.failure_phase
+        : "gate";
   const phases = Array.isArray(value.phases) ? value.phases : [];
   const stages = STAGES.map((name) => {
     const phase = phases.find((item) => item?.name === name);
@@ -161,7 +175,16 @@ function projectAggregateProgress(value) {
     failing_tests: value.failing_tests,
   });
   if (!isVersionedAggregate(value)) {
-    return { status, stages, jest, summary: null };
+    return {
+      status,
+      stages,
+      jest,
+      summary: null,
+      failure_class: failureClass,
+      failure_phase: failurePhase,
+      retryable:
+        failureClass === "INFRASTRUCTURE_TRANSIENT" && value.retryable === true,
+    };
   }
   const artifactDigest = String(
     process.env.RELEASE_BUS_SUMMARY_ARTIFACT_DIGEST ?? ""
@@ -217,6 +240,10 @@ function projectAggregateProgress(value) {
     status,
     stages,
     jest,
+    failure_class: failureClass,
+    failure_phase: failurePhase,
+    retryable:
+      failureClass === "INFRASTRUCTURE_TRANSIENT" && value.retryable === true,
     summary: {
       base_sha: value.base_sha,
       environment: value.environment,
@@ -290,6 +317,9 @@ export function buildProgressPayload() {
     workflow_run_id: process.env.GITHUB_RUN_ID,
     phase: process.env.RELEASE_BUS_REPORT_PHASE ?? "complete",
     status: failed ? "FAILED" : "SUCCEEDED",
+    failure_class: failed ? "UNKNOWN" : null,
+    failure_phase: failed ? "gate" : null,
+    retryable: false,
     stages,
     jest: readJestSummary(),
     summary: null,

--- a/scripts/release-bus-report-progress.mjs
+++ b/scripts/release-bus-report-progress.mjs
@@ -17,6 +17,8 @@ const OUTCOME_STATUS = {
 const REPORT_MAX_ATTEMPTS = 3;
 const REPORT_TIMEOUT_MS = 15_000;
 
+class NonRetryableProgressResponseError extends Error {}
+
 function stageStatus(name) {
   const key = `RELEASE_BUS_GATE_${name.toUpperCase()}_OUTCOME`;
   const outcome = String(process.env[key] ?? "skipped").toLowerCase();
@@ -357,7 +359,7 @@ export async function postProgress(
       if (response.ok) return;
       lastStatus = response.status;
       if (response.status < 500 || response.status > 599) {
-        throw new Error(
+        throw new NonRetryableProgressResponseError(
           `Release Bus progress report failed (${response.status})`
         );
       }
@@ -365,12 +367,7 @@ export async function postProgress(
         throw new Error("Release Bus progress report retryable server failure");
       }
     } catch (error) {
-      if (
-        error instanceof Error &&
-        /^Release Bus progress report failed \([1-4]\d\d\)$/.test(error.message)
-      ) {
-        throw error;
-      }
+      if (error instanceof NonRetryableProgressResponseError) throw error;
       if (attempt === REPORT_MAX_ATTEMPTS) {
         throw new Error(
           `Release Bus progress report failed after bounded transport retries${lastStatus ? ` (${lastStatus})` : ""}`
@@ -382,6 +379,7 @@ export async function postProgress(
     );
     await sleep(1_000 * attempt);
   }
+  throw new Error("Release Bus progress report retry loop exited unexpectedly");
 }
 
 async function main() {


### PR DESCRIPTION
## Summary
- verify Socket Firewall/pnpm installs and retry only transient transport or partial-install failures
- emit bounded failure classification evidence and remove dependency install from aggregate-only jobs
- harden both base-canary and frontend preflight workflows and document recovery behavior

## Validation
- Release Bus contract suite: 38 tests passed
- changed-file ESLint passed
- actual installed dependency tree verification passed

No release note.