### PR TITLE
Fix Release Bus preflight runner context

### DIFF
--- a/.github/workflows/release-bus-preflight.yml
+++ b/.github/workflows/release-bus-preflight.yml
@@ -355,13 +355,16 @@ jobs:
         environment: ${{ fromJSON(inputs.target_lane == 'PRODUCTION' && '["staging","production"]' || '["staging"]') }}
     env:
       SOURCE_SHA: ${{ inputs.expected_sha }}
-      RELEASE_BUS_INSTALL_EVIDENCE: ${{ runner.temp }}/release-bus-evidence/dependency-install-${{ matrix.environment }}.json
     steps:
       - *checkout
       - *stage-tooling
       - *setup-node
       - *activate-pnpm
       - *socket-firewall
+      - name: Select build dependency evidence path
+        env:
+          BUILD_ENVIRONMENT: ${{ matrix.environment }}
+        run: echo "RELEASE_BUS_INSTALL_EVIDENCE=$RUNNER_TEMP/release-bus-evidence/dependency-install-$BUILD_ENVIRONMENT.json" >> "$GITHUB_ENV"
       - *install
       - name: Capture build timestamp
         run: printf 'VERSION_BUILD_TIMESTAMP=%s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_ENV"

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -460,8 +460,8 @@ describe("Release Bus frontend gate contract", () => {
     expect(buildEvidenceStep?.env).toEqual({
       BUILD_ENVIRONMENT: "${{ matrix.environment }}",
     });
-    expect(buildEvidenceStep?.run).toContain(
-      "RELEASE_BUS_INSTALL_EVIDENCE=$RUNNER_TEMP/release-bus-evidence/dependency-install-$BUILD_ENVIRONMENT.json"
+    expect(buildEvidenceStep?.run).toBe(
+      'echo "RELEASE_BUS_INSTALL_EVIDENCE=$RUNNER_TEMP/release-bus-evidence/dependency-install-$BUILD_ENVIRONMENT.json" >> "$GITHUB_ENV"'
     );
     expect(preflightWorkflow.jobs?.authorize?.outputs).toMatchObject({
       inject_failure: "${{ steps.inputs.outputs.inject_failure }}",

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -451,10 +451,18 @@ describe("Release Bus frontend gate contract", () => {
     expect(preflightWorkflow.jobs?.authorize?.["timeout-minutes"]).toBe(10);
     expect(preflightWorkflow.jobs?.jest?.strategy?.["fail-fast"]).toBe(false);
     expect(preflightWorkflow.jobs?.build?.strategy?.["fail-fast"]).toBe(false);
-    expect(preflightWorkflow.jobs?.build?.env).toMatchObject({
-      RELEASE_BUS_INSTALL_EVIDENCE:
-        "${{ runner.temp }}/release-bus-evidence/dependency-install-${{ matrix.environment }}.json",
+    expect(preflightWorkflow.jobs?.build?.env).not.toHaveProperty(
+      "RELEASE_BUS_INSTALL_EVIDENCE"
+    );
+    const buildEvidenceStep = preflightWorkflow.jobs?.build?.steps?.find(
+      (step) => step.name === "Select build dependency evidence path"
+    );
+    expect(buildEvidenceStep?.env).toEqual({
+      BUILD_ENVIRONMENT: "${{ matrix.environment }}",
     });
+    expect(buildEvidenceStep?.run).toContain(
+      "RELEASE_BUS_INSTALL_EVIDENCE=$RUNNER_TEMP/release-bus-evidence/dependency-install-$BUILD_ENVIRONMENT.json"
+    );
     expect(preflightWorkflow.jobs?.authorize?.outputs).toMatchObject({
       inject_failure: "${{ steps.inputs.outputs.inject_failure }}",
     });


### PR DESCRIPTION
## Issue
- Merging PR #3405 exposed a workflow-definition failure on main because the preflight build job used the runner context in job-level env, before a runner exists.

## Fix
- Set the per-environment dependency-evidence path in a runner-time step before the shared install step.

## Changes
- Remove the unsupported job-level runner.temp expression.
- Preserve distinct staging and production dependency-install evidence filenames through GITHUB_ENV.
- Update the workflow contract test to enforce the supported context boundary.

## Validation
- actionlint v1.7.12: passed.
- Focused Release Bus frontend gate contract test: passed.
- Changed-file typecheck, formatting, lint, and typecheck recheck: passed.
- git diff --check: passed.

## Risk
- Level: Low
- Why: two-file workflow-only correction with no application runtime change.
- Rollback: revert this commit, though that would restore the invalid main workflow definition.

## Review Notes
- Focus on GitHub Actions context availability and preservation of per-build evidence paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release preflight validation by selecting dependency-install evidence paths at runtime for each build environment.
  * Added safeguards to ensure dependency evidence is correctly configured before installation and build steps run.

* **Tests**
  * Updated automated checks to verify runtime evidence-path selection and fail-closed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->