### PR TITLE
Make staging E2E setup failures retryable

### DIFF
--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -136,6 +136,29 @@ jobs:
           fi
           echo "skip=$skip" >> "$GITHUB_OUTPUT"
 
+      - name: Stage immutable Release Bus E2E tooling
+        if: steps.release-bus-marker.outputs.skip != 'true'
+        env:
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$WORKFLOW_SHA" =~ ^[a-f0-9]{40}$ ]]
+          git cat-file -e "$WORKFLOW_SHA^{commit}" 2>/dev/null || \
+            git fetch --no-tags origin "$WORKFLOW_SHA"
+          tooling="$RUNNER_TEMP/release-bus-tooling/scripts"
+          mkdir -p "$tooling" "$RUNNER_TEMP/release-bus-evidence"
+          for file in \
+            scripts/release-bus-install-dependencies.cjs \
+            scripts/release-bus-report-progress.mjs
+          do
+            git show "$WORKFLOW_SHA:$file" > "$RUNNER_TEMP/release-bus-tooling/$file"
+          done
+          {
+            echo "RELEASE_BUS_INSTALL_TOOL=$tooling/release-bus-install-dependencies.cjs"
+            echo "RELEASE_BUS_REPORT_TOOL=$tooling/release-bus-report-progress.mjs"
+            echo "RELEASE_BUS_INSTALL_EVIDENCE=$RUNNER_TEMP/release-bus-evidence/dependency-install.json"
+          } >> "$GITHUB_ENV"
+
       - name: Install Node.js
         if: steps.release-bus-marker.outputs.skip != 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -152,6 +175,7 @@ jobs:
       - name: Install Socket Firewall
         if: steps.release-bus-marker.outputs.skip != 'true'
         id: socket_firewall
+        continue-on-error: true
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
         with:
           mode: firewall
@@ -160,18 +184,25 @@ jobs:
         if: steps.release-bus-marker.outputs.skip != 'true'
         run: ./bin/6529 guard:no-package-lock
 
-      - name: Install dependencies
+      - name: Install and verify frozen dependencies
         if: steps.release-bus-marker.outputs.skip != 'true'
+        id: dependencies
+        continue-on-error: true
         env:
+          RELEASE_BUS_SOCKET_FIREWALL_OUTCOME: ${{ steps.socket_firewall.outcome }}
           SFW_BIN: ${{ steps.socket_firewall.outputs.firewall-path-binary }}
-        run: ./bin/6529 install:frozen
+        run: node "$RELEASE_BUS_INSTALL_TOOL"
 
       - name: Install Playwright browser
-        if: steps.release-bus-marker.outputs.skip != 'true'
+        if: steps.release-bus-marker.outputs.skip != 'true' && steps.dependencies.outcome == 'success'
+        id: playwright
+        continue-on-error: true
         run: ./bin/6529 exec playwright install --with-deps chromium
 
       - name: Run staging packs against staging.6529.io
-        if: steps.release-bus-marker.outputs.skip != 'true'
+        if: steps.release-bus-marker.outputs.skip != 'true' && steps.dependencies.outcome == 'success' && steps.playwright.outcome == 'success'
+        id: e2e
+        continue-on-error: true
         run: |
           set -uo pipefail
           packs=(
@@ -292,10 +323,32 @@ jobs:
           exit "$failed"
 
       - name: Upload Playwright artifacts on failure
-        if: failure() && steps.release-bus-marker.outputs.skip != 'true'
+        if: always() && steps.release-bus-marker.outputs.skip != 'true' && steps.e2e.outcome == 'failure'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: staging-e2e-artifacts
           path: staging-e2e-artifacts/
           retention-days: 7
           if-no-files-found: ignore
+
+      - name: Report structured Release Bus E2E result
+        if: always() && github.event_name == 'workflow_dispatch' && inputs.operation_key != ''
+        env:
+          RELEASE_BUS_API_URL: ${{ vars.RELEASE_BUS_API_URL }}
+          RELEASE_BUS_WORKFLOW_AUTH_TOKEN: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
+          RELEASE_BUS_TRAIN_ID: ${{ inputs.release_train_id }}
+          RELEASE_BUS_OPERATION_KEY: ${{ inputs.operation_key }}
+          RELEASE_BUS_REPORT_INCLUDE_STAGES: "false"
+          RELEASE_BUS_JOB_STATUS: ${{ steps.dependencies.outcome == 'success' && steps.playwright.outcome == 'success' && steps.e2e.outcome == 'success' && 'success' || 'failure' }}
+        run: node "$RELEASE_BUS_REPORT_TOOL"
+
+      - name: Return staging E2E result
+        if: always() && steps.release-bus-marker.outputs.skip != 'true'
+        env:
+          DEPENDENCIES_OUTCOME: ${{ steps.dependencies.outcome }}
+          E2E_OUTCOME: ${{ steps.e2e.outcome }}
+          PLAYWRIGHT_OUTCOME: ${{ steps.playwright.outcome }}
+        run: |
+          test "$DEPENDENCIES_OUTCOME" = success
+          test "$PLAYWRIGHT_OUTCOME" = success
+          test "$E2E_OUTCOME" = success

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -15,6 +15,7 @@ describe("Release Bus frontend gate contract", () => {
   const authorization = read("scripts/release-bus-authorize-operation.sh");
   const appPrCi = read(".github/workflows/app-pr-ci.yml");
   const reporter = read("scripts/release-bus-report-progress.mjs");
+  const stagingE2e = read(".github/workflows/staging-e2e.yml");
 
   type WorkflowStep = {
     env?: Record<string, string>;
@@ -77,6 +78,18 @@ describe("Release Bus frontend gate contract", () => {
     expect(canary).toContain("release-bus-report-progress.mjs");
     expect(canary).toContain("Report sanitized terminal evidence");
     expect(reporter).toContain("/deploy/release-bus/report-progress");
+  });
+
+  it("fails closed and reports retryable dependency failures from staging E2E", () => {
+    expect(stagingE2e).toContain(
+      "scripts/release-bus-install-dependencies.cjs"
+    );
+    expect(stagingE2e).toContain("continue-on-error: true");
+    expect(stagingE2e).toContain("Report structured Release Bus E2E result");
+    expect(stagingE2e).toContain("Return staging E2E result");
+    expect(stagingE2e).toContain('run: node "$RELEASE_BUS_INSTALL_TOOL"');
+    expect(stagingE2e).not.toContain("run: ./bin/6529 install:frozen");
+    expect(reporter).toContain("RELEASE_BUS_INSTALL_EVIDENCE");
   });
 
   it("bounds and retries an ambiguous authorization transport failure", () => {

--- a/__tests__/scripts/release-bus-jest-reporting.test.ts
+++ b/__tests__/scripts/release-bus-jest-reporting.test.ts
@@ -197,6 +197,51 @@ describe("Release Bus structured Jest reporting", () => {
     expect(JSON.stringify(payload)).not.toContain("OPENAI");
   });
 
+  it("classifies a failed dependency install as retryable infrastructure", () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "release-bus-dependency-report-")
+    );
+    const evidencePath = path.join(tempDir, "dependency-install.json");
+    try {
+      fs.writeFileSync(
+        evidencePath,
+        JSON.stringify({
+          status: "FAILED",
+          failure_class: "INFRASTRUCTURE_TRANSIENT",
+          failure_code: "DEPENDENCY_TRANSPORT_FAILURE",
+          raw_output: "must not leave the runner",
+        })
+      );
+      const output = execFileSync(
+        process.execPath,
+        ["scripts/release-bus-report-progress.mjs", "--payload-only"],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...process.env,
+            GITHUB_RUN_ID: "29920703076",
+            RELEASE_BUS_JOB_STATUS: "failure",
+            RELEASE_BUS_REPORT_INCLUDE_STAGES: "false",
+            RELEASE_BUS_INSTALL_EVIDENCE: evidencePath,
+          },
+        }
+      );
+      const payload = JSON.parse(output.toString("utf8"));
+
+      expect(payload).toMatchObject({
+        status: "FAILED",
+        failure_class: "INFRASTRUCTURE_TRANSIENT",
+        failure_phase: "dependency_install",
+        retryable: true,
+        stages: [],
+      });
+      expect(JSON.stringify(payload)).not.toContain("raw_output");
+      expect(JSON.stringify(payload)).not.toContain("must not leave");
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("omits malformed or unsafe Jest details deterministically", () => {
     const tempDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "release-bus-report-")

--- a/scripts/release-bus-report-progress.mjs
+++ b/scripts/release-bus-report-progress.mjs
@@ -77,6 +77,30 @@ function readJestSummary() {
   }
 }
 
+function readDependencyInstallEvidence() {
+  const filename = process.env.RELEASE_BUS_INSTALL_EVIDENCE;
+  if (!filename || !fs.existsSync(filename)) return null;
+  try {
+    const value = JSON.parse(fs.readFileSync(filename, "utf8"));
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error("invalid dependency-install evidence");
+    }
+    return {
+      status: value.status === "SUCCEEDED" ? "SUCCEEDED" : "FAILED",
+      failure_class: ["SOURCE", "INFRASTRUCTURE_TRANSIENT", "UNKNOWN"].includes(
+        value.failure_class
+      )
+        ? value.failure_class
+        : "UNKNOWN",
+    };
+  } catch {
+    process.stderr.write(
+      "Release Bus dependency-install evidence is invalid; classifying the failure as unknown.\n"
+    );
+    return { status: "FAILED", failure_class: "UNKNOWN" };
+  }
+}
+
 function safeDuration(value) {
   if (!Number.isInteger(value) || value < 0 || value > MAX_DURATION_MS) {
     throw new Error("Release Bus summary contains an invalid duration");
@@ -312,18 +336,30 @@ export function buildProgressPayload() {
   const jobStatus = String(
     process.env.RELEASE_BUS_JOB_STATUS ?? ""
   ).toLowerCase();
+  const dependencyInstall = readDependencyInstallEvidence();
   const failed =
     ["failure", "cancelled"].includes(jobStatus) ||
     stages.some((stage) => stage.status === "FAILED");
+  const dependencyInstallFailed =
+    failed && dependencyInstall?.status === "FAILED";
+  const failureClass = dependencyInstallFailed
+    ? dependencyInstall.failure_class
+    : failed
+      ? "UNKNOWN"
+      : null;
   return {
     train_id: process.env.RELEASE_BUS_TRAIN_ID,
     operation_key: process.env.RELEASE_BUS_OPERATION_KEY,
     workflow_run_id: process.env.GITHUB_RUN_ID,
     phase: process.env.RELEASE_BUS_REPORT_PHASE ?? "complete",
     status: failed ? "FAILED" : "SUCCEEDED",
-    failure_class: failed ? "UNKNOWN" : null,
-    failure_phase: failed ? "gate" : null,
-    retryable: false,
+    failure_class: failureClass,
+    failure_phase: dependencyInstallFailed
+      ? "dependency_install"
+      : failed
+        ? "gate"
+        : null,
+    retryable: failureClass === "INFRASTRUCTURE_TRANSIENT",
     stages,
     jest: readJestSummary(),
     summary: null,


### PR DESCRIPTION
## What changed
- run staging E2E dependency installation through the verified bounded retry helper
- report sanitized dependency-install classification to the Release Bus
- fail the workflow only after evidence has been reported

## Why
Socket Firewall failed during dependency setup but left a partial install, so Playwright was missing and the bus could not distinguish CI infrastructure from a candidate failure.

## Impact
Transient dependency setup failures are retried and reported as infrastructure without blaming a candidate.

## Validation
- 26 focused Jest tests
- Prettier, YAML parse, diff check
- targeted ESLint (ignored-file warnings suppressed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved staging end-to-end test workflows with dependency installation verification, browser setup checks, and structured result reporting.
  - Added retryable classification for transient dependency-installation failures.
  - Preserved diagnostic artifacts when staging tests fail.

- **Bug Fixes**
  - Staging results now correctly fail when required setup or test phases do not succeed.
  - Invalid or unavailable dependency evidence is handled safely with a clear failure classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->