### PR TITLE
Bind dependency install evidence to the build profile

### DIFF
--- a/__tests__/scripts/release-bus-install-dependencies.test.ts
+++ b/__tests__/scripts/release-bus-install-dependencies.test.ts
@@ -25,6 +25,7 @@ const identityEnvironment = (runnerTemp: string) => ({
   RELEASE_BUS_WORKFLOW_DIGEST: "d".repeat(64),
   RELEASE_BUS_NODE_VERSION: "22",
   RELEASE_BUS_PACKAGE_MANAGER: "pnpm@10.14.0",
+  RELEASE_BUS_BUILD_PROFILE_DIGEST: "e".repeat(64),
   RUNNER_TEMP: runnerTemp,
 });
 
@@ -90,6 +91,7 @@ describe("Release Bus verified dependency installation", () => {
       status: "SUCCEEDED",
       failure_class: null,
       recovered: true,
+      build_profile_digest: "e".repeat(64),
     });
     expect(evidence.attempts).toHaveLength(2);
     expect(

--- a/scripts/release-bus-install-dependencies.cjs
+++ b/scripts/release-bus-install-dependencies.cjs
@@ -172,6 +172,7 @@ function evidenceIdentity(environment = process.env) {
     workflow_digest: environment.RELEASE_BUS_WORKFLOW_DIGEST,
     node_version: environment.RELEASE_BUS_NODE_VERSION,
     package_manager: environment.RELEASE_BUS_PACKAGE_MANAGER,
+    build_profile_digest: environment.RELEASE_BUS_BUILD_PROFILE_DIGEST,
   };
 }
 


### PR DESCRIPTION
## Summary
- include the protected build-profile digest in dependency-install evidence
- keep aggregate identity checks fail closed while allowing fully matching evidence to pass

## Verification
- 15 focused dependency-install and gate-evidence tests passed
- Prettier and diff checks passed
- live run 29936951836 proved every real gate green and isolated this missing identity field

## Rollout
Workflow tooling only. Merge at the paused idle boundary; no frontend application deployment and no release notes.