### PR TITLE
Fix Release Bus preflight profile transport

### DIFF
--- a/.github/workflows/release-bus-preflight.yml
+++ b/.github/workflows/release-bus-preflight.yml
@@ -93,7 +93,7 @@ jobs:
           name: release-bus-preflight-build-profile-${{ github.run_id }}
           path: ${{ runner.temp }}/release-bus-build-profile.json
           if-no-files-found: error
-          retention-days: 14
+          retention-days: 1
 
   authorize:
     needs: build_profile
@@ -170,6 +170,10 @@ jobs:
           EXPECTED_SHA: ${{ inputs.expected_sha }}
         run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
       - *setup-node
+      # download-artifact without a run-id or repository is scoped to this
+      # workflow run. The v4 artifact is immutable, and build_profile is the
+      # only job that can run before this consumer and publish this run-bound
+      # name. A compromised producer would already possess the HMAC key.
       - name: Download protected build profile
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/.github/workflows/release-bus-preflight.yml
+++ b/.github/workflows/release-bus-preflight.yml
@@ -27,7 +27,76 @@ permissions: {}
 run-name: Preflight frontend train ${{ inputs.release_train_id }} [${{ inputs.operation_key }}]
 
 jobs:
+  build_profile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Validate profile inputs before using credentials
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          TARGET_LANE: ${{ inputs.target_lane }}
+        run: |
+          set -euo pipefail
+          [[ "$EXPECTED_SHA" =~ ^[a-f0-9]{40}$ ]]
+          [[ "$TARGET_LANE" =~ ^(STAGING|PRODUCTION)$ ]]
+      - &checkout
+        name: Check out exact train SHA
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.expected_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - &setup-node
+        name: Install Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with: { node-version: "22" }
+      - name: Derive protected target build profile
+        env:
+          RELEASE_BUS_BUILD_PROFILE_HMAC_KEY: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
+          BUILD_ENVIRONMENT: ${{ inputs.target_lane == 'PRODUCTION' && 'production' || 'staging' }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          NODE_ENV: production
+          API_ENDPOINT: ${{ inputs.target_lane == 'PRODUCTION' && 'https://api.6529.io' || vars.STAGING_API_ENDPOINT || 'https://api.staging.6529.io' }}
+          WS_ENDPOINT: ${{ inputs.target_lane == 'PRODUCTION' && 'wss://ws.6529.io' || vars.STAGING_WS_ENDPOINT || 'wss://ws.staging.6529.io' }}
+          ALLOWLIST_API_ENDPOINT: ${{ inputs.target_lane == 'PRODUCTION' && 'https://allowlist-api.6529.io' || vars.STAGING_ALLOWLIST_API_ENDPOINT || 'https://allowlist-api.staging.6529.io' }}
+          BASE_ENDPOINT: ${{ inputs.target_lane == 'PRODUCTION' && 'https://6529.io' || 'https://staging.6529.io' }}
+          VERSION: ${{ inputs.expected_sha }}
+          ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
+          NEXTGEN_CHAIN_ID: ${{ inputs.target_lane == 'PRODUCTION' && '1' || vars.STAGING_NEXTGEN_CHAIN_ID || '11155111' }}
+          MOBILE_APP_SCHEME: mobile6529
+          CORE_SCHEME: core6529
+          IPFS_API_ENDPOINT: https://api-ipfs.6529.io
+          IPFS_GATEWAY_ENDPOINT: https://ipfs.6529.io
+          GIPHY_API_KEY: ${{ secrets.GIPHY_API_KEY }}
+          AWS_RUM_APP_ID: ${{ secrets.AWS_RUM_APP_ID }}
+          AWS_RUM_REGION: ${{ secrets.AWS_RUM_REGION }}
+          AWS_RUM_SAMPLE_RATE: ${{ secrets.AWS_RUM_SAMPLE_RATE }}
+          NEXT_PUBLIC_MIXPANEL_TOKEN: ${{ secrets.NEXT_PUBLIC_MIXPANEL_TOKEN }}
+          ASSETS_FROM_S3: ${{ inputs.target_lane == 'PRODUCTION' && 'true' || 'false' }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          ANNOUNCED_VERSION_ENDPOINT: ${{ inputs.target_lane == 'PRODUCTION' && 'https://dnclu2fna0b2b.cloudfront.net/web_build/current-production-version.json' || '' }}
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          profile_tool="$RUNNER_TEMP/release-bus-build-profile.cjs"
+          git show "$WORKFLOW_SHA:scripts/release-bus-build-profile.cjs" > "$profile_tool"
+          node "$profile_tool" \
+            --source-sha "$EXPECTED_SHA" \
+            --environment "$BUILD_ENVIRONMENT" \
+            --output "$RUNNER_TEMP/release-bus-build-profile.json"
+      - name: Upload protected build profile
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-bus-preflight-build-profile-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-bus-build-profile.json
+          if-no-files-found: error
+          retention-days: 14
+
   authorize:
+    needs: build_profile
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -95,58 +164,38 @@ jobs:
               echo "promotion_eligible=false"
             fi
           } >> "$GITHUB_OUTPUT"
-      - &checkout
-        name: Check out exact train SHA
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          ref: ${{ inputs.expected_sha }}
-          fetch-depth: 0
-          persist-credentials: false
+      - *checkout
       - name: Verify immutable source
         env:
           EXPECTED_SHA: ${{ inputs.expected_sha }}
         run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
-      - &setup-node
-        name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with: { node-version: "22" }
-      - name: Derive protected target build profile
+      - *setup-node
+      - name: Download protected build profile
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: release-bus-preflight-build-profile-${{ github.run_id }}
+          path: ${{ runner.temp }}/protected-build-profile
+      - name: Verify protected target build profile
         id: build-profile
         env:
-          RELEASE_BUS_BUILD_PROFILE_HMAC_KEY: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
           BUILD_ENVIRONMENT: ${{ steps.inputs.outputs.build_environment }}
           EXPECTED_SHA: ${{ inputs.expected_sha }}
-          NODE_ENV: production
-          API_ENDPOINT: ${{ inputs.target_lane == 'PRODUCTION' && 'https://api.6529.io' || vars.STAGING_API_ENDPOINT || 'https://api.staging.6529.io' }}
-          WS_ENDPOINT: ${{ inputs.target_lane == 'PRODUCTION' && 'wss://ws.6529.io' || vars.STAGING_WS_ENDPOINT || 'wss://ws.staging.6529.io' }}
-          ALLOWLIST_API_ENDPOINT: ${{ inputs.target_lane == 'PRODUCTION' && 'https://allowlist-api.6529.io' || vars.STAGING_ALLOWLIST_API_ENDPOINT || 'https://allowlist-api.staging.6529.io' }}
-          BASE_ENDPOINT: ${{ inputs.target_lane == 'PRODUCTION' && 'https://6529.io' || 'https://staging.6529.io' }}
-          VERSION: ${{ inputs.expected_sha }}
-          ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
-          NEXTGEN_CHAIN_ID: ${{ inputs.target_lane == 'PRODUCTION' && '1' || vars.STAGING_NEXTGEN_CHAIN_ID || '11155111' }}
-          MOBILE_APP_SCHEME: mobile6529
-          CORE_SCHEME: core6529
-          IPFS_API_ENDPOINT: https://api-ipfs.6529.io
-          IPFS_GATEWAY_ENDPOINT: https://ipfs.6529.io
-          GIPHY_API_KEY: ${{ secrets.GIPHY_API_KEY }}
-          AWS_RUM_APP_ID: ${{ secrets.AWS_RUM_APP_ID }}
-          AWS_RUM_REGION: ${{ secrets.AWS_RUM_REGION }}
-          AWS_RUM_SAMPLE_RATE: ${{ secrets.AWS_RUM_SAMPLE_RATE }}
-          NEXT_PUBLIC_MIXPANEL_TOKEN: ${{ secrets.NEXT_PUBLIC_MIXPANEL_TOKEN }}
-          ASSETS_FROM_S3: ${{ inputs.target_lane == 'PRODUCTION' && 'true' || 'false' }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          ANNOUNCED_VERSION_ENDPOINT: ${{ inputs.target_lane == 'PRODUCTION' && 'https://dnclu2fna0b2b.cloudfront.net/web_build/current-production-version.json' || '' }}
-          WORKFLOW_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          profile_tool="$RUNNER_TEMP/release-bus-build-profile.cjs"
-          git show "$WORKFLOW_SHA:scripts/release-bus-build-profile.cjs" > "$profile_tool"
-          node "$profile_tool" \
-            --source-sha "$EXPECTED_SHA" \
-            --environment "$BUILD_ENVIRONMENT" \
-            --output "$RUNNER_TEMP/release-bus-build-profile.json"
-          echo "digest=$(jq -r '.digest' "$RUNNER_TEMP/release-bus-build-profile.json")" >> "$GITHUB_OUTPUT"
+          profile="$RUNNER_TEMP/protected-build-profile/release-bus-build-profile.json"
+          jq -e \
+            --arg source_sha "$EXPECTED_SHA" \
+            --arg environment "$BUILD_ENVIRONMENT" \
+            'type == "object" and
+             .schema_version == 1 and
+             .kind == "release_bus_frontend_build_profile" and
+             .environment == $environment and
+             .source_sha == $source_sha and
+             .node_version == "22" and
+             .timestamp_policy == "utc_workflow_run_start_seconds" and
+             (.digest | test("^[a-f0-9]{64}$"))' \
+            "$profile" >/dev/null
+          echo "digest=$(jq -r '.digest' "$profile")" >> "$GITHUB_OUTPUT"
       - name: Derive deterministic preflight fingerprint
         id: fingerprint
         env:

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -21,6 +21,8 @@ describe("Release Bus frontend gate contract", () => {
     env?: Record<string, string>;
     name?: string;
     run?: string;
+    uses?: string;
+    with?: Record<string, string>;
   };
 
   const canaryWorkflow = parseYaml(canary) as {
@@ -507,6 +509,7 @@ describe("Release Bus frontend gate contract", () => {
     expect(inputs.validation_only?.required).toBe(false);
     expect(inputs.validation_shard_count?.required).toBe(false);
     expect(inputs.validation_inject_failure?.required).toBe(false);
+    expect(preflightWorkflow.jobs?.authorize?.needs).toBe("build_profile");
     expect(preflightWorkflow.jobs?.authorize?.["timeout-minutes"]).toBe(10);
     expect(preflightWorkflow.jobs?.jest?.strategy?.["fail-fast"]).toBe(false);
     expect(preflightWorkflow.jobs?.build?.strategy).toBeUndefined();
@@ -525,7 +528,44 @@ describe("Release Bus frontend gate contract", () => {
     );
     expect(preflightWorkflow.jobs?.authorize?.outputs).toMatchObject({
       inject_failure: "${{ steps.inputs.outputs.inject_failure }}",
+      build_profile_digest: "${{ steps.build-profile.outputs.digest }}",
     });
+    const buildProfileSteps =
+      preflightWorkflow.jobs?.build_profile?.steps ?? [];
+    expect(
+      buildProfileSteps.find(
+        (step) => step.name === "Derive protected target build profile"
+      )?.env
+    ).toHaveProperty("RELEASE_BUS_BUILD_PROFILE_HMAC_KEY");
+    expect(
+      buildProfileSteps.find(
+        (step) => step.name === "Upload protected build profile"
+      )
+    ).toMatchObject({
+      uses: expect.stringContaining("actions/upload-artifact@"),
+      with: expect.objectContaining({
+        name: "release-bus-preflight-build-profile-${{ github.run_id }}",
+      }),
+    });
+    const authorizeSteps = preflightWorkflow.jobs?.authorize?.steps ?? [];
+    expect(
+      authorizeSteps.find(
+        (step) => step.name === "Download protected build profile"
+      )
+    ).toMatchObject({
+      uses: expect.stringContaining("actions/download-artifact@"),
+      with: expect.objectContaining({
+        name: "release-bus-preflight-build-profile-${{ github.run_id }}",
+      }),
+    });
+    expect(
+      authorizeSteps.find(
+        (step) => step.name === "Verify protected target build profile"
+      )?.run
+    ).toContain("digest=$(jq -r '.digest' \"$profile\")");
+    expect(JSON.stringify(authorizeSteps)).not.toContain(
+      "RELEASE_BUS_BUILD_PROFILE_HMAC_KEY"
+    );
     expect(preflightWorkflow.jobs?.aggregate?.needs).toEqual([
       "authorize",
       "lint",

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -22,7 +22,7 @@ describe("Release Bus frontend gate contract", () => {
     name?: string;
     run?: string;
     uses?: string;
-    with?: Record<string, string>;
+    with?: Record<string, unknown>;
   };
 
   const canaryWorkflow = parseYaml(canary) as {
@@ -53,6 +53,7 @@ describe("Release Bus frontend gate contract", () => {
         env?: Record<string, string>;
         needs?: string[] | string;
         outputs?: Record<string, string>;
+        permissions?: Record<string, string>;
         steps?: WorkflowStep[];
         strategy?: { "fail-fast"?: boolean };
         "timeout-minutes"?: number;
@@ -532,6 +533,9 @@ describe("Release Bus frontend gate contract", () => {
     });
     const buildProfileSteps =
       preflightWorkflow.jobs?.build_profile?.steps ?? [];
+    expect(preflightWorkflow.jobs?.build_profile?.permissions).toEqual({
+      contents: "read",
+    });
     expect(
       buildProfileSteps.find(
         (step) => step.name === "Derive protected target build profile"
@@ -545,6 +549,7 @@ describe("Release Bus frontend gate contract", () => {
       uses: expect.stringContaining("actions/upload-artifact@"),
       with: expect.objectContaining({
         name: "release-bus-preflight-build-profile-${{ github.run_id }}",
+        "retention-days": 1,
       }),
     });
     const authorizeSteps = preflightWorkflow.jobs?.authorize?.steps ?? [];
@@ -563,7 +568,12 @@ describe("Release Bus frontend gate contract", () => {
         (step) => step.name === "Verify protected target build profile"
       )?.run
     ).toContain("digest=$(jq -r '.digest' \"$profile\")");
-    expect(JSON.stringify(authorizeSteps)).not.toContain(
+    const nonProducerJobs = Object.fromEntries(
+      Object.entries(preflightWorkflow.jobs ?? {}).filter(
+        ([name]) => name !== "build_profile"
+      )
+    );
+    expect(JSON.stringify(nonProducerJobs)).not.toContain(
       "RELEASE_BUS_BUILD_PROFILE_HMAC_KEY"
     );
     expect(preflightWorkflow.jobs?.aggregate?.needs).toEqual([


### PR DESCRIPTION
## Summary
- derive the protected target build profile in its own credential-bearing job
- carry the verified profile to authorization through a same-run immutable artifact
- keep downstream gate/build outputs non-secret so GitHub preserves them across the job boundary
- add focused contract coverage proving the authorization job never receives the HMAC secret

## Validation
- `./bin/6529 run test:no-coverage --maxWorkers=2 --runTestsByPath __tests__/scripts/release-bus-frontend-gate.test.ts`
- `./bin/6529 run typecheck`
- Prettier check on both changed files

Workflow/tooling-only change; no frontend application deployment is required.