### PR TITLE
Invoke frontend preflight shell gate directly

### DIFF
--- a/.github/workflows/release-bus-preflight.yml
+++ b/.github/workflows/release-bus-preflight.yml
@@ -665,7 +665,7 @@ jobs:
           contract="$RUNNER_TEMP/release-bus-preflight-contract.json"
           build_result="${{ needs.build.result }}"
           if [ "$PROMOTION_ELIGIBLE" = true ]; then
-            node "$RELEASE_BUS_GATE_TOOL" fingerprint \
+            "$RELEASE_BUS_GATE_TOOL" fingerprint \
               --repo-root "$GITHUB_WORKSPACE" \
               --base-sha "$SOURCE_SHA" \
               --workflow-sha "$WORKFLOW_SHA" \

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -594,6 +594,9 @@ describe("Release Bus frontend gate contract", () => {
     const aggregate = steps.find(
       (step) => step.name === "Aggregate fail-closed preflight evidence"
     );
+    const aggregateResult = steps.find(
+      (step) => step.name === "Return aggregate result"
+    );
     const jestGate = preflightWorkflow.jobs?.jest?.steps?.find(
       (step) => step.name === "Run complete deterministic Jest shard"
     );
@@ -616,6 +619,13 @@ describe("Release Bus frontend gate contract", () => {
     );
     expect(aggregate?.run).toContain('"$RELEASE_BUS_GATE_TOOL" fingerprint');
     expect(aggregate?.run).not.toContain('node "$RELEASE_BUS_GATE_TOOL"');
+    expect(gate.startsWith("#!/usr/bin/env bash\n")).toBe(true);
+    expect(preflight).toContain(
+      'chmod +x "$tooling/release-bus-frontend-gate.sh"'
+    );
+    expect(aggregateResult?.run).toContain(
+      'test "$AGGREGATE_OUTCOME" = success'
+    );
     expect(preflight).toContain('test "$VALIDATION_ONLY" = true');
     expect(preflight).toContain(
       'echo "inject_failure=$VALIDATION_INJECT_FAILURE"'

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -614,6 +614,8 @@ describe("Release Bus frontend gate contract", () => {
     expect(aggregate?.run).toContain(
       'test "$PASSED_BEHAVIOR_DIGEST" = "$behavior_digest"'
     );
+    expect(aggregate?.run).toContain('"$RELEASE_BUS_GATE_TOOL" fingerprint');
+    expect(aggregate?.run).not.toContain('node "$RELEASE_BUS_GATE_TOOL"');
     expect(preflight).toContain('test "$VALIDATION_ONLY" = true');
     expect(preflight).toContain(
       'echo "inject_failure=$VALIDATION_INJECT_FAILURE"'


### PR DESCRIPTION
## Issue
- Frontend Release Bus preflight completed every gate and the immutable build, but aggregate invoked the shell gate through Node, causing a syntax failure before evidence was emitted.

## Fix
- Execute the staged shell gate directly for promotion-eligible fingerprint generation.

## Changes
- Remove the incorrect `node` prefix from the aggregate workflow step.
- Add a workflow contract assertion that requires direct execution and rejects the invalid invocation.

## Validation
- `./bin/6529 run test --testPathPatterns=__tests__/scripts/release-bus-frontend-gate.test.ts --maxWorkers=2` (13/13)
- `./bin/6529 run check:changed`
- `git diff --check`

## Risk
- Level: Low
- Why: one workflow command invocation and its regression contract; application code is unchanged.
- Rollback: revert this commit to restore the prior workflow invocation.

## Review Notes
- Focus on the executable boundary in the aggregate job; no frontend application deployment is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release preflight evidence fingerprinting by invoking the release gate tool through its supported command interface.
  * Added safeguards to prevent incorrect tool invocation during promotion checks.

* **Tests**
  * Expanded preflight validation to verify the correct fingerprinting command and reject unsupported invocation patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->