### PR TITLE
Use the evidence tool for preflight fingerprinting

### DIFF
--- a/.github/workflows/release-bus-preflight.yml
+++ b/.github/workflows/release-bus-preflight.yml
@@ -665,7 +665,7 @@ jobs:
           contract="$RUNNER_TEMP/release-bus-preflight-contract.json"
           build_result="${{ needs.build.result }}"
           if [ "$PROMOTION_ELIGIBLE" = true ]; then
-            "$RELEASE_BUS_GATE_TOOL" fingerprint \
+            node "$RELEASE_BUS_EVIDENCE_TOOL" fingerprint \
               --repo-root "$GITHUB_WORKSPACE" \
               --base-sha "$SOURCE_SHA" \
               --workflow-sha "$WORKFLOW_SHA" \

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -623,6 +623,7 @@ describe("Release Bus frontend gate contract", () => {
     expect(aggregate?.run).toContain(
       'node "$RELEASE_BUS_EVIDENCE_TOOL" fingerprint'
     );
+    expect(aggregate?.run).toContain('--base-sha "$SOURCE_SHA"');
     expect(aggregate?.run).not.toContain(
       '"$RELEASE_BUS_GATE_TOOL" fingerprint'
     );

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -617,7 +617,12 @@ describe("Release Bus frontend gate contract", () => {
     expect(aggregate?.run).toContain(
       'test "$PASSED_BEHAVIOR_DIGEST" = "$behavior_digest"'
     );
-    expect(aggregate?.run).toContain('"$RELEASE_BUS_GATE_TOOL" fingerprint');
+    expect(aggregate?.run).toContain(
+      'node "$RELEASE_BUS_EVIDENCE_TOOL" fingerprint'
+    );
+    expect(aggregate?.run).not.toContain(
+      '"$RELEASE_BUS_GATE_TOOL" fingerprint'
+    );
     expect(aggregate?.run).not.toContain('node "$RELEASE_BUS_GATE_TOOL"');
     expect(gate.startsWith("#!/usr/bin/env bash\n")).toBe(true);
     expect(preflight).toContain(

--- a/__tests__/scripts/release-bus-frontend-gate.test.ts
+++ b/__tests__/scripts/release-bus-frontend-gate.test.ts
@@ -594,6 +594,9 @@ describe("Release Bus frontend gate contract", () => {
     const aggregate = steps.find(
       (step) => step.name === "Aggregate fail-closed preflight evidence"
     );
+    const aggregateTooling = preflightWorkflow.jobs?.aggregate?.steps?.find(
+      (step) => step.name === "Stage immutable preflight tooling"
+    );
     const aggregateResult = steps.find(
       (step) => step.name === "Return aggregate result"
     );
@@ -624,6 +627,9 @@ describe("Release Bus frontend gate contract", () => {
       '"$RELEASE_BUS_GATE_TOOL" fingerprint'
     );
     expect(aggregate?.run).not.toContain('node "$RELEASE_BUS_GATE_TOOL"');
+    expect(aggregateTooling?.run).toContain(
+      'echo "RELEASE_BUS_EVIDENCE_TOOL=$tooling/release-bus-gate-evidence.cjs"'
+    );
     expect(gate.startsWith("#!/usr/bin/env bash\n")).toBe(true);
     expect(preflight).toContain(
       'chmod +x "$tooling/release-bus-frontend-gate.sh"'


### PR DESCRIPTION
## Issue
- Promotion-eligible frontend preflight completed every gate and the immutable build, but aggregate passed `fingerprint` to the Bash gate wrapper. That wrapper does not implement fingerprint generation, so fail-closed aggregation stopped before emitting its summary.

## Fix
- Invoke the staged CJS evidence tool for deterministic promotion-eligible fingerprint generation, matching the already-successful authorize step.

## Changes
- Replace the unsupported Bash gate subcommand with `node "$RELEASE_BUS_EVIDENCE_TOOL" fingerprint`.
- Require that exact command in the workflow contract and reject use of the Bash gate wrapper for fingerprinting.

## Validation
- `./bin/6529 run test:no-coverage --runTestsByPath __tests__/scripts/release-bus-frontend-gate.test.ts --maxWorkers=2` (13/13)
- Direct local `release-bus-gate-evidence.cjs fingerprint` invocation emitted a complete base evidence contract.
- `./bin/6529 run check:changed`
- `git diff --check`

## Risk
- Level: Low
- Why: one workflow tool target and its regression contract; application code is unchanged.
- Rollback: revert this commit to restore the prior fail-closed invocation.

## Review Notes
- No frontend application deployment is required. Merge only at an idle Release Bus boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release preflight validation by using the correct evidence fingerprinting process.
  * Strengthened safeguards to prevent invalid fingerprinting paths from being accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->