### PR TITLE
Document the Release Bus v2 maintenance route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,30 @@
 # AGENTS.md
 
+## Temporary Release Bus v2 Maintenance
+
+This section overrides the deployment skill and older Release Bus documentation
+until the v2 cutover is complete.
+
+- Do not register a candidate with Release Bus v1.
+- Before any staging or production mutation, run
+  `node ops/scripts/release-bus-status.mjs`. Continue only when it reports
+  `mode: OFF`; otherwise wait and retry.
+- For a manual route, require `RELEASE_BUS_ENFORCEMENT` to be absent or exactly
+  `false`. Stop on `true`, any other value, or a failed variable lookup.
+- Inspect active frontend and backend staging/production workflows and fetch the
+  exact remote target ref before merging or dispatching. Wait for other actors;
+  never cancel their workflows or force-push a shared branch.
+- Re-fetch immediately before pushing. If the target moved, recompute the merge
+  from its new head.
+- Deploy required backend units before dependent frontend work. Dispatch only
+  independent backend DAG units concurrently, and only with
+  `cancel-in-progress: false`.
+- Record exact deployed frontend/backend SHAs before E2E and do not mutate
+  staging until that E2E run is terminal.
+- Production still requires explicit owner authorization and successful staging
+  validation of the intended exact release set. Do not publish a release note
+  manually.
+
 <!-- BEGIN:nextjs-agent-rules -->
 
 # Next.js: ALWAYS read docs before coding

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,14 +3,17 @@
 ## Temporary Release Bus v2 Maintenance
 
 This section overrides the deployment skill and older Release Bus documentation
-until the v2 cutover is complete.
+until the v2 production cutover and rollback observation criteria in branch
+`agent/simple-release-bus-v2-plan` at commit `0d8fb5e726279b4a80592b3dc7d4ec3db75065e9`
+are complete and this section is deliberately removed.
 
 - Do not register a candidate with Release Bus v1.
 - Before any staging or production mutation, run
-  `node ops/scripts/release-bus-status.mjs`. Continue only when it reports
-  `mode: OFF`; otherwise wait and retry.
+  `./bin/6529 exec node ops/scripts/release-bus-status.mjs`. Continue only when
+  it reports `mode: OFF`; otherwise wait and retry.
 - For a manual route, require `RELEASE_BUS_ENFORCEMENT` to be absent or exactly
-  `false`. Stop on `true`, any other value, or a failed variable lookup.
+  `false`. The `OFF` result and this enforcement result are one AND gate: both
+  must pass. Stop on disagreement, `true`, any other value, or a failed lookup.
 - Inspect active frontend and backend staging/production workflows and fetch the
   exact remote target ref before merging or dispatching. Wait for other actors;
   never cancel their workflows or force-push a shared branch.

--- a/ops/docs/developer/deployment-bus-automation.md
+++ b/ops/docs/developer/deployment-bus-automation.md
@@ -1,7 +1,25 @@
 # Deployment Bus Automation and Operations
 
-Status: implementation reference and go-live runbook. Code is feature-gated;
-merging it does not by itself enable autonomous deployments.
+Status: v1 rollback reference during Release Bus v2 maintenance. V1 must not
+accept new readiness or scheduler claims. The temporary manual-deployment
+protocol in `deployment-bus-process.md` is authoritative until v2 cutover.
+
+## Maintenance boundary
+
+- Pause v1 `ALL` with an audited maintenance reason before waiting for an active
+  train.
+- Let already-dispatched workflows reach terminal state naturally; never cancel
+  them for cutover.
+- At the first boundary where the active train and all of its workflows are
+  terminal, set runtime `RELEASE_BUS_MODE=OFF`, deploy the API before the worker,
+  and pause or disable the scheduler trigger as needed.
+- Verify the API reports `OFF` and rejects readiness. Prove the disabled worker
+  cannot claim, create, dispatch, merge, or deploy.
+- Reconcile nonterminal v1 test candidates only after claiming is disabled.
+- Keep v1 code and infrastructure disabled as rollback until v2 staging and
+  production are proven; do not delete it during cutover.
+- Keep repository `RELEASE_BUS_ENFORCEMENT` absent or exactly `false` while the
+  manual route is active.
 
 ## Runtime architecture
 

--- a/ops/docs/developer/deployment-bus-automation.md
+++ b/ops/docs/developer/deployment-bus-automation.md
@@ -3,6 +3,9 @@
 Status: v1 rollback reference during Release Bus v2 maintenance. V1 must not
 accept new readiness or scheduler claims. The temporary manual-deployment
 protocol in `deployment-bus-process.md` is authoritative until v2 cutover.
+Removal is tracked by branch `agent/simple-release-bus-v2-plan` at commit
+`0d8fb5e726279b4a80592b3dc7d4ec3db75065e9` and occurs only after the v2
+production cutover and rollback observation criteria pass.
 
 ## Maintenance boundary
 
@@ -22,6 +25,10 @@ protocol in `deployment-bus-process.md` is authoritative until v2 cutover.
   manual route is active.
 
 ## Runtime architecture
+
+> **Suspended during v2 maintenance:** this v1 architecture is rollback
+> reference only. The API and workers remain `OFF`, and the scheduler remains
+> disabled.
 
 - The existing application MySQL database is the durable release ledger.
 - `releaseBusStarter` runs every minute with reserved concurrency `1`.
@@ -389,7 +396,7 @@ bounded Jest suite/test report when available.
 Agents discover live mode only through the repository helper:
 
 ```bash
-node ops/scripts/release-bus-status.mjs
+./bin/6529 exec node ops/scripts/release-bus-status.mjs
 ```
 
 It uses the authenticated `gh` token internally to call
@@ -405,6 +412,9 @@ docs, workflows, or earlier state.
 Run the helper on receipt of a release request, immediately before readiness or
 manual mutation, and again before production after a significant wait. Stop if
 `ALL` or the relevant lane is paused.
+
+> **Suspended during v2 maintenance:** only the `OFF` row below is authorized.
+> The other rows and readiness behavior are v1 rollback reference only.
 
 | Live mode    | Staging route                        | Production route                           |
 | ------------ | ------------------------------------ | ------------------------------------------ |
@@ -444,6 +454,11 @@ the live Actions variable in every repository selected for a manual route.
 `OFF` or `SHADOW` with enforcement enabled is a rollout mismatch and blocks the
 release until an operator reconciles configuration. Enable enforcement only
 after the corresponding bus mode is healthy.
+
+During the temporary v2 maintenance window, the paragraph above is rollback
+reference only. A fresh `mode: OFF` result and absent/exactly-`false`
+enforcement are one fail-closed AND gate; disagreement stops the release and
+break glass cannot override it.
 
 ## Required external setup
 

--- a/ops/docs/developer/deployment-bus-process.md
+++ b/ops/docs/developer/deployment-bus-process.md
@@ -1,8 +1,50 @@
 # Staging and Production Deployment Bus
 
-Status: implemented behind rollout controls. The live API mode selects the
-release route; repository enforcement separately controls whether a manual
-route requires audited break glass.
+Status: Release Bus v1 maintenance. V1 is being disabled while Release Bus v2
+is implemented and proven. The v1 material below is retained only as rollback
+reference.
+
+## Temporary manual-deployment protocol
+
+Do not register new candidates with Release Bus v1. Before any staging or
+production mutation, run:
+
+```bash
+node ops/scripts/release-bus-status.mjs
+```
+
+Continue only when the helper reports `mode: OFF`. If it reports any other mode
+or cannot validate the response, wait and retry. Do not queue in v1 and do not
+use break glass merely to bypass the cutover.
+
+For every repository in the release set, require the
+`RELEASE_BUS_ENFORCEMENT` Actions variable to be absent or exactly `false`.
+Stop on `true`, any other value, or lookup failure.
+
+For each manual release:
+
+1. Fetch the exact remote target head and inspect active frontend and backend
+   staging/production workflows. Wait if another actor is mutating a shared
+   environment; never cancel another actor's workflow.
+2. Merge from the current remote target without force-pushing. Re-fetch
+   immediately before the push and recompute the merge if the target moved.
+3. For backend work, merge the development branch into current `1a-staging`,
+   then dispatch only the required units in dependency-DAG order. Independent
+   units may run concurrently only when their workflows use
+   `cancel-in-progress: false`.
+4. For frontend work, merge the development branch into current `1a-staging`;
+   the existing workflow deploys staging automatically. Coupled releases deploy
+   and verify the required backend units before changing frontend staging.
+5. Record the exact deployed frontend and backend SHAs before E2E. Freeze all
+   staging mutations until that E2E run is terminal.
+6. Require explicit owner authorization and successful staging validation of
+   the intended exact release set before production. Preserve dependency order,
+   re-fetch `main`, never cancel another production workflow, and do not publish
+   a release note manually.
+
+The v2 bus will replace this manual route only after its live acceptance
+criteria pass. Staging validation will not automatically schedule production;
+production readiness remains an explicit action for an exact validated SHA.
 
 ## What changes for developers
 

--- a/ops/docs/developer/deployment-bus-process.md
+++ b/ops/docs/developer/deployment-bus-process.md
@@ -2,7 +2,9 @@
 
 Status: Release Bus v1 maintenance. V1 is being disabled while Release Bus v2
 is implemented and proven. The v1 material below is retained only as rollback
-reference.
+reference. Removal is tracked by branch `agent/simple-release-bus-v2-plan` at
+commit `0d8fb5e726279b4a80592b3dc7d4ec3db75065e9` and occurs only after the v2
+production cutover and rollback observation criteria pass.
 
 ## Temporary manual-deployment protocol
 
@@ -10,7 +12,7 @@ Do not register new candidates with Release Bus v1. Before any staging or
 production mutation, run:
 
 ```bash
-node ops/scripts/release-bus-status.mjs
+./bin/6529 exec node ops/scripts/release-bus-status.mjs
 ```
 
 Continue only when the helper reports `mode: OFF`. If it reports any other mode
@@ -19,7 +21,8 @@ use break glass merely to bypass the cutover.
 
 For every repository in the release set, require the
 `RELEASE_BUS_ENFORCEMENT` Actions variable to be absent or exactly `false`.
-Stop on `true`, any other value, or lookup failure.
+The fresh `mode: OFF` result and enforcement result are one AND gate: both must
+pass. Stop on disagreement, `true`, any other value, or lookup failure.
 
 For each manual release:
 
@@ -52,7 +55,7 @@ The live rollout mode is authoritative. The canonical agent preflight in both
 repositories is:
 
 ```bash
-node ops/scripts/release-bus-status.mjs
+./bin/6529 exec node ops/scripts/release-bus-status.mjs
 ```
 
 The helper requires an installed, authenticated `gh`, obtains its token
@@ -84,6 +87,9 @@ controls all stop the release before mutation. Failure never means `OFF` and
 never means “bus enabled.” Agents must not fall back to AWS CLI, queue a
 candidate, merge, or deploy while status is unknown.
 
+> **Suspended during v2 maintenance:** only the `OFF` row below is authorized.
+> The other rows and all v1 readiness behavior are rollback reference only.
+
 | Live mode    | Staging behavior                                                 | Production behavior                                                         |
 | ------------ | ---------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | `OFF`        | Use the legacy manual path; do not queue in the bus              | Use the legacy manual path                                                  |
@@ -100,7 +106,9 @@ repository with authenticated `gh`. `OFF` or `SHADOW` combined with enabled
 enforcement is a configuration mismatch and requires an operator. If the
 manual route is enforced, only an organization owner or active
 `release-bus-operators` member may continue, with a non-empty audited
-break-glass reason. Never bypass a blocked workflow.
+break-glass reason. This paragraph is v1 rollback reference only during the v2
+maintenance window; it cannot bypass the authoritative `OFF` AND enforcement
+gate above. Never bypass a blocked workflow.
 
 Developers and agents no longer need to merge feature branches into
 `1a-staging`, dispatch staging deployments, merge source PRs to `main`, or
@@ -330,6 +338,9 @@ publishes release notes nor invokes the legacy GelatoBot skill.
   deploy registry explicitly declares and implements a safe rollback adapter.
 
 ## Pause and break glass
+
+> **Suspended during v2 maintenance:** the break-glass path in this section is
+> v1 rollback reference only and cannot bypass the temporary manual protocol.
 
 The operator controls are on `/deploy/ui/bus`. Members of the configured
 `release-bus-operators` GitHub team, plus organization owners, may pause or

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -1,21 +1,26 @@
 ---
 name: deploy-6529
-description: Determine the live 6529 Release Bus mode through authenticated gh, then route exact frontend or coordinated frontend/backend SHAs through the required manual, shadow, staging-bus, production-bus, or operator break-glass path. Use when Codex is asked to stage, deploy, promote, merge for release, validate, pause, resume, recover, or coordinate a 6529 release.
+description: During the temporary Release Bus v2 maintenance window, require authenticated live mode OFF plus disabled enforcement and use only the serialized manual route for exact frontend or coordinated frontend/backend SHAs. Retained v1 shadow, bus, and break-glass routes are rollback reference only. Use when Codex is asked to stage, deploy, promote, merge for release, validate, pause, resume, recover, or coordinate a 6529 release.
 ---
 
 # Deploy 6529
 
 ## Temporary v2 maintenance override
 
-Until this section is removed after Release Bus v2 cutover:
+Until the v2 production cutover and rollback observation criteria tracked by
+branch `agent/simple-release-bus-v2-plan` at commit
+`0d8fb5e726279b4a80592b3dc7d4ec3db75065e9` are complete and this section is
+deliberately removed:
 
 1. Do not submit readiness to Release Bus v1.
-2. Run `node ops/scripts/release-bus-status.mjs` before any staging or
-   production mutation and continue only when it reports `mode: OFF`. If it is
-   not `OFF`, wait and retry; do not use break glass to bypass the transition.
+2. Run `./bin/6529 exec node ops/scripts/release-bus-status.mjs` before any
+   staging or production mutation and continue only when it reports `mode:
+   OFF`. If it is not `OFF`, wait and retry; do not use break glass to bypass
+   the transition.
 3. Require `RELEASE_BUS_ENFORCEMENT` to be absent or exactly `false` in every
    repository in the release set. Stop on `true`, any other value, or lookup
-   failure.
+   failure. Steps 2 and 3 are one fail-closed AND gate: both must pass, and any
+   disagreement stops the release.
 4. Fetch the exact remote target head and inspect active frontend and backend
    staging/production workflows. Wait for every other actor; never cancel their
    workflow or force-push a shared branch. Re-fetch immediately before pushing
@@ -42,7 +47,7 @@ path. Read
 Run this read-only helper from the repository root:
 
 ```bash
-node ops/scripts/release-bus-status.mjs
+./bin/6529 exec node ops/scripts/release-bus-status.mjs
 ```
 
 Run it when a staging, production, promotion, merge-for-release, or deployment
@@ -69,6 +74,10 @@ operator deliberately follows the audited break-glass procedure.
 
 ## Mode routing
 
+> **Suspended during v2 maintenance:** only the `OFF` row is authorized. The
+> other rows are v1 rollback reference and must not be actioned until the
+> temporary override is deliberately removed.
+
 | Live mode    | Staging behavior                                                 | Production behavior                                                         |
 | ------------ | ---------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | `OFF`        | Use the legacy manual path; do not queue in the bus              | Use the legacy manual path                                                  |
@@ -80,6 +89,10 @@ After an active bus lane accepts a candidate, never launch a parallel manual
 deployment because the lane appears slow.
 
 ## Manual-route enforcement gate
+
+> **Maintenance authority:** this gate is AND-combined with a fresh `mode:
+> OFF` helper result. Legacy enforcement or break-glass text below cannot
+> authorize a non-`OFF` mutation during v2 maintenance.
 
 For every repository affected by a manual route, inspect its live Actions
 variable with authenticated `gh`:
@@ -184,6 +197,9 @@ syncs `main` back into staging.
   rollback adapter.
 
 ## Operator controls and break glass
+
+> **Suspended during v2 maintenance:** the break-glass route below is v1
+> rollback reference only and cannot bypass the temporary `OFF` protocol.
 
 Only members of `release-bus-operators` or organization owners may pause,
 resume, or use break glass.

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -5,6 +5,33 @@ description: Determine the live 6529 Release Bus mode through authenticated gh, 
 
 # Deploy 6529
 
+## Temporary v2 maintenance override
+
+Until this section is removed after Release Bus v2 cutover:
+
+1. Do not submit readiness to Release Bus v1.
+2. Run `node ops/scripts/release-bus-status.mjs` before any staging or
+   production mutation and continue only when it reports `mode: OFF`. If it is
+   not `OFF`, wait and retry; do not use break glass to bypass the transition.
+3. Require `RELEASE_BUS_ENFORCEMENT` to be absent or exactly `false` in every
+   repository in the release set. Stop on `true`, any other value, or lookup
+   failure.
+4. Fetch the exact remote target head and inspect active frontend and backend
+   staging/production workflows. Wait for every other actor; never cancel their
+   workflow or force-push a shared branch. Re-fetch immediately before pushing
+   and recompute the merge if the target moved.
+5. Deploy required backend units before dependent frontend work. Dispatch only
+   independent backend DAG units concurrently, and only when their workflows
+   use `cancel-in-progress: false`.
+6. Record exact deployed frontend/backend SHAs before E2E and freeze staging
+   until that E2E run is terminal.
+7. Require explicit owner authorization and successful exact staging validation
+   for production. Do not publish a release note manually.
+
+When the helper reports `OFF`, use the legacy manual route described below.
+The older pause and mode-routing text remains rollback documentation, but it
+does not authorize v1 readiness during this maintenance window.
+
 Determine the live Release Bus mode before choosing either the bus or a manual
 path. Read
 `ops/docs/developer/deployment-bus-process.md` for lifecycle policy and


### PR DESCRIPTION
## Issue
- Release Bus v1 is being disabled while the authorized v2 replacement is implemented.
- Developers and agents need one deterministic manual staging/production route during the maintenance window.

## Fix
- Add a temporary maintenance override that forbids v1 readiness and permits manual release mutations only after the live helper reports `OFF`.
- Require serialized shared-ref and environment ownership, backend-before-frontend ordering, exact-SHA E2E evidence, and explicit production authorization.

## Changes
- Update repository agent instructions and the deployment skill.
- Publish the temporary protocol in the developer process guide.
- Preserve v1 automation details as rollback reference and document the safe shutdown boundary.

## Validation
- `git diff --check`
- Skill Creator `quick_validate.py` against `ops/skills/deploy-6529`
- `validate_docs_links.py` (280 Markdown files)

## Risk
- Level: Low
- Why: documentation and agent-instruction only; no runtime or workflow behavior changes.
- Rollback: revert this PR after v2 cutover replaces the temporary route.

## Review Notes
- Confirm the override is unambiguous about `OFF`, enforcement, shared workflow serialization, backend-first ordering, and staging freeze during E2E.
- No release note should be published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified deployment procedures during the Release Bus v2 maintenance period.
  * Added fail-closed checks before manual staging or production deployments.
  * Documented required workflow coordination, dependency ordering, and validation steps.
  * Added rollback guidance and clarified that v1 remains available only as a reference.
  * Added production release authorization and exact-commit validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->