### PR TITLE
Beta: validate Release Bus v2 frontend-only path

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -23,6 +23,7 @@ import {
 import { sharedConfig } from "@/config/nextConfig";
 const require = createRequire(import.meta.url);
 const sentryEnabled = Boolean(process.env["SENTRY_DSN"]);
+// Release Bus v2 acceptance: force full-build evidence for the frontend-only beta.
 
 // ───────
 // Helpers

--- a/public/rb2-beta-frontend-only.txt
+++ b/public/rb2-beta-frontend-only.txt
@@ -1,0 +1,2 @@
+Simple Release Bus v2 frontend-only acceptance marker.
+This inert public asset exercises the real frontend build and artifact path.


### PR DESCRIPTION
Synthetic acceptance candidate for the authorized Simple Release Bus v2 cutover.

- runtime change: inert public marker only
- exercises: exact dual-profile frontend build and staging deploy
- production readiness: explicit only after all staging beta cases pass
- release notes: do not publish