### PR TITLE
Beta: validate Release Bus v2 coupled path

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -23,6 +23,7 @@ import {
 import { sharedConfig } from "@/config/nextConfig";
 const require = createRequire(import.meta.url);
 const sentryEnabled = Boolean(process.env["SENTRY_DSN"]);
+// Release Bus v2 acceptance: force full-build evidence for the coupled beta.
 
 // ───────
 // Helpers

--- a/public/rb2-beta-coupled.txt
+++ b/public/rb2-beta-coupled.txt
@@ -1,0 +1,2 @@
+Simple Release Bus v2 coupled acceptance marker.
+This inert public asset is the frontend half of the coupled backend-DAG case.


### PR DESCRIPTION
Synthetic frontend half of the authorized Simple Release Bus v2 coupled acceptance case.

- runtime change: inert public marker only
- dependency: paired backend DAG candidate (`api -> teamLoop`)
- exercises: backend-before-frontend staging plus manifest-bound E2E
- release notes: do not publish