### PR TITLE
Clarify OFF manual deployment policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,10 +10,14 @@
   `false`. `STAGING` routes staging readiness through v2. `PRODUCTION` routes
   staging through v2 and requires a separate explicit exact-SHA production
   action after `STAGING_VALIDATED`.
+- While `OFF`, dispatch backend `Deploy a service` workflows one at a time and
+  wait for exact success before starting the next. Its shared concurrency can
+  cancel sibling service runs, including independent DAG-frontier units.
 - Stop an active v2 lane when `ALL` or that lane is paused. Paused controls in
   `OFF` intentionally disable v2 and do not block the documented manual route.
 - For coupled work, declare backend dependencies and preserve backend-before-
-  frontend ordering. Only independent backend DAG frontier units run together.
+  frontend ordering. Within v2, only independent backend DAG frontier units run
+  together.
 - `STAGING_DEPLOYED` is not validation. Do not mutate staging during manifest-
   bound E2E, and never infer production readiness from staging validation.
 - Never cancel another actor's workflow, force-push a shared ref, bypass exact

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,15 +13,18 @@
 - While `OFF`, dispatch backend `Deploy a service` workflows one at a time and
   wait for exact success before starting the next. Its shared concurrency can
   cancel sibling service runs, including independent DAG-frontier units.
-- Stop an active v2 lane when `ALL` or that lane is paused. Paused controls in
-  `OFF` intentionally disable v2 and do not block the documented manual route.
+- Stop an active v2 lane when `ALL` or that lane is paused. In `OFF`, v2
+  controls are non-authoritative and do not block manual staging or production.
+  Explicit owner production authorization is sufficient; prior staging
+  deployment or validation is not required.
 - For coupled work, declare backend dependencies and preserve backend-before-
   frontend ordering. Within v2, only independent backend DAG frontier units run
   together.
 - `STAGING_DEPLOYED` is not validation. Do not mutate staging during manifest-
   bound E2E, and never infer production readiness from staging validation.
-- Never cancel another actor's workflow, force-push a shared ref, bypass exact
-  SHA/artifact checks, or publish a release note manually.
+- Never cancel another actor's workflow, force-push a shared ref, or bypass exact
+  SHA/artifact checks. Never author or post release notes manually; preserve the
+  autonomous bot's complete grouping metadata and finalize signal.
 
 <!-- BEGIN:nextjs-agent-rules -->
 

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -58,7 +58,10 @@ and never publishes release notes.
 3. Re-fetch immediately before pushing. If a shared ref moved, recompute from
    the new head. Never force-push.
 4. Deploy required backend units in DAG order before merging/deploying dependent
-   frontend work to `1a-staging`.
+   frontend work to `1a-staging`. Dispatch exactly one backend `Deploy a
+   service` workflow at a time and wait for exact success before starting the
+   next; shared workflow concurrency can cancel sibling runs, even for
+   independent DAG-frontier units.
 5. Record exact deployed frontend/backend SHAs before E2E and freeze staging
    until E2E is terminal.
 6. Production requires explicit owner authorization and successful validation

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -18,13 +18,13 @@ description: Route and execute 6529 frontend, backend, or coupled staging and pr
 
 | Mode | Staging | Production |
 | --- | --- | --- |
-| `OFF` | Serialized manual fallback | Serialized manual fallback with explicit owner authorization and exact staging evidence |
+| `OFF` | Serialized manual fallback | Serialized manual fallback with explicit owner authorization; staging evidence is not required |
 | `STAGING` | Register the exact candidate with v2 | Manual fallback only; production automation is disabled |
 | `PRODUCTION` | Register the exact candidate with v2 | Explicitly mark an exact `STAGING_VALIDATED` candidate ready for v2 production |
 
-When mode is active, stop if `ALL` or the target lane is paused. A pause while
-mode is `OFF` intentionally disables v2 and does not prohibit the documented
-manual fallback.
+When mode is active, stop if `ALL` or the target lane is paused. In `OFF`, v2
+controls are non-authoritative and do not prohibit manual staging or production
+through the documented fallback.
 
 ## V2 readiness
 
@@ -64,9 +64,12 @@ and never publishes release notes.
    independent DAG-frontier units.
 5. Record exact deployed frontend/backend SHAs before E2E and freeze staging
    until E2E is terminal.
-6. Production requires explicit owner authorization and successful validation
-   of the intended exact release set. Re-fetch `main`, preserve dependency
-   order, and never publish a release note manually.
+6. In `OFF`, production requires explicit owner authorization but not prior
+   staging deployment or validation. Re-fetch `main` and preserve dependency
+   order. For backend services, pass the same merged PR number and full
+   canonical service set to every sequential production run, setting
+   `release_note_publish=true` only on the final service. Never author or post
+   the note—the autonomous bot owns it.
 
 ## Monitoring and recovery
 


### PR DESCRIPTION
## Issue
- Coupled OFF-mode guidance did not serialize backend service dispatches and incorrectly retained a staging-evidence prerequisite for owner-authorized production.
- Release-note wording did not distinguish manual authoring from required autonomous-bot metadata.

## Fix
- Make OFF-mode controls non-authoritative, remove the temporary staging-evidence gate, serialize backend services, and preserve the autonomous release-note pipeline.

## Changes
- Require one backend Deploy-a-service run at a time before dependent frontend deployment.
- State that explicit owner authorization is sufficient for production while mode is OFF, even without staging evidence.
- Require the same PR number and canonical service set across backend production runs, with publish enabled only on the final service.
- Distinguish never manually author/post from supplying metadata to the autonomous bot.

## Validation
- Official skill quick validator passed.
- `git diff --check` passed.

## Risk
- Level: Low
- Why: Operational documentation and agent guidance only; it reflects the current OFF maintenance policy.
- Rollback: Revert after an explicitly authorized automated bus cutover replaces this temporary policy.

## Review Notes
- Confirm OFF-mode controls/staging evidence are not manual gates and release-note metadata remains mandatory.
