### PR TITLE
Correct release note agent policy

### DIFF
--- a/ops/skills/write-prs/SKILL.md
+++ b/ops/skills/write-prs/SKILL.md
@@ -10,8 +10,12 @@ description: Write, open, iterate, and prepare pull requests for merge or deploy
 1. Determine the requested completion mode:
    - `review-ready`: create or update the PR and stop once available review bots and the agent are satisfied.
    - `merge`: do everything in `review-ready`, then hand off to `ops/skills/deploy-6529/SKILL.md` for merge execution when required checks and approvals allow it.
-   - `staging`: prepare the release notes and hand off to `ops/skills/deploy-6529/SKILL.md` for merge, staging deployment, and E2E or smoke validation.
-   - `prod`: prepare the release notes and hand off to `ops/skills/deploy-6529/SKILL.md` for staging verification, production deployment, and production E2E or smoke validation.
+   - `staging`: hand off to `ops/skills/deploy-6529/SKILL.md` for merge,
+     staging deployment, and E2E or smoke validation. Never prepare, publish,
+     or trigger a release note for staging.
+   - `prod`: hand off to `ops/skills/deploy-6529/SKILL.md` for production
+     deployment and production E2E or smoke validation. Never author or post a
+     release note; the existing autonomous bot owns production release notes.
    If the user did not explicitly request merge or deployment, stop at `review-ready`.
 
 2. Inspect the change before writing:


### PR DESCRIPTION
## Fix
- Staging never prepares, triggers, or publishes release notes.
- Production agents never author or post notes; the existing autonomous bot owns production release notes.

## Validation
- The write-prs skill passes the official skill validator.
- git diff --check passes.

## Deployment
- None; agent instructions only.