### PR TITLE
Keep sidebar group headers aligned and readable

### DIFF
--- a/components/layout/sidebar/nav/WebSidebarExpandable.tsx
+++ b/components/layout/sidebar/nav/WebSidebarExpandable.tsx
@@ -141,14 +141,16 @@ function WebSidebarExpandable({
                     <li key={item.href} className="tw-m-0 tw-p-0">
                       <Link
                         href={item.href}
-                        className={`tw-touch-action-manipulation tw-ml-[2.75rem] tw-flex tw-h-11 tw-w-[calc(100%-2.75rem)] tw-cursor-pointer tw-items-center tw-justify-start tw-rounded-xl tw-border-none tw-pl-3 tw-pr-3 tw-text-base tw-font-medium tw-no-underline tw-transition-colors tw-duration-200 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-iron-500 focus-visible:tw-ring-offset-2 motion-reduce:tw-transition-none ${
+                        className={`tw-touch-action-manipulation tw-ml-[2.75rem] tw-flex tw-min-h-10 tw-w-[calc(100%-2.75rem)] tw-cursor-pointer tw-items-center tw-justify-start tw-rounded-xl tw-border-none tw-py-2 tw-pl-3 tw-pr-3 tw-text-sm tw-font-medium tw-no-underline tw-transition-colors tw-duration-200 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-iron-500 focus-visible:tw-ring-offset-2 motion-reduce:tw-transition-none ${
                           active
                             ? "tw-bg-iron-900 tw-text-white active:tw-text-white desktop-hover:hover:tw-bg-iron-900 desktop-hover:hover:tw-text-white"
                             : "tw-bg-transparent tw-text-iron-400 active:tw-text-white desktop-hover:hover:tw-bg-transparent desktop-hover:hover:tw-text-white"
                         }`}
                         aria-current={active ? "page" : undefined}
                       >
-                        {item.name}
+                        <span className="tw-min-w-0 tw-break-words">
+                          {item.name}
+                        </span>
                       </Link>
                     </li>
                   );

--- a/components/layout/sidebar/nav/WebSidebarExpandable.tsx
+++ b/components/layout/sidebar/nav/WebSidebarExpandable.tsx
@@ -88,7 +88,7 @@ function WebSidebarExpandable({
   const flyoutId = `sidebar-flyout-${section.key}`;
 
   return (
-    <>
+    <div className="tw-@container/sidebar">
       <WebSidebarNavItem
         onClick={(e) => onToggle(e)}
         onPointerEnter={onPointerEnter}
@@ -125,7 +125,7 @@ function WebSidebarExpandable({
               aria-label={t(DEFAULT_LOCALE, "navigation.sidebar.panelLabel", {
                 section: section.name,
               })}
-              className="tw-relative tw-m-0 tw-p-0"
+              className="tw-pointer-events-none tw-relative tw-m-0 tw-p-0 tw-opacity-0 tw-transition-opacity tw-duration-150 @[15.5rem]/sidebar:tw-pointer-events-auto @[15.5rem]/sidebar:tw-opacity-100 motion-reduce:tw-transition-none"
             >
               <div
                 className={`tw-absolute tw-bottom-0 tw-left-7 tw-top-0 tw-w-px tw-bg-iron-800 tw-transition-opacity tw-duration-300 motion-reduce:tw-transition-none ${
@@ -141,7 +141,7 @@ function WebSidebarExpandable({
                     <li key={item.href} className="tw-m-0 tw-p-0">
                       <Link
                         href={item.href}
-                        className={`tw-touch-action-manipulation tw-ml-[2.75rem] tw-flex tw-min-h-10 tw-w-[calc(100%-2.75rem)] tw-cursor-pointer tw-items-center tw-justify-start tw-rounded-xl tw-border-none tw-py-2 tw-pl-3 tw-pr-3 tw-text-sm tw-font-medium tw-no-underline tw-transition-colors tw-duration-200 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-iron-500 focus-visible:tw-ring-offset-2 motion-reduce:tw-transition-none ${
+                        className={`tw-touch-action-manipulation tw-ml-[2.75rem] tw-flex tw-min-h-11 tw-w-[calc(100%-2.75rem)] tw-cursor-pointer tw-items-center tw-justify-start tw-rounded-xl tw-border-none tw-py-2 tw-pl-3 tw-pr-3 tw-text-sm tw-font-medium tw-no-underline tw-transition-colors tw-duration-200 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-iron-500 focus-visible:tw-ring-offset-2 desktop-hover:tw-min-h-10 motion-reduce:tw-transition-none ${
                           active
                             ? "tw-bg-iron-900 tw-text-white active:tw-text-white desktop-hover:hover:tw-bg-iron-900 desktop-hover:hover:tw-text-white"
                             : "tw-bg-transparent tw-text-iron-400 active:tw-text-white desktop-hover:hover:tw-bg-transparent desktop-hover:hover:tw-text-white"
@@ -180,7 +180,7 @@ function WebSidebarExpandable({
           </div>
         </div>
       )}
-    </>
+    </div>
   );
 }
 

--- a/components/layout/sidebar/nav/WebSidebarExpandable.tsx
+++ b/components/layout/sidebar/nav/WebSidebarExpandable.tsx
@@ -88,7 +88,7 @@ function WebSidebarExpandable({
   const flyoutId = `sidebar-flyout-${section.key}`;
 
   return (
-    <div className="tw-@container/sidebar">
+    <>
       <WebSidebarNavItem
         onClick={(e) => onToggle(e)}
         onPointerEnter={onPointerEnter}
@@ -125,7 +125,7 @@ function WebSidebarExpandable({
               aria-label={t(DEFAULT_LOCALE, "navigation.sidebar.panelLabel", {
                 section: section.name,
               })}
-              className="tw-pointer-events-none tw-relative tw-m-0 tw-p-0 tw-opacity-0 tw-transition-opacity tw-duration-150 @[15.5rem]/sidebar:tw-pointer-events-auto @[15.5rem]/sidebar:tw-opacity-100 motion-reduce:tw-transition-none"
+              className="tw-relative tw-m-0 tw-p-0"
             >
               <div
                 className={`tw-absolute tw-bottom-0 tw-left-7 tw-top-0 tw-w-px tw-bg-iron-800 tw-transition-opacity tw-duration-300 motion-reduce:tw-transition-none ${
@@ -180,7 +180,7 @@ function WebSidebarExpandable({
           </div>
         </div>
       )}
-    </div>
+    </>
   );
 }
 

--- a/components/layout/sidebar/nav/WebSidebarExpandableGroup.tsx
+++ b/components/layout/sidebar/nav/WebSidebarExpandableGroup.tsx
@@ -37,7 +37,7 @@ function WebSidebarExpandableGroup({
       <button
         type="button"
         onClick={handleToggle}
-        className={`tw-touch-action-manipulation tw-ml-[2.75rem] tw-flex tw-h-11 tw-w-[calc(100%-2.75rem)] tw-cursor-pointer tw-items-center tw-justify-between tw-rounded-xl tw-border-none tw-pl-3 tw-pr-3 tw-text-base tw-font-medium tw-no-underline tw-transition-colors tw-duration-200 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-iron-500 focus-visible:tw-ring-offset-2 ${
+        className={`tw-touch-action-manipulation tw-ml-[2.75rem] tw-flex tw-min-h-11 tw-w-[calc(100%-2.75rem)] tw-cursor-pointer tw-items-center tw-justify-between tw-rounded-xl tw-border-none tw-py-2 tw-pl-3 tw-pr-3 tw-text-left tw-text-base tw-font-medium tw-no-underline tw-transition-colors tw-duration-200 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-iron-500 focus-visible:tw-ring-offset-2 ${
           hasActiveItem
             ? "tw-bg-iron-900 tw-text-white active:tw-text-white desktop-hover:hover:tw-bg-iron-900 desktop-hover:hover:tw-text-white"
             : "tw-bg-transparent tw-text-iron-400 active:tw-text-white desktop-hover:hover:tw-bg-transparent desktop-hover:hover:tw-text-white"
@@ -45,9 +45,9 @@ function WebSidebarExpandableGroup({
         aria-expanded={expanded}
         aria-controls={`group-${name}`}
       >
-        <span>{name}</span>
+        <span className="tw-min-w-0 tw-flex-1 tw-break-words">{name}</span>
         <ChevronRightIcon
-          className={`tw-h-4 tw-w-4 tw-shrink-0 tw-transition-transform tw-duration-200 ${
+          className={`tw-ml-3 tw-h-4 tw-w-4 tw-shrink-0 tw-transition-transform tw-duration-200 ${
             expanded ? "tw-rotate-90" : ""
           }`}
         />

--- a/components/layout/sidebar/nav/WebSidebarExpandableGroup.tsx
+++ b/components/layout/sidebar/nav/WebSidebarExpandableGroup.tsx
@@ -31,17 +31,23 @@ function WebSidebarExpandableGroup({
     onToggle(!expanded);
   }, [expanded, onToggle]);
 
+  let stateClassName =
+    "tw-bg-transparent tw-text-iron-400 active:tw-text-white desktop-hover:hover:tw-bg-transparent desktop-hover:hover:tw-text-white";
+  if (hasActiveItem) {
+    stateClassName =
+      "tw-bg-iron-900 tw-text-white active:tw-text-white desktop-hover:hover:tw-bg-iron-900 desktop-hover:hover:tw-text-white";
+  } else if (expanded) {
+    stateClassName =
+      "tw-bg-iron-900/70 tw-text-white active:tw-text-white desktop-hover:hover:tw-bg-iron-900 desktop-hover:hover:tw-text-white";
+  }
+
   return (
     <div>
       {/* Group header with expand button */}
       <button
         type="button"
         onClick={handleToggle}
-        className={`tw-touch-action-manipulation tw-ml-[2.75rem] tw-flex tw-min-h-10 tw-w-[calc(100%-2.75rem)] tw-cursor-pointer tw-items-center tw-justify-between tw-rounded-xl tw-border-none tw-py-1 tw-pl-3 tw-pr-3 tw-text-left tw-text-sm tw-font-medium tw-no-underline tw-transition-colors tw-duration-200 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-iron-500 focus-visible:tw-ring-offset-2 ${
-          hasActiveItem
-            ? "tw-bg-iron-900 tw-text-white active:tw-text-white desktop-hover:hover:tw-bg-iron-900 desktop-hover:hover:tw-text-white"
-            : "tw-bg-transparent tw-text-iron-400 active:tw-text-white desktop-hover:hover:tw-bg-transparent desktop-hover:hover:tw-text-white"
-        }`}
+        className={`tw-touch-action-manipulation tw-ml-[2.75rem] tw-flex tw-min-h-10 tw-w-[calc(100%-2.75rem)] tw-cursor-pointer tw-items-center tw-justify-between tw-rounded-xl tw-border-none tw-py-1 tw-pl-3 tw-pr-3 tw-text-left tw-text-sm tw-font-medium tw-no-underline tw-transition-colors tw-duration-200 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-iron-500 focus-visible:tw-ring-offset-2 ${stateClassName}`}
         aria-expanded={expanded}
         aria-controls={`group-${name}`}
       >

--- a/components/layout/sidebar/nav/WebSidebarExpandableGroup.tsx
+++ b/components/layout/sidebar/nav/WebSidebarExpandableGroup.tsx
@@ -37,7 +37,7 @@ function WebSidebarExpandableGroup({
       <button
         type="button"
         onClick={handleToggle}
-        className={`tw-touch-action-manipulation tw-ml-[2.75rem] tw-flex tw-min-h-11 tw-w-[calc(100%-2.75rem)] tw-cursor-pointer tw-items-center tw-justify-between tw-rounded-xl tw-border-none tw-py-2 tw-pl-3 tw-pr-3 tw-text-left tw-text-base tw-font-medium tw-no-underline tw-transition-colors tw-duration-200 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-iron-500 focus-visible:tw-ring-offset-2 ${
+        className={`tw-touch-action-manipulation tw-ml-[2.75rem] tw-flex tw-min-h-10 tw-w-[calc(100%-2.75rem)] tw-cursor-pointer tw-items-center tw-justify-between tw-rounded-xl tw-border-none tw-py-1 tw-pl-3 tw-pr-3 tw-text-left tw-text-sm tw-font-medium tw-no-underline tw-transition-colors tw-duration-200 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-iron-500 focus-visible:tw-ring-offset-2 ${
           hasActiveItem
             ? "tw-bg-iron-900 tw-text-white active:tw-text-white desktop-hover:hover:tw-bg-iron-900 desktop-hover:hover:tw-text-white"
             : "tw-bg-transparent tw-text-iron-400 active:tw-text-white desktop-hover:hover:tw-bg-transparent desktop-hover:hover:tw-text-white"
@@ -60,7 +60,7 @@ function WebSidebarExpandableGroup({
         }`}
       >
         <div className="tw-overflow-hidden">
-          <div id={`group-${name}`} className="tw-mt-1">
+          <div id={`group-${name}`} className="tw-mt-0.5">
             {items.map((item) => (
               <GroupLink key={item.name} item={item} pathname={pathname} />
             ))}
@@ -85,14 +85,14 @@ function GroupLink({
   return (
     <Link
       href={item.href}
-      className={`tw-touch-action-manipulation tw-ml-[2.75rem] tw-flex tw-h-11 tw-w-[calc(100%-2.75rem)] tw-cursor-pointer tw-items-center tw-justify-start tw-rounded-xl tw-border-none tw-pl-3 tw-pr-3 tw-text-base tw-font-medium tw-no-underline tw-transition-colors tw-duration-200 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-iron-500 focus-visible:tw-ring-offset-2 ${
+      className={`tw-touch-action-manipulation tw-ml-[2.75rem] tw-flex tw-min-h-9 tw-w-[calc(100%-2.75rem)] tw-cursor-pointer tw-items-center tw-justify-start tw-rounded-xl tw-border-none tw-py-2 tw-pl-3 tw-pr-3 tw-text-sm tw-font-medium tw-no-underline tw-transition-colors tw-duration-200 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-iron-500 focus-visible:tw-ring-offset-2 ${
         active
           ? "tw-bg-iron-900 tw-text-white active:tw-text-white desktop-hover:hover:tw-bg-iron-900 desktop-hover:hover:tw-text-white"
           : "tw-bg-transparent tw-text-iron-400 active:tw-text-white desktop-hover:hover:tw-bg-transparent desktop-hover:hover:tw-text-white"
       }`}
       aria-current={active ? "page" : undefined}
     >
-      {item.name}
+      <span className="tw-min-w-0 tw-break-words">{item.name}</span>
     </Link>
   );
 }

--- a/components/layout/sidebar/nav/WebSidebarExpandableGroup.tsx
+++ b/components/layout/sidebar/nav/WebSidebarExpandableGroup.tsx
@@ -47,7 +47,7 @@ function WebSidebarExpandableGroup({
       <button
         type="button"
         onClick={handleToggle}
-        className={`tw-touch-action-manipulation tw-ml-[2.75rem] tw-flex tw-min-h-10 tw-w-[calc(100%-2.75rem)] tw-cursor-pointer tw-items-center tw-justify-between tw-rounded-xl tw-border-none tw-py-1 tw-pl-3 tw-pr-3 tw-text-left tw-text-sm tw-font-medium tw-no-underline tw-transition-colors tw-duration-200 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-iron-500 focus-visible:tw-ring-offset-2 ${stateClassName}`}
+        className={`tw-touch-action-manipulation tw-ml-[2.75rem] tw-flex tw-min-h-11 tw-w-[calc(100%-2.75rem)] tw-cursor-pointer tw-items-center tw-justify-between tw-rounded-xl tw-border-none tw-py-1 tw-pl-3 tw-pr-3 tw-text-left tw-text-sm tw-font-medium tw-no-underline tw-transition-colors tw-duration-200 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-iron-500 focus-visible:tw-ring-offset-2 desktop-hover:tw-min-h-10 ${stateClassName}`}
         aria-expanded={expanded}
         aria-controls={`group-${name}`}
       >
@@ -91,7 +91,7 @@ function GroupLink({
   return (
     <Link
       href={item.href}
-      className={`tw-touch-action-manipulation tw-ml-[2.75rem] tw-flex tw-min-h-9 tw-w-[calc(100%-2.75rem)] tw-cursor-pointer tw-items-center tw-justify-start tw-rounded-xl tw-border-none tw-py-2 tw-pl-3 tw-pr-3 tw-text-sm tw-font-medium tw-no-underline tw-transition-colors tw-duration-200 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-iron-500 focus-visible:tw-ring-offset-2 ${
+      className={`tw-touch-action-manipulation tw-ml-[2.75rem] tw-flex tw-min-h-11 tw-w-[calc(100%-2.75rem)] tw-cursor-pointer tw-items-center tw-justify-start tw-rounded-xl tw-border-none tw-py-2 tw-pl-3 tw-pr-3 tw-text-sm tw-font-medium tw-no-underline tw-transition-colors tw-duration-200 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-iron-500 focus-visible:tw-ring-offset-2 desktop-hover:tw-min-h-9 ${
         active
           ? "tw-bg-iron-900 tw-text-white active:tw-text-white desktop-hover:hover:tw-bg-iron-900 desktop-hover:hover:tw-text-white"
           : "tw-bg-transparent tw-text-iron-400 active:tw-text-white desktop-hover:hover:tw-bg-transparent desktop-hover:hover:tw-text-white"


### PR DESCRIPTION
## Issue

Expanded desktop sidebar group headers used fixed-height rows while centering labels. Longer labels wrapped outside their rows, collided with adjacent groups, and left chevrons visually detached. The nested navigation was also visually oversized, and an opened group had no persistent visual state beyond its rotated chevron.

## Fix

Use the established compact sidebar hierarchy in the shared desktop navigation: flexible title-case labels, content-driven rows, smaller nested text, predictable chevron placement, and a persistent open-group treatment. Open groups use white text with a subtle neutral fill; groups containing the active page retain the stronger existing selected fill.

## Notable Changes

- Replace fixed nested-row heights with minimum heights that grow only for long labels.
- Use 14px title-case text for subsection headers and nested links; keep the primary rail unchanged.
- Keep compact 40px group/direct-link rows and 36px leaf rows on fine-pointer desktops, while retaining 44px minimum targets on touch-oriented devices.
- Preserve complete labels with controlled word wrapping and a fixed, non-shrinking chevron.
- Give the currently open group a subtle `iron-900/70` background and white label/chevron; active-page groups keep the solid selected background.
- Preserve the existing visible text reflow while the desktop rail widens; no translation, concealment, or delayed fade was added.

## Validation

- `./bin/6529 run lint:uncommitted:tight`
- `./bin/6529 run typecheck:changed`
- Targeted Prettier checks for the changed components
- `./bin/6529 run react-doctor:diff` — 100/100, no issues
- Browser QA against staging-backed data at 1280px, 1440px, and 1728px desktop widths
- Verified no row collisions or document overflow; consistent title-case alignment and chevron placement
- Verified fine-pointer desktop geometry: 40px group/direct-link rows, 36px standard leaf rows, and content-driven growth for long labels
- Verified touch-oriented defaults retain 44px minimum targets
- Verified the original visible text reflow remains present during the 80px-to-275px rail expansion
- Verified mouse and keyboard expansion, persistent open-state transfer, one-open-group behavior, focus-visible styling, active subsection styling, and collapsed icon rail behavior
- Verified the separate mobile navigation path remains unaffected
- Verified no browser runtime errors after toggle and group interactions

## Risk

Low. This changes layout, responsive target sizing, and visual-state utilities in the shared nested sidebar components without changing routes, navigation state, copy, or API behavior.

## Rollback

Revert the five focused sidebar commits in this PR.

## Review Notes

All expanded-sidebar subsection groups use this shared component, so the fix applies consistently across current and future sections. The open state is intentionally subtler than the active-page state to preserve the difference between navigation disclosure and current location. WCAG 2.2 AA target-size minimum is 24 CSS pixels; this change additionally retains the enhanced 44px target on touch-oriented devices while honoring the requested compact desktop density.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated expandable sidebar navigation links with refined typography/sizing for clearer hierarchy.
  * Improved long label rendering by wrapping link text in styled spans with truncation and word-break behavior.
  * Refined expandable group header styling and spacing (including adjusted top margin) for a tighter layout.
  * Continued consistent reduced-motion behavior for hover/transition effects while tuning focus and active-state visuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->