### PR TITLE
Fix v2 frontend combined preflight runtime setup

### DIFF
--- a/.github/workflows/release-bus-v2-preflight.yml
+++ b/.github/workflows/release-bus-v2-preflight.yml
@@ -209,6 +209,8 @@ jobs:
         env:
           SFW_BIN: ${{ steps.socket-firewall.outputs.firewall-path-binary }}
         run: ./bin/6529 install:frozen
+      - name: Generate runtime environment schema
+        run: ./bin/6529 run build:env-schema
       - name: Run independent quality shard
         env:
           SHARD: ${{ matrix.shard }}
@@ -231,7 +233,7 @@ jobs:
                 --shard="$shard_index/4" \
                 | sort -u > "release-bus-test-inventory/shard-$shard_index.txt"
               test -s "release-bus-test-inventory/shard-$shard_index.txt"
-              ./bin/6529 run test:no-coverage -- --runInBand --shard="$shard_index/4"
+              ./bin/6529 run test:no-coverage --runInBand --shard="$shard_index/4"
               ;;
           esac
           test -z "$(git status --porcelain --untracked-files=no)"
@@ -294,6 +296,8 @@ jobs:
         env:
           SFW_BIN: ${{ steps.socket-firewall.outputs.firewall-path-binary }}
         run: ./bin/6529 install:frozen
+      - name: Generate runtime environment schema
+        run: ./bin/6529 run build:env-schema
       - name: Build exact environment profile once
         run: |
           if [ "$BUILD_ENVIRONMENT" = staging ]; then

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -320,6 +320,25 @@ describe("release bus v2 combined preflight", () => {
     expect(verify.run).toContain("diff -u complete.sorted shards.sorted");
     expect(upload.if).toContain("steps.inventory_verify.outcome == 'success'");
   });
+
+  it("prepares generated runtime config and forwards Jest shard flags", () => {
+    for (const jobName of ["quality", "build"]) {
+      const generate = workflow.jobs[jobName].steps.find(
+        (step: { name?: string }) =>
+          step.name === "Generate runtime environment schema"
+      );
+      expect(generate.run).toBe("./bin/6529 run build:env-schema");
+    }
+
+    const quality = workflow.jobs.quality.steps.find(
+      (step: { name?: string }) =>
+        step.name === "Run independent quality shard"
+    );
+    expect(quality.run).toContain(
+      './bin/6529 run test:no-coverage --runInBand --shard="$shard_index/4"'
+    );
+    expect(quality.run).not.toContain("test:no-coverage -- --runInBand");
+  });
 });
 
 function releaseArtifact(uri, metadata) {


### PR DESCRIPTION
## Summary
- generate the runtime environment schema in every fresh frontend v2 quality/build job
- forward Jest shard flags directly through the repository runner
- lock both contracts with focused deployment-bus tests

## Validation
- `./bin/6529 exec jest __tests__/scripts/deployment-bus.test.ts --runInBand --coverage=false` (59/59)
- `./bin/6529 run test:no-coverage --runInBand --shard=1/4 --listTests` (512 tests listed)
- generated runtime schema loads successfully

V2 remains globally OFF; this PR does not deploy application code or publish release notes.