### PR TITLE
test(release-bus-v2): add production overlap candidate C

### DIFF
--- a/ops/deployment-bus/beta-fixtures/production-overlap-c-frontend.md
+++ b/ops/deployment-bus/beta-fixtures/production-overlap-c-frontend.md
@@ -1,0 +1,8 @@
+# Release Bus v2 production-overlap candidate C
+
+Documentation-only synthetic frontend fixture for the exact reusable-manifest
+production beta. Candidate C declares candidate A as its backend prerequisite.
+
+- Candidate ID: `b430959f-3c2b-4465-a008-8633e631aff5`
+- Repository: `frontend`
+- Production beta lane: explicit opt-in only


### PR DESCRIPTION
Synthetic operator-only Release Bus v2 production-overlap acceptance fixture C.

- documentation-only exact frontend candidate
- depends on acceptance candidate A in the bus manifest
- no application behavior change

Release notes: grouped through the autonomous bot only.