### PR TITLE
test(release-bus-v2): add unrelated staging candidate E

### DIFF
--- a/ops/deployment-bus/beta-fixtures/production-overlap-e-frontend.md
+++ b/ops/deployment-bus/beta-fixtures/production-overlap-e-frontend.md
@@ -1,0 +1,8 @@
+# Release Bus v2 unrelated staging candidate E
+
+Documentation-only frontend fixture for the staging train that must overlap
+the independent production A/B/C train without cancellation or interference.
+
+- Candidate ID: `1ba68821-bfac-40d6-9bf3-8ac1cd7fb2c6`
+- Repository: `frontend`
+- Staging test: `production-overlap-d-e-1`


### PR DESCRIPTION
Synthetic operator-only Release Bus v2 overlap fixture E.

- documentation-only unrelated frontend staging candidate
- overlaps the A/B/C production train
- no application behavior change

Release notes: none.