### PR TITLE
test(release-bus-v2): add qualification staging fence E2

### DIFF
--- a/ops/deployment-bus/beta-fixtures/production-qualification-fence-e2-frontend.md
+++ b/ops/deployment-bus/beta-fixtures/production-qualification-fence-e2-frontend.md
@@ -1,0 +1,9 @@
+# Release Bus v2 qualification fence candidate E2
+
+Documentation-only frontend fixture paired with D2 for the second bounded
+staging train. Its E2E lock must remain isolated from the waiting production
+qualification train and from manual fallback workflows.
+
+- Repository: `frontend`
+- Staging test: `production-qualification-fence-d2-e2-1`
+- Production release notes: not applicable


### PR DESCRIPTION
Documentation-only operator acceptance fixture E2.

Paired with D2 for the bounded staging/E2E lock used by the missing-manifest qualification acceptance. No application behavior or production release note.