### PR TITLE
test(release-bus-v2): add qualification staging fence E3

### DIFF
--- a/ops/deployment-bus/beta-fixtures/production-qualification-fence-e3-frontend.md
+++ b/ops/deployment-bus/beta-fixtures/production-qualification-fence-e3-frontend.md
@@ -1,0 +1,9 @@
+# Release Bus v2 qualification fence candidate E3
+
+Documentation-only frontend fixture paired with D3 for the bounded staging
+train. Its shared staging lock must remain isolated from the waiting production
+qualification train and from manual fallback workflows.
+
+- Repository: `frontend`
+- Staging test: `production-qualification-fence-d3-e3-1`
+- Production release notes: not applicable

--- a/ops/deployment-bus/beta-fixtures/production-qualification-fence-e3-frontend.md
+++ b/ops/deployment-bus/beta-fixtures/production-qualification-fence-e3-frontend.md
@@ -5,5 +5,7 @@ train. Its shared staging lock must remain isolated from the waiting production
 qualification train and from manual fallback workflows.
 
 - Repository: `frontend`
+- Candidate ID: `50d7c195-9208-4c74-8894-7f0346adbb9f`
+- Backend candidate: `c47943f7-14a7-4a02-b1ab-93609ce26a66`
 - Staging test: `production-qualification-fence-d3-e3-1`
 - Production release notes: not applicable


### PR DESCRIPTION
Docs-only operator beta fixture paired with D3 for the bounded missing-manifest qualification wait proof. No production release note.