### PR TITLE
Detect generic any in the debt ratchet

### DIFF
--- a/__tests__/scripts/debt-ratchet.test.ts
+++ b/__tests__/scripts/debt-ratchet.test.ts
@@ -91,6 +91,11 @@ describe("debt-ratchet counting helpers", () => {
     expect(countGenericAnyTypeArguments(content, "Sample.tsx")).toBe(0);
   });
 
+  it("does not treat a generic parameter default as a type argument", () => {
+    const content = "function identity<T = any>(value: T): T { return value; }";
+    expect(countGenericAnyTypeArguments(content, "Sample.ts")).toBe(0);
+  });
+
   it("counts TypeScript angle-bracket any assertions", () => {
     expect(countAnyCasts("const value = <any>input;\n", "Sample.ts")).toBe(1);
   });
@@ -194,6 +199,7 @@ describe("debt-ratchet check mode", () => {
       "components/__tests__/Ignored.test.tsx",
       "const ignored: any = 1;\nconst generic = helper<any>();\n"
     );
+    writeFixture("__tests__/Root.test.ts", "const generic = helper<any>();\n");
   });
 
   afterEach(() => {
@@ -215,7 +221,7 @@ describe("debt-ratchet check mode", () => {
       )
     );
     expect(baseline.counts.any_casts).toBe(2);
-    expect(baseline.counts.test_generic_any).toBe(1);
+    expect(baseline.counts.test_generic_any).toBe(2);
     expect(baseline.counts.todo_comments).toBe(1);
     expect(baseline.counts.redux_imports).toBe(1);
 
@@ -255,7 +261,7 @@ describe("debt-ratchet check mode", () => {
 
     const check = runRatchet(root);
     expect(check.status).toBe(1);
-    expect(check.stderr).toContain("test_generic_any rose from 1 to 2");
+    expect(check.stderr).toContain("test_generic_any rose from 2 to 3");
   });
 
   it("fails on a new oversized file even when the total stays level", () => {
@@ -342,6 +348,7 @@ describe("debt-ratchet check mode", () => {
     expect(testResult.stdout).toMatch(
       /^\s*1\s+components\/__tests__\/Ignored\.test\.tsx/m
     );
+    expect(testResult.stdout).toMatch(/^\s*1\s+__tests__\/Root\.test\.ts/m);
 
     const unknown = runRatchet(root, ["--details", "nope"]);
     expect(unknown.status).toBe(1);

--- a/__tests__/scripts/debt-ratchet.test.ts
+++ b/__tests__/scripts/debt-ratchet.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const {
   countAnyCasts,
+  countGenericAnyTypeArguments,
   countImportStatements,
   countLines,
   countMatches,
@@ -13,6 +14,7 @@ const {
   isWordPressMigratedSource,
 } = require(path.join(process.cwd(), "scripts", "debt-ratchet.cjs")) as {
   countAnyCasts: (content: string, filePath?: string) => number;
+  countGenericAnyTypeArguments: (content: string, filePath?: string) => number;
   countImportStatements: (content: string, packages: string[]) => number;
   countLines: (content: string) => number;
   countMatches: (content: string, pattern: RegExp) => number;
@@ -29,7 +31,7 @@ const runRatchet = (root: string, args: string[] = []) =>
   });
 
 describe("debt-ratchet counting helpers", () => {
-  it("counts explicit any annotations and casts", () => {
+  it("counts explicit any annotations, casts, and generic arguments", () => {
     const content = [
       "const a: any = 1;",
       "const b = value as any;",
@@ -48,9 +50,45 @@ describe("debt-ratchet counting helpers", () => {
       "const many = anything; // not a match",
       "function f(x: number): number { return x; }",
     ].join("\n");
-    // Direct annotations and casts count. Strings, comments, JSX prose, type
-    // aliases, and generic arguments stay outside this metric.
-    expect(countAnyCasts(content, "Sample.tsx")).toBe(9);
+    // Direct annotations and casts plus both generic arguments count. Strings,
+    // comments, JSX prose, and a bare type-alias any stay outside this metric.
+    expect(countAnyCasts(content, "Sample.tsx")).toBe(11);
+  });
+
+  it.each([
+    ["call expression", "const value = useState<any>();", 1],
+    ["array argument", "const value = useState<any[]>([]);", 1],
+    ["type reference", "type Value = Record<string, any>;", 1],
+    ["adjacent arguments", "type Value = Map<any, any, any>;", 3],
+    [
+      "nested arguments",
+      "type Value = Outer<Record<string, any>, Array<Promise<any>>>;",
+      2,
+    ],
+    [
+      "multiline arguments",
+      ["type Value = Map<", "  any,", "  readonly any[]", ">;"].join("\n"),
+      2,
+    ],
+    ["tuple inside an argument", "type Value = Wrapper<[any, string]>;", 1],
+    ["JSX type argument", "const value = <Component<any> />;", 1],
+  ])("counts generic any in a %s", (_label, content, expected) => {
+    expect(countGenericAnyTypeArguments(content, "Sample.tsx")).toBe(expected);
+  });
+
+  it("rejects generic-any false positives outside parsed type arguments", () => {
+    const content = [
+      "// useState<any>()",
+      'const text = "Record<string, any>";',
+      "const cmp = left < anyLimit && right > anyFloor;",
+      "const identifier = many;",
+      "type Alias = any;",
+      "const value = input as any;",
+      "<span>connect deeply to an audience as powerfully as",
+      "any great art can.</span>",
+    ].join("\n");
+
+    expect(countGenericAnyTypeArguments(content, "Sample.tsx")).toBe(0);
   });
 
   it("counts TypeScript angle-bracket any assertions", () => {
@@ -140,7 +178,13 @@ describe("debt-ratchet check mode", () => {
     root = fs.mkdtempSync(path.join(os.tmpdir(), "debt-ratchet-"));
     writeFixture(
       "components/Sample.tsx",
-      'const a: any = 1;\n// TODO tidy\nimport { useSelector } from "react-redux";\n'
+      [
+        "const a: any = 1;",
+        "const generic = useState<any>();",
+        "// TODO tidy",
+        'import { useSelector } from "react-redux";',
+        "",
+      ].join("\n")
     );
     writeFixture(
       "components/Article.tsx",
@@ -148,7 +192,7 @@ describe("debt-ratchet check mode", () => {
     );
     writeFixture(
       "components/__tests__/Ignored.test.tsx",
-      "const ignored: any = 1;\n"
+      "const ignored: any = 1;\nconst generic = helper<any>();\n"
     );
   });
 
@@ -162,7 +206,7 @@ describe("debt-ratchet check mode", () => {
     expect(result.stderr).toContain("Baseline not found");
   });
 
-  it("passes when counts match the baseline and excludes test trees", () => {
+  it("passes when production and test generic counts match the baseline", () => {
     expect(runRatchet(root, ["--update"]).status).toBe(0);
     const baseline = JSON.parse(
       fs.readFileSync(
@@ -170,7 +214,8 @@ describe("debt-ratchet check mode", () => {
         "utf8"
       )
     );
-    expect(baseline.counts.any_casts).toBe(1);
+    expect(baseline.counts.any_casts).toBe(2);
+    expect(baseline.counts.test_generic_any).toBe(1);
     expect(baseline.counts.todo_comments).toBe(1);
     expect(baseline.counts.redux_imports).toBe(1);
 
@@ -198,7 +243,19 @@ describe("debt-ratchet check mode", () => {
 
     const check = runRatchet(root);
     expect(check.status).toBe(1);
-    expect(check.stderr).toContain("any_casts rose from 1 to 2");
+    expect(check.stderr).toContain("any_casts rose from 2 to 3");
+  });
+
+  it("fails when test generic-any debt rises above the baseline", () => {
+    expect(runRatchet(root, ["--update"]).status).toBe(0);
+    writeFixture(
+      "__tests__/New.test.ts",
+      "const value = helper<Record<string, any>>();\n"
+    );
+
+    const check = runRatchet(root);
+    expect(check.status).toBe(1);
+    expect(check.stderr).toContain("test_generic_any rose from 1 to 2");
   });
 
   it("fails on a new oversized file even when the total stays level", () => {
@@ -252,6 +309,7 @@ describe("debt-ratchet check mode", () => {
       "oversized_files",
       "pages_router_files",
       "redux_imports",
+      "test_generic_any",
       "todo_comments",
     ]);
   });
@@ -277,7 +335,13 @@ describe("debt-ratchet check mode", () => {
     const result = runRatchet(root, ["--details", "any_casts"]);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("components/Sample.tsx");
-    expect(result.stdout).toMatch(/^\s*1\s+components\/Sample\.tsx/m);
+    expect(result.stdout).toMatch(/^\s*2\s+components\/Sample\.tsx/m);
+
+    const testResult = runRatchet(root, ["--details", "test_generic_any"]);
+    expect(testResult.status).toBe(0);
+    expect(testResult.stdout).toMatch(
+      /^\s*1\s+components\/__tests__\/Ignored\.test\.tsx/m
+    );
 
     const unknown = runRatchet(root, ["--details", "nope"]);
     expect(unknown.status).toBe(1);

--- a/ops/workstreams/generic-any-ratchet-2026-07/README.md
+++ b/ops/workstreams/generic-any-ratchet-2026-07/README.md
@@ -1,0 +1,65 @@
+# Generic `any` Ratchet Workstream — 2026-07
+
+## Charter
+
+Close the generic type-argument blind spot in the TypeScript `any_casts`
+ratchet, then remove every newly visible production and test occurrence.
+Preserve runtime behavior and keep the checked-in baseline exact throughout
+the burn-down.
+
+## Reload order
+
+1. `AGENTS.md`
+2. This file
+3. `active-context.md`
+4. `run-log.md`
+5. `ops/workstreams/repo-health-2026-07/any-exceptions.md`
+6. `scripts/debt-ratchet.cjs`
+7. `__tests__/scripts/debt-ratchet.test.ts`
+
+## Owned paths
+
+- `scripts/debt-ratchet.cjs`
+- `scripts/debt-ratchet-baseline.json`
+- `__tests__/scripts/debt-ratchet.test.ts`
+- Generic-`any` sites identified by the parser-backed inventory
+- `ops/workstreams/repo-health-2026-07/any-exceptions.md`
+- This workstream folder
+
+## Boundaries
+
+- Do not hand-edit generated source.
+- Do not hide debt with new exclusions, suppressions, renamed metrics, or
+  unsafe assertions.
+- Do not change runtime behavior merely to satisfy the scanner.
+- Treat PR #3110 as historical evidence only; do not stack on, retarget, merge,
+  or cherry-pick it.
+- Keep user-facing documentation unchanged unless visible behavior changes.
+
+## Evidence standard
+
+- Parser-backed per-file production and test inventories.
+- Regression fixtures for nested, adjacent, and formatted generic arguments
+  plus false-positive rejection.
+- Focused scanner tests and the repository changed-file quality checks.
+- React Doctor for any React, TSX, hook, routing, or UI-state slice.
+- Latest-head review-bot and required-check evidence for every PR.
+- Exact candidate SHA evidence for staging and production validation.
+
+## Completion gates
+
+1. The scanner lands with an exact, ratcheting interim inventory.
+2. Production generic-`any` debt reaches zero.
+3. Test generic-`any` debt reaches zero.
+4. The final baseline is zero and regression-proof for both scopes.
+5. All PRs merge with signed commits and resolved latest-head feedback.
+6. The equivalent release set passes staging and production validation under
+   the deployment-bus process, followed by normal automated release closeout.
+
+## Escalation triggers
+
+- Missing required maintainer approval or repository access.
+- A conflicting active release owner or paused deployment lane.
+- A production candidate that cannot be proven equivalent to staging.
+- A proposed type change that would require an unapproved runtime contract
+  change.

--- a/ops/workstreams/generic-any-ratchet-2026-07/active-context.md
+++ b/ops/workstreams/generic-any-ratchet-2026-07/active-context.md
@@ -2,8 +2,8 @@
 
 ## Current goal
 
-Implement the scanner-correctness slice directly from current `origin/main`.
-Use the TypeScript AST to count `AnyKeyword` occurrences inside generic type
+Finish latest-head review and CI iteration for scanner PR #3444. The scanner
+uses the TypeScript AST to count `AnyKeyword` occurrences inside generic type
 arguments without counting comments, prose, strings, or identifiers.
 
 ## Current branch
@@ -42,6 +42,6 @@ arguments without counting comments, prose, strings, or identifiers.
 
 ## Next actions
 
-1. Push the signed scanner slice and open its review-ready PR.
+1. Create and push a signed review-follow-up commit.
 2. Track every latest-head review bot and required check to terminal state.
-3. Fix or justify findings, obtain current-head maintainer approval, and merge.
+3. Obtain current-head maintainer approval and merge.

--- a/ops/workstreams/generic-any-ratchet-2026-07/active-context.md
+++ b/ops/workstreams/generic-any-ratchet-2026-07/active-context.md
@@ -9,7 +9,7 @@ arguments without counting comments, prose, strings, or identifiers.
 ## Current branch
 
 `codex/generic-any-scanner`, based on `origin/main` at
-`d42c30336abe60fc76b6b4528ed8ca123e95f974`.
+`52192bf48da7cbd813324413f9eeae50fe0488ef`.
 
 ## Constraints
 
@@ -23,8 +23,9 @@ arguments without counting comments, prose, strings, or identifiers.
 
 - The starting `origin/main` `any_casts` baseline was zero despite the blind
   spot; this scanner slice refreshes it to the exact interim production count.
-- The current scanner is already TypeScript-AST-aware for direct annotations
-  and assertions but deliberately ignores generic type arguments.
+- Before this workstream, the scanner was already TypeScript-AST-aware for
+  direct annotations and assertions but deliberately ignored generic type
+  arguments. This scanner slice adds that generic-argument counting.
 - Historical PR #3110 used a delimiter regex. Its own review identified a
   delimiter-consumption weakness for adjacent generic arguments, so that
   matcher will not be reused.
@@ -42,6 +43,5 @@ arguments without counting comments, prose, strings, or identifiers.
 
 ## Next actions
 
-1. Create and push a signed review-follow-up commit.
-2. Track every latest-head review bot and required check to terminal state.
-3. Obtain current-head maintainer approval and merge.
+1. Track every latest-head review bot and required check to terminal state.
+2. Obtain current-head maintainer approval and merge.

--- a/ops/workstreams/generic-any-ratchet-2026-07/active-context.md
+++ b/ops/workstreams/generic-any-ratchet-2026-07/active-context.md
@@ -1,0 +1,47 @@
+# Active Context
+
+## Current goal
+
+Implement the scanner-correctness slice directly from current `origin/main`.
+Use the TypeScript AST to count `AnyKeyword` occurrences inside generic type
+arguments without counting comments, prose, strings, or identifiers.
+
+## Current branch
+
+`codex/generic-any-scanner`, based on `origin/main` at
+`d42c30336abe60fc76b6b4528ed8ca123e95f974`.
+
+## Constraints
+
+- Keep production and test scopes separately visible and ratcheting.
+- Land an honest temporary nonzero baseline before burn-down slices.
+- Burn production to zero before declaring the test phase complete.
+- Refresh every later slice from then-current `origin/main`; do not build a
+  stale stacked chain.
+
+## Evidence so far
+
+- The starting `origin/main` `any_casts` baseline was zero despite the blind
+  spot; this scanner slice refreshes it to the exact interim production count.
+- The current scanner is already TypeScript-AST-aware for direct annotations
+  and assertions but deliberately ignores generic type arguments.
+- Historical PR #3110 used a delimiter regex. Its own review identified a
+  delimiter-consumption weakness for adjacent generic arguments, so that
+  matcher will not be reused.
+
+## Inventory
+
+- Production: 23 occurrences across 11 files.
+- Tests: 135 occurrences across 46 files.
+- The complete per-file inventory is recorded in
+  `ops/workstreams/repo-health-2026-07/any-exceptions.md`.
+
+## Open decisions
+
+- Final PR slicing will follow the inventory's type-domain boundaries.
+
+## Next actions
+
+1. Push the signed scanner slice and open its review-ready PR.
+2. Track every latest-head review bot and required check to terminal state.
+3. Fix or justify findings, obtain current-head maintainer approval, and merge.

--- a/ops/workstreams/generic-any-ratchet-2026-07/run-log.md
+++ b/ops/workstreams/generic-any-ratchet-2026-07/run-log.md
@@ -1,0 +1,37 @@
+# Run Log
+
+## 2026-07-23 — Workstream opened
+
+- Selected autonomous-manager modes: implementation manager, PR review
+  manager, and release manager.
+- Fetched and verified current `origin/main` at
+  `d42c30336abe60fc76b6b4528ed8ca123e95f974`.
+- Created `codex/generic-any-scanner` directly from that commit in a clean
+  worktree.
+- Inspected PR #3110 for evidence only. Reusable lesson: generic `any` needs
+  regression coverage for multiple and nested type arguments. Rejected lesson:
+  its text regex consumed delimiters and could miss adjacent arguments.
+- Confirmed current main already uses the TypeScript compiler API for
+  `any_casts`, giving this workstream a parser-aware extension point.
+- Implemented parser-aware generic-argument classification with separate
+  production and test accounting.
+- Recorded the exact interim inventory: 23 production occurrences across 11
+  files and 135 test occurrences across 46 files.
+- Refreshed the baseline to those exact counts; all unrelated debt metrics
+  remain zero.
+- Added regression fixtures for adjacent, nested, multiline, tuple-contained,
+  call/type-reference, and JSX generic arguments plus parsed false positives.
+- Validation completed:
+  - `seize run test:no-coverage --testMatch=**/debt-ratchet.test.ts`:
+    28 tests passed.
+  - `seize run debt:ratchet`: production 23/23 and tests 135/135; all
+    unrelated metrics remained zero.
+  - Focused ESLint for the scanner and its test: passed.
+  - `seize run typecheck:ci`: passed.
+  - `seize run lint:changed`: passed against the exact scanner commit and
+    verified main base.
+  - `seize run typecheck:changed`: no changed files are included in
+    `tsconfig.typecheck.json`; the full typecheck above covers the repository.
+  - `seize run check:changed`: passed against the exact scanner commit and
+    verified main base.
+  - Prettier check and `codex-diff-check`: passed.

--- a/ops/workstreams/generic-any-ratchet-2026-07/run-log.md
+++ b/ops/workstreams/generic-any-ratchet-2026-07/run-log.md
@@ -35,3 +35,16 @@
   - `seize run check:changed`: passed against the exact scanner commit and
     verified main base.
   - Prettier check and `codex-diff-check`: passed.
+- Opened review-ready PR #3444:
+  <https://github.com/6529-Collections/6529seize-frontend/pull/3444>.
+- Latest-head 6529 general review requested clearer scope and discovery
+  coverage. Addressed by:
+  - documenting why generic-argument parsing is TypeScript-only;
+  - documenting the root-test plus nested-test dual walk and Set deduplication;
+  - proving both root and nested test discovery in the check-mode fixture;
+  - pinning generic parameter defaults (`<T = any>`) as distinct from generic
+    arguments and outside this bounded metric.
+- Follow-up validation:
+  - focused scanner suite: 29 tests passed;
+  - debt ratchet: production 23/23 and tests 135/135;
+  - focused ESLint and `codex-diff-check`: passed.

--- a/ops/workstreams/repo-health-2026-07/any-exceptions.md
+++ b/ops/workstreams/repo-health-2026-07/any-exceptions.md
@@ -114,9 +114,10 @@ into this bounded workstream.
 The ratchet uses the TypeScript compiler API rather than text matching.
 Production `any_casts` counts direct annotations/assertions plus every
 `AnyKeyword` parsed inside a generic type argument. `test_generic_any` applies
-the generic-argument rule to conventional test roots and nested test files.
-Nested, adjacent, multiline, tuple-contained, call-expression, type-reference,
-and JSX type arguments are covered. Comments, prose, strings, identifiers, and
+the generic-argument rule to TypeScript files under conventional test roots and
+to nested/co-located TypeScript test files. Nested, adjacent, multiline,
+tuple-contained, call-expression, type-reference, and JSX type arguments are
+covered. Comments, prose, strings, identifiers, generic parameter defaults, and
 non-generic test `any` do not count.
 
 Counts and per-file locations:

--- a/ops/workstreams/repo-health-2026-07/any-exceptions.md
+++ b/ops/workstreams/repo-health-2026-07/any-exceptions.md
@@ -1,17 +1,95 @@
 # `any` exceptions ledger
 
-Sites that keep direct `: any` / `as any` deliberately, with one-line
-justifications. Everything not listed here is expected to stay at zero; the
-debt-ratchet baseline (`scripts/debt-ratchet-baseline.json`, metric
-`any_casts`) is the enforcement backstop.
+Sites that keep direct or generic-argument `any` deliberately, with one-line
+justifications. The debt-ratchet baseline
+(`scripts/debt-ratchet-baseline.json`) is the enforcement backstop.
 
-Current floor: `any_casts` = 0.
+Current interim floors:
+
+- Production `any_casts` = 23.
+- Test `test_generic_any` = 135.
+
+Both nonzero floors are burn-down inventories, not accepted exceptions.
 
 ## Current exceptions
 
 | Site | Count | Justification           |
 | ---- | ----- | ----------------------- |
 | None | 0     | Keep the floor at zero. |
+
+## Production generic-argument burn-down inventory
+
+The parser-backed scanner finds 23 generic-argument `any` keywords in 11
+production files:
+
+| Site                                                                                                                 | Count |
+| -------------------------------------------------------------------------------------------------------------------- | ----: |
+| `app/api/pepe/resolve/route.ts`                                                                                      |     6 |
+| `components/drops/view/item/rate/give/clap/DropListItemRateGiveClap.tsx`                                             |     5 |
+| `components/waves/drop/SingleWaveDropTraits.tsx`                                                                     |     4 |
+| `components/allowlist-tool/allowlist-tool.types.ts`                                                                  |     1 |
+| `components/drops/view/item/content/media/MediaDisplayGLB.tsx`                                                       |     1 |
+| `components/nextGen/admin/NextGenAdminUploadAL.tsx`                                                                  |     1 |
+| `components/nextGen/collections/collectionParts/hooks/useSlideshowAutoplay.ts`                                       |     1 |
+| `components/react-query-wrapper/ReactQueryWrapper.tsx`                                                               |     1 |
+| `components/rememes/alchemy-sdk-types.ts`                                                                            |     1 |
+| `components/user/identity/statements/consolidated-addresses/UserPageIdentityStatementsConsolidatedAddressesItem.tsx` |     1 |
+| `components/waves/memes/traits/schema.ts`                                                                            |     1 |
+
+## Test generic-argument burn-down inventory
+
+The test-only counter finds 135 generic-argument `any` keywords in 46 files.
+It intentionally does not absorb unrelated direct test annotations or casts
+into this bounded workstream.
+
+| Site                                                                                                                                 | Count |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ----: |
+| `__tests__/components/auth/Auth.test.tsx`                                                                                            |    40 |
+| `__tests__/components/auth/SeizeConnectContext.test.tsx`                                                                             |    11 |
+| `__tests__/components/drops/create/utils/CreateDropWrapper.test.tsx`                                                                 |    10 |
+| `__tests__/components/waves/CreateDropInput.test.tsx`                                                                                |     7 |
+| `__tests__/components/react-query-wrapper/utils/updateAttachmentInCachedDrops.test.ts`                                               |     6 |
+| `__tests__/scripts/release-bus-gate-evidence.test.ts`                                                                                |     5 |
+| `__tests__/services/distribution-plan-api.test.ts`                                                                                   |     5 |
+| `__tests__/components/waves/memes/MemesArtSubmissionFile.test.tsx`                                                                   |     4 |
+| `__tests__/components/meme-calendar/meme-calendar.helpers.test.ts`                                                                   |     3 |
+| `__tests__/components/waves/WaveServerFeedSeed.test.tsx`                                                                             |     3 |
+| `__tests__/components/groups/page/create/config/nfts/GroupCreateNftSearchItems.test.tsx`                                             |     2 |
+| `__tests__/components/waves/discovery/DiscoverWaveExplorer.test.tsx`                                                                 |     2 |
+| `__tests__/contexts/wave/hooks/useWaveMessagesStore.test.ts`                                                                         |     2 |
+| `__tests__/scripts/release-bus-install-dependencies.test.ts`                                                                         |     2 |
+| `__tests__/scripts/release-bus-preflight-evidence.test.ts`                                                                           |     2 |
+| `__tests__/app/api/open-graph.ens.test.ts`                                                                                           |     1 |
+| `__tests__/components/CreateDropWrapper.test.tsx`                                                                                    |     1 |
+| `__tests__/components/about/AboutPrimaryAddress.test.tsx`                                                                            |     1 |
+| `__tests__/components/brain/my-stream/tabs/MyStreamWaveTabsDefault.test.tsx`                                                         |     1 |
+| `__tests__/components/distribution-plan-tool/build-phases/build-phase/form/component-config/select-snapshot/SelectSnapshot.test.tsx` |     1 |
+| `__tests__/components/distribution-plan-tool/create-snapshots/form/CreateSnapshotFormSearchCollectionDropdownItem.test.tsx`          |     1 |
+| `__tests__/components/drops/create/DropEditor.test.tsx`                                                                              |     1 |
+| `__tests__/components/drops/create/lexical/plugins/mentions/MentionsPlugin.test.tsx`                                                 |     1 |
+| `__tests__/components/drops/create/lexical/plugins/waves/WaveMentionsPlugin.test.tsx`                                                |     1 |
+| `__tests__/components/drops/create/utils/CreateDropContent.component.test.tsx`                                                       |     1 |
+| `__tests__/components/leaderboard/leaderboard_helpers.test.tsx`                                                                      |     1 |
+| `__tests__/components/mapping-tools/ConsolidationMappingTool.click.test.tsx`                                                         |     1 |
+| `__tests__/components/mapping-tools/ConsolidationMappingTool.drop.test.tsx`                                                          |     1 |
+| `__tests__/components/mapping-tools/ConsolidationMappingTool.test.tsx`                                                               |     1 |
+| `__tests__/components/mapping-tools/DelegationMappingTool.test.tsx`                                                                  |     1 |
+| `__tests__/components/nextGen/collections/collectionParts/mint/NextGenMintBurnWidget.test.tsx`                                       |     1 |
+| `__tests__/components/nextGen/collections/nextgenToken/NextGenTokenProvenance.test.tsx`                                              |     1 |
+| `__tests__/components/user/subscriptions/UserPageSubscriptionsUpcoming.test.tsx`                                                     |     1 |
+| `__tests__/components/waves/create-drop-content/useWaveDraftPersistence.test.tsx`                                                    |     1 |
+| `__tests__/components/waves/specs/groups/group/edit/WaveGroupEditButtons.test.tsx`                                                   |     1 |
+| `__tests__/contexts/wave/hooks/useWaveDataFetching.test.ts`                                                                          |     1 |
+| `__tests__/contracts/waves-multi-competition-phase-1.test.ts`                                                                        |     1 |
+| `__tests__/fixtures/gradientFixtures.ts`                                                                                             |     1 |
+| `__tests__/hooks/drops/useDropUpdateMutation.test.tsx`                                                                               |     1 |
+| `__tests__/hooks/useHlsPlayer.hlsSupported.test.tsx`                                                                                 |     1 |
+| `__tests__/hooks/useMemesQuickVoteQueue.test.tsx`                                                                                    |     1 |
+| `__tests__/hooks/waves/invalidateWaveApprovalStatusQueries.test.ts`                                                                  |     1 |
+| `__tests__/integration/EditDropFlow.test.tsx`                                                                                        |     1 |
+| `__tests__/scenarios/EditDropErrorScenarios.test.tsx`                                                                                |     1 |
+| `__tests__/scripts/release-bus-build-profile.test.ts`                                                                                |     1 |
+| `__tests__/useWaveRealtimeUpdater.test.ts`                                                                                           |     1 |
 
 ## Resolved deferrals (history)
 
@@ -31,17 +109,19 @@ Current floor: `any_casts` = 0.
   as a scanner false positive by switching `any_casts` from textual matching to
   TypeScript AST matching.
 
-## Known scanner blind spot (for future calibration)
+## Scanner coverage
 
-The ratchet counts direct `: any`-style annotations, `as any` assertions, and
-valid TypeScript `<any>` assertions only; generic type arguments like
-`useState<any>()` are invisible to it. Invalid TSX angle-bracket assertion
-syntax fails parsing instead of silently undercounting. A handful of such
-generics remain in
-`components/delegation/CollectionDelegation.tsx`
-(`revokeDelegationParams`, `batchRevokeDelegationParams`, three
-`useState<any[]>` key arrays). They are outside the metric and were left
-untouched by the typing wave; tighten them opportunistically when that
-file is next split (Thread D owns the split).
+The ratchet uses the TypeScript compiler API rather than text matching.
+Production `any_casts` counts direct annotations/assertions plus every
+`AnyKeyword` parsed inside a generic type argument. `test_generic_any` applies
+the generic-argument rule to conventional test roots and nested test files.
+Nested, adjacent, multiline, tuple-contained, call-expression, type-reference,
+and JSX type arguments are covered. Comments, prose, strings, identifiers, and
+non-generic test `any` do not count.
 
-Counts and per-file locations: `node scripts/debt-ratchet.cjs --details any_casts`.
+Counts and per-file locations:
+
+```text
+seize run debt:ratchet --details any_casts
+seize run debt:ratchet --details test_generic_any
+```

--- a/scripts/debt-ratchet-baseline.json
+++ b/scripts/debt-ratchet-baseline.json
@@ -2,7 +2,8 @@
   "schema_version": 1,
   "max_source_file_lines": 800,
   "counts": {
-    "any_casts": 0,
+    "any_casts": 23,
+    "test_generic_any": 135,
     "todo_comments": 0,
     "oversized_files": 0,
     "legacy_wordpress_runtime": 0,

--- a/scripts/debt-ratchet.cjs
+++ b/scripts/debt-ratchet.cjs
@@ -196,6 +196,9 @@ function isNestedTestSource(relativePath) {
 }
 
 function listTestFiles() {
+  // Root test directories also contain support files without `.test`/`.spec`
+  // names. Source directories need a separate walk for co-located test files
+  // and nested test folders; the Set keeps the combined inventory unique.
   const files = new Set();
   const collect = (dir, filter) => {
     const candidates = [];
@@ -532,6 +535,8 @@ function computeActuals() {
   }
 
   for (const relativePath of listTestFiles()) {
+    // Parsed generic type arguments are TypeScript syntax. JavaScript test
+    // files remain outside this metric, just as they are outside `any_casts`.
     if (!TYPESCRIPT_EXTENSIONS.has(path.extname(relativePath))) continue;
     testGenericAnyInputs.push({
       filePath: relativePath,

--- a/scripts/debt-ratchet.cjs
+++ b/scripts/debt-ratchet.cjs
@@ -22,10 +22,12 @@
 //
 // Counting semantics (deliberate trade-offs):
 //   - The `any_casts` metric is syntax-aware and counts direct `: any`-style
-//     annotations plus `as any` and valid TypeScript `<any>` assertions. Invalid
-//     TSX angle-bracket syntax fails parsing instead of silently undercounting.
-//     Generic type arguments such as `Record<string, any>` remain outside this
-//     metric for continuity with the original ratchet scope.
+//     annotations, `as any`, valid TypeScript `<any>` assertions, and each
+//     `any` keyword inside a generic type argument. Invalid TSX angle-bracket
+//     syntax fails parsing instead of silently undercounting.
+//   - The `test_generic_any` metric applies the same generic-argument rule to
+//     test source while leaving pre-existing direct test annotations and casts
+//     outside this workstream's scope.
 //   - Task-marker regexes match inside strings, comments, and JSDoc. Counts are
 //     symmetric between baseline and actuals, so the ratchet still moves in the
 //     right direction; do not read them as exact.
@@ -67,8 +69,10 @@ const SCAN_DIRS = [
   "utils",
   "wagmiConfig",
 ];
+const TEST_SCAN_DIRS = ["__tests__", "__mocks__", "tests", "e2e"];
 
 const EXCLUDED_DIR_NAMES = new Set(["__tests__", "__mocks__", "node_modules"]);
+const TEST_EXCLUDED_DIR_NAMES = new Set(["node_modules"]);
 const EXCLUDED_FILE_PATTERNS = [
   /\.test\.[cm]?[jt]sx?$/,
   /\.spec\.[cm]?[jt]sx?$/,
@@ -108,8 +112,12 @@ const LEGACY_WORDPRESS_RUNTIME_PATTERNS = [
 const METRIC_DEFINITIONS = {
   any_casts: {
     description:
-      "`: any` and `as any` occurrences in TypeScript source (tests excluded)",
+      "`: any`, `as any`, and generic-argument `any` occurrences in TypeScript source (tests excluded)",
     hint: "Replace `any` with a real type or `unknown` plus narrowing.",
+  },
+  test_generic_any: {
+    description: "generic-argument `any` occurrences in TypeScript test source",
+    hint: "Give the test helper, mock, or API call a truthful concrete type.",
   },
   todo_comments: {
     description: "TODO/FIXME/HACK markers in source and style files",
@@ -121,8 +129,7 @@ const METRIC_DEFINITIONS = {
   },
   legacy_wordpress_runtime: {
     description: "old live WordPress runtime markers in app source",
-    hint:
-      "Use extracted migrated WordPress content instead of WordPressLegacyAssets/postJsonHref.",
+    hint: "Use extracted migrated WordPress content instead of WordPressLegacyAssets/postJsonHref.",
   },
   bootstrap_imports: {
     description: "bootstrap / react-bootstrap import statements",
@@ -142,7 +149,9 @@ const METRIC_DEFINITIONS = {
 const isExcludedFile = (fileName) =>
   EXCLUDED_FILE_PATTERNS.some((pattern) => pattern.test(fileName));
 
-function walkFiles(absoluteDir, relativeDir, collected) {
+function walkFiles(absoluteDir, relativeDir, collected, options = {}) {
+  const excludedDirNames = options.excludedDirNames ?? EXCLUDED_DIR_NAMES;
+  const excludeTestFiles = options.excludeTestFiles ?? true;
   let entries;
   try {
     entries = fs.readdirSync(absoluteDir, { withFileTypes: true });
@@ -157,12 +166,14 @@ function walkFiles(absoluteDir, relativeDir, collected) {
       : entry.name;
 
     if (entry.isDirectory()) {
-      if (EXCLUDED_DIR_NAMES.has(entry.name)) continue;
-      walkFiles(absolutePath, relativePath, collected);
+      if (excludedDirNames.has(entry.name)) continue;
+      walkFiles(absolutePath, relativePath, collected, options);
       continue;
     }
 
-    if (!entry.isFile() || isExcludedFile(entry.name)) continue;
+    if (!entry.isFile() || (excludeTestFiles && isExcludedFile(entry.name))) {
+      continue;
+    }
     collected.push(relativePath);
   }
 }
@@ -173,6 +184,34 @@ function listSourceFiles() {
     walkFiles(path.join(REPO_ROOT, dir), dir, files);
   }
   return files.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+function isNestedTestSource(relativePath) {
+  const segments = relativePath.split("/");
+  return (
+    segments.some(
+      (segment) => segment === "__tests__" || segment === "__mocks__"
+    ) || isExcludedFile(path.basename(relativePath))
+  );
+}
+
+function listTestFiles() {
+  const files = new Set();
+  const collect = (dir, filter) => {
+    const candidates = [];
+    walkFiles(path.join(REPO_ROOT, dir), dir, candidates, {
+      excludedDirNames: TEST_EXCLUDED_DIR_NAMES,
+      excludeTestFiles: false,
+    });
+    for (const candidate of candidates) {
+      if (!filter || filter(candidate)) files.add(candidate);
+    }
+  };
+
+  for (const dir of TEST_SCAN_DIRS) collect(dir);
+  for (const dir of SCAN_DIRS) collect(dir, isNestedTestSource);
+
+  return [...files].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
 }
 
 function countMatches(content, pattern) {
@@ -350,20 +389,40 @@ function getCountedTypeNode(node) {
   return undefined;
 }
 
-function countAnyCastsInSourceFile(sourceFile) {
+function countGenericAnyTypeArgumentsInSourceFile(sourceFile) {
   let count = 0;
+
+  const visit = (node, insideTypeArgument) => {
+    if (insideTypeArgument && node.kind === ts.SyntaxKind.AnyKeyword) {
+      count += 1;
+    }
+
+    const typeArguments = node.typeArguments;
+    ts.forEachChild(node, (child) => {
+      const childIsTypeArgument =
+        typeArguments?.some((typeArgument) => typeArgument === child) ?? false;
+      visit(child, insideTypeArgument || childIsTypeArgument);
+    });
+  };
+
+  visit(sourceFile, false);
+  return count;
+}
+
+function countAnyCastsInSourceFile(sourceFile) {
+  let directCount = 0;
 
   const visit = (node) => {
     const typeNode = getCountedTypeNode(node);
     if (typeNode && hasDirectAnyType(typeNode)) {
-      count += 1;
+      directCount += 1;
     }
 
     ts.forEachChild(node, visit);
   };
 
   visit(sourceFile);
-  return count;
+  return directCount + countGenericAnyTypeArgumentsInSourceFile(sourceFile);
 }
 
 function countAnyCasts(content, filePath = "source.ts") {
@@ -373,6 +432,15 @@ function countAnyCasts(content, filePath = "source.ts") {
   const sourceFile = getAnyCastSourceFile(sourceFiles, filePath);
   throwOnSyntacticDiagnostics(program, sourceFile, filePath);
   return countAnyCastsInSourceFile(sourceFile);
+}
+
+function countGenericAnyTypeArguments(content, filePath = "source.ts") {
+  const { program, sourceFiles } = createAnyCastProgram([
+    { filePath, content },
+  ]);
+  const sourceFile = getAnyCastSourceFile(sourceFiles, filePath);
+  throwOnSyntacticDiagnostics(program, sourceFile, filePath);
+  return countGenericAnyTypeArgumentsInSourceFile(sourceFile);
 }
 
 function countLines(content) {
@@ -407,6 +475,7 @@ function countPagesRouterFiles() {
 function computeActuals() {
   const perFile = {
     any_casts: new Map(),
+    test_generic_any: new Map(),
     todo_comments: new Map(),
     legacy_wordpress_runtime: new Map(),
     bootstrap_imports: new Map(),
@@ -415,6 +484,7 @@ function computeActuals() {
   const oversizedFiles = [];
   const wordpressMigratedFiles = new Set();
   const anyCastInputs = [];
+  const testGenericAnyInputs = [];
 
   for (const relativePath of listSourceFiles()) {
     const extension = path.extname(relativePath);
@@ -461,7 +531,18 @@ function computeActuals() {
     }
   }
 
-  const anyCastProgram = createAnyCastProgram(anyCastInputs);
+  for (const relativePath of listTestFiles()) {
+    if (!TYPESCRIPT_EXTENSIONS.has(path.extname(relativePath))) continue;
+    testGenericAnyInputs.push({
+      filePath: relativePath,
+      content: fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf8"),
+    });
+  }
+
+  const anyCastProgram = createAnyCastProgram([
+    ...anyCastInputs,
+    ...testGenericAnyInputs,
+  ]);
   for (const { filePath: relativePath } of anyCastInputs) {
     const sourceFile = getAnyCastSourceFile(
       anyCastProgram.sourceFiles,
@@ -475,12 +556,26 @@ function computeActuals() {
     const anyCount = countAnyCastsInSourceFile(sourceFile);
     if (anyCount > 0) perFile.any_casts.set(relativePath, anyCount);
   }
+  for (const { filePath: relativePath } of testGenericAnyInputs) {
+    const sourceFile = getAnyCastSourceFile(
+      anyCastProgram.sourceFiles,
+      relativePath
+    );
+    throwOnSyntacticDiagnostics(
+      anyCastProgram.program,
+      sourceFile,
+      relativePath
+    );
+    const anyCount = countGenericAnyTypeArgumentsInSourceFile(sourceFile);
+    if (anyCount > 0) perFile.test_generic_any.set(relativePath, anyCount);
+  }
 
   const sum = (map) => [...map.values()].reduce((total, n) => total + n, 0);
 
   return {
     counts: {
       any_casts: sum(perFile.any_casts),
+      test_generic_any: sum(perFile.test_generic_any),
       todo_comments: sum(perFile.todo_comments),
       oversized_files: oversizedFiles.length,
       legacy_wordpress_runtime: sum(perFile.legacy_wordpress_runtime),
@@ -751,6 +846,7 @@ module.exports = {
   SCAN_DIRS,
   countImportStatements,
   countAnyCasts,
+  countGenericAnyTypeArguments,
   countLines,
   countMatches,
   isLegacyWordPressRuntimeSource,


### PR DESCRIPTION
## Issue
- The checked-in `any_casts` baseline is zero, but the parser deliberately ignores `any` inside generic type arguments such as `fetchJson<any>`, `Record<string, any>`, `useState<any>`, and `useRef<any>`.
- Tests are excluded from `any_casts`, so the same blind spot has no regression backstop in test code.

## Fix
- Extend the existing TypeScript-compiler scanner to count each parsed `AnyKeyword` inside a generic type argument.
- Keep production and test scopes explicit: production `any_casts` includes direct plus generic `any`; new `test_generic_any` covers only generic arguments in conventional test roots and nested test files.
- Refresh the interim baseline to the exact current inventory: 23 production occurrences across 11 files and 135 test occurrences across 46 files.

## Changes
- Add parser fixtures for call expressions, type references, adjacent arguments, nested arguments, multiline formatting, tuples inside arguments, and JSX type arguments.
- Prove comments, strings, prose, identifiers, bare alias `any`, and non-generic test casts do not count.
- Add a ratchet regression proving new test generic debt fails.
- Record the full per-file burn-down inventory and durable workstream state.

## Validation
- `seize run test:no-coverage --testMatch=**/debt-ratchet.test.ts` — 28 tests passed.
- `seize run debt:ratchet` — production 23/23 and tests 135/135; all unrelated metrics remain zero.
- Focused ESLint for the scanner and its test — passed.
- `seize run typecheck:ci` — passed.
- `seize run lint:changed` — passed against the exact commit/base pair.
- `seize run typecheck:changed` — no changed files are included in `tsconfig.typecheck.json`; the full typecheck above covers the repository.
- `seize run check:changed` — passed against the exact commit/base pair.
- Prettier check and `codex-diff-check` — passed.

## Risk
- Level: Low
- Why: tooling, tests, baseline, and internal ledger only; no shipped runtime behavior changes. The baseline increase makes pre-existing hidden debt visible and blocks growth.
- Rollback: revert this PR to restore the prior scanner and baseline semantics.

## Review Notes
- Review the generic-argument traversal and test-scope file discovery as the load-bearing pieces.
- Historical PR #3110 is evidence only. Its delimiter regex was not reused because review identified adjacent-argument misses such as `Map<any, any, any>`; this implementation is parser-aware and pins that case.
- The nonzero baseline is temporary and exact. Follow-up PRs will burn production to zero first, then tests, without stacking on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Debt ratchet counting now recognizes `any` inside generic type arguments and reports it via a new `test_generic_any` metric.
  - Baseline tracking and reports (JSON and detailed) were extended to include generic-`any` counts, with separate production vs. test reporting.
  - Improved test-file discovery to cover nested and co-located test cases.

- **Tests**
  - Expanded debt-ratchet test coverage and updated fixtures/expectations for new generic-`any` behavior and baseline “rose above” failures.

- **Documentation**
  - Added/updated workstream runbooks and the exceptions ledger to reflect the new generic-`any` metrics and completion gates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->