### PR TITLE
Fix staging immutable release cache exhaustion

### DIFF
--- a/.github/workflows/release-bus-deploy-staging.yml
+++ b/.github/workflows/release-bus-deploy-staging.yml
@@ -261,6 +261,39 @@ jobs:
             }
           fi
 
+          prune_release_cache() {
+            current_release=''
+            if [[ "$previous_target" =~ ^${release_root}/releases/[a-f0-9]{40}/app$ ]]; then
+              current_release="${previous_target%/app}"
+            fi
+            retained_rollback=0
+            while IFS= read -r cached_release; do
+              [ -n "$cached_release" ] || continue
+              if [ "$cached_release" = "$release_dir" ] || \
+                [ "$cached_release" = "$current_release" ]; then
+                continue
+              fi
+              if [ "$retained_rollback" -eq 0 ]; then
+                retained_rollback=1
+                continue
+              fi
+              cached_sha="${cached_release##*/}"
+              [[ "$cached_sha" =~ ^[a-f0-9]{40}$ ]]
+              [ "$cached_release" = "$release_root/releases/$cached_sha" ]
+              rm -rf -- "$cached_release"
+              echo "Pruned rebuildable staging release cache $cached_sha"
+            done < <(
+              find "$release_root/releases" -mindepth 1 -maxdepth 1 \
+                -type d -printf '%T@ %p\n' 2>/dev/null | \
+                sort -nr | cut -d' ' -f2-
+            )
+          }
+
+          # A healthy exact current release is the rollback boundary. Keep it,
+          # the incoming immutable release, and one newest additional rollback;
+          # old bundles remain reproducible from durable workflow artifacts.
+          prune_release_cache
+
           restore_legacy_process() {
             delete_6529_process || return 1
             restore_previous_link || return 1
@@ -294,6 +327,7 @@ jobs:
           install -d -o "$RUN_AS" -g "$RUN_AS" "$release_dir/app"
           unzip -q "$release_dir/package.zip" -d "$release_dir/app"
           test -f "$release_dir/app/server.js"
+          rm -f "$release_dir/package.zip"
           chown -R "$RUN_AS:$RUN_AS" "$release_dir"
           ln -sfn "$release_dir/app" "$current_link"
           cat > "$release_root/ecosystem.config.cjs" <<'PM2_CONFIG'

--- a/.github/workflows/release-bus-deploy-staging.yml
+++ b/.github/workflows/release-bus-deploy-staging.yml
@@ -266,6 +266,10 @@ jobs:
             if [[ "$previous_target" =~ ^${release_root}/releases/[a-f0-9]{40}/app$ ]]; then
               current_release="${previous_target%/app}"
             fi
+            if [ "$process_kind" = managed ] && [ -z "$current_release" ]; then
+              echo 'Refusing to prune without the exact managed current release.' >&2
+              return 1
+            fi
             retained_rollback=0
             while IFS= read -r cached_release; do
               [ -n "$cached_release" ] || continue
@@ -278,8 +282,11 @@ jobs:
                 continue
               fi
               cached_sha="${cached_release##*/}"
-              [[ "$cached_sha" =~ ^[a-f0-9]{40}$ ]]
-              [ "$cached_release" = "$release_root/releases/$cached_sha" ]
+              if ! [[ "$cached_sha" =~ ^[a-f0-9]{40}$ ]] || \
+                [ "$cached_release" != "$release_root/releases/$cached_sha" ]; then
+                echo "Preserving unrecognized staging release cache entry $cached_sha"
+                continue
+              fi
               rm -rf -- "$cached_release"
               echo "Pruned rebuildable staging release cache $cached_sha"
             done < <(
@@ -290,8 +297,9 @@ jobs:
           }
 
           # A healthy exact current release is the rollback boundary. Keep it,
-          # the incoming immutable release, and one newest additional rollback;
-          # old bundles remain reproducible from durable workflow artifacts.
+          # an already-cached incoming release when present, and one newest
+          # additional rollback. Old bundles remain reproducible from durable
+          # workflow artifacts.
           prune_release_cache
 
           restore_legacy_process() {

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -221,6 +221,37 @@ describe("release bus staging artifact transfer", () => {
       script.lastIndexOf('wait_for_local_version "$EXPECTED_SHA"')
     ).toBeLessThan(script.lastIndexOf("pm2 save"));
   });
+
+  it("bounds rebuildable staging releases without deleting the active rollback", () => {
+    const deployStep = deployWorkflow.jobs.deploy.steps.find(
+      (step: { name?: string }) =>
+        step.name === "Deploy immutable bundle through SSM"
+    );
+    const script = deployStep.run;
+
+    expect(script).toContain("prune_release_cache");
+    expect(script).toContain(
+      '[[ "$previous_target" =~ ^${release_root}/releases/[a-f0-9]{40}/app$ ]]'
+    );
+    expect(script).toContain('[ "$cached_release" = "$release_dir" ]');
+    expect(script).toContain('[ "$cached_release" = "$current_release" ]');
+    expect(script).toContain('[[ "$cached_sha" =~ ^[a-f0-9]{40}$ ]]');
+    expect(script).toContain(
+      '[ "$cached_release" = "$release_root/releases/$cached_sha" ]'
+    );
+    expect(script).toContain('rm -rf -- "$cached_release"');
+    expect(script.indexOf("prune_release_cache\n")).toBeGreaterThan(
+      script.indexOf(
+        "Refusing to deploy without an exact healthy pre-mutation local version."
+      )
+    );
+    expect(script.indexOf("prune_release_cache\n")).toBeLessThan(
+      script.indexOf('http_status="$(curl')
+    );
+    expect(script.indexOf('rm -f "$release_dir/package.zip"')).toBeGreaterThan(
+      script.indexOf('test -f "$release_dir/app/server.js"')
+    );
+  });
 });
 
 describe("release bus v2 E2E callbacks", () => {

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -235,9 +235,20 @@ describe("release bus staging artifact transfer", () => {
     );
     expect(script).toContain('[ "$cached_release" = "$release_dir" ]');
     expect(script).toContain('[ "$cached_release" = "$current_release" ]');
-    expect(script).toContain('[[ "$cached_sha" =~ ^[a-f0-9]{40}$ ]]');
     expect(script).toContain(
-      '[ "$cached_release" = "$release_root/releases/$cached_sha" ]'
+      'if ! [[ "$cached_sha" =~ ^[a-f0-9]{40}$ ]] ||'
+    );
+    expect(script).toContain(
+      '[ "$cached_release" != "$release_root/releases/$cached_sha" ]'
+    );
+    expect(script).toContain(
+      "Preserving unrecognized staging release cache entry"
+    );
+    expect(script).toContain(
+      "Refusing to prune without the exact managed current release."
+    );
+    expect(script.indexOf("continue\n")).toBeLessThan(
+      script.indexOf('rm -rf -- "$cached_release"')
     );
     expect(script).toContain('rm -rf -- "$cached_release"');
     expect(script.indexOf("prune_release_cache\n")).toBeGreaterThan(
@@ -323,9 +334,7 @@ describe("release bus v2 combined preflight", () => {
         step.name === "Build exact environment profile once"
     );
     expect(build.env.BUILD_ENVIRONMENT).toBe("${{ matrix.environment }}");
-    expect(buildStep.run).toContain(
-      'if [ "$BUILD_ENVIRONMENT" = staging ]'
-    );
+    expect(buildStep.run).toContain('if [ "$BUILD_ENVIRONMENT" = staging ]');
     expect(buildStep.run).toContain("unset ANNOUNCED_VERSION_ENDPOINT");
   });
 
@@ -362,8 +371,7 @@ describe("release bus v2 combined preflight", () => {
     }
 
     const quality = workflow.jobs.quality.steps.find(
-      (step: { name?: string }) =>
-        step.name === "Run independent quality shard"
+      (step: { name?: string }) => step.name === "Run independent quality shard"
     );
     expect(quality.run).toContain(
       './bin/6529 run test:no-coverage --runInBand --shard="$shard_index/4"'


### PR DESCRIPTION
## Issue
- Release Bus v2 staging train 29a4ee8c-aeb5-4975-827b-cb56135bf1d4 exhausted all three frontend deploy attempts because the managed instance root volume reached 100% usage.
- The immutable release directory retained every historical unpacked bundle, so future frontend trains would remain vulnerable even after one-off cleanup.

## Fix
- Bound the instance-side immutable release cache before downloading a new artifact.
- Preserve the exact healthy active rollback, the incoming release, and one newest additional rollback while pruning only validated one-level 40-hex release directories.
- Remove the transient package zip after its digest and extracted server have been verified.

## Changes
- Add fail-closed path and SHA validation around cache pruning in the Release Bus staging deploy workflow.
- Add workflow contract coverage for retention ordering, active/incoming preservation, path validation, and post-extraction zip cleanup.

## Validation
- `./bin/6529 run test __tests__/scripts/deployment-bus.test.ts --runInBand` — 60/60 passed.
- `./bin/6529 run check:changed` — changed-file typecheck and quality passed.
- `git diff --check` — clean.

## Risk
- Level: Medium
- Why: This changes staging instance cache lifecycle in a deployment workflow.
- Rollback: Revert this commit; active and incoming releases are never selected for pruning, and one extra rollback remains retained.

## Review Notes
- Focus on the exact-path safety assertions and pruning order after healthy pre-mutation verification but before artifact download.
- This does not enable Release Bus v2; both repository mode variables remain OFF and staging/production controls remain paused.