### PR TITLE
Add Release Train contributor alerts

### DIFF
--- a/.github/workflows/release-bus-deploy-production.yml
+++ b/.github/workflows/release-bus-deploy-production.yml
@@ -78,7 +78,7 @@ jobs:
           [[ "$TRAIN_REVISION" =~ ^[1-9][0-9]{0,8}$ ]]
           [[ "$OPERATION_KEY" =~ ^[A-Za-z0-9:._-]{1,180}$ ]]
           # Semantic GitHub-login validation is centralized in notify-ci-wave.mjs.
-          jq -e 'type == "array" and length <= 100 and all(.[]; type == "string" and length >= 1 and length <= 44)' <<< "$RELEASE_CONTRIBUTORS" > /dev/null
+          jq -e 'type == "array" and length <= 100 and all(.[]; type == "string" and length >= 1 and length <= 39)' <<< "$RELEASE_CONTRIBUTORS" > /dev/null
           [[ "$SOURCE_REF" =~ ^[A-Za-z0-9._/-]{1,255}$ ]]
       - name: Authorize immutable Release Bus operation
         env:

--- a/.github/workflows/release-bus-deploy-production.yml
+++ b/.github/workflows/release-bus-deploy-production.yml
@@ -77,7 +77,8 @@ jobs:
           [[ "$TRAIN_ID" =~ ^[A-Za-z0-9._-]{1,100}$ ]]
           [[ "$TRAIN_REVISION" =~ ^[1-9][0-9]{0,8}$ ]]
           [[ "$OPERATION_KEY" =~ ^[A-Za-z0-9:._-]{1,180}$ ]]
-          jq -e 'type == "array" and length <= 100 and all(.[]; type == "string" and test("^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})(?:\\[bot\\])?$"))' <<< "$RELEASE_CONTRIBUTORS" > /dev/null
+          # Semantic GitHub-login validation is centralized in notify-ci-wave.mjs.
+          jq -e 'type == "array" and length <= 100 and all(.[]; type == "string" and length >= 1 and length <= 44)' <<< "$RELEASE_CONTRIBUTORS" > /dev/null
           [[ "$SOURCE_REF" =~ ^[A-Za-z0-9._/-]{1,255}$ ]]
       - name: Authorize immutable Release Bus operation
         env:
@@ -295,8 +296,15 @@ jobs:
           path: .ci-wave-notifier
           sparse-checkout: scripts/notify-ci-wave.mjs
           sparse-checkout-cone-mode: false
+      - name: Verify CI wave notifier checkout
+        if: always()
+        run: |
+          test -f .ci-wave-notifier/scripts/notify-ci-wave.mjs || {
+            echo 'CI wave notifier checkout is unavailable.' >&2
+            exit 1
+          }
       - name: Notify CI wave about failure
-        if: failure()
+        if: failure() && hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''
         continue-on-error: true
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
@@ -311,7 +319,7 @@ jobs:
           CI_RELEASE_CONTRIBUTORS: ${{ inputs.release_contributors }}
         run: node .ci-wave-notifier/scripts/notify-ci-wave.mjs
       - name: Notify CI wave about success
-        if: success()
+        if: success() && hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''
         continue-on-error: true
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}

--- a/.github/workflows/release-bus-deploy-production.yml
+++ b/.github/workflows/release-bus-deploy-production.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       release_train_id: { type: string, required: true }
+      release_contributors: { type: string, required: false, default: "[]" }
       release_train_revision: { type: string, required: true }
       operation_key: { type: string, required: true }
       source_ref: { type: string, required: true }
@@ -49,6 +50,7 @@ jobs:
       EXPECTED_ARTIFACT_DIGEST: ${{ inputs.artifact_digest }}
       EXPECTED_SHA: ${{ inputs.expected_sha }}
       OPERATION_KEY: ${{ inputs.operation_key }}
+      RELEASE_CONTRIBUTORS: ${{ inputs.release_contributors }}
       SOURCE_REF: ${{ inputs.source_ref }}
       TRAIN_ID: ${{ inputs.release_train_id }}
       TRAIN_REVISION: ${{ inputs.release_train_revision }}
@@ -61,6 +63,7 @@ jobs:
           EXPECTED_ARTIFACT_DIGEST: ${{ inputs.artifact_digest }}
           EXPECTED_SHA: ${{ inputs.expected_sha }}
           OPERATION_KEY: ${{ inputs.operation_key }}
+          RELEASE_CONTRIBUTORS: ${{ inputs.release_contributors }}
           SOURCE_REF: ${{ inputs.source_ref }}
           TRAIN_ID: ${{ inputs.release_train_id }}
           TRAIN_REVISION: ${{ inputs.release_train_revision }}
@@ -74,6 +77,7 @@ jobs:
           [[ "$TRAIN_ID" =~ ^[A-Za-z0-9._-]{1,100}$ ]]
           [[ "$TRAIN_REVISION" =~ ^[1-9][0-9]{0,8}$ ]]
           [[ "$OPERATION_KEY" =~ ^[A-Za-z0-9:._-]{1,180}$ ]]
+          jq -e 'type == "array" and length <= 100 and all(.[]; type == "string" and test("^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})(?:\\[bot\\])?$"))' <<< "$RELEASE_CONTRIBUTORS" > /dev/null
           [[ "$SOURCE_REF" =~ ^[A-Za-z0-9._/-]{1,255}$ ]]
       - name: Authorize immutable Release Bus operation
         env:
@@ -282,3 +286,42 @@ jobs:
             -H 'Content-Type: application/json' \
             --data "$payload" \
             "$RELEASE_BUS_API_URL/deploy/release-bus-v2/report-progress"
+      - name: Check out CI wave notifier
+        if: always()
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          path: .ci-wave-notifier
+          sparse-checkout: scripts/notify-ci-wave.mjs
+          sparse-checkout-cone-mode: false
+      - name: Notify CI wave about failure
+        if: failure()
+        continue-on-error: true
+        env:
+          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
+          CI_PIPELINES_TARGET_ENV: prod
+          CI_PIPELINES_STATUS: failure
+          CI_PIPELINES_TITLE: Seize-Frontend prod DEPLOY CI pipeline is broken!!!
+          CI_PIPELINES_SERVICE: web
+          CI_PIPELINES_SHA: ${{ inputs.expected_sha }}
+          CI_RELEASE_TRAIN_ID: ${{ inputs.release_train_id }}
+          CI_RELEASE_CONTRIBUTORS: ${{ inputs.release_contributors }}
+        run: node .ci-wave-notifier/scripts/notify-ci-wave.mjs
+      - name: Notify CI wave about success
+        if: success()
+        continue-on-error: true
+        env:
+          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
+          CI_PIPELINES_TARGET_ENV: prod
+          CI_PIPELINES_STATUS: success
+          CI_PIPELINES_TITLE: Seize-Frontend prod DEPLOY CI pipeline complete
+          CI_PIPELINES_SERVICE: web
+          CI_PIPELINES_SHA: ${{ inputs.expected_sha }}
+          CI_RELEASE_TRAIN_ID: ${{ inputs.release_train_id }}
+          CI_RELEASE_CONTRIBUTORS: ${{ inputs.release_contributors }}
+        run: node .ci-wave-notifier/scripts/notify-ci-wave.mjs

--- a/.github/workflows/release-bus-deploy-staging.yml
+++ b/.github/workflows/release-bus-deploy-staging.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       release_train_id: { type: string, required: true }
+      release_contributors: { type: string, required: false, default: "[]" }
       release_train_revision: { type: string, required: true }
       operation_key: { type: string, required: true }
       source_ref: { type: string, required: true }
@@ -48,6 +49,7 @@ jobs:
       EXPECTED_ARTIFACT_DIGEST: ${{ inputs.artifact_digest }}
       EXPECTED_SHA: ${{ inputs.expected_sha }}
       OPERATION_KEY: ${{ inputs.operation_key }}
+      RELEASE_CONTRIBUTORS: ${{ inputs.release_contributors }}
       SOURCE_REF: ${{ inputs.source_ref }}
       TRAIN_ID: ${{ inputs.release_train_id }}
       TRAIN_REVISION: ${{ inputs.release_train_revision }}
@@ -60,6 +62,7 @@ jobs:
           EXPECTED_ARTIFACT_DIGEST: ${{ inputs.artifact_digest }}
           EXPECTED_SHA: ${{ inputs.expected_sha }}
           OPERATION_KEY: ${{ inputs.operation_key }}
+          RELEASE_CONTRIBUTORS: ${{ inputs.release_contributors }}
           SOURCE_REF: ${{ inputs.source_ref }}
           TRAIN_ID: ${{ inputs.release_train_id }}
           TRAIN_REVISION: ${{ inputs.release_train_revision }}
@@ -73,6 +76,7 @@ jobs:
           [[ "$TRAIN_ID" =~ ^[A-Za-z0-9._-]{1,100}$ ]]
           [[ "$TRAIN_REVISION" =~ ^[1-9][0-9]{0,8}$ ]]
           [[ "$OPERATION_KEY" =~ ^[A-Za-z0-9:._-]{1,180}$ ]]
+          jq -e 'type == "array" and length <= 100 and all(.[]; type == "string" and test("^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})(?:\\[bot\\])?$"))' <<< "$RELEASE_CONTRIBUTORS" > /dev/null
           [[ "$SOURCE_REF" =~ ^[A-Za-z0-9._/-]{1,255}$ ]]
       - name: Authorize immutable Release Bus operation
         env:
@@ -488,3 +492,42 @@ jobs:
             -H 'Content-Type: application/json' \
             --data "$payload" \
             "$RELEASE_BUS_API_URL/deploy/release-bus-v2/report-progress"
+      - name: Check out CI wave notifier
+        if: always()
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          path: .ci-wave-notifier
+          sparse-checkout: scripts/notify-ci-wave.mjs
+          sparse-checkout-cone-mode: false
+      - name: Notify CI wave about failure
+        if: failure()
+        continue-on-error: true
+        env:
+          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
+          CI_PIPELINES_TARGET_ENV: staging
+          CI_PIPELINES_STATUS: failure
+          CI_PIPELINES_TITLE: Seize-Frontend staging DEPLOY CI pipeline is broken!!!
+          CI_PIPELINES_SERVICE: web
+          CI_PIPELINES_SHA: ${{ inputs.expected_sha }}
+          CI_RELEASE_TRAIN_ID: ${{ inputs.release_train_id }}
+          CI_RELEASE_CONTRIBUTORS: ${{ inputs.release_contributors }}
+        run: node .ci-wave-notifier/scripts/notify-ci-wave.mjs
+      - name: Notify CI wave about success
+        if: success()
+        continue-on-error: true
+        env:
+          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
+          CI_PIPELINES_TARGET_ENV: staging
+          CI_PIPELINES_STATUS: success
+          CI_PIPELINES_TITLE: Seize-Frontend staging DEPLOY CI pipeline complete
+          CI_PIPELINES_SERVICE: web
+          CI_PIPELINES_SHA: ${{ inputs.expected_sha }}
+          CI_RELEASE_TRAIN_ID: ${{ inputs.release_train_id }}
+          CI_RELEASE_CONTRIBUTORS: ${{ inputs.release_contributors }}
+        run: node .ci-wave-notifier/scripts/notify-ci-wave.mjs

--- a/.github/workflows/release-bus-deploy-staging.yml
+++ b/.github/workflows/release-bus-deploy-staging.yml
@@ -77,7 +77,7 @@ jobs:
           [[ "$TRAIN_REVISION" =~ ^[1-9][0-9]{0,8}$ ]]
           [[ "$OPERATION_KEY" =~ ^[A-Za-z0-9:._-]{1,180}$ ]]
           # Semantic GitHub-login validation is centralized in notify-ci-wave.mjs.
-          jq -e 'type == "array" and length <= 100 and all(.[]; type == "string" and length >= 1 and length <= 44)' <<< "$RELEASE_CONTRIBUTORS" > /dev/null
+          jq -e 'type == "array" and length <= 100 and all(.[]; type == "string" and length >= 1 and length <= 39)' <<< "$RELEASE_CONTRIBUTORS" > /dev/null
           [[ "$SOURCE_REF" =~ ^[A-Za-z0-9._/-]{1,255}$ ]]
       - name: Authorize immutable Release Bus operation
         env:

--- a/.github/workflows/release-bus-deploy-staging.yml
+++ b/.github/workflows/release-bus-deploy-staging.yml
@@ -76,7 +76,8 @@ jobs:
           [[ "$TRAIN_ID" =~ ^[A-Za-z0-9._-]{1,100}$ ]]
           [[ "$TRAIN_REVISION" =~ ^[1-9][0-9]{0,8}$ ]]
           [[ "$OPERATION_KEY" =~ ^[A-Za-z0-9:._-]{1,180}$ ]]
-          jq -e 'type == "array" and length <= 100 and all(.[]; type == "string" and test("^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})(?:\\[bot\\])?$"))' <<< "$RELEASE_CONTRIBUTORS" > /dev/null
+          # Semantic GitHub-login validation is centralized in notify-ci-wave.mjs.
+          jq -e 'type == "array" and length <= 100 and all(.[]; type == "string" and length >= 1 and length <= 44)' <<< "$RELEASE_CONTRIBUTORS" > /dev/null
           [[ "$SOURCE_REF" =~ ^[A-Za-z0-9._/-]{1,255}$ ]]
       - name: Authorize immutable Release Bus operation
         env:
@@ -501,8 +502,15 @@ jobs:
           path: .ci-wave-notifier
           sparse-checkout: scripts/notify-ci-wave.mjs
           sparse-checkout-cone-mode: false
+      - name: Verify CI wave notifier checkout
+        if: always()
+        run: |
+          test -f .ci-wave-notifier/scripts/notify-ci-wave.mjs || {
+            echo 'CI wave notifier checkout is unavailable.' >&2
+            exit 1
+          }
       - name: Notify CI wave about failure
-        if: failure()
+        if: failure() && hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''
         continue-on-error: true
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
@@ -517,7 +525,7 @@ jobs:
           CI_RELEASE_CONTRIBUTORS: ${{ inputs.release_contributors }}
         run: node .ci-wave-notifier/scripts/notify-ci-wave.mjs
       - name: Notify CI wave about success
-        if: success()
+        if: success() && hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''
         continue-on-error: true
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -296,6 +296,10 @@ describe("release bus contributor notifications", () => {
       const checkout = steps.find(
         (step: { name?: string }) => step.name === "Check out CI wave notifier"
       );
+      const verifyCheckout = steps.find(
+        (step: { name?: string }) =>
+          step.name === "Verify CI wave notifier checkout"
+      );
       const failure = steps.find(
         (step: { name?: string }) =>
           step.name === "Notify CI wave about failure"
@@ -312,6 +316,9 @@ describe("release bus contributor notifications", () => {
       expect(validation.run).toContain(
         'jq -e \'type == "array" and length <= 100'
       );
+      expect(validation.run).toContain(
+        "Semantic GitHub-login validation is centralized in notify-ci-wave.mjs"
+      );
       expect(checkout).toMatchObject({
         if: "always()",
         with: {
@@ -320,13 +327,19 @@ describe("release bus contributor notifications", () => {
           "persist-credentials": false,
         },
       });
+      expect(verifyCheckout).toMatchObject({
+        if: "always()",
+        run: expect.stringContaining(
+          "test -f .ci-wave-notifier/scripts/notify-ci-wave.mjs"
+        ),
+      });
       expect(failure).toMatchObject({
-        if: "failure()",
+        if: "failure() && hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''",
         "continue-on-error": true,
         run: "node .ci-wave-notifier/scripts/notify-ci-wave.mjs",
       });
       expect(success).toMatchObject({
-        if: "success()",
+        if: "success() && hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''",
         "continue-on-error": true,
         run: "node .ci-wave-notifier/scripts/notify-ci-wave.mjs",
       });

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -235,9 +235,7 @@ describe("release bus staging artifact transfer", () => {
     );
     expect(script).toContain('[ "$cached_release" = "$release_dir" ]');
     expect(script).toContain('[ "$cached_release" = "$current_release" ]');
-    expect(script).toContain(
-      'if ! [[ "$cached_sha" =~ ^[a-f0-9]{40}$ ]] ||'
-    );
+    expect(script).toContain('if ! [[ "$cached_sha" =~ ^[a-f0-9]{40}$ ]] ||');
     expect(script).toContain(
       '[ "$cached_release" != "$release_root/releases/$cached_sha" ]'
     );
@@ -262,6 +260,91 @@ describe("release bus staging artifact transfer", () => {
     expect(script.indexOf('rm -f "$release_dir/package.zip"')).toBeGreaterThan(
       script.indexOf('test -f "$release_dir/app/server.js"')
     );
+  });
+});
+
+describe("release bus contributor notifications", () => {
+  const workflows = ["staging", "production"].map(
+    (environment) =>
+      [
+        environment,
+        YAML.parse(
+          fs.readFileSync(
+            path.join(
+              process.cwd(),
+              `.github/workflows/release-bus-deploy-${environment}.yml`
+            ),
+            "utf8"
+          )
+        ),
+      ] as const
+  );
+  const notifier = fs.readFileSync(
+    path.join(process.cwd(), "scripts/notify-ci-wave.mjs"),
+    "utf8"
+  );
+
+  it.each(workflows)(
+    "validates and signs %s Release Train contributor metadata",
+    (environment, workflow) => {
+      const inputs = workflow.on.workflow_dispatch.inputs;
+      const steps = workflow.jobs.deploy.steps;
+      const validation = steps.find(
+        (step: { name?: string }) =>
+          step.name === "Validate dispatch inputs before using credentials"
+      );
+      const checkout = steps.find(
+        (step: { name?: string }) => step.name === "Check out CI wave notifier"
+      );
+      const failure = steps.find(
+        (step: { name?: string }) =>
+          step.name === "Notify CI wave about failure"
+      );
+      const success = steps.find(
+        (step: { name?: string }) =>
+          step.name === "Notify CI wave about success"
+      );
+
+      expect(inputs.release_contributors).toMatchObject({
+        required: false,
+        default: "[]",
+      });
+      expect(validation.run).toContain(
+        'jq -e \'type == "array" and length <= 100'
+      );
+      expect(checkout).toMatchObject({
+        if: "always()",
+        with: {
+          ref: "${{ github.workflow_sha }}",
+          path: ".ci-wave-notifier",
+          "persist-credentials": false,
+        },
+      });
+      expect(failure).toMatchObject({
+        if: "failure()",
+        "continue-on-error": true,
+        run: "node .ci-wave-notifier/scripts/notify-ci-wave.mjs",
+      });
+      expect(success).toMatchObject({
+        if: "success()",
+        "continue-on-error": true,
+        run: "node .ci-wave-notifier/scripts/notify-ci-wave.mjs",
+      });
+      for (const notifyStep of [failure, success]) {
+        expect(notifyStep.env).toMatchObject({
+          CI_PIPELINES_SHA: "${{ inputs.expected_sha }}",
+          CI_RELEASE_TRAIN_ID: "${{ inputs.release_train_id }}",
+          CI_RELEASE_CONTRIBUTORS: "${{ inputs.release_contributors }}",
+        });
+      }
+    }
+  );
+
+  it("includes contributor fields in the signed payload", () => {
+    expect(notifier).toContain(
+      "contributor_github_logins: releaseContributors"
+    );
+    expect(notifier).toContain("sha: CI_PIPELINES_SHA || GITHUB_SHA || null");
   });
 });
 

--- a/__tests__/scripts/notify-ci-wave.test.ts
+++ b/__tests__/scripts/notify-ci-wave.test.ts
@@ -12,16 +12,24 @@ async function runNotifier(
   overrides: Record<string, string> = {}
 ): Promise<RunResult> {
   let payload: Record<string, unknown> | null = null;
+  let requestError: Error | null = null;
   const server = createServer((request, response) => {
     const chunks: Buffer[] = [];
     request.on("data", (chunk: Buffer) => chunks.push(chunk));
     request.on("end", () => {
-      payload = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<
-        string,
-        unknown
-      >;
-      response.writeHead(204);
-      response.end();
+      try {
+        payload = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<
+          string,
+          unknown
+        >;
+        response.writeHead(204);
+        response.end();
+      } catch (error) {
+        requestError =
+          error instanceof Error ? error : new Error("invalid request body");
+        response.writeHead(400);
+        response.end();
+      }
     });
   });
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
@@ -61,6 +69,7 @@ async function runNotifier(
   await new Promise<void>((resolve, reject) =>
     server.close((error) => (error ? reject(error) : resolve()))
   );
+  if (requestError) throw requestError;
   return { code, stderr, payload };
 }
 
@@ -100,7 +109,7 @@ describe("notify-ci-wave Release Train metadata", () => {
     expect(result.payload).toBeNull();
   });
 
-  it("omits new fields until a dispatcher supplies contributors", async () => {
+  it("keeps new fields atomic until the updated dispatcher supplies contributors", async () => {
     const result = await runNotifier({
       CI_RELEASE_TRAIN_ID: "train-123",
       CI_RELEASE_CONTRIBUTORS: "[]",
@@ -123,4 +132,19 @@ describe("notify-ci-wave Release Train metadata", () => {
     );
     expect(result.payload).toBeNull();
   });
+
+  it.each(["trailing-", "double--hyphen"])(
+    "rejects impossible GitHub login %s",
+    async (login) => {
+      const result = await runNotifier({
+        CI_RELEASE_TRAIN_ID: "train-123",
+        CI_RELEASE_CONTRIBUTORS: JSON.stringify([login]),
+      });
+
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain(
+        "CI_RELEASE_CONTRIBUTORS contains an invalid GitHub login"
+      );
+    }
+  );
 });

--- a/__tests__/scripts/notify-ci-wave.test.ts
+++ b/__tests__/scripts/notify-ci-wave.test.ts
@@ -133,7 +133,7 @@ describe("notify-ci-wave Release Train metadata", () => {
     expect(result.payload).toBeNull();
   });
 
-  it.each(["trailing-", "double--hyphen"])(
+  it.each(["trailing-", "double--hyphen", `${"a".repeat(35)}[bot]`])(
     "rejects impossible GitHub login %s",
     async (login) => {
       const result = await runNotifier({
@@ -147,4 +147,16 @@ describe("notify-ci-wave Release Train metadata", () => {
       );
     }
   );
+
+  it("rejects an invalid deployed SHA override", async () => {
+    const result = await runNotifier({
+      CI_PIPELINES_SHA: "not-a-git-sha",
+    });
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain(
+      "CI_PIPELINES_SHA must be a 40-character lowercase Git SHA"
+    );
+    expect(result.payload).toBeNull();
+  });
 });

--- a/__tests__/scripts/notify-ci-wave.test.ts
+++ b/__tests__/scripts/notify-ci-wave.test.ts
@@ -1,0 +1,126 @@
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import path from "node:path";
+
+type RunResult = {
+  readonly code: number | null;
+  readonly stderr: string;
+  readonly payload: Record<string, unknown> | null;
+};
+
+async function runNotifier(
+  overrides: Record<string, string> = {}
+): Promise<RunResult> {
+  let payload: Record<string, unknown> | null = null;
+  const server = createServer((request, response) => {
+    const chunks: Buffer[] = [];
+    request.on("data", (chunk: Buffer) => chunks.push(chunk));
+    request.on("end", () => {
+      payload = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<
+        string,
+        unknown
+      >;
+      response.writeHead(204);
+      response.end();
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("missing port");
+  }
+  const child = spawn(
+    process.execPath,
+    [path.join(process.cwd(), "scripts/notify-ci-wave.mjs")],
+    {
+      env: {
+        ...process.env,
+        CI_PIPELINES_ALERT_URL: `http://127.0.0.1:${address.port}`,
+        CI_PIPELINES_ALERT_SECRET: "test-secret",
+        CI_PIPELINES_TARGET_ENV: "prod",
+        CI_PIPELINES_STATUS: "success",
+        CI_PIPELINES_TITLE: "Deploy complete",
+        CI_PIPELINES_SERVICE: "web",
+        GITHUB_REPOSITORY: "6529-Collections/6529seize-frontend",
+        GITHUB_WORKFLOW: "Release Bus - Deploy Frontend Production",
+        GITHUB_RUN_ID: "123",
+        GITHUB_RUN_NUMBER: "45",
+        GITHUB_SHA: "a".repeat(40),
+        GITHUB_REF_NAME: "main",
+        ...overrides,
+      },
+    }
+  );
+  let stderr = "";
+  child.stderr.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString("utf8");
+  });
+  const code = await new Promise<number | null>((resolve) =>
+    child.on("exit", resolve)
+  );
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve()))
+  );
+  return { code, stderr, payload };
+}
+
+describe("notify-ci-wave Release Train metadata", () => {
+  it("sends canonical contributors and the deployed SHA", async () => {
+    const expectedSha = "b".repeat(40);
+    const result = await runNotifier({
+      CI_RELEASE_TRAIN_ID: "train-123",
+      CI_RELEASE_CONTRIBUTORS: JSON.stringify([
+        "GelatoGenesis",
+        "prxt6529",
+        "gelatogenesis",
+      ]),
+      CI_PIPELINES_SHA: expectedSha,
+    });
+
+    expect(result).toMatchObject({
+      code: 0,
+      stderr: "",
+      payload: {
+        release_train_id: "train-123",
+        contributor_github_logins: ["GelatoGenesis", "prxt6529"],
+        sha: expectedSha,
+      },
+    });
+  });
+
+  it("rejects contributors without a train id", async () => {
+    const result = await runNotifier({
+      CI_RELEASE_CONTRIBUTORS: JSON.stringify(["GelatoGenesis"]),
+    });
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain(
+      "CI_RELEASE_TRAIN_ID is required with CI_RELEASE_CONTRIBUTORS"
+    );
+    expect(result.payload).toBeNull();
+  });
+
+  it("omits new fields until a dispatcher supplies contributors", async () => {
+    const result = await runNotifier({
+      CI_RELEASE_TRAIN_ID: "train-123",
+      CI_RELEASE_CONTRIBUTORS: "[]",
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.payload).not.toHaveProperty("release_train_id");
+    expect(result.payload).not.toHaveProperty("contributor_github_logins");
+  });
+
+  it("rejects an invalid contributor login", async () => {
+    const result = await runNotifier({
+      CI_RELEASE_TRAIN_ID: "train-123",
+      CI_RELEASE_CONTRIBUTORS: JSON.stringify(["not a login"]),
+    });
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain(
+      "CI_RELEASE_CONTRIBUTORS contains an invalid GitHub login"
+    );
+    expect(result.payload).toBeNull();
+  });
+});

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import crypto from 'node:crypto';
+import crypto from "node:crypto";
 
 const {
   CI_PIPELINES_ALERT_URL,
@@ -15,15 +15,18 @@ const {
   CI_RELEASE_NOTES_PROMPT_PATH,
   CI_RELEASE_GROUP_ID,
   CI_RELEASE_GROUP_SERVICES,
+  CI_RELEASE_TRAIN_ID,
+  CI_RELEASE_CONTRIBUTORS,
+  CI_PIPELINES_SHA,
   GITHUB_REPOSITORY,
   GITHUB_WORKFLOW,
   GITHUB_RUN_ID,
   GITHUB_RUN_NUMBER,
-  GITHUB_SERVER_URL = 'https://github.com',
+  GITHUB_SERVER_URL = "https://github.com",
   GITHUB_SHA,
   GITHUB_REF_NAME,
   GITHUB_TRIGGERING_ACTOR,
-  GITHUB_ACTOR
+  GITHUB_ACTOR,
 } = process.env;
 
 function requireValue(name, value) {
@@ -35,35 +38,67 @@ function requireValue(name, value) {
 }
 
 function normalizeTargetEnvironment(value) {
-  const targetEnv = (value || '')
-    .trim()
-    .toLowerCase();
+  const targetEnv = (value || "").trim().toLowerCase();
   if (!targetEnv) {
     return null;
   }
-  if (targetEnv === 'staging') {
-    return 'staging';
+  if (targetEnv === "staging") {
+    return "staging";
   }
-  if (targetEnv === 'prod' || targetEnv === 'production') {
-    return 'prod';
+  if (targetEnv === "prod" || targetEnv === "production") {
+    return "prod";
   }
   return `unsupported:${targetEnv}`;
 }
 
 function getFetchFailureMessage(error) {
   if (error instanceof Error) {
-    return error.name === 'AbortError'
-      ? 'request timed out'
-      : error.message;
+    return error.name === "AbortError" ? "request timed out" : error.message;
   }
-  return 'unknown request error';
+  return "unknown request error";
+}
+
+function parseReleaseContributors(value) {
+  if (!value) return [];
+  const parsed = JSON.parse(value);
+  if (!Array.isArray(parsed) || parsed.length > 100) {
+    throw new Error(
+      "CI_RELEASE_CONTRIBUTORS must be an array with at most 100 entries"
+    );
+  }
+  const contributors = [];
+  const seen = new Set();
+  for (const value of parsed) {
+    if (
+      typeof value !== "string" ||
+      !/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})(?:\[bot\])?$/.test(value.trim())
+    ) {
+      throw new Error(
+        "CI_RELEASE_CONTRIBUTORS contains an invalid GitHub login"
+      );
+    }
+    const login = value.trim();
+    const key = login.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    contributors.push(login);
+  }
+  return contributors;
+}
+
+function releaseContributorMetadataErrorMessage(error) {
+  if (error instanceof SyntaxError) {
+    return "CI_RELEASE_CONTRIBUTORS is not valid JSON";
+  }
+  if (error instanceof Error) return error.message;
+  return "Release contributor metadata is invalid";
 }
 
 const targetEnvironment = normalizeTargetEnvironment(
   CI_PIPELINES_TARGET_ENV || CI_PIPELINES_ENVIRONMENT
 );
 
-if (targetEnvironment?.startsWith('unsupported:')) {
+if (targetEnvironment?.startsWith("unsupported:")) {
   console.error(
     `Unsupported CI pipeline alert target environment: ${targetEnvironment.slice(12)}`
   );
@@ -71,25 +106,43 @@ if (targetEnvironment?.startsWith('unsupported:')) {
 }
 
 if (!CI_PIPELINES_ALERT_URL || !CI_PIPELINES_ALERT_SECRET) {
-  console.log('CI pipeline alert receiver is not configured; skipping.');
+  console.log("CI pipeline alert receiver is not configured; skipping.");
   process.exit(0);
 }
 
-const repository = requireValue('GITHUB_REPOSITORY', GITHUB_REPOSITORY);
-const runId = requireValue('GITHUB_RUN_ID', GITHUB_RUN_ID);
-const status = requireValue('CI_PIPELINES_STATUS', CI_PIPELINES_STATUS);
-const title = requireValue('CI_PIPELINES_TITLE', CI_PIPELINES_TITLE);
+const repository = requireValue("GITHUB_REPOSITORY", GITHUB_REPOSITORY);
+const runId = requireValue("GITHUB_RUN_ID", GITHUB_RUN_ID);
+const status = requireValue("CI_PIPELINES_STATUS", CI_PIPELINES_STATUS);
+const title = requireValue("CI_PIPELINES_TITLE", CI_PIPELINES_TITLE);
 const triggeredByGithubLogin = GITHUB_TRIGGERING_ACTOR || GITHUB_ACTOR || null;
+let releaseContributors = [];
+try {
+  releaseContributors = parseReleaseContributors(CI_RELEASE_CONTRIBUTORS);
+} catch (error) {
+  console.error(releaseContributorMetadataErrorMessage(error));
+  process.exit(1);
+}
+if (
+  CI_RELEASE_TRAIN_ID &&
+  !/^[A-Za-z0-9._-]{1,100}$/.test(CI_RELEASE_TRAIN_ID)
+) {
+  console.error("CI_RELEASE_TRAIN_ID is invalid");
+  process.exit(1);
+}
+if (releaseContributors.length > 0 && !CI_RELEASE_TRAIN_ID) {
+  console.error("CI_RELEASE_TRAIN_ID is required with CI_RELEASE_CONTRIBUTORS");
+  process.exit(1);
+}
 const isReleaseNotesEligible =
-  status === 'success' &&
-  targetEnvironment === 'prod' &&
+  status === "success" &&
+  targetEnvironment === "prod" &&
   Boolean(CI_RELEASE_NOTES_PROMPT_PATH);
 const releaseGroupServices = (
   CI_RELEASE_GROUP_SERVICES ||
   CI_PIPELINES_SERVICE ||
-  ''
+  ""
 )
-  .split(',')
+  .split(",")
   .map((service) => service.trim())
   .filter(Boolean);
 const releaseNotesFields = isReleaseNotesEligible
@@ -97,13 +150,20 @@ const releaseNotesFields = isReleaseNotesEligible
       release_notes_prompt_path: CI_RELEASE_NOTES_PROMPT_PATH,
       release_group_id: CI_RELEASE_GROUP_ID || `${repository}:${runId}`,
       release_group_services: releaseGroupServices,
-      deployed_at: new Date().toISOString()
+      deployed_at: new Date().toISOString(),
     }
   : {};
+const releaseTrainFields =
+  CI_RELEASE_TRAIN_ID && releaseContributors.length > 0
+    ? {
+        release_train_id: CI_RELEASE_TRAIN_ID,
+        contributor_github_logins: releaseContributors,
+      }
+    : {};
 
 const payload = {
-  repo: repository.split('/').pop() ?? repository,
-  workflow: CI_PIPELINES_WORKFLOW || GITHUB_WORKFLOW || 'GitHub Actions',
+  repo: repository.split("/").pop() ?? repository,
+  workflow: CI_PIPELINES_WORKFLOW || GITHUB_WORKFLOW || "GitHub Actions",
   status,
   title,
   description: CI_PIPELINES_DESCRIPTION || null,
@@ -111,29 +171,30 @@ const payload = {
   run_id: runId,
   run_number: GITHUB_RUN_NUMBER || null,
   run_url: `${GITHUB_SERVER_URL}/${repository}/actions/runs/${runId}`,
-  sha: GITHUB_SHA || null,
+  sha: CI_PIPELINES_SHA || GITHUB_SHA || null,
   branch: GITHUB_REF_NAME || null,
   environment: targetEnvironment || null,
   service: CI_PIPELINES_SERVICE || null,
-  ...releaseNotesFields
+  ...releaseTrainFields,
+  ...releaseNotesFields,
 };
 
 const body = Buffer.from(JSON.stringify(payload));
 const timestamp = Math.floor(Date.now() / 1000).toString();
 const signature = crypto
-  .createHmac('sha256', CI_PIPELINES_ALERT_SECRET)
+  .createHmac("sha256", CI_PIPELINES_ALERT_SECRET)
   .update(`${timestamp}.`)
   .update(body)
-  .digest('hex');
+  .digest("hex");
 
 const headers = {
-  'content-type': 'application/json',
-  'x-6529-ci-timestamp': timestamp,
-  'x-6529-ci-signature': `sha256=${signature}`
+  "content-type": "application/json",
+  "x-6529-ci-timestamp": timestamp,
+  "x-6529-ci-signature": `sha256=${signature}`,
 };
 
 if (CI_PIPELINES_ALERT_API_AUTH) {
-  headers['x-6529-auth'] = CI_PIPELINES_ALERT_API_AUTH;
+  headers["x-6529-auth"] = CI_PIPELINES_ALERT_API_AUTH;
 }
 
 const controller = new AbortController();
@@ -142,10 +203,10 @@ const timeoutId = setTimeout(() => controller.abort(), 10_000);
 let response;
 try {
   response = await fetch(CI_PIPELINES_ALERT_URL, {
-    method: 'POST',
+    method: "POST",
     headers,
     body,
-    signal: controller.signal
+    signal: controller.signal,
   });
 } catch (error) {
   console.error(
@@ -163,4 +224,4 @@ if (!response.ok) {
   process.exit(1);
 }
 
-console.log('CI pipeline wave notification sent.');
+console.log("CI pipeline wave notification sent.");

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -58,6 +58,12 @@ function getFetchFailureMessage(error) {
   return "unknown request error";
 }
 
+function isContributorGithubLogin(value) {
+  return /^(?:[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38})(?:\[bot\])?$/.test(
+    value
+  );
+}
+
 function parseReleaseContributors(value) {
   if (!value) return [];
   const parsed = JSON.parse(value);
@@ -68,16 +74,13 @@ function parseReleaseContributors(value) {
   }
   const contributors = [];
   const seen = new Set();
-  for (const value of parsed) {
-    if (
-      typeof value !== "string" ||
-      !/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})(?:\[bot\])?$/.test(value.trim())
-    ) {
+  for (const entry of parsed) {
+    if (typeof entry !== "string" || !isContributorGithubLogin(entry.trim())) {
       throw new Error(
         "CI_RELEASE_CONTRIBUTORS contains an invalid GitHub login"
       );
     }
-    const login = value.trim();
+    const login = entry.trim();
     const key = login.toLowerCase();
     if (seen.has(key)) continue;
     seen.add(key);
@@ -153,6 +156,9 @@ const releaseNotesFields = isReleaseNotesEligible
       deployed_at: new Date().toISOString(),
     }
   : {};
+// Keep the two new fields atomic. During the ordered rollout, the old
+// dispatcher supplies an empty array and the old receiver rejects unknown
+// fields; the train id has no downstream use unless contributor credits exist.
 const releaseTrainFields =
   CI_RELEASE_TRAIN_ID && releaseContributors.length > 0
     ? {

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -59,8 +59,11 @@ function getFetchFailureMessage(error) {
 }
 
 function isContributorGithubLogin(value) {
-  return /^(?:[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38})(?:\[bot\])?$/.test(
-    value
+  return (
+    value.length <= 39 &&
+    /^(?:[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38})(?:\[bot\])?$/.test(
+      value
+    )
   );
 }
 
@@ -134,6 +137,10 @@ if (
 }
 if (releaseContributors.length > 0 && !CI_RELEASE_TRAIN_ID) {
   console.error("CI_RELEASE_TRAIN_ID is required with CI_RELEASE_CONTRIBUTORS");
+  process.exit(1);
+}
+if (CI_PIPELINES_SHA && !/^[a-f0-9]{40}$/.test(CI_PIPELINES_SHA)) {
+  console.error("CI_PIPELINES_SHA must be a 40-character lowercase Git SHA");
   process.exit(1);
 }
 const isReleaseNotesEligible =


### PR DESCRIPTION
## Summary

Add signed contributor metadata to Release Bus frontend staging and production notifications so deployment completion messages can credit and tag everyone represented by the train.

## Changes

- accept and validate the immutable contributor list dispatched by Release Bus v2
- send staging and production CI-wave success/failure notifications from the workflow definition SHA
- sign the exact deployed SHA, train id, and contributor GitHub logins
- preserve compatibility until the backend dispatcher starts supplying contributors

## Testing

- 67 focused Jest tests passed
- changed-file typecheck passed
- changed-file quality checks passed
- strict diff lint passed

## Rollout

Paired backend PR: https://github.com/6529-Collections/6529seize-backend/pull/1827

Merge this workflow PR before the backend Release Bus worker is deployed. Then deploy the backend API before the backend Release Bus worker. No frontend runtime deployment is required merely to make the workflow definitions available.

## Release status

PR only. Do not register with Release Bus or deploy to staging/production without explicit approval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release deployments now include validated contributor and release-train information in CI notifications.
  - Success and failure notifications are sent for both staging and production deployment waves.
  - Notifications include the relevant commit SHA and contributor details when available.

- **Bug Fixes**
  - Invalid contributor, release-train, environment, or required notification data is rejected before deployment proceeds.
  - Contributor information is normalized and deduplicated for more consistent notifications.

- **Tests**
  - Added coverage for notification payloads, validation failures, and staging/production workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->