### PR TITLE
chore: align staging identity for V1 data retirement

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -38,6 +38,7 @@ function getAssetPrefix(assetsFromS3: boolean, version: string): string {
 }
 
 const standaloneOutput = { output: "standalone" as const };
+// PR CI treats this config as build-sensitive so v2 can package the exact merge tree.
 const nextConfigFactory = (phase: string): NextConfig => {
   const mode = process.env.NODE_ENV;
   logOnceConfig("NODE_ENV", mode);


### PR DESCRIPTION
## Summary

- add a signed operational commit from current frontend `main`
- add one comment-only marker in build-sensitive `next.config.ts` so PR CI emits the exact dual-profile v2 artifact
- provide a frontend-bearing v2 candidate so the already validated backend V1 table-retirement candidate can rejoin one safe combined production replan
- make no runtime or configuration behavior change

## Safety

This avoids switching Release Bus v2 off or manually moving shared refs. The candidate must pass normal exact-head CI, staging deployment, manifest-bound E2E, and explicit production readiness before it may join the backend candidate.

## Release notes

Internal operational convergence only; no user-facing release note.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added build metadata for CI and packaging workflows.
  * No user-facing functionality or configuration behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->