### PR TITLE
fix: pin guarded outbound fetches

### DIFF
--- a/__tests__/app/api/open-graph.route.test.ts
+++ b/__tests__/app/api/open-graph.route.test.ts
@@ -2048,9 +2048,9 @@ describe("open-graph API route", () => {
     );
     let activeFetches = 0;
     let maxActiveFetches = 0;
-    let releaseFetches = () => undefined;
+    let releaseFetches: () => void = () => undefined;
     const allFetchesStarted = new Promise<void>((resolve) => {
-      releaseFetches = resolve;
+      releaseFetches = () => resolve();
     });
 
     mockFetchPublicUrl.mockImplementation(

--- a/__tests__/app/api/open-graph.route.test.ts
+++ b/__tests__/app/api/open-graph.route.test.ts
@@ -131,6 +131,7 @@ const DEFAULT_USER_AGENT =
 
 const originalFetch = global.fetch;
 const mockFetch = jest.fn();
+const mockPreparedRequest = jest.fn();
 
 /**
  * Creates a single-read stream body for OpenGraph request and response mocks.
@@ -222,6 +223,7 @@ describe("open-graph API route", () => {
     compound.createCompoundPlan.mockReturnValue(null);
     utils.buildGoogleWorkspaceResponse.mockResolvedValue(null);
     mockFetch.mockReset();
+    mockPreparedRequest.mockReset();
     global.fetch = mockFetch as unknown as typeof fetch;
     publicEnv.BASE_ENDPOINT = "https://6529.io";
     process.env["BASE_ENDPOINT"] = "https://6529.io";
@@ -319,15 +321,17 @@ describe("open-graph API route", () => {
       url: "https://cdn.safe.example/page",
     });
 
-    mockFetch.mockResolvedValueOnce(fetchResponse);
     mockFetchPublicUrl.mockImplementationOnce(
       async (url, init = {}, options = {}) => {
         expect(url).toEqual(new URL("http://safe.example/article"));
         expect(options).toEqual(
-          expect.objectContaining({ fetchImpl: expect.any(Function) })
+          expect.objectContaining({ buildRequestInit: expect.any(Function) })
         );
-        const result = await options.fetchImpl?.(url, init);
-        return (result ?? fetchResponse) as any;
+        expect(options).not.toHaveProperty("fetchImpl");
+        const requestInit =
+          options.buildRequestInit?.(new URL(url.toString()), init) ?? init;
+        mockPreparedRequest(url, requestInit);
+        return fetchResponse as any;
       }
     );
     utils.buildResponse.mockReturnValue(responsePayload);
@@ -382,8 +386,9 @@ describe("open-graph API route", () => {
     expect(second.status).toBe(200);
     expect(await second.json()).toEqual(responsePayload);
     expect(mockFetchPublicUrl).toHaveBeenCalledTimes(1);
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    const fetchCall = mockFetch.mock.calls[0];
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockPreparedRequest).toHaveBeenCalledTimes(1);
+    const fetchCall = mockPreparedRequest.mock.calls[0];
     expect(fetchCall[0].toString()).toBe("http://safe.example/article");
     const headers = fetchCall[1]?.headers as Headers;
     expect(headers.get("accept")).toBe(
@@ -434,14 +439,13 @@ describe("open-graph API route", () => {
       url: "https://news.example/articles/richer-card",
     });
 
-    mockFetch.mockResolvedValueOnce(fetchResponse);
     mockFetchPublicUrl.mockImplementationOnce(
       async (url, init = {}, options = {}) => {
         expect(url).toEqual(
           new URL("https://news.example/articles/richer-card")
         );
-        const result = await options.fetchImpl?.(url, init);
-        return (result ?? fetchResponse) as any;
+        options.buildRequestInit?.(new URL(url.toString()), init);
+        return fetchResponse as any;
       }
     );
     utils.buildGoogleWorkspaceResponse.mockResolvedValueOnce(null);
@@ -1385,12 +1389,11 @@ describe("open-graph API route", () => {
       cacheKey: "6529:staging:the-memes:/the-memes/509",
       execute,
     });
-    mockFetch.mockResolvedValueOnce(fetchResponse);
     mockFetchPublicUrl.mockImplementationOnce(
       async (url, init = {}, options = {}) => {
         expect(url).toEqual(new URL("https://6529.io/the-memes/509"));
-        const result = await options.fetchImpl?.(url, init);
-        return (result ?? fetchResponse) as any;
+        options.buildRequestInit?.(new URL(url.toString()), init);
+        return fetchResponse as any;
       }
     );
     utils.buildGoogleWorkspaceResponse.mockResolvedValueOnce(null);
@@ -1412,7 +1415,7 @@ describe("open-graph API route", () => {
       expect.any(Object)
     );
     expect(mockFetchPublicUrl).toHaveBeenCalledTimes(1);
-    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).not.toHaveBeenCalled();
     expect(utils.buildResponse).toHaveBeenCalledWith(
       new URL("https://6529.io/the-memes/509"),
       html,
@@ -1467,7 +1470,6 @@ describe("open-graph API route", () => {
       url: "https://www.facebook.com/some-post",
     });
 
-    mockFetch.mockResolvedValueOnce(fetchResponse);
     mockFetchPublicUrl.mockImplementationOnce(
       async (url, init = {}, options = {}) => {
         expect(url).toEqual(
@@ -1475,8 +1477,11 @@ describe("open-graph API route", () => {
             "https://www.facebook.com/20531316728/posts/10154009990506729/"
           )
         );
-        const result = await options.fetchImpl?.(url, init);
-        return (result ?? fetchResponse) as any;
+        expect(options).not.toHaveProperty("fetchImpl");
+        const requestInit =
+          options.buildRequestInit?.(new URL(url.toString()), init) ?? init;
+        mockPreparedRequest(url, requestInit);
+        return fetchResponse as any;
       }
     );
     utils.buildResponse.mockReturnValue(responsePayload);
@@ -1492,8 +1497,9 @@ describe("open-graph API route", () => {
 
     expect(response.status).toBe(200);
     expect(mockFetchPublicUrl).toHaveBeenCalledTimes(1);
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    const fbFetchCall = mockFetch.mock.calls[0];
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockPreparedRequest).toHaveBeenCalledTimes(1);
+    const fbFetchCall = mockPreparedRequest.mock.calls[0];
     expect(fbFetchCall[0].toString()).toBe(
       "https://www.facebook.com/20531316728/posts/10154009990506729/"
     );
@@ -1539,11 +1545,10 @@ describe("open-graph API route", () => {
       url: "https://docs.google.com/document/d/abc/edit",
     });
 
-    mockFetch.mockResolvedValueOnce(fetchResponse);
     mockFetchPublicUrl.mockImplementationOnce(
       async (url, init = {}, options = {}) => {
-        const result = await options.fetchImpl?.(url, init);
-        return (result ?? fetchResponse) as any;
+        options.buildRequestInit?.(new URL(url.toString()), init);
+        return fetchResponse as any;
       }
     );
     utils.buildGoogleWorkspaceResponse.mockResolvedValueOnce(googlePayload);
@@ -1572,11 +1577,10 @@ describe("open-graph API route", () => {
       url: "https://large.example/page",
     });
 
-    mockFetch.mockResolvedValueOnce(fetchResponse);
     mockFetchPublicUrl.mockImplementationOnce(
       async (url, init = {}, options = {}) => {
-        const result = await options.fetchImpl?.(url, init);
-        return (result ?? fetchResponse) as any;
+        options.buildRequestInit?.(new URL(url.toString()), init);
+        return fetchResponse as any;
       }
     );
 
@@ -1602,11 +1606,10 @@ describe("open-graph API route", () => {
       url: "https://image.example/file.png",
     });
 
-    mockFetch.mockResolvedValueOnce(fetchResponse);
     mockFetchPublicUrl.mockImplementationOnce(
       async (url, init = {}, options = {}) => {
-        const result = await options.fetchImpl?.(url, init);
-        return (result ?? fetchResponse) as any;
+        options.buildRequestInit?.(new URL(url.toString()), init);
+        return fetchResponse as any;
       }
     );
 
@@ -1646,11 +1649,10 @@ describe("open-graph API route", () => {
       url: "https://api.example/data",
     });
 
-    mockFetch.mockResolvedValueOnce(fetchResponse);
     mockFetchPublicUrl.mockImplementationOnce(
       async (url, init = {}, options = {}) => {
-        const result = await options.fetchImpl?.(url, init);
-        return (result ?? fetchResponse) as any;
+        options.buildRequestInit?.(new URL(url.toString()), init);
+        return fetchResponse as any;
       }
     );
 
@@ -1684,11 +1686,10 @@ describe("open-graph API route", () => {
       url: "https://files.example/download",
     });
 
-    mockFetch.mockResolvedValueOnce(fetchResponse);
     mockFetchPublicUrl.mockImplementationOnce(
       async (url, init = {}, options = {}) => {
-        const result = await options.fetchImpl?.(url, init);
-        return (result ?? fetchResponse) as any;
+        options.buildRequestInit?.(new URL(url.toString()), init);
+        return fetchResponse as any;
       }
     );
 
@@ -1716,11 +1717,10 @@ describe("open-graph API route", () => {
       url: "https://files.example/download?id=1",
     });
 
-    mockFetch.mockResolvedValueOnce(fetchResponse);
     mockFetchPublicUrl.mockImplementationOnce(
       async (url, init = {}, options = {}) => {
-        const result = await options.fetchImpl?.(url, init);
-        return (result ?? fetchResponse) as any;
+        options.buildRequestInit?.(new URL(url.toString()), init);
+        return fetchResponse as any;
       }
     );
 
@@ -1759,11 +1759,10 @@ describe("open-graph API route", () => {
       url: "https://files.example/download",
     });
 
-    mockFetch.mockResolvedValueOnce(fetchResponse);
     mockFetchPublicUrl.mockImplementationOnce(
       async (url, init = {}, options = {}) => {
-        const result = await options.fetchImpl?.(url, init);
-        return (result ?? fetchResponse) as any;
+        options.buildRequestInit?.(new URL(url.toString()), init);
+        return fetchResponse as any;
       }
     );
 
@@ -2040,6 +2039,58 @@ describe("open-graph API route", () => {
       },
       errors: {},
     });
+  });
+
+  it("keeps all concurrent generic POST fetches on the guarded transport", async () => {
+    const urls = Array.from(
+      { length: 5 },
+      (_, index) => `https://batch-${index}.example/article`
+    );
+    let activeFetches = 0;
+    let maxActiveFetches = 0;
+    let releaseFetches = () => undefined;
+    const allFetchesStarted = new Promise<void>((resolve) => {
+      releaseFetches = resolve;
+    });
+
+    mockFetchPublicUrl.mockImplementation(
+      async (url, init = {}, options = {}) => {
+        expect(options).not.toHaveProperty("fetchImpl");
+        const requestInit =
+          options.buildRequestInit?.(new URL(url.toString()), init) ?? init;
+        const headers = new Headers(requestInit.headers);
+        expect(headers.get("accept")).toBe(
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"
+        );
+        expect(headers.get("user-agent")).toBe(DEFAULT_USER_AGENT);
+
+        activeFetches += 1;
+        maxActiveFetches = Math.max(maxActiveFetches, activeFetches);
+        if (activeFetches === urls.length) {
+          releaseFetches();
+        }
+        await allFetchesStarted;
+        activeFetches -= 1;
+
+        return createResponse(200, {
+          headers: { "content-type": "text/html" },
+          body: "<html><head><title>Batch</title></head></html>",
+          url: url.toString(),
+        });
+      }
+    );
+    utils.buildResponse.mockImplementation((url: URL) => ({
+      requestUrl: url.toString(),
+      title: `Preview ${url.hostname}`,
+    }));
+
+    const response = await POST(createJsonRequest({ urls }));
+
+    expect(response.status).toBe(200);
+    expect(mockFetchPublicUrl).toHaveBeenCalledTimes(urls.length);
+    expect(maxActiveFetches).toBe(urls.length);
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(Object.keys((await response.json()).results)).toEqual(urls);
   });
 
   it("returns typed YouTube previews from batch requests", async () => {

--- a/__tests__/lib/security/urlGuard.test.ts
+++ b/__tests__/lib/security/urlGuard.test.ts
@@ -36,7 +36,11 @@ jest.mock("undici", () => ({
   fetch: (...args: unknown[]) => mockUndiciFetch(...args),
 }));
 
-import { fetchPublicUrl, parsePublicUrl } from "@/lib/security/urlGuard";
+import {
+  fetchPublicUrl,
+  parsePublicUrl,
+  type FetchPublicUrlOptions,
+} from "@/lib/security/urlGuard";
 
 const { lookup } = require("node:dns/promises") as {
   lookup: jest.Mock;
@@ -44,6 +48,7 @@ const { lookup } = require("node:dns/promises") as {
 
 const SAFE_EXAMPLE_ADDRESS = ["93", "184", "216", "34"].join(".");
 const CDN_SAFE_EXAMPLE_ADDRESS = ["93", "184", "216", "35"].join(".");
+const SAFE_EXAMPLE_IPV6 = "2606:2800:220:1:248:1893:25c8:1946";
 
 type MockResponseOptions = {
   readonly headers?: Record<string, string> | undefined;
@@ -105,13 +110,17 @@ describe("urlGuard", () => {
     mockUndiciFetch.mockReset();
   });
 
-  it("validates redirect hops before fetching content", async () => {
+  it("validates and pins every redirect hop before fetching content", async () => {
+    let cdnLookupCount = 0;
     lookup.mockImplementation(async (hostname: string) => {
       if (hostname === "safe.example") {
         return [{ address: SAFE_EXAMPLE_ADDRESS, family: 4 }];
       }
       if (hostname === "cdn.safe.example") {
-        return [{ address: CDN_SAFE_EXAMPLE_ADDRESS, family: 4 }];
+        cdnLookupCount += 1;
+        return cdnLookupCount === 1
+          ? [{ address: CDN_SAFE_EXAMPLE_ADDRESS, family: 4 }]
+          : [{ address: "127.0.0.1", family: 4 }];
       }
       throw new Error(`Unexpected host: ${hostname}`);
     });
@@ -139,14 +148,28 @@ describe("urlGuard", () => {
         ).resolves.toEqual({ address: CDN_SAFE_EXAMPLE_ADDRESS, family: 4 });
         return success;
       });
+    const buildRequestInit = jest.fn(
+      (_url: URL, requestInit: RequestInit) => requestInit
+    );
 
     const response = await fetchPublicUrl(
       "https://safe.example/article",
       {},
-      { userAgent: "test-agent", timeoutMs: 5000 }
+      {
+        userAgent: "test-agent",
+        timeoutMs: 5000,
+        buildRequestInit,
+        revalidateFinalUrl: false,
+      }
     );
 
     expect(mockUndiciFetch).toHaveBeenCalledTimes(2);
+    expect(lookup).toHaveBeenCalledTimes(2);
+    expect(cdnLookupCount).toBe(1);
+    expect(buildRequestInit.mock.calls.map(([url]) => url.toString())).toEqual([
+      "https://safe.example/article",
+      "https://cdn.safe.example/page",
+    ]);
     expect(mockUndiciFetch).toHaveBeenNthCalledWith(
       1,
       "https://safe.example/article",
@@ -184,6 +207,165 @@ describe("urlGuard", () => {
     expect(mockUndiciFetch).toHaveBeenCalledTimes(1);
     expect(lookup).toHaveBeenCalledTimes(1);
     expect(await response.text()).toBe("ok");
+  });
+
+  it("pins public IPv6 answers without changing the request hostname", async () => {
+    lookup.mockResolvedValue([{ address: SAFE_EXAMPLE_IPV6, family: 6 }]);
+
+    const success = createResponse(200, {
+      body: "ipv6",
+      url: "https://safe.example/article",
+    });
+    mockUndiciFetch.mockImplementation(async (url, init) => {
+      expect(url).toBe("https://safe.example/article");
+      await expect(
+        readPinnedLookupAddress("safe.example", init)
+      ).resolves.toEqual({ address: SAFE_EXAMPLE_IPV6, family: 6 });
+      return success;
+    });
+
+    const response = await fetchPublicUrl(
+      "https://safe.example/article",
+      {},
+      { revalidateFinalUrl: false }
+    );
+
+    expect(lookup).toHaveBeenCalledTimes(1);
+    expect(await response.text()).toBe("ipv6");
+  });
+
+  it("rejects mixed public and private DNS answers before opening a socket", async () => {
+    lookup.mockResolvedValue([
+      { address: SAFE_EXAMPLE_ADDRESS, family: 4 },
+      { address: "10.0.0.8", family: 4 },
+    ]);
+
+    await expect(
+      fetchPublicUrl("https://mixed.safe.example/article")
+    ).rejects.toThrow("Resolved host is not reachable.");
+
+    expect(mockUndiciFetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects IPv4-mapped IPv6 loopback answers before opening a socket", async () => {
+    lookup.mockResolvedValue([{ address: "::ffff:127.0.0.1", family: 6 }]);
+
+    await expect(
+      fetchPublicUrl("https://mapped.safe.example/article")
+    ).rejects.toThrow("Resolved host is not reachable.");
+
+    expect(mockUndiciFetch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { label: "IPv4 link-local", address: "169.254.169.254", family: 4 },
+    { label: "IPv6 link-local", address: "fe80::1", family: 6 },
+    { label: "IPv6 private-use", address: "fd00::1", family: 6 },
+  ])(
+    "rejects $label DNS answers before opening a socket",
+    async ({ address, family }) => {
+      lookup.mockResolvedValue([{ address, family }]);
+
+      await expect(
+        fetchPublicUrl("https://blocked.safe.example/article")
+      ).rejects.toThrow("Resolved host is not reachable.");
+
+      expect(mockUndiciFetch).not.toHaveBeenCalled();
+    }
+  );
+
+  it("blocks a redirect hop that resolves to a private address", async () => {
+    lookup.mockImplementation(async (hostname: string) => {
+      if (hostname === "safe.example") {
+        return [{ address: SAFE_EXAMPLE_ADDRESS, family: 4 }];
+      }
+      if (hostname === "private.safe.example") {
+        return [{ address: "192.168.1.20", family: 4 }];
+      }
+      throw new Error(`Unexpected host: ${hostname}`);
+    });
+    mockUndiciFetch.mockResolvedValue(
+      createResponse(302, {
+        headers: { location: "https://private.safe.example/secret" },
+        url: "https://safe.example/article",
+      })
+    );
+
+    await expect(
+      fetchPublicUrl("https://safe.example/article")
+    ).rejects.toThrow("Resolved host is not reachable.");
+
+    expect(mockUndiciFetch).toHaveBeenCalledTimes(1);
+    expect(lookup).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores legacy custom fetch implementations that could discard DNS pinning", async () => {
+    lookup.mockResolvedValue([{ address: SAFE_EXAMPLE_ADDRESS, family: 4 }]);
+
+    const success = createResponse(200, {
+      body: "pinned",
+      url: "https://safe.example/article",
+    });
+    mockUndiciFetch.mockImplementation(async (_url, init) => {
+      await expect(
+        readPinnedLookupAddress("safe.example", init)
+      ).resolves.toEqual({ address: SAFE_EXAMPLE_ADDRESS, family: 4 });
+      return success;
+    });
+
+    const unrestrictedFetch = jest.fn().mockResolvedValue(
+      createResponse(200, {
+        body: "unpinned",
+        url: "http://127.0.0.1/private",
+      })
+    );
+    const options = {
+      revalidateFinalUrl: false,
+      fetchImpl: unrestrictedFetch,
+    } as FetchPublicUrlOptions & { fetchImpl: typeof fetch };
+
+    const response = await fetchPublicUrl(
+      "https://safe.example/article",
+      {},
+      options
+    );
+
+    expect(unrestrictedFetch).not.toHaveBeenCalled();
+    expect(mockUndiciFetch).toHaveBeenCalledTimes(1);
+    expect(await response.text()).toBe("pinned");
+  });
+
+  it("does not let request option builders replace the pinned dispatcher", async () => {
+    lookup.mockResolvedValue([{ address: SAFE_EXAMPLE_ADDRESS, family: 4 }]);
+    const unrestrictedDispatcher = { dispatch: jest.fn() };
+    const success = createResponse(200, {
+      body: "pinned",
+      url: "https://safe.example/article",
+    });
+    mockUndiciFetch.mockImplementation(async (_url, init) => {
+      expect(
+        (init as RequestInit & { dispatcher?: unknown }).dispatcher
+      ).not.toBe(unrestrictedDispatcher);
+      await expect(
+        readPinnedLookupAddress("safe.example", init)
+      ).resolves.toEqual({ address: SAFE_EXAMPLE_ADDRESS, family: 4 });
+      return success;
+    });
+
+    const response = await fetchPublicUrl(
+      "https://safe.example/article",
+      {},
+      {
+        revalidateFinalUrl: false,
+        buildRequestInit: (_url, init) =>
+          ({
+            ...init,
+            dispatcher: unrestrictedDispatcher,
+          }) as RequestInit,
+      }
+    );
+
+    expect(await response.text()).toBe("pinned");
   });
 
   it("throws when URL cannot be parsed", () => {

--- a/__tests__/lib/security/urlGuard.test.ts
+++ b/__tests__/lib/security/urlGuard.test.ts
@@ -335,9 +335,11 @@ describe("urlGuard", () => {
     expect(await response.text()).toBe("pinned");
   });
 
-  it("does not let request option builders replace the pinned dispatcher", async () => {
+  it("does not let request options replace guard-controlled transport or abort settings", async () => {
     lookup.mockResolvedValue([{ address: SAFE_EXAMPLE_ADDRESS, family: 4 }]);
     const unrestrictedDispatcher = { dispatch: jest.fn() };
+    const unrestrictedAgent = { addRequest: jest.fn() };
+    const unrestrictedController = new AbortController();
     const success = createResponse(200, {
       body: "pinned",
       url: "https://safe.example/article",
@@ -346,6 +348,9 @@ describe("urlGuard", () => {
       expect(
         (init as RequestInit & { dispatcher?: unknown }).dispatcher
       ).not.toBe(unrestrictedDispatcher);
+      expect((init as RequestInit & { agent?: unknown }).agent).toBeUndefined();
+      expect(init.redirect).toBe("manual");
+      expect(init.signal).not.toBe(unrestrictedController.signal);
       await expect(
         readPinnedLookupAddress("safe.example", init)
       ).resolves.toEqual({ address: SAFE_EXAMPLE_ADDRESS, family: 4 });
@@ -354,13 +359,21 @@ describe("urlGuard", () => {
 
     const response = await fetchPublicUrl(
       "https://safe.example/article",
-      {},
+      {
+        dispatcher: unrestrictedDispatcher,
+        agent: unrestrictedAgent,
+        redirect: "follow",
+        signal: unrestrictedController.signal,
+      } as RequestInit,
       {
         revalidateFinalUrl: false,
         buildRequestInit: (_url, init) =>
           ({
             ...init,
             dispatcher: unrestrictedDispatcher,
+            agent: unrestrictedAgent,
+            redirect: "follow",
+            signal: unrestrictedController.signal,
           }) as RequestInit,
       }
     );

--- a/app/api/open-graph/proxy-image/route.ts
+++ b/app/api/open-graph/proxy-image/route.ts
@@ -14,33 +14,6 @@ const IMAGE_ACCEPT_HEADER = "image/avif,image/webp,image/png,image/jpeg;q=0.8,*/
 const USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
-function normalizeInputToUrl(input: RequestInfo | URL): URL {
-  if (typeof input === "string") {
-    return new URL(input);
-  }
-
-  if (input instanceof URL) {
-    return new URL(input.toString());
-  }
-
-  if (typeof Request !== "undefined" && input instanceof Request) {
-    return new URL(input.url);
-  }
-
-  if (typeof input === "object" && input !== null) {
-    const maybeUrl = (input as { url?: unknown | undefined }).url;
-    if (typeof maybeUrl === "string") {
-      return new URL(maybeUrl);
-    }
-
-    if (maybeUrl instanceof URL) {
-      return new URL(maybeUrl.toString());
-    }
-  }
-
-  throw new UrlGuardError("Unsupported request input type.", "invalid-url");
-}
-
 function ensureHttpsDefaultPort(url: URL): void {
   if (url.protocol !== "https:") {
     throw new UrlGuardError("Only HTTPS URLs are supported.", "unsupported-protocol");
@@ -51,10 +24,12 @@ function ensureHttpsDefaultPort(url: URL): void {
   }
 }
 
-const httpsOnlyFetch: typeof fetch = async (input, init) => {
-  const url = normalizeInputToUrl(input);
+const buildHttpsOnlyRequestInit = (
+  url: URL,
+  init: RequestInit
+): RequestInit => {
   ensureHttpsDefaultPort(url);
-  return fetch(input, init);
+  return init;
 };
 
 const PROXY_FETCH_OPTIONS: FetchPublicUrlOptions = {
@@ -63,7 +38,7 @@ const PROXY_FETCH_OPTIONS: FetchPublicUrlOptions = {
   },
   timeoutMs: IMAGE_PROXY_TIMEOUT_MS,
   userAgent: USER_AGENT,
-  fetchImpl: httpsOnlyFetch,
+  buildRequestInit: buildHttpsOnlyRequestInit,
 };
 
 function ensureAllowedHttps(url: URL): NextResponse | null {

--- a/app/api/open-graph/route.ts
+++ b/app/api/open-graph/route.ts
@@ -120,71 +120,12 @@ function batchBodyLimitErrorResponse(
   return NextResponse.json({ error: message }, { status: error.statusCode });
 }
 
-type FetchInput = Parameters<typeof fetch>[0];
-
-const isRequestLike = (value: unknown): value is { url: string } => {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-
-  const { url } = value as { url?: unknown | undefined };
-  return typeof url === "string" && url.length > 0;
-};
-
-const stringifiesToUrl = (value: unknown): string | null => {
-  if (
-    typeof value !== "object" ||
-    value === null ||
-    typeof (value as { toString?: unknown | undefined }).toString !== "function"
-  ) {
-    return null;
-  }
-
-  try {
-    const raw = (value as { toString: () => string }).toString();
-    return typeof raw === "string" &&
-      !raw.startsWith("[object ") &&
-      raw.length > 0
-      ? raw
-      : null;
-  } catch {
-    return null;
-  }
-};
-
-const resolveRequestUrl = (input: FetchInput): URL => {
-  if (typeof input === "string") {
-    return new URL(input);
-  }
-
-  if (input instanceof URL) {
-    return input;
-  }
-
-  if (typeof Request !== "undefined" && input instanceof Request) {
-    return new URL(input.url);
-  }
-
-  if (isRequestLike(input)) {
-    return new URL(input.url);
-  }
-
-  const stringified = stringifiesToUrl(input);
-  if (stringified) {
-    return new URL(stringified);
-  }
-
-  throw new UrlGuardError(
-    "Unsupported fetch input provided.",
-    "invalid-url",
-    400
-  );
-};
-
-// Apply host-specific header overrides while letting fetchPublicUrl enforce SSRF guardrails.
-const hostAwareFetch: typeof fetch = async (input, init = {}) => {
-  const targetUrl = resolveRequestUrl(input);
-  const { headers: baseHeaders, userAgent } = createFetchConfig(targetUrl);
+// Apply host-specific headers per hop without opening a second, unpinned fetch.
+const buildHostAwareRequestInit = (
+  url: URL,
+  init: RequestInit
+): RequestInit => {
+  const { headers: baseHeaders, userAgent } = createFetchConfig(url);
 
   const headers = new Headers(init.headers);
   const keysToReset = new Set([
@@ -203,10 +144,10 @@ const hostAwareFetch: typeof fetch = async (input, init = {}) => {
 
   headers.set("user-agent", userAgent);
 
-  return fetch(input, {
+  return {
     ...init,
     headers,
-  });
+  };
 };
 
 function ensureSuccessfulResponse(response: Response): void {
@@ -272,7 +213,7 @@ async function fetchGenericResponse(url: URL): Promise<Response> {
       ...PUBLIC_URL_OPTIONS,
       timeoutMs: FETCH_TIMEOUT_MS,
       maxRedirects: MAX_REDIRECTS,
-      fetchImpl: hostAwareFetch,
+      buildRequestInit: buildHostAwareRequestInit,
     }
   );
 

--- a/lib/security/urlGuard.ts
+++ b/lib/security/urlGuard.ts
@@ -72,7 +72,10 @@ export interface FetchPublicUrlOptions extends UrlGuardOptions {
   readonly timeoutMs?: number | undefined;
   readonly redirectStatusCodes?: ReadonlySet<number> | undefined;
   readonly userAgent?: string | undefined;
-  readonly fetchImpl?: typeof fetch | undefined;
+  /** Builds standard request options per hop; fetchPublicUrl always owns the pinned dispatcher. */
+  readonly buildRequestInit?:
+    | ((url: URL, init: RequestInit) => RequestInit)
+    | undefined;
   readonly revalidateFinalUrl?: boolean | undefined;
 }
 
@@ -545,16 +548,8 @@ function toUndiciRequestInit(init: RequestInit): UndiciRequestInit {
 function fetchWithValidatedAddresses(
   url: URL,
   init: RequestInit,
-  validated: ValidatedPublicUrl,
-  fetchImpl?: typeof fetch | undefined
+  validated: ValidatedPublicUrl
 ): Promise<Response> {
-  // SECURITY: custom fetch implementations bypass the pinned DNS dispatcher.
-  // Keep fetchImpl limited to tests or trusted callers that do not need SSRF
-  // rebinding protection.
-  if (fetchImpl) {
-    return fetchImpl(url.toString(), init);
-  }
-
   return pinnedLookupContext.run(
     validated,
     () =>
@@ -570,7 +565,6 @@ export async function fetchPublicUrl(
   init: RequestInit = {},
   options: FetchPublicUrlOptions = {}
 ): Promise<Response> {
-  const fetchImpl = options.fetchImpl;
   const maxRedirects = options.maxRedirects ?? 5;
   const redirectStatusCodes =
     options.redirectStatusCodes ?? DEFAULT_REDIRECT_STATUS_CODES;
@@ -626,16 +620,24 @@ export async function fetchPublicUrl(
 
     let response: Response;
     try {
+      const baseRequestInit: RequestInit = {
+        ...init,
+        headers,
+      };
+      const requestInit = options.buildRequestInit
+        ? options.buildRequestInit(
+            new URL(currentUrl.toString()),
+            baseRequestInit
+          )
+        : baseRequestInit;
       response = await fetchWithValidatedAddresses(
         currentUrl,
         {
-          ...init,
+          ...requestInit,
           redirect: "manual",
-          headers,
           signal: controller.signal,
         },
-        validatedUrl,
-        fetchImpl
+        validatedUrl
       );
     } catch (error) {
       if (abortedByTimeout) {


### PR DESCRIPTION
## Issue

The Open Graph preview path could validate a URL through the public-address guard and then perform the request through a separate caller-provided transport, bypassing the guard's DNS-pinned dispatcher.

## Fix

Keep transport ownership inside `fetchPublicUrl`. Callers may customize standard request options for each redirect hop, but cannot replace the validated dispatcher or network operation.

## Changes

- Replace custom fetch injection with a per-hop `RequestInit` builder.
- Preserve Open Graph host-specific headers and image-proxy HTTPS restrictions.
- Add regression coverage for initial and redirected DNS pinning, unsafe address families, legacy injection, dispatcher replacement, and concurrent batch fetches.

## Validation

- 61 focused Jest tests passed.
- Focused ESLint passed with zero warnings.
- Full strict TypeScript check passed.
- Full production build passed.
- Changed-file whitespace validation passed.

## Risk

Low-to-moderate. The transport is intentionally narrowed while request headers, redirect handling, timeouts, hostname/SNI behavior, and proxy protocol restrictions remain unchanged. The main compatibility risk is a caller that still attempts to supply the removed custom transport; repository-wide call-site review and regression tests cover that case.

## Review Notes

Please focus on redirect-hop request customization, DNS pinning ownership, and preservation of Facebook-specific headers and proxy HTTPS-only behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Strengthened protection against unsafe DNS resolutions, including private, link-local, loopback, and IPv6 addresses.
  * Improved security across redirect hops to prevent bypassing validated network destinations.
  * Ensured outbound requests retain validated connection settings and HTTPS restrictions.

* **Reliability**
  * Improved OpenGraph fetching behavior across HTML, file previews, metadata variants, and POST requests.
  * Added stronger concurrency handling for batches of OpenGraph requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->