### PR TITLE
feat: inject public review destination on staging

### DIFF
--- a/.github/workflows/release-bus-deploy-staging.yml
+++ b/.github/workflows/release-bus-deploy-staging.yml
@@ -164,15 +164,25 @@ jobs:
           EXPECTED_DIGEST: ${{ steps.artifact.outputs.package_digest }}
           EXPECTED_SHA: ${{ inputs.expected_sha }}
           INSTANCE_ID: ${{ secrets.STAGING_INSTANCE_ID }}
+          PUBLIC_REVIEW_DISCUSSION_DESTINATIONS: ${{ secrets.PUBLIC_REVIEW_DISCUSSION_DESTINATIONS }}
           REPO_DIR: ${{ env.STAGING_REPO_DIR }}
           RUN_AS: ${{ env.STAGING_RUN_AS }}
         run: |
           set -euo pipefail
           test -n "$INSTANCE_ID"
+          jq -e '
+            type == "object" and
+            has("staging") and
+            (.staging | type == "object") and
+            (.staging["stream-review"] | type == "string" and test("^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")) and
+            (has("production") | not)
+          ' <<<"$PUBLIC_REVIEW_DISCUSSION_DESTINATIONS" >/dev/null
           {
             printf 'ARTIFACT_URL=%q\n' "$ARTIFACT_URL"
             printf 'EXPECTED_DIGEST=%q\n' "$EXPECTED_DIGEST"
             printf 'EXPECTED_SHA=%q\n' "$EXPECTED_SHA"
+            printf 'PUBLIC_REVIEW_DISCUSSION_DESTINATIONS_B64=%q\n' \
+              "$(printf '%s' "$PUBLIC_REVIEW_DISCUSSION_DESTINATIONS" | base64 -w0)"
             printf 'REPO_DIR=%q\n' "$REPO_DIR"
             printf 'RUN_AS=%q\n' "$RUN_AS"
             cat <<'REMOTE'
@@ -343,7 +353,29 @@ jobs:
           rm -f "$release_dir/package.zip"
           chown -R "$RUN_AS:$RUN_AS" "$release_dir"
           ln -sfn "$release_dir/app" "$current_link"
+          review_destinations="$(
+            printf '%s' "$PUBLIC_REVIEW_DISCUSSION_DESTINATIONS_B64" | base64 -d
+          )"
+          jq -e '
+            type == "object" and
+            has("staging") and
+            (.staging | type == "object") and
+            (.staging["stream-review"] | type == "string" and test("^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")) and
+            (has("production") | not)
+          ' <<<"$review_destinations" >/dev/null
+          printf '%s' "$review_destinations" \
+            > "$release_root/public-review-discussion-destinations.json"
+          chown "$RUN_AS:$RUN_AS" \
+            "$release_root/public-review-discussion-destinations.json"
+          chmod 600 "$release_root/public-review-discussion-destinations.json"
+          unset review_destinations PUBLIC_REVIEW_DISCUSSION_DESTINATIONS_B64
           cat > "$release_root/ecosystem.config.cjs" <<'PM2_CONFIG'
+          const fs = require('node:fs');
+          const publicReviewDiscussionDestinations = fs.readFileSync(
+            __dirname + '/public-review-discussion-destinations.json',
+            'utf8'
+          ).trim();
+
           module.exports = {
             apps: [{
               name: '6529seize',
@@ -351,7 +383,13 @@ jobs:
               cwd: __dirname + '/current',
               exec_mode: 'cluster',
               instances: 1,
-              env: { PORT: '3001', HOSTNAME: '0.0.0.0', NODE_ENV: 'production' }
+              env: {
+                PORT: '3001',
+                HOSTNAME: '0.0.0.0',
+                NODE_ENV: 'production',
+                PUBLIC_REVIEW_DISCUSSION_DESTINATIONS:
+                  publicReviewDiscussionDestinations
+              }
             }]
           };
           PM2_CONFIG

--- a/.github/workflows/release-bus-deploy-staging.yml
+++ b/.github/workflows/release-bus-deploy-staging.yml
@@ -385,6 +385,9 @@ jobs:
               'utf8'
             ).trim();
           } catch (error) {
+            // A rollback may target a release from before public review existed.
+            // Omitting this env value is intentional and fail-closed: the app
+            // disables review submission rather than selecting another Wave.
             if (error?.code !== 'ENOENT') {
               throw error;
             }

--- a/.github/workflows/release-bus-deploy-staging.yml
+++ b/.github/workflows/release-bus-deploy-staging.yml
@@ -352,7 +352,6 @@ jobs:
           test -f "$release_dir/app/server.js"
           rm -f "$release_dir/package.zip"
           chown -R "$RUN_AS:$RUN_AS" "$release_dir"
-          ln -sfn "$release_dir/app" "$current_link"
           review_destinations="$(
             printf '%s' "$PUBLIC_REVIEW_DISCUSSION_DESTINATIONS_B64" | base64 -d
           )"
@@ -363,18 +362,33 @@ jobs:
             (.staging["stream-review"] | type == "string" and test("^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")) and
             (has("production") | not)
           ' <<<"$review_destinations" >/dev/null
-          printf '%s' "$review_destinations" \
-            > "$release_root/public-review-discussion-destinations.json"
+          printf '%s\n' "$review_destinations" \
+            > "$release_dir/public-review-discussion-destinations.json"
           chown "$RUN_AS:$RUN_AS" \
-            "$release_root/public-review-discussion-destinations.json"
-          chmod 600 "$release_root/public-review-discussion-destinations.json"
+            "$release_dir/public-review-discussion-destinations.json"
+          chmod 600 "$release_dir/public-review-discussion-destinations.json"
           unset review_destinations PUBLIC_REVIEW_DISCUSSION_DESTINATIONS_B64
+          ln -sfn "$release_dir/app" "$current_link"
           cat > "$release_root/ecosystem.config.cjs" <<'PM2_CONFIG'
           const fs = require('node:fs');
-          const publicReviewDiscussionDestinations = fs.readFileSync(
-            __dirname + '/public-review-discussion-destinations.json',
-            'utf8'
-          ).trim();
+          const path = require('node:path');
+
+          const currentApp = fs.realpathSync(path.join(__dirname, 'current'));
+          const destinationsPath = path.join(
+            path.dirname(currentApp),
+            'public-review-discussion-destinations.json'
+          );
+          let publicReviewDiscussionDestinations;
+          try {
+            publicReviewDiscussionDestinations = fs.readFileSync(
+              destinationsPath,
+              'utf8'
+            ).trim();
+          } catch (error) {
+            if (error?.code !== 'ENOENT') {
+              throw error;
+            }
+          }
 
           module.exports = {
             apps: [{
@@ -387,8 +401,12 @@ jobs:
                 PORT: '3001',
                 HOSTNAME: '0.0.0.0',
                 NODE_ENV: 'production',
-                PUBLIC_REVIEW_DISCUSSION_DESTINATIONS:
-                  publicReviewDiscussionDestinations
+                ...(publicReviewDiscussionDestinations
+                  ? {
+                      PUBLIC_REVIEW_DISCUSSION_DESTINATIONS:
+                        publicReviewDiscussionDestinations
+                    }
+                  : {})
               }
             }]
           };

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -30,6 +30,13 @@ const ARTIFACT_SHA256 =
 const REQUIRED_WEB_SURFACES = ["web:desktop-chromium", "web:mobile-chromium"];
 
 describe("release bus staging artifact transfer", () => {
+  const productionDeployWorkflowSource = fs.readFileSync(
+    path.join(
+      process.cwd(),
+      ".github/workflows/release-bus-deploy-production.yml"
+    ),
+    "utf8"
+  );
   const deployWorkflow = YAML.parse(
     fs.readFileSync(
       path.join(
@@ -95,6 +102,30 @@ describe("release bus staging artifact transfer", () => {
     expect(deployStep.run).toContain('test "$http_status" = 200');
     expect(deployStep.run.indexOf('test "$http_status" = 200')).toBeLessThan(
       deployStep.run.indexOf("sha256sum -c -")
+    );
+  });
+
+  it("injects public-review destinations at staging runtime only", () => {
+    const deployStep = deployWorkflow.jobs.deploy.steps.find(
+      (step: { name?: string }) =>
+        step.name === "Deploy immutable bundle through SSM"
+    );
+
+    expect(deployStep.env.PUBLIC_REVIEW_DISCUSSION_DESTINATIONS).toBe(
+      "${{ secrets.PUBLIC_REVIEW_DISCUSSION_DESTINATIONS }}"
+    );
+    expect(deployStep.run).toContain(
+      "PUBLIC_REVIEW_DISCUSSION_DESTINATIONS_B64"
+    );
+    expect(deployStep.run).toContain(
+      "public-review-discussion-destinations.json"
+    );
+    expect(deployStep.run).toContain(
+      "PUBLIC_REVIEW_DISCUSSION_DESTINATIONS:"
+    );
+    expect(deployStep.run).toContain('(has("production") | not)');
+    expect(productionDeployWorkflowSource).not.toContain(
+      "PUBLIC_REVIEW_DISCUSSION_DESTINATIONS"
     );
   });
 

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -123,6 +123,23 @@ describe("release bus staging artifact transfer", () => {
     expect(deployStep.run).toContain(
       "PUBLIC_REVIEW_DISCUSSION_DESTINATIONS:"
     );
+    expect(deployStep.run).toContain(
+      '> "$release_dir/public-review-discussion-destinations.json"'
+    );
+    expect(deployStep.run).not.toContain(
+      '> "$release_root/public-review-discussion-destinations.json"'
+    );
+    expect(deployStep.run).toContain(
+      "const currentApp = fs.realpathSync(path.join(__dirname, 'current'));"
+    );
+    expect(deployStep.run).toContain("if (error?.code !== 'ENOENT')");
+    expect(
+      deployStep.run.indexOf(
+        '> "$release_dir/public-review-discussion-destinations.json"'
+      )
+    ).toBeLessThan(
+      deployStep.run.indexOf('ln -sfn "$release_dir/app" "$current_link"')
+    );
     expect(deployStep.run).toContain('(has("production") | not)');
     expect(productionDeployWorkflowSource).not.toContain(
       "PUBLIC_REVIEW_DISCUSSION_DESTINATIONS"

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -132,6 +132,10 @@ describe("release bus staging artifact transfer", () => {
     expect(deployStep.run).toContain(
       "const currentApp = fs.realpathSync(path.join(__dirname, 'current'));"
     );
+    expect(deployStep.run).toContain("path.dirname(currentApp)");
+    expect(deployStep.run).toContain(
+      "disables review submission rather than selecting another Wave."
+    );
     expect(deployStep.run).toContain("if (error?.code !== 'ENOENT')");
     expect(
       deployStep.run.indexOf(


### PR DESCRIPTION
## Issue

The Stream public-review frontend resolves its Wave destination from a server-only environment map, but immutable staging bundles currently start without that runtime value. Baking the Wave UUID into the dual-profile artifact would leak a staging identifier into the production artifact.

## Fix

Inject `PUBLIC_REVIEW_DISCUSSION_DESTINATIONS` only in the staging deployment job. Validate the staging-only map before SSM dispatch and again on the instance, transport it without shell interpolation, persist it as a mode-600 runtime file, and load it into the PM2 environment.

## Notable changes

- Reject malformed maps, missing `staging.stream-review` UUIDs, and any `production` entry.
- Keep the destination outside the immutable build artifact and outside the production deploy workflow.
- Preserve the existing exact-SHA, digest, rollback, and PM2 process-shape controls.
- Add a regression test proving staging-only injection and production absence.
- The matching GitHub `staging` environment secret is configured; no destination value is included in this PR.

## Validation

- `seize run test:no-coverage __tests__/scripts/deployment-bus.test.ts` — 62 tests passed.
- `seize exec eslint --config eslint.config.diff.mjs --no-warn-ignored --max-warnings=0 __tests__/scripts/deployment-bus.test.ts` — passed.
- `seize run typecheck:changed` — passed.
- `codex-diff-check` — passed.

## Risk

Scoped to the staging deploy runtime. A missing or malformed environment secret intentionally fails before staging mutation. Production workflow and artifacts are unchanged.

## Review notes

Please focus on shell-safe transport, the two validation boundaries, rollback compatibility, and the assertion that production has no destination injection.