### PR TITLE
fix(public-review): normalize source commit timestamp

### DIFF
--- a/__tests__/scripts/public-review-solidity-reference-integrity.test.ts
+++ b/__tests__/scripts/public-review-solidity-reference-integrity.test.ts
@@ -186,8 +186,19 @@ describe("Solidity public-review generator trust boundaries", () => {
     expect(commitTimestampFromUnixSeconds("1785081895")).toBe(
       "2026-07-26T16:04:55Z"
     );
-    expect(() => commitTimestampFromUnixSeconds("1785081895+00:00")).toThrow(
-      "Git commit timestamp must be Unix seconds"
+    expect(commitTimestampFromUnixSeconds("8640000000000")).toBe(
+      "+275760-09-13T00:00:00Z"
+    );
+    for (const invalid of ["", "01", "-1", "+1", "1.5", "1e3"]) {
+      expect(() => commitTimestampFromUnixSeconds(invalid)).toThrow(
+        "Git commit timestamp must be Unix seconds"
+      );
+    }
+    expect(() => commitTimestampFromUnixSeconds("9007199254741")).toThrow(
+      "Git commit timestamp is outside the supported range"
+    );
+    expect(() => commitTimestampFromUnixSeconds("8640000000001")).toThrow(
+      "Git commit timestamp is outside the supported date range"
     );
   });
 

--- a/__tests__/scripts/public-review-solidity-reference-integrity.test.ts
+++ b/__tests__/scripts/public-review-solidity-reference-integrity.test.ts
@@ -46,6 +46,7 @@ const {
 const {
   acquireGenerationLock,
   check,
+  commitTimestampFromUnixSeconds,
   configSha256,
   discoveredSnapshotVersions,
   generatorSourceSha256,
@@ -58,6 +59,7 @@ const {
     configRecord: { json: Record<string, unknown>; text: string },
     dependencies?: Record<string, unknown>
   ) => void;
+  commitTimestampFromUnixSeconds: (value: string) => string;
   configSha256: (configText: string) => string;
   discoveredSnapshotVersions: (
     config: { output: { directory: string } },
@@ -179,6 +181,16 @@ function historicalShardFixture(reviewVersion: string) {
 }
 
 describe("Solidity public-review generator trust boundaries", () => {
+  it("normalizes Git commit seconds to one cross-platform UTC spelling", () => {
+    expect(commitTimestampFromUnixSeconds("0")).toBe("1970-01-01T00:00:00Z");
+    expect(commitTimestampFromUnixSeconds("1785081895")).toBe(
+      "2026-07-26T16:04:55Z"
+    );
+    expect(() => commitTimestampFromUnixSeconds("1785081895+00:00")).toThrow(
+      "Git commit timestamp must be Unix seconds"
+    );
+  });
+
   let fixtureRoot: string;
 
   beforeEach(() => {
@@ -640,7 +652,11 @@ describe("Solidity public-review generator trust boundaries", () => {
     expect(loaded.artifacts["release-artifacts/catalog.json"]?.json).toEqual({
       contracts: ["Stream"],
     });
-    expect(loaded.commitTimestamp).not.toBe("");
+    expect(loaded.commitTimestamp).toBe(
+      commitTimestampFromUnixSeconds(
+        git(fixtureRoot, "show", "-s", "--format=%ct", commit)
+      )
+    );
 
     expect(() =>
       loadPinnedInputs(fixtureRoot, {

--- a/scripts/public-reviews/solidity-reference.cjs
+++ b/scripts/public-reviews/solidity-reference.cjs
@@ -29,6 +29,7 @@ const REPOSITORY_ROOT = path.resolve(__dirname, "..", "..");
 const DEFAULT_CONFIG_PATH = "config/public-reviews/6529-stream.reference.json";
 const MAX_PROCESS_BUFFER = 512 * 1024 * 1024;
 const COMPILER_TIMEOUT_MS = 180_000;
+const MAX_DATE_MILLISECONDS = 8_640_000_000_000_000;
 
 function parseArgs(argv) {
   const args = {};
@@ -224,6 +225,10 @@ function commitTimestampFromUnixSeconds(value) {
   invariant(
     Number.isSafeInteger(milliseconds),
     `Git commit timestamp is outside the supported range: ${value}`
+  );
+  invariant(
+    milliseconds <= MAX_DATE_MILLISECONDS,
+    `Git commit timestamp is outside the supported date range: ${value}`
   );
   const timestamp = new Date(milliseconds).toISOString();
   return timestamp.endsWith(".000Z") ? `${timestamp.slice(0, -5)}Z` : timestamp;

--- a/scripts/public-reviews/solidity-reference.cjs
+++ b/scripts/public-reviews/solidity-reference.cjs
@@ -215,6 +215,20 @@ function listSolidityPaths(sourceRepo, config) {
   return sourcePaths;
 }
 
+function commitTimestampFromUnixSeconds(value) {
+  invariant(
+    typeof value === "string" && /^(0|[1-9]\d*)$/.test(value),
+    `Git commit timestamp must be Unix seconds, received: ${value}`
+  );
+  const milliseconds = Number(value) * 1000;
+  invariant(
+    Number.isSafeInteger(milliseconds),
+    `Git commit timestamp is outside the supported range: ${value}`
+  );
+  const timestamp = new Date(milliseconds).toISOString();
+  return timestamp.endsWith(".000Z") ? `${timestamp.slice(0, -5)}Z` : timestamp;
+}
+
 function loadPinnedInputs(sourceRepo, config) {
   const resolvedCommit = gitText(sourceRepo, [
     "rev-parse",
@@ -232,12 +246,9 @@ function loadPinnedInputs(sourceRepo, config) {
     resolvedTree === config.source.tree,
     `Pinned tree resolved to ${resolvedTree}, expected ${config.source.tree}.`
   );
-  const commitTimestamp = gitText(sourceRepo, [
-    "show",
-    "-s",
-    "--format=%cI",
-    config.source.commit,
-  ]);
+  const commitTimestamp = commitTimestampFromUnixSeconds(
+    gitText(sourceRepo, ["show", "-s", "--format=%ct", config.source.commit])
+  );
   const sourceBuffers = new Map();
   for (const sourcePath of listSolidityPaths(sourceRepo, config)) {
     sourceBuffers.set(
@@ -950,6 +961,7 @@ module.exports = {
   bundlePublicPath,
   check,
   compilePinnedSources,
+  commitTimestampFromUnixSeconds,
   configSha256,
   ensureImmutableSnapshot,
   expectedSnapshotFiles,


### PR DESCRIPTION
## Issue The trusted snapshot replay exposed a cross-platform determinism gap: `git show --format=%cI` spells UTC as `Z` on Windows Git and `+00:00` on Ubuntu Git. The instant is identical, but those bytes change the generated reference manifest and index checksum.  ## Fix Derive the pinned commit time from Git's numeric `%ct` value and serialize it to one UTC ISO representation before it enters the immutable bundle.  ## Notable changes - adds a fail-closed Unix-seconds canonicalizer; - switches pinned input loading from `%cI` to `%ct`; - verifies the exact canonical output and the real fixture-loading path.  ## Validation - 59 focused public-review generator and snapshot-trust tests pass; - changed-file lint passes; - Jest and Playwright test typechecking pass; - Knip passes; - whitespace check passes; - an independent Ubuntu replay found this exact mismatch and will re-run against the regenerated snapshot after merge.  ## Risk Low and intentionally narrow. The generator source checksum changes, so the still-unpublished snapshot must be regenerated. Existing published snapshots remain immutable and offline-checkable with their recorded generator checksum.  ## Review notes Please focus on cross-platform timestamp semantics and failure behavior for malformed Git output. 
## Expected trust-root gate
The base-owned snapshot trust workflow fails intentionally because this PR changes the protected generator trust root. Its log requires an explicit maintainer bypass. The snapshot itself is not part of this PR; it will be regenerated and independently replayed after this fix merges.
