### PR TITLE
Validate Stream record-family review evidence

### DIFF
--- a/__tests__/scripts/public-review-solidity-reference.test.ts
+++ b/__tests__/scripts/public-review-solidity-reference.test.ts
@@ -924,6 +924,40 @@ describe("Solidity public-review reference generator", () => {
     expect(() =>
       validateRecordFamilyAuthorizationSourceCatalog(sources, artifacts)
     ).toThrow("source binding checksum drifted");
+
+    sources.set(sourcePath, { sha256: `sha256:${sourceSha256}` });
+    expect(() =>
+      validateRecordFamilyAuthorizationSourceCatalog(sources, {
+        "release-artifacts/record-family-authorization-source-catalog.json": {
+          ...catalogArtifact,
+          json: {
+            ...catalogArtifact.json,
+            family_groups: [
+              {
+                name: "ARTIST",
+                id: `0x${"c".repeat(64)}`,
+                allowed_authorization_class_ids: [2],
+              },
+            ],
+          },
+        },
+      })
+    ).toThrow("family evidence is malformed");
+
+    expect(() =>
+      validateRecordFamilyAuthorizationSourceCatalog(sources, {
+        "release-artifacts/record-family-authorization-source-catalog.json": {
+          ...catalogArtifact,
+          json: {
+            ...catalogArtifact.json,
+            source_bindings: [
+              ...catalogArtifact.json.source_bindings,
+              ...catalogArtifact.json.source_bindings,
+            ],
+          },
+        },
+      })
+    ).toThrow("duplicate record-family authorization source binding");
   });
 
   it("rejects a same-count custom-error catalog mutation", () => {

--- a/__tests__/scripts/public-review-solidity-reference.test.ts
+++ b/__tests__/scripts/public-review-solidity-reference.test.ts
@@ -29,6 +29,7 @@ const {
   validateRetainedSourceRanges,
   validateReleaseArtifactManifest,
   validateReleaseManifest,
+  validateRecordFamilyAuthorizationSourceCatalog,
 } = require("../../scripts/public-reviews/solidity-reference-lib.cjs") as {
   BUNDLE_SCHEMA_VERSION: string;
   DEFINITION_SHARD_SCHEMA_VERSION: string;
@@ -124,6 +125,16 @@ const {
       string,
       {
         buffer: Buffer;
+        json: Record<string, unknown>;
+        sha256: string;
+      }
+    >
+  ) => Record<string, unknown>;
+  validateRecordFamilyAuthorizationSourceCatalog: (
+    sources: Map<string, { sha256: string }>,
+    artifacts: Record<
+      string,
+      {
         json: Record<string, unknown>;
         sha256: string;
       }
@@ -760,6 +771,12 @@ describe("Solidity public-review reference generator", () => {
         ],
       }
     );
+    artifacts[
+      "release-artifacts/record-family-authorization-source-catalog.json"
+    ] = artifact(
+      "6529stream.record-family-authorization-source-catalog.v1",
+      {}
+    );
 
     const manifestKeysByPath: Record<string, string> = {
       "release-artifacts/contracts.json": "contract_config",
@@ -797,6 +814,18 @@ describe("Solidity public-review reference generator", () => {
         schema_version: bound.json["schema_version"],
       };
     }
+    const recordFamilyCatalog =
+      artifacts[
+        "release-artifacts/record-family-authorization-source-catalog.json"
+      ]!;
+    releaseArtifacts["record_family_authorization"] = {
+      source_catalog: {
+        path: "release-artifacts/record-family-authorization-source-catalog.json",
+        sha256: recordFamilyCatalog.sha256,
+        size_bytes: recordFamilyCatalog.buffer.length,
+        schema_version: recordFamilyCatalog.json["schema_version"],
+      },
+    };
     Object.assign(releaseArtifacts["public_beta_evidence"]!, {
       status: {
         public_beta: "blocked",
@@ -853,6 +882,48 @@ describe("Solidity public-review reference generator", () => {
     expect(() => validateReleaseManifest(artifacts)).toThrow(
       "readiness blocker counts drifted"
     );
+  });
+
+  it("validates record-family authorization source bindings against pinned blobs", () => {
+    const sourcePath = "smart-contracts/StreamRecordFamilyRegistry.sol";
+    const sourceSha256 = "a".repeat(64);
+    const catalogArtifact = {
+      sha256: `sha256:${"b".repeat(64)}`,
+      json: {
+        schema_version:
+          "6529stream.record-family-authorization-source-catalog.v1",
+        status: "source_implemented_candidate_unbound",
+        source_bindings: [{ path: sourcePath, sha256: sourceSha256 }],
+        classifier: { candidate_binding_status: "not_available" },
+        authorization_classes: [{ id: 1, name: "ARTIST_SIGNER" }],
+        family_groups: [
+          {
+            name: "ARTIST",
+            id: `0x${"c".repeat(64)}`,
+            allowed_authorization_class_ids: [1],
+          },
+        ],
+        host_bindings: [{ contract: "StreamCollectionMetadata" }],
+        source_tests: ["test/StreamRecordFamilyAuthorization.t.sol"],
+        remaining_blockers: ["exact_candidate_binding_not_available"],
+      },
+    };
+    const artifacts = {
+      "release-artifacts/record-family-authorization-source-catalog.json":
+        catalogArtifact,
+    };
+    const sources = new Map([
+      [sourcePath, { sha256: `sha256:${sourceSha256}` }],
+    ]);
+
+    expect(() =>
+      validateRecordFamilyAuthorizationSourceCatalog(sources, artifacts)
+    ).not.toThrow();
+
+    sources.set(sourcePath, { sha256: `sha256:${"d".repeat(64)}` });
+    expect(() =>
+      validateRecordFamilyAuthorizationSourceCatalog(sources, artifacts)
+    ).toThrow("source binding checksum drifted");
   });
 
   it("rejects a same-count custom-error catalog mutation", () => {

--- a/__tests__/scripts/public-review-solidity-reference.test.ts
+++ b/__tests__/scripts/public-review-solidity-reference.test.ts
@@ -958,6 +958,53 @@ describe("Solidity public-review reference generator", () => {
         },
       })
     ).toThrow("duplicate record-family authorization source binding");
+
+    expect(() =>
+      validateRecordFamilyAuthorizationSourceCatalog(sources, {
+        "release-artifacts/record-family-authorization-source-catalog.json": {
+          ...catalogArtifact,
+          json: {
+            ...catalogArtifact.json,
+            authorization_classes: [
+              ...catalogArtifact.json.authorization_classes,
+              ...catalogArtifact.json.authorization_classes,
+            ],
+          },
+        },
+      })
+    ).toThrow("class identifiers are invalid");
+
+    expect(() =>
+      validateRecordFamilyAuthorizationSourceCatalog(sources, {
+        "release-artifacts/record-family-authorization-source-catalog.json": {
+          ...catalogArtifact,
+          json: {
+            ...catalogArtifact.json,
+            family_groups: [
+              ...catalogArtifact.json.family_groups,
+              ...catalogArtifact.json.family_groups,
+            ],
+          },
+        },
+      })
+    ).toThrow("family identifiers are duplicated");
+
+    expect(() =>
+      validateRecordFamilyAuthorizationSourceCatalog(sources, {
+        "release-artifacts/record-family-authorization-source-catalog.json": {
+          ...catalogArtifact,
+          json: {
+            ...catalogArtifact.json,
+            family_groups: [
+              {
+                ...catalogArtifact.json.family_groups[0],
+                id: "0x01",
+              },
+            ],
+          },
+        },
+      })
+    ).toThrow("family evidence is malformed");
   });
 
   it("rejects a same-count custom-error catalog mutation", () => {

--- a/scripts/public-reviews/solidity-reference-lib.cjs
+++ b/scripts/public-reviews/solidity-reference-lib.cjs
@@ -1844,9 +1844,23 @@ function validateReleaseManifest(artifacts) {
       "release-artifacts/baselines/v0.1.0/natspec-coverage.json",
     ],
   ];
+  const recordFamilyArtifactPath =
+    "release-artifacts/record-family-authorization-source-catalog.json";
+  if (artifacts[recordFamilyArtifactPath]) {
+    bindings.splice(3, 0, [
+      ["record_family_authorization", "source_catalog"],
+      recordFamilyArtifactPath,
+    ]);
+  }
   const boundArtifactDigests = {};
   for (const [manifestKey, artifactPath] of bindings) {
-    const record = manifest.release_artifacts?.[manifestKey];
+    const manifestPath = Array.isArray(manifestKey)
+      ? manifestKey
+      : [manifestKey];
+    const record = manifestPath.reduce(
+      (value, key) => value?.[key],
+      manifest.release_artifacts
+    );
     const artifact = artifacts[artifactPath];
     invariant(
       record?.path === artifactPath &&
@@ -1984,9 +1998,106 @@ function validateReleaseManifest(artifacts) {
     },
     riskRegister,
     governedParameterInventory: governedParameters,
+    ...(artifacts[recordFamilyArtifactPath]
+      ? {
+          recordFamilyAuthorizationSourceCatalog:
+            artifacts[recordFamilyArtifactPath].json,
+        }
+      : {}),
     boundArtifactDigests,
     checksumBundle: manifest.checksum_bundle,
     unavailableReleaseCeremony: manifest.unavailable_release_ceremony,
+  };
+}
+
+function validateRecordFamilyAuthorizationSourceCatalog(sources, artifacts) {
+  const artifact =
+    artifacts[
+      "release-artifacts/record-family-authorization-source-catalog.json"
+    ];
+  const catalog = artifact?.json;
+  invariant(
+    catalog?.schema_version ===
+      "6529stream.record-family-authorization-source-catalog.v1",
+    "Record-family authorization source catalog identity drifted."
+  );
+  invariant(
+    catalog.status === "source_implemented_candidate_unbound" &&
+      catalog.classifier?.candidate_binding_status === "not_available",
+    "Record-family authorization source/candidate status drifted."
+  );
+  invariant(
+    Array.isArray(catalog.source_bindings) &&
+      catalog.source_bindings.length > 0,
+    "Record-family authorization source catalog has no source bindings."
+  );
+  const seenSourcePaths = new Set();
+  for (const binding of catalog.source_bindings) {
+    invariant(
+      typeof binding?.path === "string" &&
+        /^[0-9a-f]{64}$/.test(binding?.sha256),
+      "Record-family authorization source binding is malformed."
+    );
+    invariant(
+      !seenSourcePaths.has(binding.path),
+      `${binding.path}: duplicate record-family authorization source binding.`
+    );
+    seenSourcePaths.add(binding.path);
+    const source = sources.get(binding.path);
+    invariant(
+      source,
+      `${binding.path}: record-family authorization source binding is not in the pinned source set.`
+    );
+    invariant(
+      source.sha256 === `sha256:${binding.sha256}`,
+      `${binding.path}: record-family authorization source binding checksum drifted.`
+    );
+  }
+  for (const key of [
+    "authorization_classes",
+    "family_groups",
+    "host_bindings",
+    "source_tests",
+    "remaining_blockers",
+  ]) {
+    invariant(
+      Array.isArray(catalog[key]) && catalog[key].length > 0,
+      `Record-family authorization ${key} evidence is empty.`
+    );
+  }
+  const uniqueIds = (records, label) => {
+    const ids = records.map((record) => record.id);
+    invariant(
+      ids.every((id) => Number.isSafeInteger(id) && id > 0) &&
+        new Set(ids).size === ids.length,
+      `Record-family authorization ${label} identifiers are invalid.`
+    );
+  };
+  uniqueIds(catalog.authorization_classes, "class");
+  invariant(
+    catalog.family_groups.every(
+      (family) =>
+        typeof family?.name === "string" &&
+        /^0x[0-9a-f]{64}$/.test(family?.id) &&
+        Array.isArray(family?.allowed_authorization_class_ids) &&
+        family.allowed_authorization_class_ids.length > 0
+    ),
+    "Record-family authorization family evidence is malformed."
+  );
+  const familyIds = catalog.family_groups.map((family) => family.id);
+  invariant(
+    new Set(familyIds).size === familyIds.length,
+    "Record-family authorization family identifiers are duplicated."
+  );
+  return {
+    path: "release-artifacts/record-family-authorization-source-catalog.json",
+    sha256: artifact.sha256,
+    status: catalog.status,
+    sourceBindingCount: catalog.source_bindings.length,
+    authorizationClassCount: catalog.authorization_classes.length,
+    familyGroupCount: catalog.family_groups.length,
+    hostBindingCount: catalog.host_bindings.length,
+    remainingBlockerCount: catalog.remaining_blockers.length,
   };
 }
 
@@ -3258,6 +3369,14 @@ function buildBundle({
       )
     );
   }
+  if (
+    artifacts[
+      "release-artifacts/record-family-authorization-source-catalog.json"
+    ]
+  ) {
+    auditorEvidence.recordFamilyAuthorizationValidation =
+      validateRecordFamilyAuthorizationSourceCatalog(sources, artifacts);
+  }
   validateSourceVerification(sources, artifacts, config);
   const { rawDefinitions, classificationContext } = prepareDefinitions(
     config,
@@ -4095,5 +4214,6 @@ module.exports = {
   validateRetainedSourceRanges,
   validateReleaseArtifactManifest,
   validateReleaseManifest,
+  validateRecordFamilyAuthorizationSourceCatalog,
   assertCanonicalSurfaceEqual,
 };

--- a/scripts/public-reviews/solidity-reference-lib.cjs
+++ b/scripts/public-reviews/solidity-reference-lib.cjs
@@ -2066,21 +2066,32 @@ function validateRecordFamilyAuthorizationSourceCatalog(sources, artifacts) {
     );
   }
   const uniqueIds = (records, label) => {
-    const ids = records.map((record) => record.id);
+    const ids = records.map((record) =>
+      record && typeof record === "object" ? record.id : null
+    );
     invariant(
       ids.every((id) => Number.isSafeInteger(id) && id > 0) &&
         new Set(ids).size === ids.length,
       `Record-family authorization ${label} identifiers are invalid.`
     );
+    return new Set(ids);
   };
-  uniqueIds(catalog.authorization_classes, "class");
+  const authorizationClassIds = uniqueIds(
+    catalog.authorization_classes,
+    "class"
+  );
   invariant(
     catalog.family_groups.every(
       (family) =>
         typeof family?.name === "string" &&
         /^0x[0-9a-f]{64}$/.test(family?.id) &&
         Array.isArray(family?.allowed_authorization_class_ids) &&
-        family.allowed_authorization_class_ids.length > 0
+        family.allowed_authorization_class_ids.length > 0 &&
+        family.allowed_authorization_class_ids.every(
+          (classId) =>
+            Number.isSafeInteger(classId) &&
+            authorizationClassIds.has(classId)
+        )
     ),
     "Record-family authorization family evidence is malformed."
   );


### PR DESCRIPTION
## Issue

- Stream now publishes typed record-family authorization evidence, but the deterministic public-review generator did not validate that evidence against the release manifest and pinned Solidity blobs.
- A selected semantic artifact could therefore be loaded without proving that its declared source bindings matched the exact review source.

## Fix

- Bind an optional record-family source catalog through its nested release-manifest record.
- Validate its source/candidate status, source blob checksums, authorization classes, family groups, host bindings, tests, and remaining blockers.
- Emit the validated catalog and a compact deterministic validation summary as auditor evidence.
- Keep older review configurations compatible when they predate this artifact.

## Notable Changes

- Add fail-closed record-family source-binding validation to the base-owned generator library.
- Add unit coverage for valid and drifted source hashes plus nested manifest binding.
- No review snapshot, route, runtime UI, or deployment behavior is changed in this PR.

## Validation

- Focused generator unit suite: 18 tests passed.
- The updated generator was also exercised against the pinned Stream `018c8788750980e143c38ace0666684bf641ec4f` corpus: 206 files, 420 definitions, 5,612 declarations, and all eight catalog source bindings validated.
- Changed-file lint and typecheck passed in the consuming snapshot worktree.
- Whitespace check passed.

## Risk

- Level: Medium.
- This changes a protected trust-root parser and must be merged before the data-only snapshot PR is accepted.
- Older configurations remain supported because the additional validation activates only when the artifact is selected.

## Review Notes

- Review the nested manifest lookup, exact checksum comparison, closed evidence-shape checks, and compatibility guard.
- The protected snapshot workflow is expected to require maintainer handling because this PR intentionally changes the base-owned generator; all other CI and bot feedback must be green first.