### PR TITLE
Trust Stream record-family review input

### DIFF
--- a/config/public-reviews/6529-stream.reference.json
+++ b/config/public-reviews/6529-stream.reference.json
@@ -4,8 +4,8 @@
   "reviewVersion": "2026-07-26.1",
   "source": {
     "repository": "6529-Collections/6529Stream",
-    "commit": "e73d4b9cb15c3c868a76b99aa3f438d4e9e75cb8",
-    "tree": "3a8e3cb8102e891a73972282026d2811e7591852",
+    "commit": "513bd7e079eafe109df6ae1ae21bfbca6fec6786",
+    "tree": "b50ec53109f5f8d6b4f4b07f4cb6fd3c1d0e3100",
     "compilerVersion": "0.8.19+commit.7dd6d404",
     "evmVersion": "paris",
     "viaIR": true,
@@ -40,6 +40,10 @@
     {
       "path": "release-artifacts/governed-parameter-inventory.json",
       "schemaVersion": "6529stream.governed-parameter-inventory.v1"
+    },
+    {
+      "path": "release-artifacts/record-family-authorization-source-catalog.json",
+      "schemaVersion": "6529stream.record-family-authorization-source-catalog.v1"
     },
     {
       "path": "release-artifacts/latest/abi-checksums.json",


### PR DESCRIPTION
## Issue

- The base-owned public-review policy does not yet select Stream's record-family authorization source catalog.
- Keeping that selection in the generated-data PR correctly fails the immutable-policy trust check, so the policy extension and data snapshot must remain separate.

## Fix

- Advance the trusted initial Stream input to exact commit `513bd7e079eafe109df6ae1ae21bfbca6fec6786` and tree `b50ec53109f5f8d6b4f4b07f4cb6fd3c1d0e3100`.
- Add the schema-pinned record-family authorization source catalog to the trusted selected-artifact list.

## Changes

- Update only `config/public-reviews/6529-stream.reference.json`.
- Preserve review version `2026-07-26.1`, compiler settings, output policy, and every existing selected artifact.

## Validation

- The config is byte-identical to the independently replayed candidate config used by PR #3472.
- Independent Linux generation and offline check passed at this exact source/tree with official solc `0.8.19+commit.7dd6d404`.
- Replayed config digest: `sha256:3ed7da78731b919186226af8ad9c39e951e3af1bb31e78937105b2762dab7d4c`.
- Changed-file whitespace check passed.

## Risk

- Level: Medium
- Why: This changes a protected generator input policy and source identity, but adds no runtime code or generated data. The selected artifact is already validated by the base-owned schema/source-binding logic merged in #3473.
- Rollback: Revert this config-only commit before accepting a generated snapshot.

## Review Notes

- The protected snapshot-trust check is expected to fail because this PR intentionally changes a trust-root config path; merge only through the explicit maintainer path after ordinary CI and bot review pass.
- PR #3472 must remain blocked until this config lands and its branch merges the resulting base.