### PR TITLE
Wire GIPHY configuration into Release Bus preflight

### DIFF
--- a/.github/workflows/release-bus-v2-preflight.yml
+++ b/.github/workflows/release-bus-v2-preflight.yml
@@ -270,6 +270,7 @@ jobs:
       CORE_SCHEME: core6529
       IPFS_API_ENDPOINT: https://api-ipfs.6529.io
       IPFS_GATEWAY_ENDPOINT: https://ipfs.6529.io
+      GIPHY_API_KEY: ${{ vars.GIPHY_API_KEY }}
       ASSETS_FROM_S3: ${{ matrix.environment == 'production' && 'true' || 'false' }}
       ANNOUNCED_VERSION_ENDPOINT: ${{ matrix.environment == 'production' && 'https://dnclu2fna0b2b.cloudfront.net/web_build/current-production-version.json' || '' }}
     steps:


### PR DESCRIPTION
## Issue

- Release Bus v2 loads its workflow definition from `main`, so candidate changes cannot bootstrap newly required build configuration themselves.
- The dual-profile production package fails closed when `GIPHY_API_KEY` is not supplied.

## Fix

- Expose the existing repository `GIPHY_API_KEY` variable to the Release Bus frontend build matrix.

## Changes

- Add one environment mapping to `.github/workflows/release-bus-v2-preflight.yml`.
- No application code or secret values are included.

## Validation

- Workflow contract suites completed successfully.
- `git diff --check` passed.

## Risk

- Level: Low
- Why: One workflow environment mapping using an existing repository variable.
- Rollback: Revert the single workflow line.

## Review Notes

- This is the bootstrap required before application packaging can safely enforce that the value is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release preflight configuration to provide the GIPHY API key for staging and production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->