### PR TITLE
Render canonical X Article previews

### DIFF
--- a/__tests__/components/waves/TwitterPreviewCard.test.tsx
+++ b/__tests__/components/waves/TwitterPreviewCard.test.tsx
@@ -125,6 +125,53 @@ describe("TwitterPreviewCard", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("renders canonical X Article metadata instead of the redirect URL", async () => {
+    mockedFetchTwitterPreview.mockResolvedValue({
+      tweetId: "2081708447628959923",
+      url: "https://x.com/intrepid_p/status/2081708447628959923",
+      authorName: "Intrepid",
+      authorHandle: "intrepid_p",
+      article: {
+        url: "https://x.com/i/article/2081571498809298944",
+        title: "Intrepid Ocean - Season Two",
+        previewText:
+          "The Intrepid Ocean has taken me through twenty-four countries and territories over four years.",
+        coverImageUrl: "https://pbs.twimg.com/media/HOM6eO9asAAiZJi.jpg",
+      },
+      favoriteCount: 5,
+      conversationCount: 1,
+    });
+
+    const { container } = render(
+      <TwitterPreviewCard
+        href="https://x.com/intrepid_p/status/2081708447628959923"
+        tweetId="2081708447628959923"
+      />
+    );
+
+    await screen.findByTestId("twitter-article-preview");
+
+    expect(screen.getByText("Article")).toBeInTheDocument();
+    expect(screen.queryByText("Post")).not.toBeInTheDocument();
+    expect(screen.getByText("Intrepid Ocean - Season Two")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "The Intrepid Ocean has taken me through twenty-four countries and territories over four years."
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByText("https://t.co/DQJw6K0lUm")).toBeNull();
+    expect(
+      screen.getByRole("link", {
+        name: "Read article: Intrepid Ocean - Season Two",
+      })
+    ).toHaveAttribute("href", "https://x.com/i/article/2081571498809298944");
+    expect(
+      container.querySelector(
+        'img[src="https://pbs.twimg.com/media/HOM6eO9asAAiZJi.jpg"]'
+      )
+    ).toBeInTheDocument();
+  });
+
   it("deduplicates duplicate tweet preview requests by tweet id", async () => {
     mockedFetchTwitterPreview.mockResolvedValue({
       tweetId: "2049202644879565155",

--- a/__tests__/lib/twitter/fetcher.test.ts
+++ b/__tests__/lib/twitter/fetcher.test.ts
@@ -82,6 +82,93 @@ describe("fetchTweetPreview", () => {
     expect(endpoint?.searchParams.get("token")).toBeTruthy();
   });
 
+  it("parses canonical X Article metadata and removes its redirect URL", async () => {
+    const response = {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        __typename: "Tweet",
+        id_str: "2081708447628959923",
+        text: "https://t.co/DQJw6K0lUm",
+        created_at: "2026-07-27T11:49:04.000Z",
+        user: {
+          name: "Intrepid",
+          screen_name: "intrepid_p",
+        },
+        entities: {
+          urls: [
+            {
+              url: "https://t.co/DQJw6K0lUm",
+              expanded_url: "http://x.com/i/article/2081571498809298944",
+            },
+          ],
+        },
+        article: {
+          rest_id: "2081571498809298944",
+          title: "Intrepid Ocean - Season Two",
+          preview_text:
+            "The Intrepid Ocean has taken me through twenty-four countries and territories over four years.",
+          cover_media: {
+            media_info: {
+              original_img_url:
+                "https://pbs.twimg.com/media/HOM6eO9asAAiZJi.jpg",
+            },
+          },
+        },
+      }),
+    };
+    const fetchImpl = jest.fn().mockResolvedValueOnce(response);
+
+    const preview = await fetchTweetPreview(
+      "https://x.com/intrepid_p/status/2081708447628959923",
+      { fetchImpl }
+    );
+
+    expect(preview.text).toBeUndefined();
+    expect(preview).toMatchObject({
+      article: {
+        url: "https://x.com/i/article/2081571498809298944",
+        title: "Intrepid Ocean - Season Two",
+        previewText:
+          "The Intrepid Ocean has taken me through twenty-four countries and territories over four years.",
+        coverImageUrl: "https://pbs.twimg.com/media/HOM6eO9asAAiZJi.jpg",
+      },
+    });
+  });
+
+  it("preserves ordinary post text containing a t.co link", async () => {
+    const response = {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        __typename: "Tweet",
+        id_str: "2081708447628959924",
+        text: "Read this link https://t.co/ordinary",
+        user: {
+          name: "Intrepid",
+          screen_name: "intrepid_p",
+        },
+        entities: {
+          urls: [
+            {
+              url: "https://t.co/ordinary",
+              expanded_url: "https://example.com/story",
+            },
+          ],
+        },
+      }),
+    };
+    const fetchImpl = jest.fn().mockResolvedValueOnce(response);
+
+    const preview = await fetchTweetPreview(
+      "https://x.com/intrepid_p/status/2081708447628959924",
+      { fetchImpl }
+    );
+
+    expect(preview.text).toBe("Read this link https://t.co/ordinary");
+    expect(preview.article).toBeUndefined();
+  });
+
   it("does not treat arbitrary hosts containing twimg.com as Twitter media", async () => {
     const response = {
       ok: true,

--- a/components/waves/TwitterPreviewCard.tsx
+++ b/components/waves/TwitterPreviewCard.tsx
@@ -4,13 +4,12 @@ import { LinkIcon } from "@heroicons/react/24/outline";
 import Link from "next/link";
 import { useMemo, useState, type MouseEvent, type ReactNode } from "react";
 import XIcon from "@/components/user/utils/icons/XIcon";
-import type {
-  TweetPreview,
-  TweetPreviewArticle,
-  TweetPreviewMedia,
-} from "@/lib/twitter";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import { t } from "@/i18n/messages";
+import type { TweetPreview, TweetPreviewMedia } from "@/lib/twitter";
 import { parseTweetUrl } from "@/lib/twitter/url";
 import { useTwitterPreview } from "@/hooks/useTwitterPreview";
+import { TwitterPreviewArticle } from "./twitter-preview/TwitterPreviewArticle";
 import {
   TweetMediaGridVideo,
   TweetVideo,
@@ -362,12 +361,12 @@ function TweetHeader({
 
 function TweetKicker({
   href,
-  isArticle,
+  kindLabel,
   timestamp,
   xPostPath,
 }: {
   readonly href: string;
-  readonly isArticle: boolean;
+  readonly kindLabel: string;
   readonly timestamp: string | undefined;
   readonly xPostPath: string;
 }) {
@@ -377,7 +376,7 @@ function TweetKicker({
         X
       </span>
       <span className="tw-inline-flex tw-items-center tw-rounded-md tw-border tw-border-solid tw-border-sky-400/30 tw-bg-sky-400/10 tw-px-2 tw-py-1 tw-text-[11px] tw-font-semibold tw-leading-none tw-text-sky-100">
-        {isArticle ? "Article" : "Post"}
+        {kindLabel}
       </span>
       <Link
         href={href}
@@ -433,45 +432,6 @@ function TweetBodyText({
         {href || authorName}
       </p>
     </div>
-  );
-}
-
-function TweetArticle({ article }: { readonly article: TweetPreviewArticle }) {
-  return (
-    <Link
-      href={article.url}
-      target="_blank"
-      rel="noopener noreferrer nofollow"
-      onClick={stopCardEvent}
-      aria-label={`Read article: ${article.title}`}
-      className="tw-group tw-block tw-overflow-hidden tw-rounded-lg tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-900/60 tw-text-inherit tw-no-underline tw-transition hover:tw-border-sky-400/40 hover:tw-bg-iron-900"
-      data-testid="twitter-article-preview"
-    >
-      {article.coverImageUrl && (
-        <div className="tw-aspect-video tw-w-full tw-overflow-hidden tw-bg-black">
-          {/* eslint-disable-next-line @next/next/no-img-element -- X cover URLs are validated raw embed assets, matching existing tweet media handling. */}
-          <img
-            src={article.coverImageUrl}
-            alt=""
-            className="tw-h-full tw-w-full tw-object-cover tw-transition tw-duration-300 group-hover:tw-scale-[1.01]"
-            loading="lazy"
-          />
-        </div>
-      )}
-      <div className="tw-flex tw-flex-col tw-gap-y-1.5 tw-p-3">
-        <p className="tw-m-0 tw-text-[11px] tw-font-semibold tw-uppercase tw-leading-4 tw-tracking-wide tw-text-sky-200">
-          Article on X
-        </p>
-        <h3 className="tw-m-0 tw-line-clamp-2 tw-text-base tw-font-semibold tw-leading-6 tw-text-iron-50 group-hover:tw-text-white">
-          {article.title}
-        </h3>
-        {article.previewText && (
-          <p className="tw-m-0 tw-line-clamp-3 tw-text-sm tw-leading-5 tw-text-iron-300">
-            {article.previewText}
-          </p>
-        )}
-      </div>
-    </Link>
   );
 }
 
@@ -687,6 +647,7 @@ export default function TwitterPreviewCard({
   tweetId,
 }: TwitterPreviewCardProps) {
   const [copied, setCopied] = useState(false);
+  const locale = useBrowserLocale();
   const { data: twitterPreview, isLoading } = useTwitterPreview({
     href,
     tweetId,
@@ -753,7 +714,12 @@ export default function TwitterPreviewCard({
       <div className="tw-pointer-events-none tw-relative tw-z-10 tw-flex tw-flex-col tw-gap-y-3 tw-p-3 tw-pl-4 sm:tw-p-4 sm:tw-pl-5 [&_a]:tw-pointer-events-auto [&_button]:tw-pointer-events-auto [&_video]:tw-pointer-events-auto">
         <TweetKicker
           href={href}
-          isArticle={preview.article !== undefined}
+          kindLabel={t(
+            locale,
+            preview.article
+              ? "linkPreview.twitter.kind.article"
+              : "linkPreview.twitter.kind.post"
+          )}
           timestamp={timestamp}
           xPostPath={xPostPath}
         />
@@ -772,7 +738,15 @@ export default function TwitterPreviewCard({
           hasArticle={preview.article !== undefined}
         />
 
-        {preview.article && <TweetArticle article={preview.article} />}
+        {preview.article && (
+          <TwitterPreviewArticle
+            article={preview.article}
+            articleOnXLabel={t(locale, "linkPreview.twitter.article.provider")}
+            readArticleLabel={t(locale, "linkPreview.twitter.article.read", {
+              title: preview.article.title,
+            })}
+          />
+        )}
 
         <TweetMedia authorName={authorName} href={href} preview={preview} />
 

--- a/components/waves/TwitterPreviewCard.tsx
+++ b/components/waves/TwitterPreviewCard.tsx
@@ -4,7 +4,11 @@ import { LinkIcon } from "@heroicons/react/24/outline";
 import Link from "next/link";
 import { useMemo, useState, type MouseEvent, type ReactNode } from "react";
 import XIcon from "@/components/user/utils/icons/XIcon";
-import type { TweetPreview, TweetPreviewMedia } from "@/lib/twitter";
+import type {
+  TweetPreview,
+  TweetPreviewArticle,
+  TweetPreviewMedia,
+} from "@/lib/twitter";
 import { parseTweetUrl } from "@/lib/twitter/url";
 import { useTwitterPreview } from "@/hooks/useTwitterPreview";
 import {
@@ -358,10 +362,12 @@ function TweetHeader({
 
 function TweetKicker({
   href,
+  isArticle,
   timestamp,
   xPostPath,
 }: {
   readonly href: string;
+  readonly isArticle: boolean;
   readonly timestamp: string | undefined;
   readonly xPostPath: string;
 }) {
@@ -371,7 +377,7 @@ function TweetKicker({
         X
       </span>
       <span className="tw-inline-flex tw-items-center tw-rounded-md tw-border tw-border-solid tw-border-sky-400/30 tw-bg-sky-400/10 tw-px-2 tw-py-1 tw-text-[11px] tw-font-semibold tw-leading-none tw-text-sky-100">
-        Post
+        {isArticle ? "Article" : "Post"}
       </span>
       <Link
         href={href}
@@ -388,6 +394,7 @@ function TweetKicker({
 
 function TweetBodyText({
   authorName,
+  hasArticle,
   href,
   replyToHandle,
   text,
@@ -396,6 +403,7 @@ function TweetBodyText({
   readonly href: string;
   readonly replyToHandle: string | undefined;
   readonly text: string | undefined;
+  readonly hasArticle: boolean;
 }) {
   if (text) {
     return (
@@ -412,6 +420,10 @@ function TweetBodyText({
     );
   }
 
+  if (hasArticle) {
+    return null;
+  }
+
   return (
     <div className="tw-flex tw-flex-col tw-gap-y-2">
       <p className="tw-m-0 tw-text-base tw-font-semibold tw-leading-6 tw-text-iron-50">
@@ -421,6 +433,45 @@ function TweetBodyText({
         {href || authorName}
       </p>
     </div>
+  );
+}
+
+function TweetArticle({ article }: { readonly article: TweetPreviewArticle }) {
+  return (
+    <Link
+      href={article.url}
+      target="_blank"
+      rel="noopener noreferrer nofollow"
+      onClick={stopCardEvent}
+      aria-label={`Read article: ${article.title}`}
+      className="tw-group tw-block tw-overflow-hidden tw-rounded-lg tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-900/60 tw-text-inherit tw-no-underline tw-transition hover:tw-border-sky-400/40 hover:tw-bg-iron-900"
+      data-testid="twitter-article-preview"
+    >
+      {article.coverImageUrl && (
+        <div className="tw-aspect-video tw-w-full tw-overflow-hidden tw-bg-black">
+          {/* eslint-disable-next-line @next/next/no-img-element -- X cover URLs are validated raw embed assets, matching existing tweet media handling. */}
+          <img
+            src={article.coverImageUrl}
+            alt=""
+            className="tw-h-full tw-w-full tw-object-cover tw-transition tw-duration-300 group-hover:tw-scale-[1.01]"
+            loading="lazy"
+          />
+        </div>
+      )}
+      <div className="tw-flex tw-flex-col tw-gap-y-1.5 tw-p-3">
+        <p className="tw-m-0 tw-text-[11px] tw-font-semibold tw-uppercase tw-leading-4 tw-tracking-wide tw-text-sky-200">
+          Article on X
+        </p>
+        <h3 className="tw-m-0 tw-line-clamp-2 tw-text-base tw-font-semibold tw-leading-6 tw-text-iron-50 group-hover:tw-text-white">
+          {article.title}
+        </h3>
+        {article.previewText && (
+          <p className="tw-m-0 tw-line-clamp-3 tw-text-sm tw-leading-5 tw-text-iron-300">
+            {article.previewText}
+          </p>
+        )}
+      </div>
+    </Link>
   );
 }
 
@@ -700,7 +751,12 @@ export default function TwitterPreviewCard({
         className="tw-absolute tw-inset-0 tw-z-0 tw-rounded-lg"
       />
       <div className="tw-pointer-events-none tw-relative tw-z-10 tw-flex tw-flex-col tw-gap-y-3 tw-p-3 tw-pl-4 sm:tw-p-4 sm:tw-pl-5 [&_a]:tw-pointer-events-auto [&_button]:tw-pointer-events-auto [&_video]:tw-pointer-events-auto">
-        <TweetKicker href={href} timestamp={timestamp} xPostPath={xPostPath} />
+        <TweetKicker
+          href={href}
+          isArticle={preview.article !== undefined}
+          timestamp={timestamp}
+          xPostPath={xPostPath}
+        />
 
         <TweetHeader
           authorHref={authorHref}
@@ -713,7 +769,10 @@ export default function TwitterPreviewCard({
           href={href}
           replyToHandle={preview.replyToHandle}
           text={preview.text}
+          hasArticle={preview.article !== undefined}
         />
+
+        {preview.article && <TweetArticle article={preview.article} />}
 
         <TweetMedia authorName={authorName} href={href} preview={preview} />
 

--- a/components/waves/twitter-preview/TwitterPreviewArticle.tsx
+++ b/components/waves/twitter-preview/TwitterPreviewArticle.tsx
@@ -1,0 +1,56 @@
+import Link from "next/link";
+import type { MouseEvent } from "react";
+
+import type { TweetPreviewArticle } from "@/lib/twitter";
+
+function stopCardEvent(event: MouseEvent<HTMLElement>) {
+  event.stopPropagation();
+  event.nativeEvent.stopImmediatePropagation();
+}
+
+export function TwitterPreviewArticle({
+  article,
+  articleOnXLabel,
+  readArticleLabel,
+}: {
+  readonly article: TweetPreviewArticle;
+  readonly articleOnXLabel: string;
+  readonly readArticleLabel: string;
+}) {
+  return (
+    <Link
+      href={article.url}
+      target="_blank"
+      rel="noopener noreferrer nofollow"
+      onClick={stopCardEvent}
+      aria-label={readArticleLabel}
+      className="tw-group tw-block tw-overflow-hidden tw-rounded-lg tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-900/60 tw-text-inherit tw-no-underline tw-transition hover:tw-border-sky-400/40 hover:tw-bg-iron-900"
+      data-testid="twitter-article-preview"
+    >
+      {article.coverImageUrl && (
+        <div className="tw-aspect-video tw-w-full tw-overflow-hidden tw-bg-black">
+          {/* eslint-disable-next-line @next/next/no-img-element -- X cover URLs are validated raw embed assets, matching existing tweet media handling. */}
+          <img
+            src={article.coverImageUrl}
+            alt=""
+            className="tw-h-full tw-w-full tw-object-cover tw-transition tw-duration-300 group-hover:tw-scale-[1.01]"
+            loading="lazy"
+          />
+        </div>
+      )}
+      <div className="tw-flex tw-flex-col tw-gap-y-1.5 tw-p-3">
+        <p className="tw-m-0 tw-text-[11px] tw-font-semibold tw-uppercase tw-leading-4 tw-tracking-wide tw-text-sky-200">
+          {articleOnXLabel}
+        </p>
+        <p className="tw-m-0 tw-line-clamp-2 tw-text-base tw-font-semibold tw-leading-6 tw-text-iron-50 group-hover:tw-text-white">
+          {article.title}
+        </p>
+        {article.previewText && (
+          <p className="tw-m-0 tw-line-clamp-3 tw-text-sm tw-leading-5 tw-text-iron-300">
+            {article.previewText}
+          </p>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/i18n/messages/de-DE.ts
+++ b/i18n/messages/de-DE.ts
@@ -8,6 +8,10 @@ import stormComposerDeMessages from "@/i18n/messages/stormComposer.de-DE.json";
 import type { MessageKey } from "@/i18n/messages/en-US";
 
 export const DE_DE_MESSAGES = {
+  "linkPreview.twitter.kind.article": "Artikel",
+  "linkPreview.twitter.kind.post": "Beitrag",
+  "linkPreview.twitter.article.provider": "Artikel auf X",
+  "linkPreview.twitter.article.read": "Artikel lesen: {title}",
   "waves.drop.actions.copyText": "Text kopieren",
   "waves.drop.actions.copyLink": "Link kopieren",
   "waves.drop.actions.copied": "Kopiert!",

--- a/i18n/messages/en-GB.ts
+++ b/i18n/messages/en-GB.ts
@@ -6,6 +6,10 @@ import { TRANSFER_MESSAGES } from "@/i18n/messages/transfer";
 import type { MessageKey } from "@/i18n/messages/en-US";
 
 export const EN_GB_MESSAGES = {
+  "linkPreview.twitter.kind.article": "Article",
+  "linkPreview.twitter.kind.post": "Post",
+  "linkPreview.twitter.article.provider": "Article on X",
+  "linkPreview.twitter.article.read": "Read article: {title}",
   "media.video.captions": "Captions",
   "media.video.download": "Download media",
   "media.video.downloading": "Downloading media",

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -1472,6 +1472,10 @@ const HEADER_SEARCH_MESSAGES = objectMessages("headerSearch", {
 } as const);
 
 export const EN_US_MESSAGES = {
+  "linkPreview.twitter.kind.article": "Article",
+  "linkPreview.twitter.kind.post": "Post",
+  "linkPreview.twitter.article.provider": "Article on X",
+  "linkPreview.twitter.article.read": "Read article: {title}",
   ...IDENTITY_FILTER_MESSAGES,
   ...XTDH_COLLECTION_MESSAGES,
   ...COLLECTION_DELEGATION_MESSAGES,

--- a/i18n/messages/es-ES.ts
+++ b/i18n/messages/es-ES.ts
@@ -8,6 +8,10 @@ import stormComposerEsMessages from "@/i18n/messages/stormComposer.es-ES.json";
 import type { MessageKey } from "@/i18n/messages/en-US";
 
 export const ES_ES_MESSAGES = {
+  "linkPreview.twitter.kind.article": "Artículo",
+  "linkPreview.twitter.kind.post": "Publicación",
+  "linkPreview.twitter.article.provider": "Artículo en X",
+  "linkPreview.twitter.article.read": "Leer artículo: {title}",
   "waves.drop.actions.copyText": "Copiar texto",
   "waves.drop.actions.copyLink": "Copiar enlace",
   "waves.drop.actions.copied": "Copiado!",

--- a/i18n/messages/fr-FR.ts
+++ b/i18n/messages/fr-FR.ts
@@ -8,6 +8,10 @@ import stormComposerFrMessages from "@/i18n/messages/stormComposer.fr-FR.json";
 import type { MessageKey } from "@/i18n/messages/en-US";
 
 export const FR_FR_MESSAGES = {
+  "linkPreview.twitter.kind.article": "Article",
+  "linkPreview.twitter.kind.post": "Publication",
+  "linkPreview.twitter.article.provider": "Article sur X",
+  "linkPreview.twitter.article.read": "Lire l’article : {title}",
   "waves.drop.actions.copyText": "Copier le texte",
   "waves.drop.actions.copyLink": "Copier le lien",
   "waves.drop.actions.copied": "Copie !",

--- a/lib/twitter/article.ts
+++ b/lib/twitter/article.ts
@@ -1,0 +1,104 @@
+import { matchesDomainOrSubdomain } from "@/lib/url/domains";
+
+import { isSafeTwitterImageUrl } from "./media-url";
+import type { TweetPreviewArticle } from "./types";
+
+interface SyndicationArticleResult {
+  readonly article?: TweetPreviewArticle;
+  readonly redirectUrl?: string;
+}
+
+const readRecord = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
+
+const readString = (value: unknown): string | undefined => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const isNumericId = (value: string): boolean => /^\d+$/u.test(value);
+
+const readArticle = (
+  record: Record<string, unknown>
+): TweetPreviewArticle | undefined => {
+  const article = readRecord(record["article"]);
+  const restId = readString(article?.["rest_id"]);
+  const title = readString(article?.["title"]);
+  if (!article || !restId || !isNumericId(restId) || !title) {
+    return undefined;
+  }
+
+  const mediaInfo = readRecord(
+    readRecord(article["cover_media"])?.["media_info"]
+  );
+  const coverImageCandidate = readString(mediaInfo?.["original_img_url"]);
+  const coverImageUrl =
+    coverImageCandidate && isSafeTwitterImageUrl(coverImageCandidate)
+      ? coverImageCandidate
+      : undefined;
+  const previewText = readString(article["preview_text"]);
+
+  return {
+    // X exposes this stable canonical path alongside the numeric article ID.
+    url: `https://x.com/i/article/${restId}`,
+    title,
+    ...(previewText ? { previewText } : {}),
+    ...(coverImageUrl ? { coverImageUrl } : {}),
+  };
+};
+
+const isMatchingArticleEntity = (
+  value: unknown,
+  article: TweetPreviewArticle
+): boolean => {
+  const expandedUrl = readString(readRecord(value)?.["expanded_url"]);
+  if (!expandedUrl) {
+    return false;
+  }
+
+  try {
+    const parsedExpandedUrl = new URL(expandedUrl);
+    const parsedArticleUrl = new URL(article.url);
+    return (
+      matchesDomainOrSubdomain(parsedExpandedUrl.hostname, "x.com") &&
+      parsedExpandedUrl.pathname === parsedArticleUrl.pathname
+    );
+  } catch {
+    return false;
+  }
+};
+
+const findArticleRedirectUrl = (
+  entities: Record<string, unknown>,
+  article: TweetPreviewArticle
+): string | undefined => {
+  const urls: readonly unknown[] = Array.isArray(entities["urls"])
+    ? entities["urls"]
+    : [];
+  const entity = urls.find((candidate) =>
+    isMatchingArticleEntity(candidate, article)
+  );
+  return readString(readRecord(entity)?.["url"]);
+};
+
+export function parseSyndicationArticle(
+  record: Record<string, unknown>,
+  entities: Record<string, unknown>
+): SyndicationArticleResult {
+  const article = readArticle(record);
+  if (!article) {
+    return {};
+  }
+
+  const redirectUrl = findArticleRedirectUrl(entities, article);
+  return {
+    article,
+    ...(redirectUrl ? { redirectUrl } : {}),
+  };
+}

--- a/lib/twitter/fetcher.ts
+++ b/lib/twitter/fetcher.ts
@@ -1,9 +1,9 @@
 import LruTtlCache from "@/lib/cache/lruTtl";
 import { parseTwitterOEmbed } from "./parser";
+import { extractMetaImage } from "./meta";
 import type { TweetPreview, TwitterOEmbedResponse } from "./types";
 import { parseTweetUrl } from "./url";
 import {
-  extractMetaImage,
   findFirstImageUrl,
   getSyndicationToken,
   parseSyndicationPreview,

--- a/lib/twitter/index.ts
+++ b/lib/twitter/index.ts
@@ -2,6 +2,7 @@ export { fetchTweetPreview } from "./fetcher";
 export { parseTweetUrl, TWITTER_DOMAINS } from "./url";
 export type {
   TweetPreview,
+  TweetPreviewArticle,
   TweetPreviewMedia,
   TweetPreviewVideoVariant,
 } from "./types";

--- a/lib/twitter/media-url.ts
+++ b/lib/twitter/media-url.ts
@@ -1,0 +1,38 @@
+import { matchesDomainOrSubdomain } from "@/lib/url/domains";
+
+export const isImageUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+    const pathname = url.pathname.toLowerCase();
+    return (
+      matchesDomainOrSubdomain(url.hostname, "twimg.com") ||
+      pathname.endsWith(".jpg") ||
+      pathname.endsWith(".jpeg") ||
+      pathname.endsWith(".png") ||
+      pathname.endsWith(".webp")
+    );
+  } catch {
+    return false;
+  }
+};
+
+export const isTwitterMediaUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+    return matchesDomainOrSubdomain(url.hostname, "twimg.com");
+  } catch {
+    return false;
+  }
+};
+
+export const isSafeTwitterImageUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "https:" &&
+      matchesDomainOrSubdomain(url.hostname, "twimg.com")
+    );
+  } catch {
+    return false;
+  }
+};

--- a/lib/twitter/meta.ts
+++ b/lib/twitter/meta.ts
@@ -1,0 +1,9 @@
+import { isImageUrl } from "./media-url";
+
+export const extractMetaImage = (html: string): string | undefined => {
+  const match =
+    /<meta[^>]+(?:property|name)=["'](?:og:image|twitter:image|twitter:image:src)["'][^>]+content=["']([^"']+)["'][^>]*>/i.exec(
+      html
+    );
+  return match?.[1] && isImageUrl(match[1]) ? match[1] : undefined;
+};

--- a/lib/twitter/syndication.ts
+++ b/lib/twitter/syndication.ts
@@ -1,8 +1,7 @@
-import { matchesDomainOrSubdomain } from "@/lib/url/domains";
-
+import { parseSyndicationArticle } from "./article";
+import { isImageUrl, isTwitterMediaUrl } from "./media-url";
 import type {
   TweetPreview,
-  TweetPreviewArticle,
   TweetPreviewMedia,
   TweetPreviewVideoVariant,
 } from "./types";
@@ -183,99 +182,6 @@ const excerptTweetText = (text: string | undefined): string | undefined => {
       ? candidate.slice(0, wordBoundaryIndex)
       : candidate;
   return `${trimTrailingPreviewPunctuation(excerpt)}...`;
-};
-
-const isImageUrl = (value: string): boolean => {
-  try {
-    const url = new URL(value);
-    const pathname = url.pathname.toLowerCase();
-    return (
-      matchesDomainOrSubdomain(url.hostname, "twimg.com") ||
-      pathname.endsWith(".jpg") ||
-      pathname.endsWith(".jpeg") ||
-      pathname.endsWith(".png") ||
-      pathname.endsWith(".webp")
-    );
-  } catch {
-    return false;
-  }
-};
-
-const isTwitterMediaUrl = (value: string): boolean => {
-  try {
-    const url = new URL(value);
-    return matchesDomainOrSubdomain(url.hostname, "twimg.com");
-  } catch {
-    return false;
-  }
-};
-
-const isNumericId = (value: string): boolean => /^\d+$/u.test(value);
-
-const readArticle = (
-  record: Record<string, unknown>
-): TweetPreviewArticle | undefined => {
-  const article = readRecord(record["article"]);
-  const restId = readString(article?.["rest_id"]);
-  const title = readString(article?.["title"]);
-  if (!article || !restId || !isNumericId(restId) || !title) {
-    return undefined;
-  }
-
-  const mediaInfo = readRecord(
-    readRecord(article["cover_media"])?.["media_info"]
-  );
-  const coverImageCandidate = readString(mediaInfo?.["original_img_url"]);
-  const coverImageUrl =
-    coverImageCandidate &&
-    isImageUrl(coverImageCandidate) &&
-    isTwitterMediaUrl(coverImageCandidate)
-      ? coverImageCandidate
-      : undefined;
-  const previewText = readString(article["preview_text"]);
-
-  return {
-    url: `https://x.com/i/article/${restId}`,
-    title,
-    ...(previewText ? { previewText } : {}),
-    ...(coverImageUrl ? { coverImageUrl } : {}),
-  };
-};
-
-const isMatchingArticleEntity = (
-  value: unknown,
-  article: TweetPreviewArticle
-): boolean => {
-  const entity = readRecord(value);
-  const expandedUrl = readString(entity?.["expanded_url"]);
-  if (!expandedUrl) {
-    return false;
-  }
-
-  try {
-    const parsedExpandedUrl = new URL(expandedUrl);
-    const parsedArticleUrl = new URL(article.url);
-    return (
-      matchesDomainOrSubdomain(parsedExpandedUrl.hostname, "x.com") &&
-      parsedExpandedUrl.pathname === parsedArticleUrl.pathname
-    );
-  } catch {
-    return false;
-  }
-};
-
-const findArticleRedirectUrl = (
-  entities: Record<string, unknown>,
-  article: TweetPreviewArticle | undefined
-): string | undefined => {
-  if (!article) {
-    return undefined;
-  }
-
-  const entity = readArray(entities["urls"]).find((candidate) =>
-    isMatchingArticleEntity(candidate, article)
-  );
-  return readString(readRecord(entity)?.["url"]);
 };
 
 const findFirstImageInArray = (
@@ -749,14 +655,6 @@ const setPreviewValue = <Key extends keyof TweetPreview>(
   }
 };
 
-export const extractMetaImage = (html: string): string | undefined => {
-  const match =
-    /<meta[^>]+(?:property|name)=["'](?:og:image|twitter:image|twitter:image:src)["'][^>]+content=["']([^"']+)["'][^>]*>/i.exec(
-      html
-    );
-  return match?.[1] && isImageUrl(match[1]) ? match[1] : undefined;
-};
-
 export function parseSyndicationPreview(
   payload: unknown,
   href: string,
@@ -784,8 +682,10 @@ function buildSyndicationPreview(
   const firstMedia = getFirstSyndicationMedia(entities);
   const authorHandle = readString(user["screen_name"]);
   const mediaLink = readString(firstMedia["url"]);
-  const article = readArticle(record);
-  const articleRedirectUrl = findArticleRedirectUrl(entities, article);
+  const { article, redirectUrl: articleRedirectUrl } = parseSyndicationArticle(
+    record,
+    entities
+  );
   const mediaItems = findMediaItems(record);
   const firstImageMedia = findFirstMedia(mediaItems, "image");
   const firstVideoMedia = findFirstMedia(mediaItems, "video");

--- a/lib/twitter/syndication.ts
+++ b/lib/twitter/syndication.ts
@@ -2,6 +2,7 @@ import { matchesDomainOrSubdomain } from "@/lib/url/domains";
 
 import type {
   TweetPreview,
+  TweetPreviewArticle,
   TweetPreviewMedia,
   TweetPreviewVideoVariant,
 } from "./types";
@@ -207,6 +208,74 @@ const isTwitterMediaUrl = (value: string): boolean => {
   } catch {
     return false;
   }
+};
+
+const isNumericId = (value: string): boolean => /^\d+$/u.test(value);
+
+const readArticle = (
+  record: Record<string, unknown>
+): TweetPreviewArticle | undefined => {
+  const article = readRecord(record["article"]);
+  const restId = readString(article?.["rest_id"]);
+  const title = readString(article?.["title"]);
+  if (!article || !restId || !isNumericId(restId) || !title) {
+    return undefined;
+  }
+
+  const mediaInfo = readRecord(
+    readRecord(article["cover_media"])?.["media_info"]
+  );
+  const coverImageCandidate = readString(mediaInfo?.["original_img_url"]);
+  const coverImageUrl =
+    coverImageCandidate &&
+    isImageUrl(coverImageCandidate) &&
+    isTwitterMediaUrl(coverImageCandidate)
+      ? coverImageCandidate
+      : undefined;
+  const previewText = readString(article["preview_text"]);
+
+  return {
+    url: `https://x.com/i/article/${restId}`,
+    title,
+    ...(previewText ? { previewText } : {}),
+    ...(coverImageUrl ? { coverImageUrl } : {}),
+  };
+};
+
+const isMatchingArticleEntity = (
+  value: unknown,
+  article: TweetPreviewArticle
+): boolean => {
+  const entity = readRecord(value);
+  const expandedUrl = readString(entity?.["expanded_url"]);
+  if (!expandedUrl) {
+    return false;
+  }
+
+  try {
+    const parsedExpandedUrl = new URL(expandedUrl);
+    const parsedArticleUrl = new URL(article.url);
+    return (
+      matchesDomainOrSubdomain(parsedExpandedUrl.hostname, "x.com") &&
+      parsedExpandedUrl.pathname === parsedArticleUrl.pathname
+    );
+  } catch {
+    return false;
+  }
+};
+
+const findArticleRedirectUrl = (
+  entities: Record<string, unknown>,
+  article: TweetPreviewArticle | undefined
+): string | undefined => {
+  if (!article) {
+    return undefined;
+  }
+
+  const entity = readArray(entities["urls"]).find((candidate) =>
+    isMatchingArticleEntity(candidate, article)
+  );
+  return readString(readRecord(entity)?.["url"]);
 };
 
 const findFirstImageInArray = (
@@ -715,6 +784,8 @@ function buildSyndicationPreview(
   const firstMedia = getFirstSyndicationMedia(entities);
   const authorHandle = readString(user["screen_name"]);
   const mediaLink = readString(firstMedia["url"]);
+  const article = readArticle(record);
+  const articleRedirectUrl = findArticleRedirectUrl(entities, article);
   const mediaItems = findMediaItems(record);
   const firstImageMedia = findFirstMedia(mediaItems, "image");
   const firstVideoMedia = findFirstMedia(mediaItems, "video");
@@ -749,7 +820,10 @@ function buildSyndicationPreview(
   setPreviewValue(
     preview,
     "text",
-    removeTrailingMediaUrl(previewText, mediaLink)
+    removeTrailingMediaUrl(
+      removeTrailingMediaUrl(previewText, articleRedirectUrl),
+      mediaLink
+    )
   );
   setPreviewValue(preview, "mediaLink", mediaLink);
   setPreviewValue(
@@ -788,6 +862,7 @@ function buildSyndicationPreview(
     readNumberish(record["bookmark_count"])
   );
   setPreviewValue(preview, "viewCount", readNumberish(record["view_count"]));
+  setPreviewValue(preview, "article", article);
 
   return preview;
 }

--- a/lib/twitter/types.ts
+++ b/lib/twitter/types.ts
@@ -16,6 +16,13 @@ export interface TweetPreviewMedia {
   readonly videoVariants?: readonly TweetPreviewVideoVariant[];
 }
 
+export interface TweetPreviewArticle {
+  readonly url: string;
+  readonly title: string;
+  readonly previewText?: string;
+  readonly coverImageUrl?: string;
+}
+
 export interface TweetPreview {
   readonly tweetId: string;
   readonly url: string;
@@ -40,6 +47,7 @@ export interface TweetPreview {
   readonly retweetCount?: number;
   readonly bookmarkCount?: number;
   readonly viewCount?: number;
+  readonly article?: TweetPreviewArticle;
 }
 
 export interface TwitterOEmbedResponse {

--- a/ops/docs/waves/link-previews/feature-twitter-link-previews.md
+++ b/ops/docs/waves/link-previews/feature-twitter-link-previews.md
@@ -50,10 +50,12 @@ Links that do not match these rules stay regular links.
 1. Open a surface with a supported Twitter/X status link.
 2. The renderer validates the link and extracts the tweet ID.
 3. A tweet-shaped loading state appears.
-4. The app requests `/api/twitter/preview`, which fetches
-   `https://publish.twitter.com/oembed` server-side and parses the returned HTML.
-5. If oEmbed metadata loads, the source, author, post text, media, timestamp,
-   and available engagement facts render inline.
+4. The app requests `/api/twitter/preview`, which loads X's server-side
+   syndication metadata and falls back to Twitter oEmbed when needed.
+5. If preview metadata loads, the source, author, post text, media, timestamp,
+   and available engagement facts render inline. X Articles render their
+   canonical title, excerpt, cover image, and article link instead of exposing
+   the raw redirect URL used by X.
 6. Engagement facts are passive labels. The card links to the original post,
    while wave side actions provide open/copy controls where that layout supports
    them.
@@ -63,6 +65,8 @@ Links that do not match these rules stay regular links.
 ## Common Scenarios
 
 - Multiple supported Twitter/X links in one drop each render their own tweet card.
+- X Article posts render as article cards. Commentary added to the post remains
+  visible above the article, while X's article redirect URL is hidden.
 - If previews are hidden for a drop, Twitter/X links stay plain until previews are
   shown again.
 - Hidden previews can be restored from the desktop `More` menu on eligible
@@ -78,6 +82,9 @@ Links that do not match these rules stay regular links.
   regular links.
 - Supported links render with the local Twitter preview card instead of the generic
   OpenGraph card.
+- A post is treated as an X Article only when X's preview payload includes
+  canonical article metadata. Ordinary posts containing `t.co` links keep their
+  existing post and link behavior.
 
 ## Failure and Recovery
 

--- a/ops/docs/waves/link-previews/feature-twitter-link-previews.md
+++ b/ops/docs/waves/link-previews/feature-twitter-link-previews.md
@@ -104,6 +104,18 @@ Links that do not match these rules stay regular links.
 - Real-time X engagement counts are not fetched. Any engagement facts shown come
   from the preview payload and are not interactive X intent actions.
 
+### Localization fallback debt
+
+- Component: `TwitterPreviewCard`.
+- Article-specific labels and accessible names use the supported locale message
+  dictionaries.
+- Remaining post-card copy and date/count formatting still use the card's
+  established `en-US` fallback, so non-English users can see English text around
+  otherwise localized article labels.
+- Ownership and remediation: frontend localization follow-up should migrate the
+  remaining X preview copy and formatting through the shared message and `Intl`
+  helpers as one coherent surface.
+
 ## Related Pages
 
 - [Wave Link Previews Index](README.md)

--- a/pr-reports/3482.md
+++ b/pr-reports/3482.md
@@ -1,0 +1,40 @@
+# PR Report: X Article previews
+
+PR: https://github.com/6529-Collections/6529seize-frontend/pull/3482
+Branch: `agent-prxt/x-article-preview` -> `main`
+Related PRs: None
+
+## Summary
+
+X Article posts now use the canonical article metadata supplied by X instead of
+appearing as generic posts containing only a raw redirect URL.
+
+## What Changed
+
+- Parses canonical article titles, excerpts, cover images, and article IDs from
+  the existing X syndication response.
+- Removes an article redirect from post text only when it explicitly maps to
+  the parsed article.
+- Renders a native article surface within the established X preview card.
+- Preserves ordinary posts and their `t.co` links when no canonical article
+  metadata is present.
+
+## Frontend Impact
+
+- Routes/views: Wave, direct-message, leaderboard, and boosted-drop surfaces
+  that already render X status-link previews.
+- Components: The X preview card gains a dedicated article treatment.
+- Generated API/client: Not affected.
+- User-visible behavior: Article cards show the X Article title, excerpt,
+  cover image, and canonical article link while retaining post commentary and
+  engagement facts.
+
+## Config / Env
+
+None.
+
+## Release Notes
+
+X Articles shared through X status links now have meaningful inline previews.
+Ordinary X posts, replies, quotes, media, links, and unavailable-content
+fallbacks keep their existing behavior.

--- a/pr-reports/3482.md
+++ b/pr-reports/3482.md
@@ -15,7 +15,10 @@ appearing as generic posts containing only a raw redirect URL.
   the existing X syndication response.
 - Removes an article redirect from post text only when it explicitly maps to
   the parsed article.
-- Renders a native article surface within the established X preview card.
+- Keeps article parsing and rendering in focused modules that preserve the
+  repository's file-size debt ratchet.
+- Renders a native, localized article surface within the established X preview
+  card.
 - Preserves ordinary posts and their `t.co` links when no canonical article
   metadata is present.
 


### PR DESCRIPTION
## Issue

- X Article posts render as generic X posts and expose only the raw `t.co` article redirect, so the article is not meaningfully previewed.

## Fix

- Parse X Article metadata already present in the canonical syndication payload and render it through the existing native X preview card.
- Remove only the redirect URL that explicitly maps to the parsed article, preserving ordinary `t.co` links and any post commentary.

## Changes

- Add a typed article preview contract with canonical URL, title, excerpt, and validated X-hosted cover image.
- Label article cards as `Article` and add an inline article surface using the established X card styling and interaction model.
- Keep ordinary post, reply, media, engagement, fallback, and unavailable-content behavior unchanged.
- Update the Wave X preview guide for article behavior and failure boundaries.

## Validation

- Focused X ingestion and card tests (27 tests)
- Changed-file typecheck, lint, formatting, and quality checks
- Full production TypeScript check and test-code typecheck
- React Doctor diff: 100/100
- Documentation link validation

A local development server was not started, per workspace policy.

## Risk

- Level: Low
- Why: The new renderer is gated by X canonical `article` metadata and strict numeric/article host validation; ordinary posts retain the existing path.
- Rollback: Revert this PR to restore the previous generic X post rendering.

## Review Notes

- Please focus on article redirect matching, X-hosted cover validation, and preservation of ordinary `t.co` post text.