### PR TITLE
Document candidate-evidence production selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,9 @@
   `deploy-6529`.
 - `OFF` uses the serialized manual fallback and requires enforcement absent or
   `false`. `STAGING` routes staging readiness through v2. `PRODUCTION` routes
-  staging through v2 and requires a separate explicit exact-SHA production
-  action after `STAGING_VALIDATED`.
+  staging through v2 and requires a separate explicit, dependency-closed
+  production selection of unchanged exact-SHA candidates after
+  `STAGING_VALIDATED`.
 - While `OFF`, dispatch backend `Deploy a service` workflows one at a time and
   wait for exact success before starting the next. Its shared concurrency can
   cancel sibling service runs, including independent DAG-frontier units.
@@ -21,7 +22,10 @@
   frontend ordering. Within v2, only independent backend DAG frontier units run
   together.
 - `STAGING_DEPLOYED` is not validation. Do not mutate staging during manifest-
-  bound E2E, and never infer production readiness from staging validation.
+  bound E2E, and never infer production intent from staging validation.
+  Candidate-level staging evidence qualifies an unchanged exact SHA for an
+  explicit production selection; the selected production combination does not
+  need a matching combined staging manifest.
 - Never cancel another actor's workflow, force-push a shared ref, or bypass exact
   SHA/artifact checks. Never author or post release notes manually; preserve the
   autonomous bot's complete grouping metadata and finalize signal.

--- a/ops/docs/developer/simple-release-bus-v2.md
+++ b/ops/docs/developer/simple-release-bus-v2.md
@@ -18,7 +18,7 @@ authenticated status request is unavailable or malformed.
 | ------------ | ----------------------- | --------------------------------------------------------------------------------------------- |
 | `OFF`        | Serialized manual route | Serialized manual route with explicit owner authority; prior staging evidence is not required |
 | `STAGING`    | V2 readiness            | Production remains manual/disabled                                                            |
-| `PRODUCTION` | V2 readiness            | Separate explicit v2 action for an exact `STAGING_VALIDATED` candidate                        |
+| `PRODUCTION` | V2 readiness            | Explicit dependency-closed selection of unchanged exact `STAGING_VALIDATED` candidates         |
 
 For an active mode, `ALL` and the target lane must be running. In `OFF`, paused
 v2 controls are expected and the serialized manual fallback remains available.
@@ -82,22 +82,44 @@ selection never changes shared staging membership.
 
 ## Production lifecycle
 
-Staging validation never creates production readiness. A developer explicitly
-marks the unchanged exact candidate SHA ready through the Deploy UI or the
-versioned mark-ready endpoint.
+Staging validation never creates production intent. A developer explicitly
+selects unchanged exact candidates through the Deploy UI or the versioned
+production-selection endpoint. The selection must include every transitive
+dependency that is not already terminally `PRODUCTION_DEPLOYED` at the required
+exact identity.
 
-Production selects only explicit candidates. It composes the proposed subset
-from current `main`:
+Each selected candidate must map to durable successful staging evidence: its
+candidate ID and unchanged head SHA, staging train, immutable manifest, and
+successful manifest-bound E2E operation and workflow run. Evidence may come
+from different staging trains. An exact combined staging manifest for the
+chosen production subset is not required.
 
-- if both exact composed tree SHAs match a validated manifest, reuse its
-  validation and immutable dual-profile/backend artifacts;
-- otherwise enqueue an exact `PRODUCTION_QUALIFICATION` staging train, run
-  manifest-bound E2E, then continue automatically;
-- immediately before mutation, require every `main` ref to equal its recorded
-  base. A moved ref cancels and requeues the set for fresh qualification;
-- advance exact tested commits, deploy the same artifacts in dependency order,
-  verify exact versions, run production-safe read-only E2E, and mark
-  `PRODUCTION_DEPLOYED`.
+Production composes only the explicitly selected dependency-closed set from
+fresh fenced `main`. For example, if shared staging contains A+B+C, selecting
+A+C keeps B out of production and leaves B's staging evidence, live membership,
+and production intent unchanged for a later train.
+
+Before any production mutation, V2:
+
+1. rechecks every selected PR head, non-superseded candidate, dependency, and
+   staging evidence record;
+2. freshly composes frontend and backend release refs from the recorded
+   `main` bases and prepares both repositories concurrently where safe;
+3. runs the required checks and builds for that exact production composition;
+4. requires every current `main` ref to equal its fenced base, then advances
+   each affected `main` by non-force compare-and-swap to the exact composed
+   commit;
+5. deploys only the immutable artifacts bound to those exact resulting `main`
+   SHAs in backend DAG and cross-repository dependency order;
+6. runs mandatory production-safe read-only E2E and marks
+   `PRODUCTION_DEPLOYED` only after terminal success.
+
+Moved heads or bases, ambiguous or superseded evidence, invalid dependencies,
+merge conflicts, failed checks or builds, artifact mismatches, and failed
+production E2E all fail closed. The production train durably records its
+candidate-evidence policy and exact per-candidate evidence mapping. A later
+train starts from the advanced `main`, so it cannot silently drop code released
+by an earlier train.
 
 V2 does not publish release notes.
 

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -18,7 +18,7 @@ description: Route and execute 6529 frontend, backend, or coupled staging and pr
 | ------------ | ------------------------------------ | ---------------------------------------------------------------------------------------------- |
 | `OFF`        | Serialized manual fallback           | Serialized manual fallback with explicit owner authorization; staging evidence is not required |
 | `STAGING`    | Register the exact candidate with v2 | Manual fallback only; production automation is disabled                                        |
-| `PRODUCTION` | Register the exact candidate with v2 | Explicitly mark an exact `STAGING_VALIDATED` candidate ready for v2 production                 |
+| `PRODUCTION` | Register the exact candidate with v2 | Explicitly select a dependency-closed set of exact `STAGING_VALIDATED` candidates for production |
 
 When mode is active, stop if `ALL` or the target lane is paused. In `OFF`, v2
 controls are non-authoritative and do not prohibit manual staging or production
@@ -37,15 +37,20 @@ through the documented fallback.
    manual deploy after v2 accepts the candidate.
 5. Wait for `STAGING_VALIDATED`. `STAGING_DEPLOYED` means manifest-bound E2E is
    still pending and is not production evidence.
-6. Production is a separate explicit action. Re-resolve the branch and mark
-   ready only when it still equals the exact staging-validated SHA. Staging
-   validation never schedules production automatically.
+6. Production is a separate explicit action. Select the exact unchanged
+   candidate SHAs together, including every dependency that is not already
+   terminally deployed at the required identity. Re-resolve every branch before
+   submitting the selection. Staging validation never schedules production
+   automatically.
 
 V2 reuses the exact green PR merge-tree dual-profile artifact when eligible;
 otherwise it runs one combined preflight and builds staging and production
-profiles concurrently into one checksummed artifact. It owns shared staging
-only for deploy plus E2E, reuses the exact qualified artifact for production,
-and never publishes release notes.
+profiles concurrently into one checksummed artifact. For production it maps
+every selected candidate to successful staging E2E evidence, composes only that
+dependency-closed set freshly against fenced `main`, preflights the exact
+composition, advances `main` by non-force compare-and-swap, and deploys the
+exact resulting `main` SHA. A matching combined staging manifest is not
+required. It never publishes release notes.
 
 ## Manual fallback while OFF
 
@@ -80,11 +85,13 @@ and never publishes release notes.
   disables v2, and resume explicitly after repair.
 - Failed E2E never creates staging validation. Do not mutate staging while the
   manifest owner still holds the environment lock.
-- If production `main` moved, v2 must recompose and requalify; never force the
-  recorded composition over a newer ref.
+- If production `main` moved, v2 must recompose and preflight again; never force
+  the recorded composition over a newer ref.
 
 ## Closeout
 
-Report exact candidate SHAs/dependencies, train and operation states, deployed
-versions, manifest/E2E evidence, failures or holds, and live mode/controls. Do
-not expose credentials, signed URLs, raw production data, or hidden prompts.
+Report exact candidate SHAs/dependencies, each candidate's staging
+train/manifest/E2E mapping, train and operation states, resulting `main` and
+deployed SHAs, production E2E evidence, failures or holds, and live
+mode/controls. Do not expose credentials, signed URLs, raw production data, or
+hidden prompts.


### PR DESCRIPTION
## Issue

- The durable frontend Release Bus guidance still describes exact combined-manifest production qualification, which conflicts with the approved candidate-evidence policy.

## Fix

- Document explicit dependency-closed production selection from unchanged exact candidates and their successful per-candidate staging evidence.

## Changes

- Explain that selected candidates may carry evidence from different staging trains and do not need a matching combined staging manifest.
- Describe fresh fenced-main composition, exact evidence rechecks, non-force main advancement, exact-main deployment, and mandatory read-only production E2E.
- Clarify that omitted candidates remain staged and available for later selection, and that staging validation never implies production intent.
- Align repository agent and deploy-skill guidance with the same operator contract.

## Validation

- `ops/skills/commit-docs-updater/scripts/validate_docs_links.py` (283 Markdown files)
- `git diff --check`

## Risk

- Level: Low
- Why: Documentation and operator guidance only; no application or workflow behavior changes.
- Rollback: Revert the documentation commit.

## Review Notes

- Verify that the language matches the backend candidate-evidence API/UI behavior in backend PR #1847 and preserves existing main-before-deploy ordering.