### PR TITLE
Compose forward-only staging release commits

### DIFF
--- a/.github/workflows/release-bus-v2-compose.yml
+++ b/.github/workflows/release-bus-v2-compose.yml
@@ -79,8 +79,10 @@ jobs:
             git merge-base --is-ancestor "$BASE_SHA" "$existing"
             if [ -n "${RELEASE_PARENT_SHA:-}" ]; then
               git fetch --no-tags origin "$RELEASE_PARENT_SHA"
-              if [ "$existing" != "$RELEASE_PARENT_SHA" ]; then
-                test "$(git rev-parse "$existing^1")" = "$RELEASE_PARENT_SHA"
+              existing_parent="$(git rev-parse --verify "$existing^1" 2>/dev/null || true)"
+              if [ "$existing_parent" != "$RELEASE_PARENT_SHA" ]; then
+                echo "Existing release branch does not have the recorded staging ref as its first parent" >&2
+                exit 1
               fi
             fi
             excluded='[]'
@@ -95,6 +97,29 @@ jobs:
           git config user.name "$RELEASE_BUS_GIT_NAME"
           git config user.email "$RELEASE_BUS_GIT_EMAIL"
           git switch -c "$RELEASE_BRANCH"
+          if [ -n "${RELEASE_PARENT_SHA:-}" ]; then
+            git fetch --no-tags origin "$RELEASE_PARENT_SHA"
+            case "$RELEASE_BRANCH" in
+              release-bus-v2/rollback-train-*)
+                # Rollback deliberately restores the validated BASE_SHA tree
+                # while retaining the failed release as its first parent.
+                ;;
+              *)
+                # Normal cumulative releases compose on the live staging
+                # parent, then merge current main and every admitted candidate.
+                # This makes content preservation structural, not an assumption
+                # about two independently-composed trees.
+                git reset --hard "$RELEASE_PARENT_SHA"
+                if ! git merge-base --is-ancestor "$BASE_SHA" HEAD; then
+                  git merge --no-ff --no-commit "$BASE_SHA"
+                  git -c core.hooksPath=/dev/null commit -s \
+                    -m "Release Bus v2 train $TRAIN_ID: merge frontend base" \
+                    -m "Base-SHA: $BASE_SHA" \
+                    -m "Release-Bus-v2-Train: $TRAIN_ID"
+                fi
+                ;;
+            esac
+          fi
           excluded='[]'
           while IFS= read -r sha; do
             git fetch --no-tags origin "$sha"
@@ -117,19 +142,23 @@ jobs:
             fi
           done < <(jq -r '.[]' <<< "$CANDIDATE_SHAS")
           scratch_sha="$(git rev-parse HEAD)"
-          if [ -n "${RELEASE_PARENT_SHA:-}" ] && [ "$scratch_sha" != "$RELEASE_PARENT_SHA" ]; then
-            git fetch --no-tags origin "$RELEASE_PARENT_SHA"
+          if [ -n "${RELEASE_PARENT_SHA:-}" ]; then
+            case "$RELEASE_BRANCH" in
+              release-bus-v2/rollback-train-*) ;;
+              *) git merge-base --is-ancestor "$RELEASE_PARENT_SHA" "$scratch_sha" ;;
+            esac
             tree_sha="$(git rev-parse "$scratch_sha^{tree}")"
-            release_sha="$(
-              git commit-tree "$tree_sha" \
-                -p "$RELEASE_PARENT_SHA" \
-                -p "$scratch_sha" \
-                -m "Release Bus v2 train $TRAIN_ID: bind frontend staging release" \
-                -m "Release-Parent-SHA: $RELEASE_PARENT_SHA" \
-                -m "Release-Composition-SHA: $scratch_sha" \
-                -m "Release-Bus-v2-Train: $TRAIN_ID" \
-                -m "Signed-off-by: $RELEASE_BUS_GIT_NAME <$RELEASE_BUS_GIT_EMAIL>"
-            )"
+            parent_args=(-p "$RELEASE_PARENT_SHA")
+            if [ "$scratch_sha" != "$RELEASE_PARENT_SHA" ]; then
+              parent_args+=(-p "$scratch_sha")
+            fi
+            release_sha="$(git commit-tree "$tree_sha" \
+              "${parent_args[@]}" \
+              -m "Release Bus v2 train $TRAIN_ID: bind frontend staging release" \
+              -m "Release-Parent-SHA: $RELEASE_PARENT_SHA" \
+              -m "Release-Composition-SHA: $scratch_sha" \
+              -m "Release-Bus-v2-Train: $TRAIN_ID" \
+              -m "Signed-off-by: $RELEASE_BUS_GIT_NAME <$RELEASE_BUS_GIT_EMAIL>")"
             git reset --hard "$release_sha"
           fi
           git fsck --no-dangling

--- a/.github/workflows/release-bus-v2-compose.yml
+++ b/.github/workflows/release-bus-v2-compose.yml
@@ -10,6 +10,7 @@ on:
       expected_sha: { type: string, required: true }
       candidate_shas: { type: string, required: true }
       release_branch: { type: string, required: true }
+      release_parent_sha: { type: string, required: false, default: "" }
 
 permissions:
   contents: read
@@ -28,6 +29,7 @@ jobs:
           EXPECTED_SHA: ${{ inputs.expected_sha }}
           OPERATION_KEY: ${{ inputs.operation_key }}
           RELEASE_BRANCH: ${{ inputs.release_branch }}
+          RELEASE_PARENT_SHA: ${{ inputs.release_parent_sha }}
           TRAIN_ID: ${{ inputs.release_train_id }}
         run: |
           set -euo pipefail
@@ -35,7 +37,8 @@ jobs:
           test "$BASE_SHA" = "$EXPECTED_SHA"
           [[ "$TRAIN_ID" =~ ^[A-Za-z0-9._-]{1,100}$ ]]
           [[ "$OPERATION_KEY" =~ ^rb2:[A-Za-z0-9:._-]+:a[1-9][0-9]*$ ]]
-          [[ "$RELEASE_BRANCH" =~ ^release-bus-v2/(staging|production|qualification)-train-[A-Za-z0-9._-]+$ ]]
+          [[ "$RELEASE_BRANCH" =~ ^release-bus-v2/(staging|production|qualification|rollback)-train-[A-Za-z0-9._-]+$ ]]
+          test -z "$RELEASE_PARENT_SHA" || [[ "$RELEASE_PARENT_SHA" =~ ^[a-f0-9]{40}$ ]]
           jq -e 'type == "array" and length > 0 and all(.[]; test("^[a-f0-9]{40}$"))' <<< "$CANDIDATE_SHAS"
       - name: Authorize exact v2 operation
         env:
@@ -64,6 +67,7 @@ jobs:
           BASE_SHA: ${{ inputs.base_sha }}
           CANDIDATE_SHAS: ${{ inputs.candidate_shas }}
           RELEASE_BRANCH: ${{ inputs.release_branch }}
+          RELEASE_PARENT_SHA: ${{ inputs.release_parent_sha }}
           RELEASE_BUS_GIT_EMAIL: ${{ vars.RELEASE_BUS_GIT_EMAIL || 'release-bus@users.noreply.github.com' }}
           RELEASE_BUS_GIT_NAME: ${{ vars.RELEASE_BUS_GIT_NAME || '6529 Release Bus' }}
           TRAIN_ID: ${{ inputs.release_train_id }}
@@ -73,6 +77,12 @@ jobs:
           if [ -n "$existing" ]; then
             git fetch --no-tags origin "$existing"
             git merge-base --is-ancestor "$BASE_SHA" "$existing"
+            if [ -n "${RELEASE_PARENT_SHA:-}" ]; then
+              git fetch --no-tags origin "$RELEASE_PARENT_SHA"
+              if [ "$existing" != "$RELEASE_PARENT_SHA" ]; then
+                test "$(git rev-parse "$existing^1")" = "$RELEASE_PARENT_SHA"
+              fi
+            fi
             excluded='[]'
             while IFS= read -r sha; do
               if ! git merge-base --is-ancestor "$sha" "$existing"; then
@@ -88,6 +98,14 @@ jobs:
           excluded='[]'
           while IFS= read -r sha; do
             git fetch --no-tags origin "$sha"
+            ancestor_status=0
+            git merge-base --is-ancestor "$sha" HEAD || ancestor_status=$?
+            if [ "$ancestor_status" -eq 0 ]; then
+              continue
+            fi
+            if [ "$ancestor_status" -ne 1 ]; then
+              exit "$ancestor_status"
+            fi
             if git merge --no-ff --no-commit "$sha"; then
               git -c core.hooksPath=/dev/null commit -s \
                 -m "Release Bus v2 train $TRAIN_ID: merge frontend candidate" \
@@ -98,6 +116,22 @@ jobs:
               excluded="$(jq -c --arg sha "$sha" '. + [$sha]' <<< "$excluded")"
             fi
           done < <(jq -r '.[]' <<< "$CANDIDATE_SHAS")
+          scratch_sha="$(git rev-parse HEAD)"
+          if [ -n "${RELEASE_PARENT_SHA:-}" ] && [ "$scratch_sha" != "$RELEASE_PARENT_SHA" ]; then
+            git fetch --no-tags origin "$RELEASE_PARENT_SHA"
+            tree_sha="$(git rev-parse "$scratch_sha^{tree}")"
+            release_sha="$(
+              git commit-tree "$tree_sha" \
+                -p "$RELEASE_PARENT_SHA" \
+                -p "$scratch_sha" \
+                -m "Release Bus v2 train $TRAIN_ID: bind frontend staging release" \
+                -m "Release-Parent-SHA: $RELEASE_PARENT_SHA" \
+                -m "Release-Composition-SHA: $scratch_sha" \
+                -m "Release-Bus-v2-Train: $TRAIN_ID" \
+                -m "Signed-off-by: $RELEASE_BUS_GIT_NAME <$RELEASE_BUS_GIT_EMAIL>"
+            )"
+            git reset --hard "$release_sha"
+          fi
           git fsck --no-dangling
           jq -n --arg composed_sha "$(git rev-parse HEAD)" --argjson excluded_shas "$excluded" '{composed_sha:$composed_sha,excluded_shas:$excluded_shas,reused:false}' > "$RUNNER_TEMP/composition.json"
       - name: Create scoped GitHub App token

--- a/__tests__/scripts/release-bus-v2-compose-workflow.test.ts
+++ b/__tests__/scripts/release-bus-v2-compose-workflow.test.ts
@@ -22,6 +22,8 @@ function composeScript(): string {
     path.join(process.cwd(), ".github/workflows/release-bus-v2-compose.yml"),
     "utf8"
   );
+  // This executes the workflow's shell verbatim; keep the expression coupled
+  // to the YAML step indentation so formatting drift fails the test loudly.
   const match = workflow.match(
     /\n {8}id: compose\n[\s\S]*?\n {8}run: \|\n([\s\S]*?)(?=\n {6}- )/
   );
@@ -122,6 +124,83 @@ describe("Release Bus v2 frontend composition workflow", () => {
         excluded_shas: [],
         reused: false,
       });
+
+      const releaseBranch = "release-bus-v2/staging-train-cumulative-frontend";
+      git(
+        repository,
+        "push",
+        "origin",
+        `${releaseSha}:refs/heads/${releaseBranch}`
+      );
+      git(repository, "switch", "main");
+      execFileSync("bash", ["-c", composeScript()], {
+        cwd: repository,
+        env: {
+          ...process.env,
+          BASE_SHA: baseSha,
+          CANDIDATE_SHAS: JSON.stringify([stagingParentSha, candidateSha]),
+          RELEASE_BRANCH: releaseBranch,
+          RELEASE_BUS_GIT_EMAIL: "release-bus-test@example.com",
+          RELEASE_BUS_GIT_NAME: "Release Bus Test",
+          RELEASE_PARENT_SHA: stagingParentSha,
+          RUNNER_TEMP: runnerTemp,
+          TRAIN_ID: "cumulative",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      expect(
+        JSON.parse(
+          readFileSync(path.join(runnerTemp, "composition.json"), "utf8")
+        )
+      ).toEqual({
+        composed_sha: releaseSha,
+        excluded_shas: [],
+        reused: true,
+      });
+
+      expect(() =>
+        execFileSync("bash", ["-c", composeScript()], {
+          cwd: repository,
+          env: {
+            ...process.env,
+            BASE_SHA: baseSha,
+            CANDIDATE_SHAS: JSON.stringify([stagingParentSha, candidateSha]),
+            RELEASE_BRANCH: releaseBranch,
+            RELEASE_BUS_GIT_EMAIL: "release-bus-test@example.com",
+            RELEASE_BUS_GIT_NAME: "Release Bus Test",
+            RELEASE_PARENT_SHA: baseSha,
+            RUNNER_TEMP: runnerTemp,
+            TRAIN_ID: "wrong-parent",
+          },
+          stdio: ["ignore", "pipe", "pipe"],
+        })
+      ).toThrow();
+
+      git(repository, "switch", "--detach", stagingParentSha);
+      execFileSync("bash", ["-c", composeScript()], {
+        cwd: repository,
+        env: {
+          ...process.env,
+          BASE_SHA: stagingParentSha,
+          CANDIDATE_SHAS: JSON.stringify([stagingParentSha]),
+          RELEASE_BRANCH:
+            "release-bus-v2/staging-train-empty-cumulative-frontend",
+          RELEASE_BUS_GIT_EMAIL: "release-bus-test@example.com",
+          RELEASE_BUS_GIT_NAME: "Release Bus Test",
+          RELEASE_PARENT_SHA: stagingParentSha,
+          RUNNER_TEMP: runnerTemp,
+          TRAIN_ID: "empty-cumulative",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const emptyReleaseSha = git(repository, "rev-parse", "HEAD");
+      expect(emptyReleaseSha).not.toBe(stagingParentSha);
+      expect(
+        git(repository, "rev-list", "--parents", "-n", "1", emptyReleaseSha)
+      ).toBe(`${emptyReleaseSha} ${stagingParentSha}`);
+      expect(
+        git(repository, "show", "-s", "--format=%B", emptyReleaseSha)
+      ).toContain(`Release-Parent-SHA: ${stagingParentSha}`);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/__tests__/scripts/release-bus-v2-compose-workflow.test.ts
+++ b/__tests__/scripts/release-bus-v2-compose-workflow.test.ts
@@ -1,0 +1,129 @@
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function composeScript(): string {
+  const workflow = readFileSync(
+    path.join(process.cwd(), ".github/workflows/release-bus-v2-compose.yml"),
+    "utf8"
+  );
+  const match = workflow.match(
+    /\n {8}id: compose\n[\s\S]*?\n {8}run: \|\n([\s\S]*?)(?=\n {6}- )/
+  );
+  if (!match) {
+    throw new Error("Compose workflow script was not found");
+  }
+  return match[1]!
+    .split("\n")
+    .map((line) => line.replace(/^ {10}/, ""))
+    .join("\n");
+}
+
+describe("Release Bus v2 frontend composition workflow", () => {
+  it("accepts immutable rollback branches for forward-only staging recovery", () => {
+    const workflow = readFileSync(
+      path.join(process.cwd(), ".github/workflows/release-bus-v2-compose.yml"),
+      "utf8"
+    );
+    expect(workflow).toContain(
+      "(staging|production|qualification|rollback)-train-"
+    );
+  });
+
+  it("creates a cumulative release whose first parent is exact staging", () => {
+    const root = mkdtempSync(
+      path.join(tmpdir(), "release-bus-v2-frontend-compose-")
+    );
+    const origin = path.join(root, "origin.git");
+    const repository = path.join(root, "repository");
+    const runnerTemp = path.join(root, "runner-temp");
+
+    try {
+      execFileSync("git", ["init", "--bare", origin]);
+      execFileSync("git", ["init", "--initial-branch=main", repository]);
+      mkdirSync(runnerTemp);
+      git(repository, "config", "user.name", "Release Bus Test");
+      git(repository, "config", "user.email", "release-bus-test@example.com");
+      git(repository, "remote", "add", "origin", origin);
+      writeFileSync(path.join(repository, "main.txt"), "main\n");
+      git(repository, "add", "main.txt");
+      git(repository, "commit", "-m", "main");
+      const baseSha = git(repository, "rev-parse", "HEAD");
+      git(repository, "push", "origin", "main");
+
+      git(repository, "switch", "-c", "staging-parent", baseSha);
+      writeFileSync(path.join(repository, "candidate-a.txt"), "candidate a\n");
+      git(repository, "add", "candidate-a.txt");
+      git(repository, "commit", "-m", "candidate a");
+      const stagingParentSha = git(repository, "rev-parse", "HEAD");
+      git(repository, "push", "origin", "staging-parent");
+
+      git(repository, "switch", "-c", "candidate-b", baseSha);
+      writeFileSync(path.join(repository, "candidate-b.txt"), "candidate b\n");
+      git(repository, "add", "candidate-b.txt");
+      git(repository, "commit", "-m", "candidate b");
+      const candidateSha = git(repository, "rev-parse", "HEAD");
+      git(repository, "push", "origin", "candidate-b");
+      git(repository, "switch", "main");
+
+      execFileSync("bash", ["-c", composeScript()], {
+        cwd: repository,
+        env: {
+          ...process.env,
+          BASE_SHA: baseSha,
+          CANDIDATE_SHAS: JSON.stringify([stagingParentSha, candidateSha]),
+          RELEASE_BRANCH: "release-bus-v2/staging-train-cumulative-frontend",
+          RELEASE_BUS_GIT_EMAIL: "release-bus-test@example.com",
+          RELEASE_BUS_GIT_NAME: "Release Bus Test",
+          RELEASE_PARENT_SHA: stagingParentSha,
+          RUNNER_TEMP: runnerTemp,
+          TRAIN_ID: "cumulative",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+      const releaseSha = git(repository, "rev-parse", "HEAD");
+      const parents = git(
+        repository,
+        "rev-list",
+        "--parents",
+        "-n",
+        "1",
+        releaseSha
+      ).split(" ");
+      expect(parents[1]).toBe(stagingParentSha);
+      expect(git(repository, "show", `${releaseSha}:candidate-a.txt`)).toBe(
+        "candidate a"
+      );
+      expect(git(repository, "show", `${releaseSha}:candidate-b.txt`)).toBe(
+        "candidate b"
+      );
+      expect(
+        JSON.parse(
+          readFileSync(path.join(runnerTemp, "composition.json"), "utf8")
+        )
+      ).toEqual({
+        composed_sha: releaseSha,
+        excluded_shas: [],
+        reused: false,
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/ops/docs/developer/simple-release-bus-v2.md
+++ b/ops/docs/developer/simple-release-bus-v2.md
@@ -52,7 +52,10 @@ register backend first and declare it as the frontend prerequisite.
    Frontend staging/production profiles build concurrently into one checksummed
    dual-profile artifact. For an affected repository, the staging release
    commit has the recorded current `1a-staging` SHA as its first parent and the
-   dependency-closed composition as its second parent.
+   dependency-closed composition as its second parent. Normal staging
+   composition starts from that recorded parent and merges current `main` plus
+   every admitted candidate; only rollback deliberately binds a last-validated
+   replacement tree.
 4. Preparation may finish while another train owns staging.
 5. The train acquires the staging lock and repeats the idle/ref snapshot.
 6. Before deployment, every affected `1a-staging` ref advances to the immutable

--- a/ops/docs/developer/simple-release-bus-v2.md
+++ b/ops/docs/developer/simple-release-bus-v2.md
@@ -50,16 +50,30 @@ register backend first and declare it as the frontend prerequisite.
 3. A single exact PR merge-tree artifact is reused when eligible. Otherwise,
    each application runs one combined sharded preflight and one immutable build.
    Frontend staging/production profiles build concurrently into one checksummed
-   dual-profile artifact.
+   dual-profile artifact. For an affected repository, the staging release
+   commit has the recorded current `1a-staging` SHA as its first parent and the
+   dependency-closed composition as its second parent.
 4. Preparation may finish while another train owns staging.
-5. The train acquires the staging lock only for deployment plus E2E.
-6. Independent backend DAG frontier units deploy concurrently; dependency edges
+5. The train acquires the staging lock and repeats the idle/ref snapshot.
+6. Before deployment, every affected `1a-staging` ref advances to the immutable
+   release commit through a non-force compare-and-swap from its recorded base.
+   Unaffected repositories do not move. A stale or moved ref starts no train
+   deployment and pauses only staging for serialized recovery.
+7. Independent backend DAG frontier units deploy concurrently; dependency edges
    serialize only required units. Dependent frontend deploys after backend.
-7. The controller persists `STAGING_DEPLOYED` with exact SHAs, artifact digests,
+8. The controller persists `STAGING_DEPLOYED` with exact SHAs, artifact digests,
    services, operation runs, and timings.
-8. E2E receives and authorizes against that manifest identity. Staging remains
-   locked until E2E is terminal.
-9. Only E2E success produces `STAGING_VALIDATED`.
+9. E2E runs from an immutable ref at the exact frontend release SHA and receives
+   the paired manifest identity. Staging remains locked until E2E is terminal.
+10. Only E2E success plus exact agreement among both `1a-staging` refs, runtime
+    evidence, the manifest, and E2E produces `STAGING_VALIDATED`.
+
+Ref advances are durable and retry-safe. A crash after CAS resumes by observing
+the exact target and continues with the same deployment idempotency keys. A
+post-CAS deployment or E2E failure cannot validate; rollback creates a new
+forward-only restore commit with the last validated tree, advances
+`1a-staging` by non-force CAS, deploys that exact commit, and requires rollback
+E2E. Recovery never force-pushes a shared ref backward.
 
 `STAGING_DEPLOYED` and `STAGING_VALIDATED` are separate milestones.
 `STAGING_VALIDATED` is historical certification; it is not a current-presence
@@ -103,13 +117,13 @@ V2 does not publish release notes.
 
 ## Failure behavior
 
-| Class                | Behavior                                                                             |
-| -------------------- | ------------------------------------------------------------------------------------ |
-| Candidate merge/test | Before shared mutation, fail closed and leave the last validated admitted manifest live; mark only the new direct candidate `NEEDS_REBASE` as applicable |
-| Infrastructure       | Bounded idempotent retry; no candidate isolation                                     |
-| Retryable deployment | Retry only the failed operation; preserve successful sibling evidence                |
-| Control plane        | Fail the train, requeue candidates, pause automated claiming, retain manual fallback |
-| E2E                  | Keep the failed manifest unvalidated and restore, deploy, and E2E the exact last validated live manifest under the same staging lock before committing any membership change |
+| Class                | Behavior                                                                                                                                                                                                 |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Candidate merge/test | Before shared mutation, fail closed and leave the last validated admitted manifest live; mark only the new direct candidate `NEEDS_REBASE` as applicable                                                 |
+| Infrastructure       | Bounded idempotent retry; no candidate isolation                                                                                                                                                         |
+| Retryable deployment | Retry only the failed operation at the same release SHA and idempotency key; preserve successful sibling evidence                                                                                        |
+| Control plane        | Fail the train, requeue candidates, pause automated claiming, retain manual fallback                                                                                                                     |
+| E2E                  | Keep the failed manifest unvalidated and forward-CAS, deploy, and E2E an immutable restore commit with the exact last validated tree under the same staging lock before committing any membership change |
 
 Every pending GitHub status must map to a visible candidate/train/operation state
 and recovery message. Duplicate callbacks and worker invocations reuse immutable


### PR DESCRIPTION
## Issue

- The frontend composition workflow could build the exact cumulative candidate tree, but it could not bind that tree to the current managed `1a-staging` head for a safe forward-only CAS.
- Forward-only rollback branches were also rejected by the workflow's immutable branch validator.

## Fix

- Accept an optional exact `release_parent_sha` and create a release commit whose first parent is that staging SHA and whose tree is the dependency-closed composition.
- Validate an existing immutable release branch against the exact first parent on retry.
- Accept immutable rollback branches so recovery can move shared staging forward to a restore commit instead of rewinding it.

## Changes

- Extend `release-bus-v2-compose.yml` with the release-parent input, first-parent validation, ancestor skipping, and deterministic `git commit-tree` release binding.
- Add an executable workflow regression proving the resulting commit contains cumulative A+B while first-parenting exact staging.
- Document CAS-before-deploy parity, durable crash recovery, and forward-only rollback in the durable operations guide.

## Validation

- `./bin/6529 run check:changed`
- `./bin/6529 run typecheck:jest`
- `./bin/6529 run test -- --runInBand __tests__/scripts/release-bus-v2-compose-workflow.test.ts` — 2 tests passed
- Prettier check for all changed files
- Composition workflow YAML parse
- `git diff --check`

## Risk

- Level: Medium
- Why: the application bundle is unchanged, but this expands an operational workflow contract used by the Release Bus controller.
- Rollback: pause `STAGING`, keep the backend controller undeployed or restore its prior version, and revert this workflow change. Existing callers that omit `release_parent_sha` retain the prior composition behavior.

## Review Notes

- Backend companion: 6529-Collections/6529seize-backend#1848. Merge this frontend workflow contract first.
- No frontend application deployment is required after merge.
- Focus on first-parent identity, immutable retry validation, DCO provenance, and rollback branch validation.
- This does not add a Reset Staging control or alter production qualification policy.
