### PR TITLE
docs: preload Stream review editorial 2026-07-27.1

### DIFF
--- a/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/artwork-lifecycle.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/artwork-lifecycle.md
@@ -1,0 +1,411 @@
+# Artwork lifecycle
+
+This review covers an incomplete, undeployed candidate; [Current Implementation and Readiness](./security-testing-and-known-limitations) is the authoritative record of what is connected, implemented, proposed, and still required.
+
+A Stream artwork moves through a sequence of deliberate commitments. Collection
+identity comes first. Artwork materials, distribution, payment, randomness, and
+metadata are then assembled around it. Supply and Core configuration can later
+be closed, preservation evidence can accumulate, and a final ceremony can make
+the remaining artwork state terminal.
+
+That sequence is a major part of the design. “Minted,” “sold,” “frozen,”
+“preserved,” and “final” describe different facts. Treating them as one state
+would make the system simpler to name and harder to reason about.
+
+This page follows one collection through the lifecycle and explains what each
+stage protects.
+
+## 1. The collection receives a permanent identity
+
+An authorized caller creates a collection through
+[`StreamCore.createCollection`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L336).
+The Core assigns the collection ID and stores its descriptive collection
+information.
+[`setCollectionData`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L379)
+separately records the artist address, maximum collection purchases, total
+supply, and final-supply delay.
+
+The identity exists before a sale or mint opens. That separation matters: a
+collection should not acquire its identity from whichever sale mechanism
+happens to distribute its first token.
+
+Stream uses one shared ERC-721 Core for many native collections. Tokens receive
+globally sequential IDs and collection-local serials, allowing a work to be
+identified both in the protocol as a whole and within its artist collection.
+
+## 2. The artwork package is assembled
+
+An artwork package can include:
+
+- collection information;
+- token-specific data;
+- scripts and their order;
+- images, animation, and attributes;
+- dependency names, versions, bytes, and locations;
+- a metadata mode;
+- a randomness provider and policy;
+- maximum supply and mint rules;
+- sale terms;
+- revenue recipients;
+- preservation and finality manifests.
+
+Different modules hold different parts because those parts have different
+change horizons. Token identity belongs in the permanent Core. A browser
+dependency, sale module, or randomness provider may need a successor years
+later.
+
+The authority to write each part is as important as the value itself.
+Collection metadata and preservation records use record-family checks so that
+an artist statement, owner statement, institutional attestation, independent
+observation, rights record, and archive record do not all inherit the same
+writer merely because they are “metadata.”
+
+## 3. The artist can approve a specific state
+
+The current artist-approval mechanism accepts signatures from ordinary accounts
+and ERC-1271 contract wallets. Its EIP-712 domain binds the chain and Core
+contract. The signed collection-state hash binds:
+
+- artist address;
+- collection-freeze manifest hash;
+- maximum collection purchases;
+- collection total supply;
+- final-supply delay.
+
+The typed fields are defined in
+[`StreamArtistApprovals`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamArtistApprovals.sol#L8-L21)
+and assembled from Core state in
+[`_hashArtistApproval`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L1631-L1639).
+
+If a bound field changes, the earlier signature no longer describes the
+current state. This makes approval version-specific rather than a reusable
+statement that can be attached to later terms.
+
+Artist approval and administrative authority remain distinct. The current
+approval is not a universal veto over every metadata, freeze, governance, or
+finality action. Deciding which transitions need fresh artist consent is one of
+the central questions of this review.
+
+## 4. A distribution policy is selected
+
+Stream separates permanent token rules from replaceable distribution policy.
+That allows a one-of-one sale, fixed edition, free claim, airdrop, or future
+mechanism to use the same Core identity without placing every possible sale
+profile in the permanent contract.
+
+The reviewed source contains two mint lanes with different responsibilities.
+The signed Drop and current auction route use `StreamMinter`, which applies its
+own time and supply checks before calling the legacy Core mint entry.
+[`StreamDrops._executeFixedPriceDrop`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L609-L632)
+and
+[`StreamMinter.mint`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMinter.sol#L130-L175)
+show that path.
+
+The source also contains a manager-and-ledger lane.
+[`StreamMintManager`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMintManager.sol)
+defines phases, executors, gates, time windows, supply constraints, and counter
+policies.
+[`StreamMintLedger`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMintLedger.sol)
+keeps usage across wallets, recipients, tokens, authorizers, and policy
+contexts so replacing a manager need not erase historical limits.
+
+These lanes should not be mentally merged. Every supported sale profile needs
+one explicit caller sequence, one counter model, and one Core entry.
+
+## 5. Curation becomes a bound authorization
+
+For a 6529 drop, an offchain process applies the relevant curation or TDH rules
+and constructs an EIP-712 authorization. The configured signer then signs the
+exact payload.
+
+The payload binds values including:
+
+- chain and verifying contract;
+- signer epoch;
+- collection;
+- payer and token recipient;
+- quantity;
+- price or auction terms;
+- token-data hash;
+- deadline;
+- sale mode;
+- replay identifier.
+
+Solidity verifies that authorization. It does not calculate TDH, choose the
+artist, or decide whether the community process was fair. Its responsibility is
+to prevent the submitted transaction from becoming a different action from the
+one that was signed.
+
+A valid authorization can drive a fixed-price execution or register an English
+auction, depending on the bound sale mode.
+
+## 6. The selected mint lane executes atomically
+
+The legacy lane checks its configured pause, collection time window, and supply
+before calling Core.
+
+The manager lane has a more explicit composition sequence. It validates the
+active phase, executor, optional gate, policy hash, and counters, then performs
+a prepared mint through:
+
+- [`prepareMintFromManager`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L492-L518);
+- [`completePreparedMintFromManager`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L520-L550).
+
+[`StreamMintManager.mintPrepared`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMintManager.sol#L241-L299)
+consumes counters and calls the Core entries in one transaction. If a later
+check fails, transaction rollback restores the earlier state.
+
+The lifecycle invariant is larger than “the token was not minted.” After a
+revert, supply reservations, counters, replay identifiers, credits, and token
+state must all return to one coherent result.
+
+## 7. The token receives an identity that is not reused
+
+The Core allocates a global token ID, associates it with the collection, and
+records its collection-local serial. Supply is tracked as minted-ever history,
+not merely as the number of tokens currently held.
+
+That distinction lets the protocol preserve the fact that a token existed even
+if the owner later burns it. A burned identifier is not returned to the
+allocation pool.
+
+## 8. Randomness enters a recorded lifecycle
+
+If the collection uses randomness, minting creates a request bound to the
+token, collection, provider address, and provider epoch.
+
+The request can be:
+
+1. pending;
+2. fulfilled;
+3. marked stale;
+4. left with failed post-processing after provider output was accepted.
+
+The lifecycle stores the provider request ID, request and fulfillment times,
+derived seed, hash of the raw provider output, failure hash, and retry count.
+The final seed binds the provider, request, collection, token, epoch, and raw
+output commitment.
+
+If writing an accepted seed into Core fails, the retry path uses the same
+derived seed. It does not ask the provider for a new result. This distinction
+protects a technical recovery from becoming a redraw.
+
+Provider delay, stale handling, post-processing failure, provider migration,
+and token burn can intersect. Those transitions are why randomness is modeled
+as a state machine rather than a function that simply “gets a number.”
+
+## 9. Metadata turns stored state into an artwork description
+
+`tokenURI` is produced from the collection's metadata mode and the token's
+current state. Depending on the work, the renderer can combine collection
+information, scripts, token data, dependencies, images, attributes, and
+randomness output.
+
+Metadata availability and artwork finality are different:
+
+- Randomness can leave metadata pending.
+- A data URI can contain JSON while the JSON still points to external bytes.
+- A script can be onchain while its browser or dependencies remain external.
+- A content hash can verify retrieved bytes without making those bytes
+  retrievable.
+
+The protocol therefore needs both an accurate `tokenURI` and a broader
+description of what is required to reconstruct the artwork.
+
+## 10. Sale value becomes explicit liabilities
+
+A paid fixed-price sale and an English auction both place value under contract
+control. The accounting model uses credits and pull withdrawals rather than
+making sale progress depend on every recipient accepting ETH during the
+transaction.
+
+In the current native fixed-price path, `StreamDrops` selects a token,
+collection, or contract-default proceeds split and creates poster, protocol,
+and curator-reserve credits. The auction contract separately accounts for
+poster, protocol, curator, and bidder credits.
+
+The exact native fixed-price credit path is in
+[`_creditFixedPriceProceeds`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L635-L680).
+Auction proceeds are handled by
+[`AuctionContract._creditAuctionProceeds`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol#L471-L508).
+
+The repository also contains a revenue resolver, deterministic split-wallet
+factory, split wallets, an asset-policy registry, and a primary-sale settlement
+contract. Their purpose is to make revenue precedence, recipients, supported
+assets, and settlement identity explicit outside the sale modules.
+
+Whichever accounting path is used, the invariant is the same: every credited
+unit must have one source, one owner, and sufficient backing, and emergency
+surplus must exclude all liabilities.
+
+## 11. An auction reaches a terminal outcome
+
+Auction registration mints the token into contract custody. Bids establish a
+leader and amount. A displaced bidder receives a withdrawal credit rather than
+an inline refund that could block the next bid.
+
+After the end time, any caller may trigger settlement because the caller does
+not choose the winner, price, recipient, or proceeds. Those values are already
+fixed by state.
+
+With a winner, settlement credits proceeds and transfers the token from
+custody. With no bids, the token returns to the poster or follows the
+contract-poster claim path. Cancellation is available only within the defined
+pre-bid boundary.
+
+The lifecycle must make each outcome terminal: settled with a winner, settled
+without a bid, or cancelled. No path should settle, refund, or transfer the
+same auction twice.
+
+## 12. A token may be burned without erasing its history
+
+[`StreamCore.burn`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L631)
+removes the live ERC-721 ownership record. The token ID remains consumed and
+the protocol retains burn audit information.
+
+Burn has consequences beyond ownership. Reviewers must trace its interaction
+with:
+
+- pending or fulfilled randomness;
+- sale settlement and credits;
+- minted-ever and live supply;
+- metadata and preservation records;
+- curator and revenue accounting;
+- finality;
+- offchain indexes.
+
+A protocol that preserves provenance should let future readers distinguish
+“never existed” from “minted and later burned.”
+
+## 13. Supply is closed
+
+Supply closure is intended to establish that no further tokens may enter the
+collection. It is based on minted-ever history and is separate from whether
+scripts, metadata, or other artwork state can still change.
+
+Closing supply must cover every mint route, phase, executor, authorization, and
+auction path. A signed action prepared before closure must not become a hidden
+way to mint afterward.
+
+The final value should be visible in state and events, including the case where
+the collection closes before minting any token.
+
+## 14. The permanent Core boundary is frozen
+
+[`freezeCollection`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L827)
+checks collection existence, required data, timing, supply, and pending metadata
+conditions. It records a freeze-manifest commitment and permanently rejects the
+Core mutations within its freeze boundary.
+
+Core freeze closes minting, burn, artist-approval changes, randomizer changes,
+and covered live-token or collection metadata mutations. Ordinary ERC-721
+transfers remain possible. Append-only preservation records and some
+post-freeze evidence operations remain separate.
+
+This is why “collection frozen” needs an exact field and selector inventory.
+Core freeze protects the permanent collection boundary; it is not a synonym
+for terminal artwork finality across every module.
+
+## 15. Preservation evidence remains available to grow
+
+Preservation records can commit hashes, locations, manifests, signatures, and
+other typed evidence about the materials needed to understand or reproduce the
+work.
+
+They are append-only rather than overwriteable. An older record remains part
+of history even when a later record becomes the current `latest` record for its
+type and subject. That allows a future archive or institution to add recovery
+evidence without rewriting the package the artist originally finalized.
+
+A commitment is not storage. Long-term preservation still requires the bytes,
+independent retrieval, operating storage providers, and enough runtime
+information to execute the work.
+
+## 16. Artwork finality becomes a visible ceremony
+
+[`StreamArtworkFinalityRegistry`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamArtworkFinalityRegistry.sol)
+defines a delayed finality process with scheduling, execution windows,
+cancellation or veto, component manifests, and terminal state.
+
+The delay gives the artist, collectors, guardians, and independent reviewers
+time to inspect:
+
+- the exact collection and one-of-one manifests;
+- the files, dependencies, and content hashes they cover;
+- the proposed execution time and expiry;
+- the artist approval;
+- every mutation path the terminal state is expected to close.
+
+Execution should apply the same payload that was visible during the waiting
+period. A guardian can stop a suspicious proposal but should not be able to
+replace its artistic commitments. A cancelled or expired proposal should
+require a new identity and fresh approval.
+
+The ceremony exists because irreversibility deserves a reviewable boundary, not
+a surprise administrative transaction.
+
+## 17. Successor modules can carry future duties
+
+Over decades, a renderer, storage route, randomness integration, or operational
+module may fail or become obsolete. Stream's long-term model records module
+identity, code hashes, interfaces, status, and successor relationships.
+
+A successor does not rewrite the predecessor or the token's Core history. It
+changes which replaceable module is recognized for a future duty.
+
+A safe transition must answer:
+
+- Which new actions route to the successor?
+- Which liabilities and pending work remain with the predecessor?
+- Which state is shared, read, migrated, or intentionally left behind?
+- Can both modules act at the same time?
+- Do signatures, nonces, counters, or replay keys cross the boundary?
+- Which old artwork commitments remain binding?
+
+This is the final lifecycle responsibility: preserve the artwork's identity
+while making the evolution of surrounding infrastructure explicit.
+
+## Design position
+
+A collector should be able to understand this lifecycle without reconstructing
+transaction traces. The product should show whether a token is awaiting
+randomness, whether metadata is complete, whether supply is closed, whether
+the Core boundary is frozen, which preservation package applies, and whether
+terminal artwork finality has occurred.
+
+Those states should never be collapsed into one “immutable” badge. Stream's
+sophistication is valuable only if the lifecycle becomes more legible to
+artists and collectors, not merely more detailed in Solidity.
+
+## Failure modes reviewers should test
+
+- a collection is created with the wrong artist, supply, or module pointers;
+- an artist signs a human-readable package that does not match the hashed state;
+- a signed authorization is stolen, stale, replayed, or incorrectly assembled;
+- a mint failure restores the token but not its counters, replay state, or
+  credits;
+- overlapping phases or executors exceed the intended supply;
+- a randomness provider delays, fails, or leaves a token in an unrecoverable
+  state;
+- metadata is correctly hashed but unavailable or impossible to execute;
+- sale liabilities become unbacked or a hostile recipient blocks withdrawal;
+- burn erases provenance or restores an allowance unintentionally;
+- supply closes while another mint path remains open;
+- Core freeze leaves an unexpected alternate mutation path;
+- a finality proposal binds the wrong manifest or rereads mutable values at
+  execution;
+- a successor duplicates authority, replay state, or liabilities.
+
+## Questions for reviewers
+
+1. Is every stage necessary, and is its purpose understandable without Solidity
+   knowledge?
+2. Which transitions require an artist signature in addition to protocol
+   governance?
+3. Which failures should revert atomically, and which should enter a visible
+   recoverable state?
+4. Are supply closure, Core freeze, preservation, and artwork finality separated
+   clearly enough?
+5. Which burn and provenance records must remain readable forever?
+6. What evidence must be published before terminal finality can be scheduled?
+7. What invariants must hold before a successor module becomes current?

--- a/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/community-review.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/community-review.md
@@ -1,0 +1,324 @@
+# How to participate in the community review
+
+This review covers an incomplete, undeployed candidate; [Current Implementation and Readiness](./security-testing-and-known-limitations) is the authoritative record of what is connected, implemented, proposed, and still required.
+
+Community review is where Stream's architectural claim is pressure-tested: does
+this system produce clearer artist consent, stronger permanence, safer
+evolution, and better public accountability than a simpler mint contract?
+
+The objective is to improve the protocol before its permanent boundaries are
+fixed, not to collect endorsements. A useful contribution can support a design,
+challenge it, identify an implementation error, expose an assumption, or show
+that an explanation does not match how an artist or collector would understand
+it.
+
+The reviewed source is
+[`513bd7e079eafe109df6ae1ae21bfbca6fec6786`](https://github.com/6529-Collections/6529Stream/tree/513bd7e079eafe109df6ae1ae21bfbca6fec6786).
+The review version is `2026-07-27.1`. Check both values before commenting so
+the discussion remains attached to the code it examined.
+
+## Who should comment
+
+This review needs different kinds of expertise:
+
+- **Artists** can decide whether approvals, mutation boundaries, preservation,
+  recovery, and finality match a real artistic practice.
+- **Collectors** can test whether ownership, artwork access, sale terms, trust,
+  and long-term state are understandable.
+- **Solidity engineers** can trace authorization, accounting, state
+  transitions, reentrancy, replay, and cross-contract invariants.
+- **Protocol designers** can challenge the permanent Core, module, governance,
+  pause, and successor boundaries.
+- **Auditors and security researchers** can build hypotheses, reproduce
+  failures, and identify missing evidence.
+- **Frontend and product reviewers** can find cases where the interface could
+  cause a person to approve or pay for something different from what the
+  contract will do.
+- **Storage, browser, metadata, indexing, and infrastructure engineers** can
+  test assumptions that Solidity cannot establish.
+- **Accessibility and localization reviewers** can identify explanations or
+  workflows that exclude people.
+- **Community members** can ask whether the stated architecture matches 6529's
+  values and whether the tradeoffs are worth making permanent.
+
+You do not need to read Solidity to identify an unclear promise, unfair
+workflow, missing recovery case, unacceptable authority, or term that means
+something different to an ordinary reader.
+
+## Start from the page you are reading
+
+Each review page has a feedback composer. Submitting from that page records the
+review version and page context so another reviewer can find the relevant
+discussion.
+
+When a page links to generated code, feedback can also reference a specific
+contract, interface, function, event, error, or source range. Technical
+references use stable semantic keys derived from the pinned source rather than
+positions in a list.
+
+The discussion is written to the Stream review subwave. It is a public part of
+the review record, not a private support ticket.
+
+If a report spans several modules, submit it from the page that best represents
+the primary issue and link the other relevant code or pages. Important failures
+often occur between two individually reasonable modules.
+
+## Choose the closest feedback type
+
+The type describes the principal contribution:
+
+- **Question** — something is unclear or needs an authoritative answer.
+- **Documentation** — an explanation is inaccurate, incomplete, or difficult
+  to understand.
+- **Artist workflow** — approval, metadata, preservation, sale, recovery, or
+  finality does not work for an artist's real process.
+- **Product or UX** — an interaction, state, consequence, or recovery path is
+  confusing.
+- **Protocol design** — a role, boundary, invariant, lifecycle, or permanent
+  choice should change.
+- **Implementation bug** — the Solidity appears not to implement the stated
+  behavior.
+- **Possible exploitable security vulnerability** — a path may permit theft,
+  unauthorized mutation, permanent lock, manipulation, takeover, or another
+  security failure.
+- **Testing or evidence gap** — an important property lacks a reproducible test
+  or operational proof.
+- **Accessibility or localization** — the review or intended product excludes
+  a class of users.
+
+Choose the best fit rather than trying to encode every consequence in the type.
+The report itself can explain how the issue crosses categories.
+
+## Assess likely impact
+
+Severity is a starting signal, not a final verdict:
+
+- **Critical** — credible loss of all or substantial assets, permanent
+  unauthorized artwork change, protocol-wide takeover, or comparable impact.
+- **High** — serious asset, authorization, availability, or finality failure
+  with a plausible path.
+- **Medium** — meaningful failure with narrower impact, stronger preconditions,
+  or a practical workaround.
+- **Low** — limited impact or a defense-in-depth issue.
+- **Informational** — clarification, convention, maintainability, or evidence
+  improvement.
+- **Not assessed** — use this when the impact is uncertain.
+
+Do not make an observation less precise to force it into a severity. Describe
+the facts, assumptions, and uncertainty. Reviewers and maintainers can revise
+the assessment after reproduction and discussion.
+
+## Write a useful report
+
+A strong report answers as many of these questions as the submitter can:
+
+1. What did you expect?
+2. What does the pinned code or review page do instead?
+3. Which collection, token, role, module, field, or lifecycle state is
+   involved?
+4. What must an actor control or do?
+5. What is the likely consequence?
+6. Can you reproduce it with a call sequence, transaction, test, or example?
+7. Is the issue prevented or reduced elsewhere?
+8. Which assumptions remain uncertain?
+9. What fix or design alternative should be considered?
+
+Short reports are welcome. A precise question can expose a missing
+specification before it becomes a code defect.
+
+For a product or documentation issue, include the wording or screen state that
+created the misunderstanding and the conclusion a reasonable reader might draw.
+For an artist-workflow issue, describe the actual studio, collaborator,
+signing, preservation, or estate process the design fails to serve.
+
+## Reference code precisely
+
+Prefer a generated Technical Reference link because it carries the review
+version and semantic declaration identity.
+
+If you use GitHub, link to the exact reviewed commit rather than `main`. For a
+cross-contract issue:
+
+- link every important function or definition;
+- describe the order of calls;
+- identify storage or accounting that crosses the boundary;
+- state which transaction steps revert together and which survive;
+- include the test, script, or configuration needed to reproduce the path.
+
+A report about an upgrade, successor, pause, or finality bypass should include
+every alternate selector or module that can reach the same effect.
+
+## The structured review record
+
+Each submission carries four machine-readable metadata fields:
+
+- `review_schema` — the schema version used to decode the report;
+- `type` — the feedback category;
+- `severity` — the submitter's initial impact assessment;
+- `context` — review, version, page, section, submission, and optional code
+  references.
+
+The visible comment remains ordinary human language. The structured fields make
+reports filterable, exportable, deduplicable, and traceable to the exact page
+and code without asking future reviewers to infer that context from prose.
+
+For this review version, feedback schema version `1` uses these values:
+
+- `type`: `question`, `documentation`, `artist-workflow`, `product-or-ux`,
+  `protocol-design`, `implementation-bug`,
+  `possible-exploitable-security-vulnerability`,
+  `testing-or-evidence-gap`, or `accessibility-or-localization`;
+- `severity`: `critical`, `high`, `medium`, `low`, `informational`, or
+  `not-assessed`.
+
+`context` is canonical JSON. Optional properties are omitted when they do not
+apply rather than filled with placeholder values.
+
+## What happens after submission
+
+Every new top-level structured report enters the review ledger in a
+deterministic `NEW` state. Replies remain in the linked Wave discussion.
+
+`NEW` means the report exists. It does not mean the report is accepted,
+rejected, confirmed, fixed, or assigned a final severity.
+
+The initial ledger does not infer an authoritative disposition from free-form
+conversation. When an official resolution is recorded, it should identify:
+
+- the disposition;
+- who made it and under which authority;
+- the source commit or design decision that resolves the report;
+- a regression test or other verification where applicable;
+- any remaining risk;
+- the review version in which the resolution appears.
+
+This preserves the difference between a community hypothesis, a reproduced
+finding, an accepted design change, and a verified fix.
+
+## When the source changes
+
+The active review points to one exact commit. A later candidate receives a new
+immutable review-data bundle and version-specific routes. Earlier explanations,
+source links, and reports remain available.
+
+For each new candidate, the review system should:
+
+1. compile and inventory the exact new Git tree;
+2. validate declarations against compiler output;
+3. publish a new immutable bundle;
+4. retain the older version and its source links;
+5. attach new feedback to the version it examined;
+6. record which earlier reports still apply, were fixed, or need
+   re-evaluation.
+
+Automated structural diffs and formal carry-forward dispositions are not
+available in this first review version. Until they are, compare the pinned
+versions directly and state which code each conclusion examined.
+
+## What the generated reference establishes
+
+The generated Technical Reference compiles the pinned Solidity corpus and
+extracts the definitions, functions, events, errors, signatures, selectors,
+source ranges, and documentation visible to the compiler.
+
+It establishes that the published inventory corresponds to the pinned source.
+It does not establish that:
+
+- the implementation matches the intended specification;
+- a function is safe in composition;
+- the deployment is initialized correctly;
+- an external provider will operate reliably;
+- an economic or governance assumption is acceptable.
+
+The inventory supports human review, static analysis, tests, and audit. It does
+not replace them.
+
+## What to review
+
+Useful feedback can address:
+
+- artist identity, consent, delegation, recovery, and estates;
+- curation, TDH, authorization construction, signer custody, and replay;
+- shared collection identity, supply, mint phases, gates, and counters;
+- fixed-price sales, auction custody, bids, extensions, refunds, and
+  settlement;
+- collaborators, split profiles, curator rewards, accounting, and royalties;
+- randomness providers, failure states, retries, migration, and reserves;
+- metadata modes, scripts, dependencies, encoding, and browser behavior;
+- preservation, manifests, Core freeze, and artwork finality;
+- roles, pauses, governance action binding, guardians, and successors;
+- threat model, tests, deployment evidence, and release criteria;
+- whether the total system is more complex than the requirements justify;
+- whether the explanations make that complexity legible.
+
+The best review does not assume that complexity is either proof of
+sophistication or evidence of failure. It asks what each mechanism protects,
+whether that protection belongs onchain, and whether the same result can be
+achieved with a smaller authority or state surface.
+
+## Public conduct and sensitive information
+
+Be direct about code and design, and civil toward people. Disagreement about
+severity, architecture, and permanence is expected.
+
+Do not post:
+
+- private keys, seed phrases, credentials, cookies, or API keys;
+- personal information unnecessary to the report;
+- secrets from unrelated systems;
+- instructions or data for attacking a live system outside this review;
+- copyrighted material not needed to establish the issue.
+
+Under this review version's published disclosure policy, a possible
+exploitable vulnerability in Stream may be described publicly in the review
+Wave. If the same technique affects another live protocol, limit the Stream
+report to Stream and coordinate the separate disclosure responsibly.
+
+## For auditors
+
+The review is designed to be exportable without scraping meaning from rendered
+pages. The immutable generated bundle, editorial manifest, structured Wave
+metadata, pinned source, and review ledger form the audit-support package.
+
+Auditors should be able to:
+
+- reproduce the compiler inventory;
+- enumerate every code-linked report;
+- filter by module, declaration, type, severity, and disposition;
+- identify reports that cross review versions;
+- distinguish community hypotheses from validated findings;
+- verify official replies, source changes, and regression evidence;
+- recover the exact explanation shown when a comment was submitted.
+
+Public review can improve the specification, reveal assumptions, and find
+important defects. It does not replace independent expert audit of the exact
+release candidate and deployment configuration.
+
+## Closing the review
+
+At closeout, the team should publish:
+
+- final candidate commit and Git tree;
+- every review version and available structural diff;
+- feedback counts by type and disposition;
+- unresolved questions and accepted risks;
+- fix commits and regression evidence;
+- audit reports and remediation status;
+- deployment-blocker checklist;
+- machine-readable archive of the review record.
+
+Closing feedback marks the boundary used to prepare a release candidate. It
+does not erase the discussion or detach a report from the source it examined.
+
+## Questions for reviewers
+
+1. Can an artist or collector identify the right place to comment without
+   understanding the contract structure?
+2. Are the feedback types and severity choices sufficient?
+3. What context should be captured automatically with every code reference?
+4. Which official dispositions and authority rules should the ledger support?
+5. How should unresolved reports carry forward when the source commit changes?
+6. What export format would be most useful to auditors?
+7. Which explanation remains too technical for a non-Solidity reader?
+8. Does this process invite genuine disagreement about whether Stream's
+   complexity is justified?

--- a/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/curation-and-tdh-authorization.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/curation-and-tdh-authorization.md
@@ -1,0 +1,323 @@
+# Community curation, TDH, and signed authorization
+
+This review covers an incomplete, undeployed candidate; [Current Implementation and Readiness](./security-testing-and-known-limitations) is the authoritative record of what is connected, implemented, proposed, and still required.
+
+Stream converts a social curation decision into a cryptographically bound
+action. The community process remains offchain; once its result is signed, the
+collection, participants, economics, timing, and sale mode cannot quietly drift
+during execution.
+
+**TDH means Total Days Held.** It is 6529's time-weighted measure of how long
+eligible assets have been held, not a token or value stored by Stream. The
+[TDH guide](/network/tdh) explains the calculation and categories.
+
+The decisive boundary is:
+
+**TDH and curation are calculated outside Solidity. Stream verifies a signed
+authorization for the resulting action.**
+
+The contract does not choose an artist, measure TDH, hold an onchain TDH vote,
+or decide that a work crossed a community threshold. Its job is to receive an
+exact authorized action and enforce the parts of that action that Solidity can
+verify.
+
+## From a community decision to a contract call
+
+A typical flow is:
+
+1. an offchain process applies the published curation or TDH rules;
+2. a service constructs the exact mint or auction authorization;
+3. the configured signer signs the EIP-712 payload;
+4. the payer or another caller submits that signed payload to Stream;
+5. Stream verifies the signature, signer epoch, deadline, replay state, and
+   bound values;
+6. Stream executes only the sale mode and parameters contained in the
+   authorization.
+
+The first two steps are social and operational. The signature is the bridge.
+The remaining steps are cryptographic and contractual.
+
+This division allows community judgment to remain flexible without making the
+onchain result vague. It also makes the signer and the authorization-building
+service important trust boundaries that must be visible to artists and
+collectors.
+
+## The exact authorization
+
+The signed drop path in
+[`StreamDrops.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L24-L60)
+uses EIP-712 typed data. Its domain binds the chain ID and verifying contract.
+The signed `DropAuthorization` contains:
+
+| Field                 | What it fixes                                                    |
+| --------------------- | ---------------------------------------------------------------- |
+| `dropId`              | The authorization identity consumed or cancelled by the contract |
+| `poster`              | The sale poster and current native-sale proceeds recipient       |
+| `recipient`           | The account that receives the token                              |
+| `payer`               | The account allowed to fund the execution                        |
+| `collectionId`        | The collection that may be minted or auctioned                   |
+| `saleMode`            | Fixed price or auction                                           |
+| `tokenDataHash`       | The hash of the token data supplied at execution                 |
+| `price`               | The fixed-price amount                                           |
+| `quantity`            | The authorized quantity                                          |
+| `auctionReservePrice` | The minimum auction price                                        |
+| `auctionEndTime`      | The intended auction end                                         |
+| `salt`                | Additional signed uniqueness                                     |
+| `nonce`               | Signer-scoped sequence input used to derive the drop identity    |
+| `deadline`            | The last valid execution time                                    |
+| `signerEpoch`         | The signing-key era that must still be current                   |
+
+Reviewers should compare the typed-data definition, Solidity encoding, offchain
+construction code, wallet display, and emitted events byte for byte. A field
+that appears in only one of those layers can create a gap between what the
+community approved, what the signer signed, what a payer saw, and what the
+contract executed.
+
+## Why each field exists
+
+### Chain and verifying contract
+
+A chain-and-contract domain prevents a valid payload intended for one Stream
+deployment from being accepted on another chain or by another contract.
+
+### Signer epoch
+
+A signer epoch gives rotation a clear boundary. A payload from an earlier
+signing era should not become current merely because the old public key still
+verifies a signature.
+
+Epochs also make incident response legible. When a signer is replaced,
+reviewers can ask whether prior payloads expire immediately, survive for a
+grace period, or remain valid only after another explicit action.
+
+### Payer and recipient
+
+The account providing funds and the account receiving the token may differ.
+Binding both supports sponsored or delegated purchases without letting a copied
+transaction redirect the artwork or charge an unintended payer.
+
+### Collection and token data
+
+An authorization for one collection must not mint into another. The
+`tokenDataHash` binds the supplied token data so execution cannot substitute a
+different artwork input while retaining the rest of the signed terms.
+
+### Quantity
+
+The structure contains a quantity field, but the current Drop validation
+requires `quantity == 1`. One consumed Drop authorization therefore authorizes
+one token, not a multi-token batch.
+
+See
+[`StreamDrops._validateAuthorization`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L561-L581).
+
+An edition can contain many tokens, but this path needs a separate
+authorization for each one. The UI should describe the actual execution path
+rather than infer batch behavior from the existence of a field.
+
+### Price and sale mode
+
+A fixed-price authorization must not become an auction registration, and a
+free claim must not become a paid sale. The current signed paths are native-ETH
+paths; the authorization has no token-address field. Any future
+token-denominated path would need to bind the asset as well as the amount.
+
+### Auction terms
+
+The reserve and intended end time connect the curation decision to the initial
+auction state. They do not replace the auction contract's later custody, bid,
+extension, cancellation, refund, and settlement rules.
+
+### Deadline
+
+A deadline limits how long a signed action can remain useful. A generous
+deadline improves operational reliability while increasing the exposure window
+if a payload leaks or the community decision changes.
+
+### Replay identity
+
+A successful authorization must not be reusable for an unintended second sale.
+The replay identity, cancellation state, signer epoch, and transaction rollback
+must continue to agree under failed execution, rotation, and concurrent
+submission.
+
+## EOA and contract-wallet signers
+
+The signing system supports ordinary ECDSA accounts and ERC-1271 contract
+wallets. ERC-1271 permits a Safe or another smart account to authorize the
+payload, which can improve key management and shared control.
+
+It also adds an explicit assumption: a contract wallet's owners, threshold, and
+validation behavior can change.
+
+The public signing record should identify:
+
+- signing address;
+- whether it is an ordinary account or contract wallet;
+- Safe threshold and owner policy where applicable;
+- current signer epoch;
+- rotation and emergency-revocation procedure;
+- monitoring for unexpected authorizations;
+- software version that constructed the typed data.
+
+Private keys, seed phrases, and recovery secrets never belong in that record.
+
+## Fixed-price execution
+
+A valid fixed-price authorization can describe a free or paid mint. Before
+minting, the current path checks:
+
+- Drop pause state;
+- replay and cancellation state;
+- token-data hash;
+- deadline;
+- payer and recipient;
+- quantity;
+- sale mode;
+- native payment;
+- mint time and supply rules;
+- Core freeze state.
+
+Signature validity does not override those checks. If execution fails, the
+transaction reverts rather than leaving a partially consumed authorization and
+partially minted token.
+
+A free authorization still needs identity, recipient, replay, deadline, phase,
+and supply protection. Removing payment does not remove policy.
+
+## Auction registration
+
+An auction-mode authorization registers the intended auction parameters. The
+auction contract then owns custody and governs bidding, extensions,
+cancellation, refunds, and settlement.
+
+The signed payload is the bridge between the curation decision and the initial
+auction state. It is not itself a bid, and it should not remain replayable as a
+second auction.
+
+Once an auction is registered, reviewers should distinguish signer authority
+from auction state. Rotating a signer or cancelling an unused authorization
+does not automatically answer what should happen to a token already in auction
+custody or to bids already placed.
+
+## Cancellation, consumption, and rotation
+
+The protocol includes authorization cancellation and signer-epoch rotation.
+The complete lifecycle should make the following observable:
+
+- who may cancel;
+- whether cancellation applies to one authorization, one drop identity, or a
+  broader set;
+- when consumed state is written;
+- whether a failed transaction consumes anything;
+- how rotation affects already issued payloads;
+- whether old-epoch payloads have a grace period;
+- what happens to an auction registered before rotation;
+- which events reconstruct every cancellation and epoch change.
+
+Cancellation is part of the public promise. A website hiding a payload is not
+equivalent to an onchain cancellation.
+
+## Transaction ordering and MEV
+
+The repository includes MEV-timing and EIP-712 tests. Binding payer, recipient,
+collection, price, quantity, mode, deadline, and token data limits what a copied
+transaction can change.
+
+That does not remove every ordering effect. A public mempool can still affect:
+
+- who submits first;
+- when a transaction is observed;
+- whether it lands before a deadline;
+- whether another bid arrives first;
+- which block timestamp applies.
+
+The authorization should bind every sensitive outcome that must not be changed
+by copying or relaying. The product should not promise ordering guarantees that
+Ethereum itself does not provide.
+
+## What the authorization cannot establish
+
+Stream can verify that the configured signer authorized the exact typed
+payload. It cannot establish that:
+
+- the offchain TDH calculation was correct;
+- the curation policy was applied fairly;
+- the community intended the payload produced by the service;
+- the signer was not mistaken, coerced, or compromised;
+- the artist saw an accurate rendering of the terms;
+- an operator retained the evidence supporting the decision.
+
+Those claims require transparent offchain records, reproducible calculations,
+operational controls, and accountable signers.
+
+This is not a weakness that can be solved by adding a field to Solidity. It is
+the boundary between a community decision and the contract that faithfully
+executes it.
+
+## The authorization receipt
+
+Every authorized drop should have a public, human-readable receipt containing:
+
+- curation rule and version;
+- relevant offchain decision identifier;
+- collection and artist identity;
+- typed payload in readable and canonical machine form;
+- signer address and epoch;
+- chain and verifying contract;
+- payer and recipient rules;
+- price, asset, quantity, deadline, and sale mode;
+- token-data hash and authorization identity;
+- transaction and emitted events after execution;
+- cancellation, expiry, or exception record where applicable.
+
+The receipt lets an artist, collector, auditor, or community member compare the
+decision, signature, contract execution, and public explanation without
+trusting a private service database.
+
+## Design position
+
+Keeping curation outside Solidity is reasonable only when the boundary is
+explicit. The public experience should never suggest that an onchain vote
+selected a work when a configured signer authorized the result of an offchain
+process.
+
+The architecture is valuable when it does two things at once:
+
+1. preserves room for human judgment and evolving community rules; and
+2. prevents the resulting onchain action from changing after approval.
+
+That is the standard against which the signer, payload, UI, replay storage, and
+public receipt should be reviewed.
+
+## Failure modes reviewers should test
+
+- TDH or curation input is wrong;
+- the authorization service constructs different terms from the approved
+  decision;
+- the human-readable display omits or misstates a signed field;
+- a signer key or Safe is compromised;
+- signer rotation leaves an old payload valid unexpectedly;
+- domain separator, type hash, or field encoding differs across implementations;
+- a replay or cancellation marker is written too early or too late;
+- a copied transaction changes an incompletely bound field;
+- a deadline, chain, asset, or sale mode is misunderstood;
+- auction registration and later signer cancellation produce inconsistent
+  expectations;
+- a failed execution consumes an authorization without completing the intended
+  action.
+
+## Questions for reviewers
+
+1. Does the typed payload bind every value that could harm an artist, payer,
+   recipient, or collector if changed?
+2. Can a non-technical reader compare the curation decision with the exact
+   action they are asked to sign or submit?
+3. What public evidence should prove the offchain curation result?
+4. Who may rotate or revoke a signer, and how quickly?
+5. Should issued authorizations survive signer rotation?
+6. Are cancellation and replay rules clear under every revert path?
+7. Which parts of the TDH and curation process should be independently
+   reproducible?
+8. What should happen to a registered auction when the signer or underlying
+   community decision later changes?

--- a/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/fixed-price-sales-and-auctions.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/fixed-price-sales-and-auctions.md
@@ -1,0 +1,353 @@
+# Fixed-price sales and auctions
+
+This review covers an incomplete, undeployed candidate; [Current Implementation and Readiness](./security-testing-and-known-limitations) is the authoritative record of what is connected, implemented, proposed, and still required.
+
+A sale contract does more than collect ETH. It turns approved terms into
+custody, payment, allocation, refunds, and a terminal result. Stream's sales
+layer is designed to prevent a copied signature from changing the buyer or
+recipient, an arbitrary bidder from blocking an auction, a failed refund from
+halting progress, or a settlement from leaving ownership and funds in different
+states.
+
+Those protections create visible state and accounting. A smaller sale function
+can omit them only by accepting narrower behavior or moving the missing rules
+to a trusted marketplace, operator, or database.
+
+## Signed terms are the bridge from decision to execution
+
+Both current sale paths begin with a
+[`DropAuthorization`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L24-L61).
+Its EIP-712 domain binds the chain and verifying contract. Its payload binds:
+
+- authorization identity and replay inputs;
+- poster;
+- token recipient;
+- payer;
+- collection;
+- fixed-price or auction mode;
+- token-data hash;
+- fixed price;
+- quantity;
+- auction reserve and end time;
+- deadline;
+- signer epoch.
+
+This is how an offchain curation decision becomes a constrained onchain action.
+The contract does not need to reproduce the TDH or curation process. It does
+need to ensure that the signed result cannot quietly become a different sale.
+
+Without chain and verifying-contract binding, a signature can be replayed in a
+different domain. Without distinct payer and recipient fields, a copied
+transaction can redirect the work or charge an unintended account. Without a
+mode, amount, token-data hash, deadline, epoch, and one-use identity, a valid
+signature can authorize more than the signer and community intended.
+
+Signature validity remains only one condition. Supply, mint policy, pause
+state, payment, freeze, and sale-specific checks still apply.
+
+The current authorization has no currency or token-address field. The
+implemented Drop and auction paths are native-ETH paths, so currency is fixed
+by the execution path. Any future token-denominated authorization would need to
+bind the asset address separately from its amount.
+
+## Current signed sales use the legacy mint lane
+
+The signed Drop and auction paths call the legacy `StreamMinter`, not
+`StreamMintManager`. The rehearsal separately installs the manager in Core, but
+passes the legacy minter to both current sale contracts. See
+[`RehearseDeployment.s.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/script/RehearseDeployment.s.sol#L218-L269).
+
+That distinction matters because the current sale path does not consume the
+manager lane's durable counters or prepared-mint records. A launch candidate
+must identify one exact end-to-end path and demonstrate its supply, replay,
+payment, and Core-entry behavior as a composition.
+
+## Fixed-price execution protects both paid and free mints
+
+A fixed-price authorization can describe a paid mint or a zero-price claim.
+
+For a paid mint, submitted ETH must match the authorized economics. Execution
+does not trust a price supplied only by the frontend. The product must describe
+the currency as ETH rather than imply that the signed authorization selected
+from multiple assets.
+
+The current Drop contract selects a local proceeds split in token, collection,
+then contract-default order. It creates separate poster, protocol, and
+curator-reserve credits rather than pushing ETH to arbitrary recipients during
+mint. See
+[`proceedsSplitFor`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L542-L558)
+and
+[`_creditFixedPriceProceeds`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L635-L680).
+
+A zero-price authorization removes payment, not policy. Replay, collection,
+quantity, recipient, token data, deadline, mint capacity, and freeze checks
+still matter. "Free" must not become shorthand for "any caller may mint
+anything."
+
+The current signed Drop requires `quantity == 1`; one authorization mints one
+token. Stream can represent editions at the collection level, but the current
+signed path is not a batch mint.
+
+## Payer and recipient are intentionally different concepts
+
+The account funding a mint and the account receiving the token can differ. That
+supports gifts, sponsored actions, and other delegated payment patterns without
+leaving the beneficiary ambiguous.
+
+Both values are signed. A public transaction can be copied, but the copier
+cannot change the recipient or use the same payload to charge another payer.
+The protocol does not promise private order flow or first-inclusion guarantees;
+it constrains what a copied payload can accomplish.
+
+## Auction registration commits the item to one state machine
+
+An auction-mode authorization registers the approved collection, token, poster,
+reserve, and end-time context with
+[`AuctionContract.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol).
+The authorization is the bridge from curation to auction registration; it is
+not itself a bid.
+
+The token is minted into auction custody during registration. Registration
+confirms that custody before the auction becomes active. That ordering protects
+the bidder from paying into an auction whose contract does not hold the work it
+is supposed to deliver.
+
+A simpler design can mint to an operator and ask that operator to transfer
+later. That reduces contract state, but replaces onchain custody with trust in
+the operator and creates ambiguity when settlement, cancellation, or the
+operator itself fails.
+
+## Bids create liabilities as well as a leader
+
+Each valid bid places ETH under contract control. The auction records the
+highest bidder and amount and enforces a minimum next bid.
+
+When another bidder becomes the leader, the displaced bidder receives a
+withdrawable credit. The contract does not synchronously push ETH back during
+the new bid.
+
+Pull refunds protect auction progress from an arbitrary bidder contract that
+rejects ETH or tries to reenter. They also create a strict solvency obligation:
+every bidder credit must remain backed and must be excluded from emergency
+surplus.
+
+The simplification tradeoff is direct. Synchronous refunds require less
+credit-tracking state, but they let a hostile or incompatible recipient decide
+whether another user's valid bid can proceed.
+
+## The minimum next bid is exact
+
+The first bid must meet the reserve. Later bids must be at least the current
+highest bid plus a percentage of that bid. The percentage begins at 5%, and
+integer division rounds its component down:
+
+`current highest bid + floor(current highest bid * 5 / 100)`
+
+After a 1 ETH bid, the default next minimum is 1.05 ETH. At very small values,
+rounding can produce no increase. The authoritative read is
+[`minimumNextBid`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol#L251-L265);
+the same calculation is enforced by
+[`participateToAuction`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol#L279-L312).
+
+This rule is easy to explain only if its parameters are stable. In the current
+candidate, a function-scoped or global admin can change the one global
+`incPercent` value at any time, including while auctions are active. There is
+no bound, delay, change event, or per-auction snapshot. Every active auction
+uses the value that is live when the next bid arrives. See
+[`updatePercentAndExtensionTime`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol#L549-L558).
+
+Reviewers should decide whether terms visible when an auction starts must remain
+fixed for that auction. At minimum, tests should cover:
+
+- first bid and reserve equality;
+- the exact next minimum;
+- one wei below the minimum;
+- small-value rounding;
+- large values and multiplication bounds;
+- zero or extreme configured percentages;
+- changes during an active auction;
+- bidder replacement;
+- bids at the time boundary.
+
+## Anti-sniping needs a reproducible clock rule
+
+The extension time begins at 300 seconds. When a valid bid arrives with five
+minutes or less remaining, the contract adds another full five minutes to the
+recorded end time. It adds to the old end time, not to the current block time.
+Every qualifying late bid can extend again, and the current code has no cap on
+the number of extensions or total duration.
+
+Each extension emits `AuctionExtended` with the old and new end times. The
+auction is considered ended only after `block.timestamp` is greater than the
+recorded end. A bid included at exactly the end timestamp can still qualify and
+extend the auction.
+
+Like the increment, `extensionTime` is one mutable global value. A
+function-scoped or global admin can change it during active auctions without a
+bound, delay, or dedicated change event, and later bids use the current value.
+
+The extension protects bidders from a last-second auction that ends before they
+can respond. It cannot guarantee inclusion during network congestion. A product
+that wants no timing state at all must accept a different fairness model, not
+pretend that Ethereum supplies one automatically.
+
+## Winner settlement is permissionless but not discretionary
+
+After the recorded end time passes, any address may call
+[`claimAuction`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol#L371-L388).
+The caller cannot choose the winner, price, or proceeds. Those values are
+already fixed in auction state.
+
+Settlement must:
+
+1. confirm that the auction can settle;
+2. use the recorded winning bid and bidder;
+3. transfer the escrowed token exactly once;
+4. apply the auction's token, collection, or default proceeds split;
+5. create poster, protocol, and curator credits;
+6. preserve bidder and seller accounting;
+7. emit reconstructable events;
+8. make cancellation and second settlement impossible.
+
+In the current candidate, settlement transfers the token held in auction
+custody and credits Auction-local balances through
+[`_creditAuctionProceeds`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol#L471-L508).
+It does not use the separately deployed revenue resolver or split wallets.
+
+Permissionless settlement is safe only because the caller supplies no sensitive
+choice. This is a useful complexity boundary: keep the trigger open, but commit
+the consequences before the trigger is available.
+
+## No-bid settlement still has a token to resolve
+
+The token already exists in auction custody when bidding begins. A no-bid
+result therefore does not undo the mint or restore supply. It decides where the
+already-minted token goes.
+
+If the poster is an ordinary address, `claimAuction` transfers the token back
+and records `SettledNoBid`. If the poster is a contract, the auction records it
+as a pending claimant instead of attempting an immediate safe transfer. Only
+that exact contract may call
+[`claimNoBidAuctionToken`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol#L390-L407),
+and it may choose a nonzero recipient. The second call clears the claim,
+transfers the token, and makes the auction terminal. See
+[`_settleNoBidAuction`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol#L438-L454).
+
+This extra state exists because contract recipients can reject or mishandle an
+ERC-721 transfer. The alternative is simpler code that can permanently strand
+the token or block the auction's terminal state.
+
+Reviewers should still decide whether a contract poster should be able to name
+any recipient and whether returning an already-minted work is the right supply
+and collector outcome.
+
+## Cancellation must respect custody and bidder rights
+
+The poster, or an admin authorized for `cancelAuction`, may cancel only while
+the auction is active and the highest bid is zero. Once any bid exists, or the
+auction has ended, this path is unavailable.
+
+Cancellation makes the auction terminal and returns the token from custody to
+the poster. The current function does not check the bidding or settlement pause.
+See
+[`cancelAuction`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol#L409-L426).
+
+A broader emergency-cancel button would be shorter to describe but would give
+an operator power over a bidder's acquired expectation. If cancellation after
+a bid is ever needed, its refund, consent, timing, and evidence rules must be
+explicit.
+
+## Recoverable surplus is not contract balance
+
+Auction and Drop contracts hold funds that belong to other people. An
+authorized recovery must not treat the following liabilities as surplus:
+
+- active highest-bid escrow;
+- refundable outbid credits;
+- seller proceeds;
+- protocol or curator credits;
+- any other accounted liability.
+
+The recoverable amount is balance minus liabilities. Raw contract balance is
+not a safe definition of surplus, including when forced ETH or rounding
+residuals exist.
+
+Both contracts expose liability-aware surplus information. Only
+`AuctionContract` exposes an `emergencyWithdraw` action at this commit, and it
+caps that withdrawal at the calculated surplus. `StreamDrops` exposes the
+surplus views but no emergency withdrawal function.
+
+## Hostile recipients remain part of the design
+
+Auction, refund, proceeds, and token-transfer paths interact with arbitrary
+addresses. Pull credits remove some synchronous calls from critical paths, but
+the contracts still need:
+
+- state updates before external transfer;
+- reentrancy protection where required;
+- credits that survive a failed withdrawal;
+- alternate recipient handling for incompatible contract wallets;
+- exact accounting for every external effect.
+
+No design should rely on gas-stipend folklore or assume that every wallet is an
+ordinary address.
+
+## Additional sale mechanics belong behind reviewed adapters
+
+The sales specifications discuss Dutch auctions, private sales, refund windows,
+sealed bids, raffles, burn-to-mint, ERC-20 bidding, and other profiles. They are
+proposed or deferred unless they appear in the reviewed release contracts and
+tests.
+
+Adding a sale profile is not a UI-only change. It can change custody, pricing,
+ordering, refund, eligibility, replay, and finality assumptions. The permanent
+Core should not absorb speculative mechanics. New profiles should use explicit,
+reviewed modules whose authority over identity and supply remains bounded.
+
+## What a simpler design would externalize
+
+A bare payable mint or marketplace-run auction can remove much of this state.
+It also makes another system responsible for:
+
+- proving the displayed terms match execution;
+- protecting copied authorizations;
+- holding the work during bidding;
+- refunding displaced bidders;
+- deciding time extensions;
+- handling contract-wallet recipients;
+- retaining solvency through settlement;
+- producing a reconstructable terminal record.
+
+That may be a reasonable trust model for a particular sale. It is not the same
+guarantee. Stream's complexity should be judged against those responsibilities,
+not against the line count of a contract that delegates them to an operator.
+
+## What can fail
+
+- A signed price, participant, asset, quantity, or sale mode is incompletely
+  bound.
+- A replay registers or settles twice.
+- The signed sale enters a mint lane with different limits than reviewers
+  expect.
+- A global parameter change silently alters an active auction.
+- A refund or proceeds credit becomes unbacked.
+- An extension calculation differs across clients.
+- Winner settlement leaves token custody and funds out of sync.
+- No-bid handling strands a token.
+- Cancellation violates bidder expectations.
+- Emergency withdrawal treats liabilities as surplus.
+- A hostile recipient blocks progress or reenters.
+
+## Questions for reviewers
+
+1. Does the authorization bind every participant, economic term, asset, and
+   replay input needed by the current sale?
+2. Should bid increment and extension rules be fixed per auction?
+3. Are the exact boundary-time and rounding rules understandable to bidders?
+4. Is direct auction custody the right model for the work before settlement?
+5. Should any cancellation path exist after a valid bid?
+6. Is no-bid behavior fair to the artist and potential collector?
+7. Can every liability and terminal state be reconstructed from public storage
+   and events?
+8. Which additional sale profiles, if any, are important enough to justify
+   genesis audit surface?

--- a/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/for-artists.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/for-artists.md
@@ -1,0 +1,413 @@
+# For artists
+
+This review covers an incomplete, undeployed candidate; [Current Implementation and Readiness](./security-testing-and-known-limitations) is the authoritative record of what is connected, implemented, proposed, and still required.
+
+Stream is designed to let an artist define more than a token. It can describe
+the life of a work: its identity, files and scripts, supply, distribution,
+sale, collaborators and revenue recipients, randomness, mutable state,
+preservation package, and path to finality.
+
+The artist-centered promise is not that an artist must operate every contract.
+It is that the artist can inspect the commitments made in the artist's name,
+understand which other actors still have power, and recognize the point at
+which an artistic decision becomes irreversible.
+
+## Your collection has a durable identity
+
+Stream uses one shared ERC-721 Core for many native collections. The Core stores
+a collection record and the artist address associated with it. Each token
+receives both a globally sequential token ID and a collection-local serial.
+
+This means a Stream collection does not receive a separate ERC-721 contract
+address. Its identity comes from the Core collection record, collection reads,
+and token metadata rather than from a unique contract deployment for every
+artist or project.
+
+The advantage is continuity. An artwork does not acquire a new identity when a
+sale module, renderer, randomness integration, or other replaceable component
+changes. The tradeoff is that the correctness and governance of the shared Core
+matter to every collection, and marketplaces or indexers must understand
+Stream's native collection identity instead of relying only on contract
+address.
+
+The collection can refer to:
+
+- artist identity;
+- maximum and current supply;
+- mint policy;
+- token data, scripts, images, and attributes;
+- dependency versions;
+- metadata mode;
+- randomness provider;
+- sale and revenue configuration;
+- freeze and preservation commitments.
+
+Those values do not all carry the same authority or permanence. The artist
+should be able to see which contract owns each value, who may change it, and
+what closes that mutation path.
+
+## Approving a specific collection state
+
+The current artist-approval mechanism in
+[`StreamArtistApprovals.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamArtistApprovals.sol#L8-L21)
+computes a collection-state hash and verifies the artist's signature over that
+state.
+
+The EIP-712 domain binds the chain and Core contract. The signed state binds:
+
+- artist address;
+- current collection-freeze manifest hash;
+- maximum collection purchases;
+- collection total supply;
+- final-supply delay.
+
+The signature can come from:
+
+- an ordinary externally owned account; or
+- an ERC-1271 contract wallet such as a Safe.
+
+If one of the bound fields changes, the old signature describes an earlier
+state rather than silently approving the new one. That is the essential value
+of typed approval: the artist approves one inspectable version of the work.
+
+Signing a hash is not meaningful consent by itself. The artist-facing product
+should render the hashed state in ordinary language, show the exact source
+version and contract, and make every irreversible consequence visible before
+the wallet asks for a signature.
+
+## Approval is not the same as total control
+
+The current artist approval is not a universal veto over all administrative
+actions. Different modules and roles can still change fields within their
+authority. The present Core-freeze call is an administrative action and does
+not itself demand a new artist signature.
+
+The design decision is therefore not “does the artist approve Stream?” It is
+which exact actions become impossible without current artist consent.
+
+The most consequential candidates are:
+
+- initial collection state;
+- maximum and final supply;
+- sale and revenue terms;
+- randomness-provider selection;
+- collection and one-of-one manifests;
+- Core freeze;
+- terminal artwork finality;
+- recovery or successor actions that change what viewers receive.
+
+Some actions may reasonably need both artist approval and protocol governance.
+A guardian may have power to stop a suspicious action without gaining power to
+author a different artistic payload. Those combinations should be described
+action by action.
+
+## Statements made in the artist's name
+
+Collection metadata and preservation records can carry different kinds of
+claims. Stream's record-family design distinguishes artist, owner, independent,
+curator, institution, rights, archive, fixity, C2PA, IIIF, media-relationship,
+identity-display, snapshot, and agent records.
+
+That distinction protects provenance. An owner statement should not be mistaken
+for an artist statement. An archive location should not be mistaken for a
+rights grant. A permissionless independent observation should remain
+self-attributed rather than appearing as protocol endorsement.
+
+In the current source, artist, owner, institution, and independent families
+reject ordinary administrative grants. Artist authority must come through the
+artist-authority provider, and an exact record type can be admitted to only one
+family.
+
+The implementation is in
+[`StreamRecordFamilyRegistry`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRecordFamilyRegistry.sol#L17-L285).
+
+The artist-facing interface should show:
+
+- the record family and exact type;
+- who authored the record;
+- which wallet or provider established that authority;
+- the collection or token it concerns;
+- whether it can be revised, locked, superseded, or only supplemented;
+- whether the protocol checked only authorship or also validated the record's
+  contents.
+
+A recorded statement can prove who submitted it under the configured authority
+model. It does not automatically make a rights claim, institutional
+attestation, archive location, or provenance credential true.
+
+## Artwork files, scripts, and token data
+
+Stream can represent work through collection information, scripts,
+token-specific data, images, attributes, dependency records, metadata modes,
+and randomness output.
+
+That breadth matters for generative and executable art. A `tokenURI` alone may
+not reveal:
+
+- which script bytes create the work;
+- the order in which scripts run;
+- which library and version the script expects;
+- which image, font, codec, or data file is required;
+- which browser or runtime assumptions affect the result;
+- which values are onchain and which must be retrieved elsewhere.
+
+Before approval or finality, the artist should receive a human-readable
+dependency bill of materials showing:
+
+1. every file and exact byte hash;
+2. every script and its execution order;
+3. every external dependency and version;
+4. the locations from which each byte sequence can be retrieved;
+5. the token data and randomness inputs;
+6. instructions for reconstructing the work;
+7. browser, font, codec, and runtime assumptions;
+8. one or more reference outputs where visual equivalence matters.
+
+A content hash proves that retrieved bytes match a commitment. It does not
+upload the file, keep it available, operate a gateway, or preserve the software
+needed to execute it.
+
+## One-of-ones and editions
+
+The shared Core can represent a one-of-one, a fixed edition, or another
+supported collection pattern by assigning a collection supply and mint policy.
+
+The protocol gives one-of-one work special attention where collection-wide
+records are not enough. A token can require its own materials and manifest so
+that the finality package binds the exact work rather than only a shared
+collection description.
+
+For any collection pattern, the artist should be able to inspect:
+
+- maximum possible supply;
+- minted-ever supply;
+- live supply after burns;
+- collection-local serials;
+- every phase or authorization that can still mint;
+- who may change a time window or supply setting;
+- what closes supply permanently;
+- whether a successor can reopen a path that was represented as closed.
+
+Minted-ever and live supply answer different questions. Burning a token should
+not erase the fact that it was minted or automatically restore a lifetime mint
+allowance.
+
+## Choosing who can mint
+
+Stream separates collection identity from distribution policy. Mint phases can
+describe:
+
+- opening and closing times;
+- phase supply;
+- executors;
+- optional eligibility gates;
+- per-wallet, per-recipient, or other durable limits;
+- policy hashes;
+- authorizers and replay protection.
+
+That separation allows an artist to choose a distribution model without making
+every future sale mechanism part of the permanent Core.
+
+The signed Drop path binds a sale to a payer, recipient, collection, quantity,
+price, deadline, sale mode, token-data hash, signer epoch, and replay
+identifier. In that path, `quantity` is currently required to equal `1`, so one
+authorization mints one token. A many-token edition can use multiple
+authorizations or another configured mint lane; the field should not be
+presented as a batch mint when this path does not provide one.
+
+See
+[`StreamDrops._validateAuthorization`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L561-L581)
+and
+[`_executeFixedPriceDrop`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L609-L632).
+
+## Curation and TDH
+
+TDH and curation are calculated outside Solidity. Stream does not choose an
+artist or run an onchain TDH vote. A service constructs the exact authorized
+action, a configured signer signs it, and the contract verifies the payload.
+
+This creates a clear division:
+
+- the community and its processes decide what should happen;
+- the signed payload records the intended result;
+- the contract prevents execution from quietly changing the bound collection,
+  participants, price, quantity, timing, or sale mode.
+
+Artists still depend on transparent curation rules, correct authorization
+construction, signer security, visible key rotation, and public evidence of the
+offchain decision.
+
+An artist should be able to inspect the complete typed payload before the sale,
+not merely a website summary.
+
+## Fixed-price sales and auctions
+
+A sale can be a free or paid fixed-price mint or an English auction.
+
+For fixed-price execution, the artist should see:
+
+- the collection and token data;
+- price and currency;
+- payer and token recipient;
+- deadline;
+- proceeds recipients and percentages;
+- curator and protocol allocation;
+- withdrawal behavior;
+- cancellation and replay state.
+
+For an auction, the artist should additionally see:
+
+- reserve price;
+- start and end conditions;
+- minimum next-bid calculation;
+- late-bid extension rule;
+- custody of the token;
+- bidder refund method;
+- cancellation boundary;
+- winner and no-bid settlement;
+- treatment of the already-minted token if no one bids.
+
+The contract uses pull credits for proceeds and refunds so an arbitrary
+recipient cannot block sale progress by rejecting an inline ETH transfer.
+That design also creates an accounting obligation: every bidder, artist,
+curator, and protocol credit must remain fully backed.
+
+Additional sale profiles can be introduced through future modules without
+placing speculative mechanisms in the permanent Core. A generic extension
+point does not make an unreviewed sale profile safe; each profile needs its own
+custody, pricing, refund, replay, and settlement analysis.
+
+## Revenue, collaborators, and royalties
+
+An artist may need to divide primary-sale value among collaborators, a curator,
+an institution, the protocol, or other recipients. The artist should be able
+to approve one human-readable revenue statement that identifies:
+
+- every recipient and share;
+- which token, collection, or default profile has precedence;
+- when the profile can change;
+- supported currencies;
+- rounding direction and residual owner;
+- withdrawal behavior;
+- curator allocation and claim method;
+- emergency-surplus boundaries;
+- royalty receiver and rate;
+- which claims are enforced by Stream and which depend on marketplaces.
+
+The reviewed source contains native Drop and Auction credit accounting as well
+as a separate resolver, split-wallet, asset-policy, and primary-settlement
+foundation. Those are distinct value paths, and an artist-facing sale should
+identify the one it actually uses.
+
+Core also exposes ERC-2981 royalty information. ERC-2981 is a signal to a
+marketplace, not a mechanism that forces every secondary sale to pay.
+
+## Randomness
+
+If a work uses randomness, the artist should know the provider and failure
+policy before minting.
+
+Stream can bind a request to the token, collection, provider address, and
+provider epoch. It stores a hash of the raw provider output, derives a
+context-bound seed, and exposes pending, fulfilled, stale, and
+failed-post-processing states.
+
+If provider output is accepted but the Core write fails, the retry path uses the
+same derived seed rather than requesting a new random result. That protects
+technical recovery from becoming a reroll.
+
+The artist should be able to answer:
+
+- Can I reject a provider before minting?
+- Who can change the provider?
+- What happens to pending or failed requests?
+- When may a request be declared stale?
+- Can a stale token recover without creating selective rerolls?
+- Can a token be burned while randomness is pending?
+- Which provider fees or subscriptions must remain funded?
+- Which provider settings can change without creating a new Core epoch?
+
+Randomness should not be described as trustless without naming the selected
+provider and its operating assumptions.
+
+## Freezing the work
+
+Stream separates final supply, Core freeze, preservation records, and artwork
+finality because each closes a different question.
+
+- **Final supply** answers whether more tokens can be minted.
+- **Core freeze** closes the covered collection and live-token mutations in the
+  permanent contract.
+- **Preservation records** commit evidence about the materials needed to
+  understand or reconstruct the work.
+- **Artwork finality** is a delayed terminal ceremony intended to close the
+  remaining artwork-affecting paths.
+
+Before Core freeze or artwork finality, the artist should complete this
+checklist:
+
+1. Verify collection identity and the artist address.
+2. Verify maximum, minted-ever, live, and intended final supply.
+3. Verify every open mint phase, executor, gate, sale, and authorization.
+4. Verify every live token's randomness and metadata state.
+5. Verify scripts, token data, images, attributes, dependency versions, and
+   content hashes.
+6. Retrieve every required file from the published locations.
+7. Reconstruct the work independently from the package.
+8. Verify revenue recipients, percentages, currencies, curator allocation, and
+   royalty information.
+9. Verify all burn and provenance records.
+10. Inspect the exact collection and one-of-one manifests.
+11. Inspect which mutation paths Core freeze closes and which remain outside it.
+12. Sign only the exact state intended for approval.
+13. Preserve an independent copy of the approval and finality package.
+
+The finality delay should give the artist and independent reviewers enough time
+to find a missing file, wrong hash, incorrect manifest, or unexpected remaining
+writer before execution becomes terminal.
+
+## Collaborators, delegation, recovery, and estates
+
+The current artist-state approval is narrower than a complete lifetime artist
+authority system.
+
+A broader design under discussion would need to address:
+
+- collaborators with narrow responsibilities;
+- delegated signing powers;
+- key rotation and loss;
+- contract-wallet ownership changes;
+- guardians and recovery;
+- disputes and sanctions;
+- estate instructions;
+- the boundary between artist, owner, institution, and protocol authority.
+
+One proposal would keep artist authority and history in a single registry while
+delegating only narrow validation to a stateless helper. Replacing that helper
+would require the full successor process. Artists should decide whether that
+recovery and delegation model is understandable and worthy of permanence.
+
+## Design position
+
+Artists should not have to read transaction traces to understand what they are
+signing. The approval experience should name the work, exact source, materials,
+supply, sale terms, revenue recipients, randomness provider, mutable fields,
+other actors with power, and irreversible actions.
+
+The strongest version of Stream is not merely a contract that respects an
+artist address. It is a system in which artistic consent is inspectable,
+version-specific, and carried through the full lifecycle of the work.
+
+## Questions for artists
+
+1. Which actions must be impossible without your current signature?
+2. Which actions should require both artist approval and protocol governance?
+3. Should collaborators receive narrow onchain roles, or should the artist
+   remain the only signing identity?
+4. What recovery and estate process is credible over a fifty-year horizon?
+5. Is the approval package understandable enough to sign without Solidity
+   knowledge?
+6. What preservation evidence would make you comfortable freezing a work?
+7. Which sale, revenue, and royalty settings must become permanent, and when?
+8. Would the finality ceremony make you more confident, or does it place too
+   much operational burden on the artist?

--- a/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/freezing-preservation-and-artwork-finality.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/freezing-preservation-and-artwork-finality.md
@@ -1,0 +1,427 @@
+# Freezing, preservation, and artwork finality
+
+This review covers an incomplete, undeployed candidate; [Current Implementation and Readiness](./security-testing-and-known-limitations) is the authoritative record of what is connected, implemented, proposed, and still required.
+
+Digital art needs more than one meaning of "finished." No more tokens, no more
+Core changes, a preserved set of files, and no remaining artwork mutation path
+are different promises. Stream separates them so an artist and collector can
+see exactly which promise has been made.
+
+A single `frozen = true` flag is simpler. It can also hide a live mint path,
+mutable dependency, replaceable renderer, missing file, or administrative
+writer. Stream's layered finality exists to make irreversible claims precise
+rather than ceremonial.
+
+## Four completion promises
+
+Stream currently distinguishes:
+
+1. **Final supply** — no more tokens should be mintable for the collection.
+2. **Core freeze** — selected collection configuration in the permanent token
+   contract can no longer change.
+3. **Preservation records** — append-only evidence identifies artwork
+   materials, hashes, locations, and context.
+4. **Artwork finality** — a delayed terminal ceremony is intended to close the
+   remaining artwork-affecting paths for a defined scope.
+
+The relevant implementations include
+[`StreamCore.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol),
+[`StreamPreservationRecords.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamPreservationRecords.sol),
+and
+[`StreamArtworkFinalityRegistry.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamArtworkFinalityRegistry.sol).
+
+These mechanisms are complementary. A collection can stop minting while
+metadata remains editable. It can freeze Core while later preservation evidence
+is still appended. It can commit exact files while the software needed to
+execute them remains an external dependency.
+
+## Final supply is a supply promise
+
+For a collection that has minted at least one token, `setFinalSupply` lowers the
+configured cap to the number minted so far. Future minting then fails at that
+cap. This says nothing about artwork bytes, scripts, or metadata.
+
+The zero-mint case contains a current defect. When no token has ever been
+minted, the implementation writes `0` as final supply. The same `0` also means
+uninitialized supply to `setCollectionData`. While the collection remains
+unfrozen, a function admin can set a new nonzero cap and reopen minting. See
+[`setFinalSupply`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L888-L907),
+[`_finalizeCollectionSupply`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L1497-L1501),
+and
+[`setCollectionData`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L377-L408).
+
+There is no separate final-supply flag or event in the pinned candidate. Calling
+`setFinalSupply` alone is therefore not irreversible for a zero-minted,
+unfrozen collection. Core freeze closes this route, but that is a different
+action.
+
+Before final supply can support a permanent promise, the release should prove:
+
+- one monotonic finalized state, including when supply is zero;
+- closure or exhaustion of every mint phase and executor;
+- defined behavior for signed Drops, auctions, and reservations created before
+  finalization;
+- an event carrying the final value;
+- no successor path that bypasses the final state.
+
+A single cap with a sentinel value is less storage. It also makes "zero
+authorized works" indistinguishable from "supply not initialized," which is
+exactly the kind of ambiguity a permanent system should avoid.
+
+## Core freeze fixes a defined boundary
+
+Core freeze is one of the protocol's most consequential actions because Core is
+intended to preserve token and collection identity.
+
+At the pinned commit, Core freeze:
+
+- finalizes supply;
+- stores a freeze-manifest hash;
+- blocks legacy and manager mint entries;
+- blocks burning live tokens;
+- blocks changing the collection randomizer;
+- blocks artist-approval changes;
+- blocks token-data, image, and attribute changes;
+- blocks new or revised collection-metadata records;
+- blocks reserved collection-metadata lock changes.
+
+See
+[`freezeCollection`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L826-L841),
+the
+[`mint entries`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L445-L503),
+[`burn`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L628-L640),
+and
+[`artist approval`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L734-L761).
+
+Core freeze does not stop every possible action around the work. The following
+remain possible under the pinned behavior:
+
+- ordinary ERC-721 transfers and approvals;
+- append-only preservation records;
+- post-burn randomness audit evidence for an already burned token;
+- collection-metadata snapshot publication if snapshot locks remain open;
+- nonreserved record-specific locks;
+- shared contract-level metadata changes;
+- reads, exports, and historical event reconstruction;
+- global module, successor, or governance actions unless a separate terminal
+  rule blocks them.
+
+Normal transfer behavior remains open by design. See the
+[`transfer posture`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L1008-L1011).
+Collection-record revisions check Core freeze, but snapshot publication does
+not, and nonreserved record locks remain available. See the
+[`metadata mutation checks`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCollectionMetadata.sol#L363-L397).
+
+The product should enumerate this boundary. "Collection frozen" is misleading
+if readers infer that shared presentation, preservation history, or every
+successor module has also become immutable.
+
+## A freeze manifest gives the boundary one identity
+
+Core stores a hash of its relevant freeze state. That commitment lets another
+party compare an independently reconstructed package with the state that was
+frozen.
+
+The value is useful only when its preimage is canonical and inspectable.
+Reviewers need to know:
+
+- which fields and versions enter the manifest;
+- how each value is serialized;
+- how live, burned, and unminted tokens affect it;
+- which dependency and randomness facts are covered;
+- how a human-readable package maps to the hash;
+- which mutable surfaces remain outside it.
+
+A generic hash with no reproducible preimage would be shorter to store but would
+not tell an artist what they approved or a collector what became fixed.
+
+## Preservation records keep history append-only
+
+[`StreamPreservationRecords`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamPreservationRecords.sol)
+can record typed evidence about materials needed to understand or reproduce the
+artwork.
+
+A useful record identifies:
+
+- the collection or token scope;
+- record type and subject;
+- who was authorized to submit it;
+- digest algorithm and bytes;
+- URI or other location context;
+- effective time;
+- relationship to prior evidence;
+- the exact record hash.
+
+The implementation supports several digest reference types, including
+Keccak-256, SHA-256, BLAKE3, multihash, IPFS CID, and Arweave transaction
+references. It bounds URI and digest sizes and stores complete records behind
+their hashes.
+
+Preservation records remain appendable after Core freeze. An old record is
+never overwritten, but a later record can update the
+collection/type/subject `latest` pointer. `Latest` means most recently recorded
+onchain, not greatest `effectiveAt`.
+
+This allows future conservators to add a new storage location, fixity check, or
+format note without pretending that the original final package changed.
+
+It also means "append-only" does not mean "there is one final preservation
+record." Readers must distinguish:
+
+- the original package associated with finality;
+- later preservation evidence;
+- the current latest pointer;
+- a record's author and authority class;
+- a signature hash from a signature that another verifier actually checked.
+
+The preservation contract stores signature-related hash commitments but does
+not itself verify a signature. See
+[`IStreamPreservationRecords`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/IStreamPreservationRecords.sol#L106-L126).
+
+## Integrity is not availability
+
+A valid hash answers one question:
+
+> Do the retrieved bytes match the commitment?
+
+It does not:
+
+- recover missing bytes;
+- pay storage providers;
+- keep a domain or gateway available;
+- preserve an RPC service;
+- preserve a browser, font, codec, GPU, or JavaScript runtime;
+- prove that an external location is independently controlled.
+
+Stream's preservation model is strongest when it states both the onchain
+commitment and the operational storage guarantee. Calling a hash "permanent
+storage" would collapse two different promises.
+
+## One-of-one materials need token-specific commitments
+
+One-of-one works can have source, media, or authenticity evidence that does not
+fit a collection-wide package. The finality design includes token-specific
+manifest handling so individual commitments can be bound to the intended token.
+
+That does not make Stream one-of-one-only. Collections and editions remain part
+of the shared protocol.
+
+Reviewers should verify that:
+
+- every token requiring an individual manifest is covered;
+- a manifest cannot be substituted between token IDs;
+- encoding and hashing are unambiguous;
+- shared edition materials are not duplicated without need;
+- burned and unminted cases are defined.
+
+The current release-artifact model also distinguishes a 1/1 provenance manifest
+from a collector-verifiable permanence package. Provenance carries artist,
+story, and authenticity context. A permanence package binds renderer,
+dependencies, source archives, replay instructions, output hashes, browser
+proof, and storage assumptions. Neither artifact should be confused with
+ownership, marketplace acceptance, or royalty enforcement.
+
+## Terminal finality is delayed for a reason
+
+Artwork finality is scheduled rather than applied immediately. The delay gives
+artists, guardians, reviewers, and independent retrievers time to find:
+
+- a wrong file or manifest;
+- an incorrect digest;
+- missing dependencies;
+- a mismatched collection or token;
+- premature artist approval;
+- an unaccounted writer;
+- a route that cannot actually be reproduced.
+
+The implemented registry supports scheduling, a veto floor, an execution
+window, cancellation, expiry, staged manifest bytes, component expectations,
+and collection or scoped finality records. See
+[`StreamArtworkFinalityRegistry.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamArtworkFinalityRegistry.sol#L39-L81)
+and its
+[`schedule and finalization entries`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamArtworkFinalityRegistry.sol#L297-L589).
+
+A delay is useful only if reviewers see the exact action that will execute.
+The scheduled record must bind the complete payload. Execution must not reread
+a mutable value and finalize a different package from the one reviewed during
+the waiting period.
+
+The current review evidence does not yet establish complete payload binding and
+writer coverage across every terminal path. Finality should not be described as
+a proven terminal guarantee until that evidence exists.
+
+## Artist approval must be approval of readable facts
+
+Finality is an artistic decision as well as a protocol transition. The artist's
+approval should bind:
+
+- chain and verifying contract;
+- collection or token scope;
+- exact manifests and component commitments;
+- nonce;
+- deadline;
+- finality action identity.
+
+A vague message or signature over an unexplained hash is not meaningful consent.
+The artist should receive a human-readable package whose fields deterministically
+produce the signed commitment.
+
+Contract-wallet artists need a documented ERC-1271 path if supported.
+Operational recovery matters too: loss of an artist key before finality should
+not silently turn the platform administrator into the artist.
+
+The current Core artist approval binds a narrower collection state and is not a
+universal veto. The broader relationship among artist approval, Core freeze,
+preservation, and terminal finality remains a critical design decision.
+
+## A guardian may stop finality, not author it
+
+The finality source includes a guardian veto during the delay. That role is a
+safety brake.
+
+The intended separation is:
+
+- proposal supplies the payload;
+- artist approval confirms the artistic commitment;
+- guardian veto prevents execution;
+- execution applies the already-bound payload;
+- expiry closes an abandoned proposal.
+
+A guardian should not replace manifests, substitute components, or choose a new
+work. If an action is cancelled or expires, a later attempt should use a new
+identifier and fresh approvals. Reusing an old signature would erase the
+benefit of the review period.
+
+## Terminal means every effective writer is accounted for
+
+After terminal artwork finality, each artwork-affecting route should either be
+impossible or explicitly outside the promise.
+
+The proof needs a selector-level and effect-level inventory covering:
+
+- token and collection metadata writes;
+- scripts and token data;
+- dependency versions and pointers;
+- image and animation locations;
+- renderer inputs and attributes;
+- randomness provider and final seed;
+- preservation records;
+- refresh helpers;
+- module or renderer successors;
+- global paths that can reach the same mutation through another contract.
+
+Testing one function named `setMetadata` is insufficient when another module,
+registry, executor, or fallback path can produce the same effect.
+
+Record-family authorization exists in source, but complete candidate evidence
+for admitted types, provider addresses, grants, runtime code hashes,
+rotation/revocation, and independent review is not available. A terminal
+writer-inventory proof must use the actual candidate bindings, not the intended
+role diagram.
+
+## Recovery after finality would change the promise
+
+The repository contains a proposal for an append-only recovery companion when a
+frozen renderer, dependency, or serving route later fails. It is not accepted
+or implemented.
+
+Under that proposal:
+
+- the original finality record remains unchanged;
+- Governance V2 is the sole scheduler and executor authority;
+- a companion contract appends a separate recovery lineage;
+- the record binds scope, predecessor, old route, replacement, manifest, and
+  reason;
+- changing a route is treated as changing artwork bytes unless a later accepted
+  equivalence verifier proves otherwise;
+- artist and owner evidence comes from separately owned append-only sources;
+- the metadata router serves the recovered route only after exact pointer,
+  interface, and route checks.
+
+This may preserve access while changing the bytes a viewer receives. It is not
+ordinary maintenance. Community review should address artist consent, owner
+notice, guardian veto, objection time, competing recoveries, and whether any
+byte-changing recovery should exist.
+
+See
+[`ADR 0020 status and blockers`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/docs/adr/0020-executor-only-finality-recovery.md#L3-L24)
+and its
+[`proposed decision`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/docs/adr/0020-executor-only-finality-recovery.md#L75-L138).
+
+## Irreversible actions deserve separate ceremonies
+
+A single "finalize" button can hide several decisions that deserve independent
+inspection.
+
+A safer artist workflow is:
+
+1. confirm maximum and final supply;
+2. close every mint path;
+3. inspect and freeze Core configuration;
+4. retrieve and independently verify preservation materials;
+5. inspect collection-wide and one-of-one manifests;
+6. compare a human-readable package with the exact signed payload;
+7. wait through the review and veto period;
+8. execute terminal finality;
+9. verify the resulting state through an independent reader.
+
+Each step should produce a machine-readable receipt. The UI should make
+irreversibility unmistakable without forcing the artist to decode calldata or
+trust a block explorer.
+
+Before production, someone who did not prepare the package should be able to
+recover and replay it using only published instructions and commitments.
+
+## What a simpler design would externalize
+
+A freeze flag and one content hash can remove most of this machinery. They also
+leave external actors to decide:
+
+- whether all mint paths really closed;
+- which metadata fields remained mutable;
+- whether the hash covered the intended encoding;
+- whether every token-specific artifact was included;
+- whether the bytes still exist;
+- whether the current browser can execute them;
+- whether a replacement renderer changed the work;
+- whether the artist approved the exact final state;
+- whether an admin path can still mutate it.
+
+That may be enough for a token whose permanent promise is deliberately narrow.
+Stream is attempting a stronger promise. Its complexity should be judged by
+whether each step makes that promise more exact and verifiable.
+
+The design should still remove duplicate concepts and unbound paths. Layered
+finality is valuable only when every layer has one precise meaning.
+
+## What can fail
+
+- Final supply leaves another lane able to mint.
+- A broad freeze label hides mutable fields or modules.
+- The freeze or finality manifest commits the wrong encoding, scope, or token.
+- Required bytes are unavailable despite a valid hash.
+- Finality execution rereads values changed after scheduling.
+- An old artist approval is replayed for a different action.
+- A guardian can author changes instead of only stopping them.
+- A metadata, preservation, refresh, governance, or successor path bypasses the
+  terminal state.
+- A later recovery is presented as preserving the same bytes when it changes
+  them.
+
+## Questions for reviewers
+
+1. Are final supply, Core freeze, preservation, and artwork finality each
+   defined narrowly enough to verify?
+2. Does mint closure cover every current and successor lane, including the
+   zero-mint case?
+3. Which exact Core and satellite fields enter each manifest?
+4. Is the finality delay long enough for independent retrieval and replay?
+5. Should current artist approval be expanded, or should terminal finality use
+   a separate exact artist signature?
+6. Can a guardian only veto, or can any path let it shape the final payload?
+7. Does the terminal writer inventory include every indirect mutation route?
+8. Which independent storage locations and runtime artifacts are mandatory?
+9. What receipt lets an artist and collector verify the terminal state without
+   trusting the current website?
+10. Should any byte-changing recovery exist after finality, and what evidence
+    would distinguish recovery from replacement?

--- a/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/governance-pausing-and-successors.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/governance-pausing-and-successors.md
@@ -1,0 +1,363 @@
+# Governance, pausing, and successors
+
+This review covers an incomplete, undeployed candidate; [Current Implementation and Readiness](./security-testing-and-known-limitations) is the authoritative record of what is connected, implemented, proposed, and still required.
+
+Stream does not use a conventional upgradeable proxy for its permanent Core.
+Governance cannot silently replace the Core's bytecode while leaving the same
+address in place. Instead, it can recognize modules, schedule sensitive actions,
+pause defined domains, freeze selected powers, and record explicit successors.
+
+That choice is central to the protocol's long-term design. The identity and
+history of the artwork remain anchored in the old contracts, while replaceable
+duties can move to new, separately visible contracts. It does not eliminate
+governance risk; it makes the change and the actor responsible for it easier to
+inspect.
+
+This page explains **how authority changes over time**. [Roles and
+Trust](./roles-and-trust) explains who holds each capability.
+
+## From bootstrap to governed operation
+
+A new system needs temporary authority to deploy contracts, bind their
+dependencies, assign initial roles, and prove that the intended graph exists.
+That bootstrap power should not become a permanent alternate governor.
+
+The intended transition is:
+
+1. deploy the immutable contracts;
+2. bind the expected role registry, Governance Root, Core, system-manifest
+   satellite, code hashes, guardian set, trigger set, manifest, and inventory
+   root;
+3. independently verify that configuration;
+4. seal the system manifest;
+5. transfer executor ownership to the Governance Root;
+6. leave no hidden route back to the bootstrap authority.
+
+The source implements this one-way lifecycle in
+[`StreamGovernanceManifest`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamGovernanceManifest.sol#L12-L54)
+and
+[`bindSystemManifestBootstrap` / `sealSystemManifestBootstrap`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamGovernanceExecutor.sol#L807-L893).
+
+This ceremony is security-critical. A wrong address, code hash, guardian set, or
+inventory root can become authoritative when sealing succeeds. The reviewed
+source contains the mechanism; the complete candidate bindings, independent
+readback, and non-local ceremony evidence remain readiness requirements.
+
+## Module registration
+
+The module registry records recognized contracts and their lifecycle status. A
+registration can bind runtime code hash and interface expectations, so
+governance cannot point clients at an unrelated address without leaving
+evidence.
+
+Reviewers should verify:
+
+- when the code hash is measured;
+- whether a target can be a proxy or metamorphic contract;
+- which interface check is required;
+- whether an inactive or deprecated module remains reachable through another
+  path;
+- whether status changes are delayed;
+- whether historical module records remain queryable;
+- how clients discover the current module without trusting a private index.
+
+A matching code hash proves which runtime bytecode occupied an address at the
+measured time. It does not prove that the code is safe, correctly initialized,
+or connected to the intended dependencies.
+
+## Scheduled actions
+
+The governance executor can publish a proposed call, enforce its waiting period,
+permit cancellation or guardian intervention, and allow execution after the
+delay. Execution is safe only when the action observed during the delay is the
+same action later applied.
+
+For every governed selector, the scheduled record must commit to:
+
+- target;
+- native value;
+- calldata, including selector and every argument;
+- predecessor or ordering requirements;
+- scope;
+- old-state and new-state commitments where required;
+- earliest execution time;
+- expiry;
+- governing epoch or configuration;
+- reason and manifest;
+- a unique salt or nonce.
+
+Execution must use that exact record. It must not accept a fresh recipient,
+value, address, or calldata fragment that was invisible during review.
+
+The current source binds target, native value, selector, calldata hash, scope,
+old-state hash, new-state hash, earliest execution, expiry, reason, and manifest.
+It publishes the calldata preimage onchain. Authorized actors schedule or
+cancel; execution is permissionless inside the committed window. See the
+[`scheduled-call binding`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamGovernanceExecutor.sol#L305-L403).
+
+The mechanism exists, but the review evidence does not yet prove complete
+binding for every governed selector in a concrete candidate. That proof belongs
+in the readiness record, not in a role name or design claim.
+
+## Action classes and minimum delays
+
+Governance classifies actions by consequence:
+
+| Class                 |  ID | Minimum delay |
+| --------------------- | --: | ------------: |
+| Immediate tightening  |   0 |             0 |
+| Delayed loosening     |   1 |      48 hours |
+| Terminal freeze       |   2 |      72 hours |
+| Pointer replacement   |   3 |      48 hours |
+| Funds recovery        |   4 |       14 days |
+| Successor declaration |   5 |       30 days |
+
+Numeric IDs are append-only. Former class `6` is retired and cannot be reused.
+Delayed classes also require an open execution window. The source constants and
+delay rules are visible in the
+[`action-class interface`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/IStreamGovernanceExecutor.sol#L69-L79)
+and
+[`delay function`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamGovernanceBootstrap.sol#L299-L311).
+
+The distinctions matter:
+
+- an action that only removes authority may be safe immediately;
+- an action that expands authority should be visible before it takes effect;
+- a terminal freeze needs time for artists and collectors to inspect the exact
+  boundary;
+- replacing a module pointer must expose both old and new contracts;
+- recovering funds requires a precise proof that liabilities are not being
+  withdrawn;
+- declaring a successor changes the protocol's long-term interpretation and
+  deserves the longest default review.
+
+## Native-value authority
+
+The source risk register identifies governance-executor native-value authority
+as open High risk `RISK-GOV-003`. A generic executor that can send ETH controls
+more than configuration. It can fund payable calls, move unaccounted balances,
+or interact with targets in ways a selector label does not reveal.
+
+The final design needs a precise answer for:
+
+- which balances the executor may receive or control;
+- whether native value is included in the scheduled-action commitment;
+- whether value is capped, class-limited, or target-restricted;
+- how bidder, seller, curator, randomness, and other liabilities are excluded;
+- what event proves the transfer;
+- whether an emergency path has the same power;
+- how residual ETH is recovered without creating a general withdrawal key.
+
+This is a code and accounting boundary, not merely an operational policy.
+
+## Governed parameter binding
+
+For each governed selector, reviewers should compare:
+
+1. values visible when the action is scheduled;
+2. values included in the action identifier;
+3. values checked at execution;
+4. mutable storage read again at execution;
+5. values emitted in events.
+
+If a mutable registry, global default, or caller-supplied argument fills a gap at
+execution time, the delayed action can mean something different from what
+reviewers saw.
+
+The accepted policy for launch gas and time parameters is deliberately one-way:
+
+- only a Governance V2 `DELAYED_LOOSENING` action may change a value;
+- the minimum delay is 48 hours;
+- the new value must be strictly higher;
+- one action may raise it by no more than 2x;
+- there is no lowering, emergency raise, probe repair, or permissionless
+  mutation path;
+- zero governance authority makes the host immutable;
+- permanent governance loss leaves values readable but unchangeable;
+- tightening later requires a reviewed successor host or deployment line.
+
+This trades recovery flexibility for a smaller and more auditable authority
+surface. The source hosts implement the rule. The complete candidate parameter
+catalog and proposal-to-execution binding proof are still required. See
+[`ADR 0017`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/docs/adr/0017-raise-only-parameter-governance.md#L48-L71)
+and its
+[`governance-loss consequence`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/docs/adr/0017-raise-only-parameter-governance.md#L140-L153).
+
+## Guardian intervention
+
+The guardian is a rapid defensive role. It can stop or veto a defined operation,
+particularly during a timelock. It should not quietly become a second governor.
+
+Where practical, guardian actions should be monotonic safety actions:
+
+- pause a domain;
+- veto a pending action;
+- prevent a suspicious successor cutover.
+
+Resuming operations, replacing modules, moving funds, or changing artwork should
+normally require the full governance path. A guardian veto should prevent an
+already-proposed payload; it should not substitute a different payload.
+
+The guardian also creates an operational obligation. Someone must monitor
+scheduled actions, understand their complete effect, and act within the veto
+window. A veto power that is not watched is only theoretical.
+
+## Pause domains
+
+`StreamAdmins` defines six pause domains in the current source. The owner or a
+registered pause guardian can pause. The owner or a registered unpause
+administrator can resume.
+
+| Domain             | Stops                                                                                               | Does not stop                                                              |
+| ------------------ | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Drop execution     | New signed Drop execution                                                                           | Withdrawals and unrelated reads                                            |
+| Mint               | Legacy `StreamMinter.mint` and `mintAndAuction`                                                     | Existing ownership and the separate manager unless its phase is paused     |
+| Auction bid        | New bids                                                                                            | Auction-credit withdrawals                                                 |
+| Auction settlement | Winner and no-bid settlement entries                                                                | Bidder and seller credit withdrawals                                       |
+| Metadata mutation  | Core, contract-metadata, collection-metadata, and preservation writes that consult the shared check | Existing metadata reads                                                    |
+| Randomness request | New requests in the current randomizer adapters                                                     | Existing request reads and provider callbacks governed by their own checks |
+
+The identifiers are in
+[`StreamPauseDomains`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamPauseDomains.sol#L5-L12).
+Pause and resume authority are implemented in
+[`StreamAdmins.setPaused`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamAdmins.sol#L137-L157)
+and its
+[`authority checks`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamAdmins.sol#L223-L229).
+
+`StreamMintManager` has a separate per-phase pause and does not consult the
+global `MINT` domain. Any cutover must decide whether that distinction is
+intentional and present it explicitly.
+
+Pausing should preserve withdrawals and other safe user exits wherever possible.
+Otherwise an incident-control mechanism can trap the users it is meant to
+protect.
+
+## Permanent selector freezes
+
+Governance can make selected operations permanently unavailable. A selector
+freeze is stronger than a temporary pause and must identify the complete
+effective call surface, including aliases and module paths that reach the same
+state change.
+
+Freezing a selector in one executor does not help if another privileged module
+can perform the same write directly. The final freeze evidence should enumerate
+all equivalent mutation paths and prove they are closed.
+
+## Signer epochs
+
+Signed authorizations are tied to signer epochs. Rotation can invalidate prior
+authorizations without confusing them with signatures issued by the new signer.
+
+Reviewers should establish:
+
+- which signatures become invalid after rotation;
+- whether an epoch can ever be reused;
+- how ERC-1271 contract-wallet signatures are checked;
+- whether auctions registered under the prior epoch remain valid;
+- what happens during emergency compromise;
+- how the public learns which signer and epoch were active.
+
+Epochs make a change visible. They do not prove that the new signer is correctly
+controlled or that the signing service applies the community's policy.
+
+## Explicit successor modules
+
+A successor is a new immutable contract recognized as following an older
+module. The predecessor, its bytecode, and its history remain onchain. Governance
+records the transition instead of rewriting the old implementation behind a
+proxy address.
+
+That is valuable for art because a collector can distinguish:
+
+- the contract that originally acted;
+- the later contract recognized for future duties;
+- the governance decision that connected them;
+- the commitments and liabilities that remained with the predecessor.
+
+A safe cutover must answer:
+
+- which new actions route to the successor;
+- which reads and liabilities remain with the predecessor;
+- whether state is read, copied, or recomputed;
+- whether both contracts can act concurrently;
+- which signatures, nonces, counters, and balances are shared;
+- how clients discover the current module;
+- whether the permanent Core can reject an incompatible successor;
+- what evidence proves continuity before the pointer changes.
+
+A successor should not rewrite token history or silently relax an artwork
+commitment. If it changes what bytes are served, who can mint, how funds move, or
+which metadata is authoritative, that consequence must be stated directly.
+
+Successor declaration therefore has a 30-day minimum delay in the source action
+classes. The production checklist should treat cutover as a separate ceremony
+with before-and-after invariants, independent readback, and a published
+continuity record.
+
+## Emergency actions
+
+Emergency authority is still authority. A faster path should have a narrower
+effect, stronger monitoring, and a clear route back to ordinary governance.
+
+The code and public catalog should enumerate exactly what emergency actors can
+pause, veto, rotate, or withdraw. A statement that a multisig "can fix things"
+is not a security model.
+
+Emergency recovery must not become:
+
+- a shortcut around action delays;
+- an unbounded native-value transfer;
+- a hidden module replacement;
+- a way to alter an artist-approved payload;
+- a route that strands user withdrawals or refunds.
+
+## Why this governance is intentionally explicit
+
+Stream is designed for a much longer horizon than a typical application
+release. Over that horizon, providers fail, cryptographic and operational
+assumptions change, and some modules will need successors. Pretending nothing
+will ever change would not make the system simpler; it would push change into
+unrecorded social coordination, abandoned interfaces, or emergency keys.
+
+The governance design therefore separates:
+
+- the permanent identity that should not be rewritten;
+- replaceable duties that may need a successor;
+- temporary intervention that should stop harm without authoring policy;
+- delayed decisions whose complete effects should be inspectable in advance;
+- powers that can be surrendered permanently.
+
+The standard for simplification is not fewer contracts or roles by itself. A
+simplification is successful only if it preserves the same artistic,
+operational, and security guarantees with a smaller effective authority surface.
+
+The safest governance action is one whose complete effect can be simulated from
+the published bytes before its delay begins.
+
+## What can fail
+
+- bootstrap authority remains an alternate governor after sealing;
+- the system manifest binds a wrong address, code hash, or inventory root;
+- a role reaches more selectors than its name suggests;
+- a module is registered with wrong code or initialization;
+- a scheduled action omits native value or another security-sensitive field;
+- execution rereads mutable state and changes the reviewed meaning;
+- a guardian can author a replacement instead of only vetoing;
+- a pause blocks user exits or misses an alternate call path;
+- a selector freeze has an alias bypass;
+- a predecessor and successor accept the same authorization or spend the same
+  liability;
+- clients follow a new module without verifying the governed continuity record.
+
+## Questions for reviewers
+
+1. Is every effective role expressible as a selector-level capability list?
+2. Should the governance executor ever be able to send native value?
+3. Are all action parameters fixed and visible at scheduling time?
+4. Which pause domains must preserve withdrawals and refunds?
+5. What invariants must hold before a successor becomes current?
+6. Which governance powers should become permanently unavailable after launch?
+7. Is 30 days enough notice for a successor that changes an artwork-affecting
+   duty?
+8. Which governance mechanism can be removed without creating an opaque upgrade,
+   emergency, or offchain coordination path?

--- a/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/manifest.json
+++ b/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/manifest.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "review_id": "6529-stream",
+  "review_version": "2026-07-27.1",
+  "locale": "en-US",
+  "source_repository": "https://github.com/6529-Collections/6529Stream",
+  "source_commit": "513bd7e079eafe109df6ae1ae21bfbca6fec6786",
+  "pages": [
+    {
+      "id": "overview",
+      "title": "Overview",
+      "file": "overview.md"
+    },
+    {
+      "id": "artwork-lifecycle",
+      "title": "Artwork Lifecycle",
+      "file": "artwork-lifecycle.md"
+    },
+    {
+      "id": "for-artists",
+      "title": "For Artists",
+      "file": "for-artists.md"
+    },
+    {
+      "id": "roles-and-trust",
+      "title": "Roles and Trust",
+      "file": "roles-and-trust.md"
+    },
+    {
+      "id": "curation-and-tdh-authorization",
+      "title": "Curation and TDH Authorization",
+      "file": "curation-and-tdh-authorization.md"
+    },
+    {
+      "id": "tokens-collections-and-minting",
+      "title": "Tokens, Collections, and Minting",
+      "file": "tokens-collections-and-minting.md"
+    },
+    {
+      "id": "fixed-price-sales-and-auctions",
+      "title": "Fixed-Price Sales and Auctions",
+      "file": "fixed-price-sales-and-auctions.md"
+    },
+    {
+      "id": "revenue-splits-and-royalties",
+      "title": "Revenue, Splits, and Royalties",
+      "file": "revenue-splits-and-royalties.md"
+    },
+    {
+      "id": "randomness",
+      "title": "Randomness",
+      "file": "randomness.md"
+    },
+    {
+      "id": "metadata-scripts-and-dependencies",
+      "title": "Metadata, Scripts, and Dependencies",
+      "file": "metadata-scripts-and-dependencies.md"
+    },
+    {
+      "id": "freezing-preservation-and-artwork-finality",
+      "title": "Freezing, Preservation, and Artwork Finality",
+      "file": "freezing-preservation-and-artwork-finality.md"
+    },
+    {
+      "id": "governance-pausing-and-successors",
+      "title": "Governance, Pausing, and Successors",
+      "file": "governance-pausing-and-successors.md"
+    },
+    {
+      "id": "security-testing-and-known-limitations",
+      "title": "Current Implementation and Readiness",
+      "file": "security-testing-and-known-limitations.md"
+    },
+    {
+      "id": "community-review",
+      "title": "Community Review",
+      "file": "community-review.md"
+    }
+  ]
+}

--- a/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/metadata-scripts-and-dependencies.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/metadata-scripts-and-dependencies.md
@@ -1,0 +1,394 @@
+# Metadata, scripts, and dependencies
+
+This review covers an incomplete, undeployed candidate; [Current Implementation and Readiness](./security-testing-and-known-limitations) is the authoritative record of what is connected, implemented, proposed, and still required.
+
+For digital art, metadata is not merely a name and image URL. It can be the
+recipe for reconstructing the work: token data, scripts, library versions,
+media, attributes, content hashes, execution assumptions, and the record of who
+was allowed to describe or preserve each part.
+
+Stream's metadata system is designed to make that recipe inspectable. A simple
+`baseURI` can make the contract much smaller, but then a server operator, domain
+owner, gateway, or mutable dependency can silently determine what collectors
+see. The complexity has not disappeared; it has moved outside the protocol.
+
+## The first question is: where are the bytes?
+
+Stream can represent:
+
+- artwork described and assembled entirely from onchain inputs;
+- artwork whose metadata or media lives at external locations;
+- generative work combining token data, collection scripts, randomness, and
+  versioned dependencies;
+- hybrid arrangements with commitments onchain and some bytes elsewhere.
+
+The principal rendering logic is in
+[`StreamMetadataRenderer.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMetadataRenderer.sol).
+Collection-level records are in
+[`StreamCollectionMetadata.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCollectionMetadata.sol),
+contract-level presentation is in
+[`StreamContractMetadata.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamContractMetadata.sol),
+and reusable libraries are in
+[`DependencyRegistry.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/DependencyRegistry.sol).
+
+"Onchain metadata" is too imprecise on its own. It can mean:
+
+- `tokenURI()` returns encoded JSON;
+- the JSON contains an encoded image or HTML document;
+- the JSON points to an onchain script that still imports other dependencies;
+- the JSON or media points to IPFS, Arweave, HTTPS, or another external
+  location.
+
+Reviewers should follow every layer and identify which exact bytes are onchain,
+which are content-addressed, which use a conventional location, and which
+software must execute them. A data URI at the first layer does not prove that
+the entire work is self-contained.
+
+## Metadata modes express different preservation promises
+
+The renderer can build a token URI from stored collection configuration and
+token state. Depending on the selected mode, it can return or assemble
+different combinations of JSON, media, scripts, and external locations.
+
+That flexibility is useful because not every artwork has the same medium or
+storage model. It must not be collapsed into one visual "onchain" badge.
+
+An artist and collector should be able to tell:
+
+- whether token JSON is generated onchain;
+- whether image or animation bytes are embedded or referenced;
+- whether scripts are stored in chunks or fetched elsewhere;
+- which dependency versions are required;
+- whether URLs can change;
+- which hashes cover which representation;
+- which parts remain mutable;
+- what a third party needs to reconstruct the work.
+
+The honest guarantee may be excellent without being "everything is onchain."
+Precision is stronger than a badge.
+
+## String construction is a security boundary
+
+The renderer constructs values that wallets, marketplaces, indexers, RPC
+clients, and browsers parse as JSON, URIs, HTML, or JavaScript.
+
+Every artist-controlled value needs encoding for the context where it is used.
+Valid JSON escaping is not automatically safe in JavaScript. HTML-attribute
+escaping is not automatically safe in a URI. A string may pass one parser and
+close a tag or change meaning in the next.
+
+The current renderer contains:
+
+- JSON-string escaping;
+- HTML-attribute escaping;
+- JavaScript single-quoted-string escaping;
+- script-end-tag handling;
+- UTF-8 validation;
+- URI policy checks;
+- structured raw-attribute validation;
+- explicit limits for collection text, token data, images, attributes, script
+  chunks, chunk counts, and generated token URIs.
+
+See the validation and encoding surface in
+[`StreamMetadataRenderer.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMetadataRenderer.sol#L453-L925).
+
+Reviewers should still test:
+
+- quotes, backslashes, newlines, null bytes, and control characters;
+- valid and invalid UTF-8;
+- combining characters and right-to-left text;
+- closing script and HTML tags;
+- very long text, attributes, media, and URLs;
+- data-URI media types and base64 boundaries;
+- numeric and boolean attributes that must remain typed;
+- return values near RPC and consumer limits.
+
+A contract can return bytes that are valid by its own rules while ordinary
+consumers refuse or truncate them. Real compatibility needs real consumer
+evidence.
+
+## Scripts are ordered, byte-exact artwork inputs
+
+Collections can store or reference scripts and token-specific data used to
+render generative work. Script order, chunk order, encoding, and exact bytes all
+matter.
+
+The renderer hashes script chunks and their positions rather than treating an
+unordered set of strings as equivalent. That protects against rearrangement or
+partial reconstruction.
+
+The point at which scripts become immutable is equally important. Before
+freeze, authorized mutation may be part of the artist's working process. After
+the relevant commitment, a collector should not have to trust an operator to
+remember which draft was final.
+
+A hash gives integrity:
+
+> If these bytes are available, do they match the committed work?
+
+It does not give availability:
+
+> Can anyone still obtain these bytes?
+
+An external URI plus a hash needs both answers. The hash does not pay a storage
+provider, renew a domain, or preserve a browser runtime.
+
+## Versioned dependencies prevent silent library replacement
+
+Generative artwork often depends on a shared library. The
+[`DependencyRegistry`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/DependencyRegistry.sol)
+records dependencies by name and version, with:
+
+- ordered script chunks;
+- per-chunk hashes;
+- a content hash for the assembled script;
+- provenance text;
+- creator and creation context;
+- deprecation state;
+- explicit size and chunk-count limits.
+
+Publishing a new library should create a new version, not change what an old
+version means. Deprecation can warn against new use without erasing the source
+needed to render existing artwork.
+
+Reviewers should establish:
+
+- who can create a dependency name;
+- who can add a version;
+- when byte content and chunk order become fixed;
+- whether a location can change;
+- which hash covers the chunk and which covers the assembled dependency;
+- how consumers detect a missing, duplicated, or reordered chunk;
+- what deprecation changes and what it deliberately leaves intact;
+- where every version is retained outside the contract.
+
+The simpler alternative is an ordinary CDN or package name. That is operationally
+convenient, but it lets mutable hosting and version resolution decide what old
+art executes.
+
+## Collection metadata separates claims by purpose and authority
+
+Collection metadata is different from token metadata. It can carry artist
+statements, rights, preservation locations, fixity evidence, institutional
+records, media relationships, and presentation context.
+
+Separating those records avoids giving one broad "metadata admin" every
+artwork-adjacent power. A party authorized to update a public description should
+not automatically be able to replace scripts, supply, revenue policy, or the
+artist's own statement.
+
+The pinned source provides a closed family-to-writer model:
+
+| Record family      | Purpose                                                                        | Allowed source classes                                  | Why the distinction matters                                                    |
+| ------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Artist             | Statement attributed to the recognized artist                                  | Artist signer only                                      | Separates the artist's words from platform or third-party commentary           |
+| Owner              | Statement attributed to the recognized current owner                           | Owner signer only                                       | Shows owner authorship without implying artist endorsement                     |
+| Independent        | Self-attributed third-party observation or analysis                            | Any independent attestor                                | Permissionless evidence is attributable, not protocol-approved                 |
+| Curator            | Selection, interpretation, or exhibition context                               | Curator signer or global admin                          | Identifies the source of curatorial framing                                    |
+| Institution        | Museum, archive, university, or other recognized institution attestation       | Institution signer only                                 | Separates institutional evidence from artist and owner claims                  |
+| Rights             | Copyright, license, usage, or permissions information                          | Metadata admin or global admin                          | Affects use and display, but is not legal advice merely because it is recorded |
+| Archive            | Location of preservation materials or manifests                                | Preservation admin or global admin                      | A location record does not guarantee continued availability                    |
+| Fixity             | Checksums, sizes, or other alteration-detection evidence                       | Institution signer, preservation admin, or global admin | Tests retrieved bytes when those bytes remain available                        |
+| C2PA               | Content-provenance credential context                                          | Institution signer, preservation admin, or global admin | Recording a credential does not make its assertions true                       |
+| IIIF               | Interoperable cultural-heritage presentation or retrieval context              | Preservation admin, metadata admin, or global admin     | Helps compatible viewers find and present high-resolution media                |
+| Media relationship | Master, derivative, thumbnail, soundtrack, or alternate-rendering relationship | Preservation admin or metadata admin                    | Prevents a preview or derivative from being mistaken for the canonical work    |
+| Identity display   | Preferred names, credits, and attribution presentation                         | Metadata admin or global admin                          | Changes display, not the underlying authority identity                         |
+| Snapshot           | Immutable commitment to selected metadata records at one time                  | Metadata admin or global admin                          | Lets later readers compare a known bundle with newer records                   |
+| Agent              | Record of an automated service or machine-produced action                      | Metadata admin or global admin                          | Makes automation visible without proving it was safe                           |
+
+The registry controls who may write an admitted record type. It does not
+validate the truth of a rights claim, archive location, credential, IIIF
+response, or agent statement.
+
+Artist, owner, independent, and institution families reject admin grants. An
+independent record is directly self-attributed by its caller, not endorsed by
+the artist, 6529, or the protocol. Each exact record type is admitted once and
+cannot later be remapped to another family. See
+[`StreamRecordFamilyRegistry`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRecordFamilyRegistry.sol#L85-L228).
+
+The source contains these authorization rules. The candidate's actual admitted
+record types, live authority providers, grants, runtime code hashes, and
+rotation or revocation evidence are not yet published. The family model should
+not be presented as proof that a future deployment recognizes the correct
+wallets.
+
+## Snapshots preserve a view without freezing all future context
+
+A collection snapshot is an immutable record with its own identifier, record
+hash, and hash of the covered record-type list.
+
+Publication requires:
+
+1. an admitted snapshot-family record type;
+2. authority to write that snapshot type;
+3. a nonempty, strictly ascending list of exact covered record types;
+4. fresh authorization for every covered record type;
+5. an unlocked snapshot path.
+
+A snapshot is not a permission shortcut. The contract emits authorization
+evidence for every covered record type. A later snapshot can become `latest`,
+and underlying records may continue to change until their own lock or Core
+freeze.
+
+Snapshot publication itself does not check Core collection freeze. That allows
+an authorized writer to snapshot already-frozen record state if the snapshot
+locks remain open. Nonreserved record-specific locks can also still be added
+after Core freeze. These are narrower actions than revising frozen records, but
+they must appear in any explanation of what freeze means.
+
+See
+[`publishCollectionSnapshot`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCollectionMetadata.sol#L124-L180)
+and
+[`_requireSnapshotFamilyIntersection`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCollectionMetadata.sol#L504-L524).
+
+## Shared contract metadata is not an artist's token identity
+
+Contract-level metadata describes the shared Stream ERC-721 surface. It can
+affect marketplace-facing name, description, image, and links for every
+collection.
+
+The current
+[`updateContractURI`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamContractMetadata.sol#L109-L145)
+checks metadata pause and function-admin authority, but it does not consult an
+individual collection's Core freeze.
+
+A frozen artwork collection and the shared contract's presentation are
+therefore different states. A label can change without changing ownership,
+token identity, or the collection's frozen artwork inputs. That does not make
+shared presentation unimportant; it means the authority and promise must be
+named accurately.
+
+## Refresh events tell consumers that state changed
+
+Core implements ERC-4906 refresh signals for specific mutation paths:
+
+- token-data and image/attribute changes emit `MetadataUpdate(tokenId)`;
+- live-token randomness fulfillment emits `MetadataUpdate(tokenId)`;
+- collection-info and metadata-mode changes emit a broad
+  `BatchMetadataUpdate(1, lastAllocatedTokenId)` when tokens exist.
+
+The broad range is an intentional superset because tokens from different Stream
+collections can interleave in the global ID sequence.
+
+See the
+[`token-level emissions`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L786-L823),
+[`randomness emission`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L844-L883),
+and
+[`collection helper`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L1035-L1044).
+
+These events are notifications, not enforcement. A consumer can ignore them,
+cache longer than expected, or interpret a broad range differently.
+
+The accepted launch target also calls for restricted Core helpers that
+authorized satellite contracts can use to emit standard ERC-4906 signals plus
+Stream-native context. No such public or external helper exists in the pinned
+Solidity. Exact caller checks, lifecycle and range bounds, abuse analysis,
+implementation, and tests remain target work. See the
+[`launch target`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/docs/launch-v1-target-architecture.md#L320-L333).
+
+## Size limits protect more than gas
+
+Onchain strings and chunks cost gas to write and can produce large `eth_call`
+responses. Limits must be meaningful at several layers:
+
+- transaction and block gas;
+- deployed bytecode;
+- RPC response size;
+- wallet and marketplace parsers;
+- browser memory and execution time.
+
+A unit test that accepts a maximum value does not prove that ordinary public RPC
+providers or consumer applications can retrieve and render it. Maximum-size
+evidence should exercise the real delivery path.
+
+## The browser is part of the artwork's environment
+
+Generative HTML and JavaScript ultimately execute in software Stream does not
+control. Browser engines, security policies, APIs, fonts, codecs, GPUs, timing,
+randomness APIs, and cross-origin rules change.
+
+Where reproducibility matters, source code alone may be insufficient. A useful
+preservation package can need:
+
+- exact dependency and asset bytes;
+- browser or runtime version;
+- fonts and codecs;
+- build and replay instructions;
+- expected metadata and animation hashes;
+- a reference output or browser proof.
+
+The contract can remain secure while the artwork stops rendering. Contract
+security and artwork preservation are related but distinct release
+requirements.
+
+## Every collection needs a dependency bill of materials
+
+A human-readable package should state:
+
+- which bytes are onchain;
+- which bytes are content-addressed;
+- which locations are conventional URLs;
+- which dependencies and versions are required;
+- which values can still change;
+- who can change each one;
+- which hashes cover each representation;
+- which software assumptions remain;
+- how an independent party reconstructs the work without the current website.
+
+"Fully onchain" should be the conclusion of that evidence, with a defined
+scope—not a publisher-selected marketing badge.
+
+## What a simpler design would externalize
+
+A base URI and mutable JSON server can eliminate much of this contract surface.
+It also lets external operators determine:
+
+- which image or animation a token displays;
+- which script and dependency version executes;
+- whether historical bytes remain available;
+- which statements really came from the artist, owner, institution, or third
+  party;
+- whether a collection was reconstructed completely;
+- whether consumer-visible content changed after a supposed freeze.
+
+That can be a legitimate architecture when the trust model is explicit.
+Stream's metadata complexity exists because it is trying to make more of those
+responsibilities durable, attributable, and independently verifiable.
+
+The right simplification is to consolidate duplicate writers and representations
+while preserving exact provenance and authority—not to replace them with an
+opaque server.
+
+## What can fail
+
+- Artist-controlled text breaks or changes constructed JSON, HTML, JavaScript,
+  SVG, or URI meaning.
+- A dependency version is mutable or incompletely hashed.
+- An external asset disappears despite a valid onchain hash.
+- Chunk order or completeness is ambiguous.
+- A metadata writer has authority over the wrong record family.
+- The deployed authority providers or grants do not match the reviewed model.
+- A snapshot or lock is mistaken for a broader freeze than it provides.
+- A refresh helper targets unrelated tokens or creates excessive indexer work.
+- An RPC, wallet, indexer, marketplace, or browser cannot process the output.
+- Future software renders the same source differently.
+
+## Questions for reviewers
+
+1. Which exact bytes must be present before any Stream collection can be called
+   fully onchain?
+2. Are all artist-controlled values encoded for every context where they
+   appear?
+3. Do dependency records make chunk order, content identity, provenance, and
+   deprecation unambiguous?
+4. Which metadata writes require direct artist authority?
+5. Are the record families narrow enough to prevent one role from making claims
+   in another actor's name?
+6. Which snapshot and lock actions remain valid after Core freeze, and are they
+   presented clearly?
+7. Does the protocol need external refresh helpers, and if so who may signal
+   which token or range?
+8. What maximum sizes have been tested through real RPC and consumer
+   infrastructure?
+9. What must be preserved outside Ethereum for each supported artwork mode to
+   remain reproducible?

--- a/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/overview.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/overview.md
@@ -1,0 +1,266 @@
+# 6529 Stream: public review
+
+This review covers an incomplete, undeployed candidate; [Current Implementation and Readiness](./security-testing-and-known-limitations) is the authoritative record of what is connected, implemented, proposed, and still required.
+
+Stream is our attempt to build what we believe may be the most sophisticated
+and complete artist-centered contract system yet designed for serious 1/1
+digital art.
+
+That does not mean the contract with the most code. It means a protocol willing
+to take responsibility for problems that simpler mint contracts leave to
+websites, private databases, marketplaces, keyholders, storage providers, and
+future operators.
+
+A work of digital art is more than a token ID. It can depend on an artist's
+approval, exact files and scripts, a randomness source, versioned software,
+sale terms, collaborators and revenue recipients, preservation materials, and
+a credible decision about when the work is final. Those facts do not all have
+the same lifespan. Some should become permanent. Some must be able to evolve.
+Some will always depend on people and infrastructure outside Ethereum.
+
+Stream's central design is to separate those categories without separating the
+artwork's history. A permanent ERC-721 Core anchors token and collection
+identity. Specialized modules handle responsibilities that may need to change.
+When a replaceable module has a successor, the old contract and its history
+remain visible rather than being rewritten behind an upgradeable Core proxy.
+
+Although the shared Core can support editions and other collection structures,
+the hardest case—and the one that most clearly motivates this architecture—is a
+serious 1/1 artwork whose identity, materials, provenance, and final state
+should remain intelligible for decades.
+
+## What Stream is designed to hold together
+
+The protocol treats the following as parts of one artwork lifecycle:
+
+- a permanent token and collection identity;
+- artist approval of a specific, inspectable collection state;
+- community curation translated into a cryptographically bound authorization;
+- fixed-price sales and English auctions with explicit payer, recipient,
+  custody, refund, cancellation, and settlement rules;
+- mint policy that can express phases, gates, limits, and durable usage
+  counters without putting every future distribution mechanism in the Core;
+- primary-sale accounting, collaborator and curator allocations, pull
+  withdrawals, and ERC-2981 royalty information;
+- randomness with provider identity, request state, stored evidence,
+  deterministic post-processing retry, and migration rules;
+- onchain and offchain metadata modes, token data, scripts, images, attributes,
+  and versioned dependencies;
+- separate commitments for final supply, Core freeze, preservation records, and
+  terminal artwork finality;
+- explicit roles, domain-specific pauses, delayed governance actions, guardian
+  vetoes, selector freezes, and successor modules.
+
+The point is not that every artwork needs every mechanism. The point is that a
+permanent art protocol should make the relevant choices explicit instead of
+leaving them as undocumented assumptions.
+
+## Why this complexity exists
+
+Complexity should earn its place. The useful question is not whether Stream has
+many components, but which real requirement each component addresses and where
+that responsibility would go if the component were removed. The table describes
+the design response; the linked readiness page owns the exact maturity of each
+mechanism.
+
+| Requirement                                                   | Design response                                                                                                                          | What simplification would externalize                                                                             |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Keep an artwork's identity stable                             | A permanent shared Core records token and collection identity                                                                            | Identity becomes dependent on one sale contract, renderer, website, or later migration                            |
+| Let infrastructure improve without silently rewriting the art | Source-implemented module and successor records surround the non-proxy Core                                                              | Either old infrastructure can never change, or an upgradeable proxy can replace behavior beneath the same address |
+| Make artist consent specific                                  | EIP-712 state approval, with ordinary-account and ERC-1271 contract-wallet support                                                       | Consent becomes a vague message, an operator assertion, or a private workflow                                     |
+| Connect community curation to exact execution                 | A signed authorization binds the chain, contract, signer era, collection, participants, economics, timing, and sale mode                 | The offchain decision and the onchain action can drift apart                                                      |
+| Support different distribution policies safely                | A connected mint-manager foundation provides phases, executors, gates, policy hashes, and durable counters outside the permanent Core    | Every new distribution rule either bloats the Core or depends on a private eligibility database                   |
+| Handle generative randomness without reroll ambiguity         | Requests bind the provider and epoch; fulfillment stores evidence; failed Core writes retry the same derived seed                        | Provider delay, callback failure, retries, and migration become informal operator decisions                       |
+| Preserve executable artwork, not only a token URI             | Scripts, token data, dependencies, content commitments, manifests, and preservation records describe what the work needs                 | Critical materials and runtime assumptions remain scattered across mutable services                               |
+| Say exactly what “final” means                                | The source separates supply finalization, Core freeze, preservation evidence, and terminal artwork finality                              | One “immutable” badge conceals which mutation paths, dependencies, or operational duties remain                   |
+| Represent real artistic economics                             | Current local accounting and a connected resolver-and-split foundation make allocation, refunds, asset policy, and royalties inspectable | Collaborator payments, curator rewards, refunds, rounding, and royalty policy move into private accounting        |
+| Survive organizational and technical change                   | Source-implemented delayed actions, guardians, module registration, selector freezes, and successors make change visible                 | Future operators either have no recovery path or rely on opaque emergency authority                               |
+| Respond to incidents without freezing everything              | Current pause controls and source-defined domains separate incident response from restart authority                                      | A single emergency switch either misses the affected path or unnecessarily strands unrelated users                |
+
+This table is also an invitation to simplify. If a mechanism is unnecessary,
+reviewers should identify the requirement that can be dropped, narrowed, moved
+offchain, or served by a smaller design. “Too complex” is the beginning of that
+analysis, not its conclusion.
+
+## A permanent center and evolvable edges
+
+The permanent Core is intended to hold the smallest common surface that should
+survive changes in sale mechanics, randomness providers, metadata
+infrastructure, and governance operations. It assigns globally sequential token
+IDs, associates each token with a native Stream collection, records
+collection-local serials, and enforces Core-level supply and identity rules.
+
+The surrounding modules address concerns with different change horizons:
+minting, sales, auctions, revenue resolution, split wallets, metadata,
+dependencies, randomness, preservation, roles, governance, and artwork
+finality.
+
+This is not a conventional proxy-upgrade model. A successor does not erase the
+predecessor's code or history. The important governance questions therefore
+become visible:
+
+- Which facts are permanent in Core?
+- Which duties may move to a successor?
+- Who can authorize that transition?
+- What delay, veto, code-hash, interface, and continuity evidence is required?
+- Which signatures, counters, liabilities, and commitments remain with the old
+  module?
+
+That boundary is one of the most consequential choices in the review.
+
+## Artist-centered means inspectable consent
+
+The current artist-approval mechanism signs a specific collection-state hash.
+The signed state binds the artist address, collection-freeze manifest hash,
+maximum collection purchases, total supply, and final-supply delay. A change to
+a bound field makes the earlier approval stale. The mechanism supports both
+ordinary account signatures and ERC-1271 contract wallets such as a Safe.
+
+This approval is not a decorative signature. Its purpose is to make one version
+of the work distinguishable from another. It is also not yet a universal artist
+veto over every administrative or finality action. The review must decide which
+irreversible actions require an artist signature, protocol governance, a
+waiting period, or more than one of those.
+
+The same standard should apply to every artist-facing commitment. A readable
+approval package should show the collection, source version, artwork materials,
+supply, sale rules, revenue recipients, randomness provider, mutable fields,
+and irreversible actions before the artist signs.
+
+## From social decisions to bound actions
+
+Stream does not calculate TDH or choose artists inside Solidity. Community
+curation remains a social and operational process. The contract's job begins
+when that process produces an authorization.
+
+The signed Drop path binds the resulting action to values including the chain,
+verifying contract, signer epoch, collection, payer, recipient, quantity,
+price, deadline, sale mode, token-data hash, and replay identifier. Solidity
+can then verify that the submitted transaction matches the authorized action.
+It cannot prove that the offchain curation rule was fair or correctly applied.
+
+This division is deliberate: keep human judgment where it belongs, while
+preventing its onchain execution from quietly becoming a different sale.
+
+## Art that depends on code and infrastructure
+
+Stream can describe artwork that is assembled entirely onchain, artwork whose
+files live elsewhere, and generative work that combines token-specific data,
+scripts, images, randomness, and versioned dependencies.
+
+Those modes carry different preservation claims:
+
+- A content hash can prove that retrieved bytes match a commitment. It cannot
+  make missing bytes available.
+- An onchain script can remain readable while the browser, font, codec, library,
+  or external asset it expects changes.
+- A dependency version can identify the intended library. A durable rendering
+  still requires the exact bytes, their order, and the execution assumptions.
+- A preservation record can establish a public history. It cannot operate a
+  storage service or independently verify every claim recorded in it.
+
+For that reason, Stream separates token metadata, collection metadata, reusable
+dependencies, preservation records, Core freeze, and terminal artwork
+finality. “Onchain” and “immutable” should describe exact properties, not serve
+as undifferentiated badges.
+
+## Finality as a ceremony
+
+Stream distinguishes four questions that simpler systems often collapse:
+
+1. Can more tokens still be minted?
+2. Can the permanent collection configuration still change?
+3. Can future readers retrieve and verify the materials needed to understand or
+   reproduce the work?
+4. Can any remaining artwork-affecting path still act?
+
+Final supply, Core freeze, preservation records, and artwork finality answer
+those questions separately. The artwork-finality design uses a scheduled
+process with a visible waiting period, exact manifests, cancellation or
+guardian veto, and terminal execution. One-of-one works can carry
+token-specific manifest commitments rather than relying only on a
+collection-wide package.
+
+The aim is not to add ceremony for its own sake. It is to give artists,
+collectors, and independent reviewers time to inspect an irreversible action
+before it becomes final.
+
+## What the chain can and cannot promise
+
+Stream can make important claims verifiable:
+
+- a configured signer authorized a particular typed payload;
+- a token belongs to a particular Stream collection;
+- a stored hash commits to particular bytes;
+- a randomness result was derived from recorded provider output and context;
+- a governance action was scheduled with specified call data;
+- an old module has a recorded successor;
+- a collection has crossed defined freeze or finality states.
+
+Other claims remain outside the contract:
+
+- that TDH or curation was calculated fairly;
+- that an artist was shown an accurate human-readable approval package;
+- that committed artwork bytes will remain retrievable;
+- that a future browser will render a script identically;
+- that a randomness provider will remain funded and available;
+- that a marketplace will honor ERC-2981 royalty information;
+- that operators, signers, guardians, and governance participants will always
+  act wisely.
+
+The protocol is strongest when it names these boundaries rather than using
+“trustless” to hide them.
+
+## The source under review
+
+The source is pinned to
+[`513bd7e079eafe109df6ae1ae21bfbca6fec6786`](https://github.com/6529-Collections/6529Stream/tree/513bd7e079eafe109df6ae1ae21bfbca6fec6786),
+with exact Git tree
+`b50ec53109f5f8d6b4f4b07f4cb6fd3c1d0e3100`. Every code link in this review
+points to that commit. A later candidate receives a new review version so the
+explanation, code, and feedback remain historically reproducible.
+
+The generated Technical Reference is compiled from that pinned source. It
+inventories the contracts, interfaces, libraries, functions, events, errors,
+signatures, selectors, and source ranges seen by the compiler. That inventory
+supports navigation and completeness checks; it does not decide whether the
+design or implementation is correct.
+
+The editorial pages explain the protocol from different perspectives:
+
+- **Artwork Lifecycle** follows one work from collection creation through
+  finality and succession.
+- **For Artists** explains consent, materials, sales, revenue, randomness, and
+  irreversible decisions.
+- The technical topic pages cover curation, minting, sales, accounting,
+  randomness, metadata, preservation, governance, and trust.
+- **Community Review** explains how to submit a question, design objection,
+  evidence gap, bug, or possible vulnerability against the exact version.
+
+## Design position
+
+A permanent art protocol should be judged by more than whether it can mint a
+token. It should make artist consent legible, keep token identity stable,
+expose the trust it still requires, preserve the materials needed to understand
+the work, and provide a credible path for infrastructure to evolve without
+quietly rewriting the artwork.
+
+Stream is ambitious because the problem is ambitious. The purpose of this
+review is to determine whether every part of that ambition is necessary,
+coherent, bounded, and safe enough to deserve permanence.
+
+## Questions for reviewers
+
+1. Does Stream take responsibility for the right parts of a serious 1/1
+   artwork's lifecycle?
+2. Which mechanisms solve a real long-term requirement, and which should be
+   removed or narrowed?
+3. Is a shared, multi-collection permanent Core the right long-term identity
+   model?
+4. Is the boundary between permanent and replaceable components clear enough?
+5. Which powers should require an artist signature, a delay, a guardian veto,
+   or more than one of those?
+6. Which external dependencies are acceptable for artwork intended to remain
+   usable for decades?
+7. Does the design make complexity inspectable, or merely distribute it across
+   more contracts?

--- a/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/randomness.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/randomness.md
@@ -1,0 +1,315 @@
+# Randomness
+
+This review covers an incomplete, undeployed candidate; [Current Implementation and Readiness](./security-testing-and-known-limitations) is the authoritative record of what is connected, implemented, proposed, and still required.
+
+For generative art, randomness is not merely a number. It is part of the work's
+provenance. A collector should be able to determine which provider produced the
+input, which request it answered, which token and collection it belonged to,
+whether a callback failed, whether anyone requested new randomness, and why the
+final seed cannot later be replaced.
+
+That is why Stream treats randomness as a lifecycle rather than a one-shot
+callback. A smaller design can request a value and store the result, but then
+delays, failures, provider changes, retries, and disputed outputs have no
+durable state model.
+
+## Two providers do not mean one trust model
+
+The shared lifecycle is implemented in
+[`StreamRandomizerLifecycle.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRandomizerLifecycle.sol).
+The two provider implementations covered by this review are:
+
+- [`RandomizerVRF.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/RandomizerVRF.sol),
+  which requests Chainlink VRF through a configured coordinator and
+  subscription;
+- [`RandomizerRNG.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/RandomizerRNG.sol),
+  which sends a configured ETH amount to an external arRNG controller and later
+  receives its authorized callback.
+
+The VRF adapter depends on a configured coordinator, subscription ID, key hash,
+callback gas limit, confirmation count, and word count. The arRNG adapter
+depends on a controller fixed at construction plus a mutable per-request ETH
+cost.
+
+In both cases, Stream pins the provider address and Core randomizer epoch to the
+request. It does not prove that a subscription remains funded, that a controller
+remains available and honest, or that mutable operating parameters are
+appropriate.
+
+The shared lifecycle standardizes what Stream records around a request. It does
+not make different external providers equivalent or "trustless."
+
+## Provider assignment creates an authorization era
+
+A collection has one configured randomizer address. Calling Core's assignment
+path records the new provider and increments the collection's randomizer epoch.
+If the old provider reports a pending request for the collection, replacement
+reverts. See
+[`StreamCore.addRandomizer`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L411-L443).
+
+Each request records the provider and current Core epoch. Fulfillment checks
+that the collection still points to that same provider and epoch before
+accepting output.
+
+This prevents a callback from one provider era from being mistaken for a
+current result after migration. A simple provider pointer with no request-bound
+epoch would leave the contract unable to distinguish an authorized old callback
+from an unauthorized current one.
+
+The current epoch has a narrow scope. It changes through the Core provider
+assignment path. Changing settings inside the same adapter—such as VRF callback
+gas, key hash, subscription, confirmations, word count, or arRNG cost—does not
+increment the Core epoch. The review should not claim that every provider
+configuration change creates a new authorization era.
+
+## Each request has an explicit state
+
+The implemented lifecycle has five states:
+
+1. `None` — no request record exists;
+2. `Pending` — the request is recorded and may be fulfilled;
+3. `Fulfilled` — provider output was accepted, a seed was derived, and the Core
+   write succeeded;
+4. `Stale` — an authorized admin marked a pending request stale;
+5. `FailedPostProcessing` — output was accepted and the seed derived, but
+   writing the seed to Core failed.
+
+The request record stores:
+
+- collection and token;
+- provider and provider request ID;
+- Core randomizer epoch;
+- request and fulfillment times;
+- derived seed;
+- `rawOutputHash`;
+- failure hash;
+- post-processing retry count.
+
+See
+[`RandomnessRequest`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRandomizerLifecycle.sol#L13-L36).
+
+Typed state matters because "not finalized" can mean several different things.
+A request that has never existed, one still waiting on a provider, one whose
+accepted seed failed during Core storage, and one deliberately abandoned should
+not all look like zero.
+
+## Stream commits to raw output without storing every word
+
+The lifecycle does not store the provider's raw word array. It stores:
+
+`keccak256(abi.encode(randomWords))`
+
+See
+[`_hashRawRandomWords`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRandomizerLifecycle.sol#L480-L502).
+
+The hash lets a reviewer compare independently obtained provider output with
+the onchain commitment. It avoids permanently storing the full array while
+retaining a precise integrity check.
+
+That tradeoff separates integrity from availability. The hash proves that
+retrieved words match the commitment. It does not preserve those words or make
+them retrievable. Provider and release operations must retain the raw evidence
+if later verification matters.
+
+## Seed derivation binds the output to one context
+
+The final seed is derived as:
+
+`keccak256(abi.encode(typehash, provider, requestId, collectionId, tokenId, randomizerEpoch, rawOutputHash))`
+
+See
+[`_deriveRandomnessSeed`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRandomizerLifecycle.sol#L484-L502).
+
+This binds the accepted provider output to:
+
+- one provider;
+- one provider request;
+- one collection;
+- one token;
+- one Core provider epoch.
+
+Without those fields, the same provider output could be ambiguous across
+requests or works. The exact domain string, ABI encoding, request-ID uniqueness,
+and callback authentication are therefore part of the artwork's provenance and
+should be reviewed byte for byte.
+
+## Fulfillment checks more than the callback sender
+
+A callback is accepted only for a known `Pending` request. The lifecycle checks
+the token's collection, the recorded provider, and the live Core provider and
+epoch before deriving a seed.
+
+Those checks prevent:
+
+- a provider from fulfilling an unknown request;
+- a request from being applied to the wrong token;
+- a callback from an obsolete provider era;
+- a terminal request from being fulfilled twice;
+- a provider output from being accepted after relevant collection assignment
+  changed.
+
+Calling the right callback function is not sufficient. The request context must
+still match.
+
+## A failed Core write must not become a reroll
+
+The lifecycle marks the request fulfilled before attempting the Core write. If
+that write fails, the request becomes `FailedPostProcessing`.
+
+An authorized admin can retry the Core write at most three times. Every retry
+uses the already accepted `derivedSeed` and `rawOutputHash`. It does not call
+the provider, request new words, or derive a different seed. See
+[`_prepareRandomnessPostProcessingRetry`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRandomizerLifecycle.sol#L360-L405),
+the
+[`VRF retry`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/RandomizerVRF.sol#L116-L135),
+and the
+[`arRNG retry`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/RandomizerRNG.sol#L115-L134).
+
+This distinction is central. Retrying delivery of an accepted seed is a
+reliability action. Requesting fresh randomness after seeing an outcome is a
+reroll and can become a selection mechanism.
+
+The repository tests successful fulfillment, empty-word rejection, wrong
+provider and epoch handling, failed Core writes, same-seed retries, retry
+success, repeated failure, the three-attempt limit, unauthorized retry, burned
+tokens, and stateful lifecycle invariants. Focused evidence is in
+[`StreamRandomizerRetry.t.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/test/StreamRandomizerRetry.t.sol).
+
+Those tests establish local behavior. They do not prove that external provider
+infrastructure will operate correctly on the intended network.
+
+## The current stale state is immediate and terminal
+
+Both provider contracts expose an admin-authorized `markStaleRequest`. The call
+contains no elapsed-time or block-delay check. An authorized caller can mark a
+newly pending request stale immediately. See
+[`RandomizerVRF.markStaleRequest`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/RandomizerVRF.sol#L109-L114),
+[`RandomizerRNG.markStaleRequest`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/RandomizerRNG.sol#L108-L113),
+and
+[`_markRandomnessRequestStale`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRandomizerLifecycle.sol#L454-L472).
+
+`Stale` is terminal for that request. A late callback fails because the request
+is no longer pending. The token-to-request binding remains, and
+[`_recordRandomnessRequest`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRandomizerLifecycle.sol#L178-L217)
+rejects a second request for that token.
+
+Marking a request stale decrements the provider's pending count. That can remove
+the collection-level obstacle to assigning another provider, but it does not
+clear the affected token's binding or make that token eligible for a new
+request.
+
+An alternative policy could require an objective waiting period and define one
+tightly bounded recovery transition. That policy is proposed, not implemented.
+It would need to specify:
+
+- who may act;
+- the minimum delay and how it is measured;
+- whether recovery reuses or replaces the provider;
+- how selective rerolls are prevented;
+- which events preserve the full lineage.
+
+The current design decision is therefore consequential: strong admin discretion
+can place a token into an immediate terminal state with no recovery.
+
+## Provider migration is prospective, not retroactive recovery
+
+Provider replacement applies to new requests. A fulfilled seed cannot be
+rewritten because Core accepts a token hash only once. Pending requests block
+replacement until they are fulfilled, fail during post-processing, or are
+marked stale and no pending requests remain.
+
+`FailedPostProcessing` is no longer counted as pending. Core can therefore
+replace the provider while an accepted seed still needs a same-seed retry. After
+replacement, the retry preparation rejects the old provider or epoch. The
+request can be stranded.
+
+The current source has no separate guard or recovery transition for that
+ordering. Provider migration should not be described as a recovery mechanism
+for stale or failed tokens.
+
+This is complexity that needs reconciliation, not celebration. The lifecycle
+should have one unambiguous answer for every ordering between provider
+replacement and unresolved accepted work.
+
+## Burn does not erase randomness evidence
+
+A token can be burned while randomness is pending. The lifecycle record
+remains. A later provider callback can preserve post-burn audit evidence without
+recreating the token or emitting a live-token metadata update.
+
+This keeps the historical question answerable: did the provider eventually
+return an output for the request associated with the burned token?
+
+Burn, callback, retry, provider accounting, and metadata behavior still need to
+be reviewed together. A module that treats "burned" as "never existed" can lose
+request or liability state.
+
+## Provider funding is part of correctness
+
+The VRF path depends on a funded external subscription. The arRNG path reserves
+native value for payable requests. Provider obligations must remain separate
+from:
+
+- sale proceeds;
+- auction bids and refunds;
+- recipient credits;
+- accidental or recoverable surplus.
+
+Operational evidence must identify the real coordinator or controller,
+configuration, funded accounts, callback permissions, request health, failure
+alerts, and replenishment process.
+
+`RandomizerNXT.sol` remains in the source tree but is not approved by the
+reviewed release policy as a production provider. Source presence is not
+operating evidence.
+
+## What a simpler design would externalize
+
+A one-shot provider callback can be shorter than a persistent lifecycle. It
+also leaves an operator, indexer, or private database to explain:
+
+- which request belonged to which token;
+- whether an output came from the current provider era;
+- whether the provider returned nothing;
+- whether a callback was accepted but Core storage failed;
+- whether a retry reused the accepted seed;
+- whether a stale result was abandoned legitimately;
+- whether anyone received a chance to reroll;
+- where the raw provider output can be found.
+
+For generative artwork, those are not incidental operational details. They are
+part of the provenance and manipulation-resistance story.
+
+The right simplification is a smaller, complete state machine—not an absent one.
+
+## What can fail
+
+- Mutable provider settings change without a new Core epoch.
+- An authorized admin marks a healthy request stale immediately.
+- Terminal stale state leaves a token permanently unresolved.
+- Provider replacement strands a `FailedPostProcessing` request.
+- A callback is accepted for the wrong request, token, collection, provider, or
+  epoch.
+- A failed Core write exhausts all same-seed retries.
+- A late result overwrites or attempts to reopen a terminal state.
+- Raw provider words cannot be retrieved to verify `rawOutputHash`.
+- A subscription, reserve, coordinator, controller, or operational account
+  fails.
+- Burn leaves request or reserve accounting inconsistent.
+
+## Questions for reviewers
+
+1. Which provider properties and configuration changes must create a new Core
+   epoch?
+2. Should stale marking require a minimum elapsed time, and how should that time
+   be measured?
+3. Should a stale token have exactly one recovery route, or is permanent
+   unresolved state intentional?
+4. Can provider replacement occur while any accepted seed still needs
+   post-processing?
+5. Is three the right maximum for deterministic same-seed Core-write retries?
+6. Where must raw provider output remain available so its hash can be checked?
+7. Which provider funding, callback, monitoring, and failure-drill evidence must
+   block production use?
+8. Does every supported provider give artists and collectors an equally clear
+   provenance record even though its trust model differs?

--- a/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/revenue-splits-and-royalties.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/revenue-splits-and-royalties.md
@@ -1,0 +1,372 @@
+# Revenue, splits, and royalties
+
+This review covers an incomplete, undeployed candidate; [Current Implementation and Readiness](./security-testing-and-known-limitations) is the authoritative record of what is connected, implemented, proposed, and still required.
+
+Art sales often need to pay more than one person: an artist, collaborator,
+poster, protocol, curator, institution, or estate. The hard problem is not
+writing down percentages. It is ensuring that the sale selects the intended
+profile, every unit of value is accounted for once, hostile recipients cannot
+block everyone else, replacements do not lose liabilities, and collectors are
+not promised royalties a marketplace can ignore.
+
+Stream makes those questions explicit. A smaller contract can push all value to
+one address, but then the split, withdrawal, reconciliation, and recovery
+obligations move to that recipient or to a private accounting system.
+
+## One wei should have one accountable path
+
+Every sale path should answer:
+
+- Which sale created the value?
+- Which asset and amount were received?
+- Which revenue rule was selected, and by what precedence?
+- Which accounts became entitled?
+- How were division and residual units handled?
+- Where is the value held before withdrawal?
+- Which liabilities must be excluded from emergency recovery?
+- Which events and reads reconstruct every later movement?
+
+These are protocol invariants, not accounting polish. If the same wei is
+credited twice, a liability is omitted from surplus, or a profile changes
+between approval and settlement, the contract can remain syntactically correct
+while paying the wrong people.
+
+## The current native-sale paths keep local accounting
+
+At the pinned commit, signed fixed-price ETH runs through `StreamDrops`.
+English-auction ETH runs through `AuctionContract`.
+
+Each contract selects a local proceeds split in this order:
+
+1. token-specific rule;
+2. collection rule;
+3. contract default.
+
+The Drop contract creates poster, protocol, and curator-reserve credits. The
+Auction contract creates poster, protocol, curator, and bidder credits. Both use
+pull withdrawals rather than pushing arbitrary recipients during the mint,
+bid, or settlement that created the liability.
+
+This local accounting is the current sale behavior. It does not call the
+repository's separate revenue resolver, primary-sale settlement contract, split
+factory, or split wallets. The rehearsal deploys that wider foundation but does
+not connect current native Drops and Auctions to it.
+
+Parallel accounting systems are not a benefit by themselves. Before launch,
+the design needs one deliberate answer: retain and fully specify the local
+native paths, or integrate the resolver and settlement foundation without
+leaving ambiguous duplicate routes.
+
+## Pull credits keep one recipient from blocking everyone
+
+Synchronous payment looks simple: calculate shares and call each recipient
+during mint or settlement. It also puts the entire transaction at the mercy of
+every recipient contract.
+
+Pull accounting records an entitlement first and lets the recipient withdraw
+later. That means:
+
+- a recipient that rejects ETH does not block the sale;
+- a failed withdrawal can preserve the credit;
+- state can be updated before external transfer;
+- liabilities remain visible between sale and withdrawal;
+- a recipient can use an alternate compatible address where the contract
+  permits it.
+
+The complexity moves from a fragile chain of external calls into explicit
+credit and solvency state. It does not disappear. Each value-holding contract
+must still prove that credits plus reserves never exceed held value.
+
+The current system has no single protocol-wide credit ledger. Fixed-price
+recipients withdraw Drop-local credits, auction recipients and displaced
+bidders withdraw Auction-local credits, and split-wallet recipients withdraw
+wallet-local allocations after that wallet has been funded. Cross-contract
+solvency evidence is therefore essential.
+
+## The settlement foundation gives a sale one replay-safe identity
+
+The separately deployed
+[`StreamPrimarySaleSettlement.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamPrimarySaleSettlement.sol#L96-L145)
+records and settles primary-sale value. It uses a typed settlement key so one
+sale cannot be officially credited twice.
+
+A settlement record is intended to bind:
+
+- sale identity;
+- token or collection context;
+- payer and other participant context;
+- asset;
+- amount;
+- revenue class;
+- selected profile or template;
+- policy context.
+
+That binding matters because "already paid" cannot safely be a row in a private
+database. A successor settlement caller, retried transaction, or alternate sale
+adapter must reach the same answer about whether the value has already been
+consumed.
+
+This contract is a foundation, not a current collector-to-mint path. It accepts
+only owner-approved settlement callers, and the rehearsal does not approve one.
+Its source and tests show a settlement mechanism; they do not show that a
+current signed sale uses it.
+
+## Resolution separates policy from the sale mechanic
+
+[`StreamRevenueResolver.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRevenueResolver.sol#L170-L279)
+can resolve a revenue assignment at several levels. A token-specific rule can
+take precedence over collection configuration, which can take precedence over
+defaults.
+
+This separation protects two different concerns:
+
+- a sale adapter decides how and when a sale occurs;
+- a revenue resolver decides which approved economic profile applies.
+
+Without that boundary, every sale mechanic has to duplicate split selection and
+freeze semantics. Different adapters can then disagree about who should be
+paid. With a resolver, precedence and profile identity can be inspected once
+and reused—provided every supported sale actually calls it.
+
+Artists need to see the selected assignment, all higher-priority overrides,
+whether the assignment can still change, and when it freezes. A generic label
+such as "artist split" is not sufficient when token, collection, and default
+rules can compete.
+
+The resolver in the pinned source is not the complete accepted target. The
+accepted design keeps one registered, state-owning resolver as the sole Core
+royalty pointer target and adds one immutable, stateless,
+implementation-private validation adapter. The adapter would hold no state,
+authority, roles, funds, or normative events. Resolver writes would fail closed
+if exact validation could not be completed, while Core royalty reads would use
+resolver storage and pure computation rather than an external adapter call.
+
+That validation-adapter target is accepted for pre-genesis work but is not
+implemented at this commit. Complete normative interface approval,
+implementation, integration, and deployment evidence remain separate work.
+
+## Immutable split profiles make collaboration inspectable
+
+A split profile defines recipients and shares. The
+[`StreamSplitFactory`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamSplitFactory.sol)
+canonicalizes a profile and can deploy its
+[`StreamSplitWallet`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamSplitWallet.sol)
+at a deterministic address.
+
+The profile is immutable. Rather than changing the recipients inside an
+existing profile, the system can create a new profile and update an assignment
+under the resolver's mutability and freeze rules. That preserves what the old
+profile meant and makes the change visible.
+
+Reviewers should verify:
+
+- every recipient address is valid;
+- shares sum to the exact denominator;
+- duplicate recipients are rejected or combined deterministically;
+- canonical ordering produces one profile identity;
+- the expected wallet address cannot deploy different code;
+- a wallet proves that its stored entries match the profile;
+- profile changes have an explicit effective boundary;
+- artists can inspect the exact recipients and shares before approval.
+
+A spreadsheet can express the same percentages with far less Solidity. It
+cannot, by itself, prove which profile a sale used, preserve historical profile
+identity, or let a recipient withdraw without trusting the spreadsheet
+operator.
+
+## Native ETH accounting must distinguish liabilities from surplus
+
+For every ETH-holding path, reviewers should establish:
+
+- `msg.value` matches the required amount;
+- the same value is never allocated twice;
+- credits and reserves remain backed;
+- rounding residuals have a defined owner;
+- forced ETH does not create a false liability;
+- failed withdrawals preserve entitlement;
+- emergency recovery uses balance minus liabilities.
+
+The contract's balance answers how much ETH it holds. It does not answer how
+much it owns.
+
+## Approved ERC-20 support needs more than `transferFrom`
+
+The separate settlement foundation accepts only asset contracts whose
+deployment-wide
+[`StreamAssetPolicyRegistry`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamAssetPolicyRegistry.sol#L7-L83)
+status is active. Unknown, inactive, deprecated, or unsupported assets fail
+closed. The registry stores an evidence hash and effective timestamp for each
+policy decision.
+
+Settlement requires a successful boolean-returning transfer and checks the
+exact before-and-after balances of the payer, settlement contract, and split
+wallet. The
+[`StreamPrimarySaleSettlement`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamPrimarySaleSettlement.sol#L124-L145)
+path rejects:
+
+- missing or false return values;
+- fee-on-transfer behavior;
+- no-op transfers;
+- failed balance reads;
+- unexpected balance deltas.
+
+The pinned
+[`settlement tests`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/test/StreamPrimarySaleSettlement.t.sol#L778-L1043)
+exercise the supported standard-token path and those rejection cases.
+
+This extra checking exists because ERC-20 contracts do not all behave like the
+same asset. A simple `transferFrom` can record more value than arrived, accept a
+token that returned no meaningful result, or expose recipient accounting to
+token-specific behavior.
+
+The accepted asset set is deployment configuration, not a hardcoded list.
+Reviewers must inspect the actual registry state. A frontend allowlist alone is
+not an onchain accounting control.
+
+## Payer-bound token sales remain a proposal
+
+The current ERC-20 settlement foundation can pull an approved token directly
+from a payer. It is not a conforming genesis sale path.
+
+The proposed architecture separates:
+
+1. a primary-sale adapter that verifies a payer-signed `PaymentIntent` and is
+   the only protocol contract allowed to use the payer's token allowance;
+2. `StreamPrimarySaleSettlement`, which resolves revenue, consumes the
+   settlement key, routes value, and records the official settlement without
+   pulling the payer.
+
+That separation is intended to bind one exact token payment to one exact sale
+and keep allowance authority out of the accounting recorder. The final
+`PaymentIntent` fields and verification contract do not exist in this
+candidate. Signer-scoped replay, revocation, escrow fallback, and top-level sale
+orchestration also remain unresolved. See
+[`ADR 0019`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/docs/adr/0019-payment-intent-orchestration.md#L3-L82).
+
+## Rounding is an allocation decision
+
+Integer division can leave residual units. The public economic statement and
+contract behavior should say:
+
+- the denominator;
+- the rounding direction;
+- which account receives residual units;
+- whether dust accumulates;
+- how it can be withdrawn;
+- whether repeated small settlements bias one participant.
+
+"Approximately" is not a safe split rule. Small residuals become material when
+repeated across many payments, and an unspecified residual owner can turn into
+an emergency-withdrawal dispute.
+
+## Curator rewards connect onchain claims to offchain allocation
+
+The current Drop and Auction contracts create curator-reserve credits for the
+configured `StreamCuratorsPool`. An authorized release moves the reserve to the
+pool. The pool uses a collection Merkle root and pull credits for individual
+claims.
+
+The Merkle proof protects membership in the committed allocation without
+storing every leaf in the contract. It does not prove that the offchain process
+which constructed the root was fair or used correct inputs.
+
+Reviewers should establish:
+
+- who constructs and publishes the root;
+- which data and policy version it represents;
+- whether and how a root can be replaced;
+- claim replay protection;
+- proof encoding;
+- treatment of unclaimed value;
+- public reproducibility and contestability.
+
+This is another example where a cryptographic commitment makes an external
+decision inspectable but does not make the decision itself onchain.
+
+## ERC-2981 is royalty information, not enforcement
+
+The Core implements ERC-2981 `royaltyInfo`. At the pinned commit it returns:
+
+- receiver `0xC8ed02aFEBD9aCB14c33B5330c803feacAF01377`;
+- `690` basis points out of `10,000`;
+- amount `salePrice * 690 / 10_000`;
+- the same result for arbitrary token IDs;
+- no runtime setter or per-token override.
+
+See
+[`StreamCore.royaltyInfo`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L1013-L1027).
+The current Core does not call `StreamRevenueResolver` for this read.
+
+ERC-2981 tells a caller which royalty recipient and amount the contract
+reports. It cannot force a marketplace to pay. The honest terms are "royalty
+information" or "royalty signal," not "guaranteed royalty."
+
+Transfer-restricting enforcement would be a different protocol and collector
+tradeoff. Stream should not imply that a display standard supplies enforcement
+it does not contain.
+
+## Every value movement should be reconstructable
+
+Public reads and events should let an independent reviewer rebuild:
+
+- sale identity and gross value;
+- selected revenue assignment and precedence;
+- split profile and every allocation;
+- every credit and withdrawal;
+- curator reserve, root, and claims;
+- royalty configuration;
+- rounding residuals;
+- emergency or surplus movements.
+
+If complete reconstruction requires a private database, the public accounting
+record is incomplete.
+
+## What a simpler design would externalize
+
+Sending all proceeds to one operator makes the contracts smaller. It also asks
+artists, collaborators, curators, collectors, and auditors to trust that
+operator to:
+
+- apply the agreed split;
+- retain enough funds for every claimant;
+- handle failed recipients;
+- reconcile refunds and residuals;
+- preserve historical profiles;
+- survive key loss, succession, and organizational change;
+- report secondary royalty limitations honestly.
+
+Stream's split and accounting machinery exists to make those responsibilities
+durable and inspectable. The system should still remove duplicated paths and
+give each invariant one owner. Simplification is valuable when it eliminates
+overlap, not when it turns a public obligation back into an unwritten promise.
+
+## What can fail
+
+- Current native-sale accounting and the separate foundation remain ambiguous
+  parallel paths.
+- The wrong token, collection, or default profile wins precedence.
+- A sale or settlement key is consumed twice.
+- Shares or rounding allocate the wrong amount.
+- Contract liabilities exceed held value.
+- Emergency recovery withdraws reserved funds.
+- A fee-on-transfer or otherwise nonstandard token creates a false accounting
+  record.
+- A split wallet's code or stored profile differs from its expected identity.
+- A curator root is valid but built from wrong inputs.
+- Successor cutover duplicates or abandons credits.
+- A marketplace ignores ERC-2981.
+
+## Questions for reviewers
+
+1. Should genesis retain the current local native-sale accounting, or connect
+   every sale to the resolver and settlement foundation?
+2. Can artists see exactly which assignment wins before approving a sale?
+3. When should a split or royalty assignment become immutable?
+4. Which assets belong in the initial onchain asset policy?
+5. Who receives rounding residuals, and can repeated dust create bias?
+6. Can aggregate liabilities be proven across every value-holding contract?
+7. Is the curator-root process reproducible and contestable?
+8. What continuity proof is required before a successor can inherit accounting
+   duties?
+9. Is every public royalty statement explicit that ERC-2981 does not compel
+   marketplace payment?

--- a/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/roles-and-trust.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/roles-and-trust.md
@@ -1,0 +1,284 @@
+# Roles and trust
+
+This review covers an incomplete, undeployed candidate; [Current Implementation and Readiness](./security-testing-and-known-limitations) is the authoritative record of what is connected, implemented, proposed, and still required.
+
+Smart contracts do not remove trust. They make some powers explicit, constrain
+some of them, and leave others in the hands of people and external systems.
+Stream's authority model is deliberately more precise than a single owner or
+multisig: it separates routine administration, emergency intervention, signed
+sale authorization, artist approval, governed change, and permissionless
+execution.
+
+This page answers **who can do what**.
+
+## Authority is a capability, not a title
+
+The useful question is not "is this account an admin?" It is:
+
+- which exact function or record family can the account reach;
+- on which contract, collection, token, or subject;
+- whether the action is immediate or delayed;
+- whether another party can veto it;
+- whether the actor can grant itself or someone else more authority;
+- how the authority expires, freezes, rotates, or is revoked;
+- what public evidence reconstructs its use.
+
+A reassuring role name is not a security boundary. Effective authority comes
+from every reachable selector, registry check, executor, fallback, module
+relationship, and external service.
+
+## Actor matrix
+
+| Actor                             | Principal capability                                         | Trust question                                                                 |
+| --------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| Core owner                        | Bootstrap and ownership duties                               | When is this authority removed, transferred, or constrained?                   |
+| Global administrator              | Broad protocol administration                                | Is any global role necessary after launch?                                     |
+| Target/function administrator     | Call a specific selector on a specific target                | Does the selector grant more power than its name suggests?                     |
+| Pause guardian                    | Stop a configured domain                                     | Can it limit damage without becoming a censorship key?                         |
+| Unpause administrator             | Resume a paused domain                                       | What evidence is required before restart?                                      |
+| Signer manager                    | Rotate authorization signers and epochs                      | Can a stolen or mistaken signer be removed quickly and visibly?                |
+| TDH authorization signer          | Authorize a specific Drop action                             | Does the signed payload bind every fact that matters?                          |
+| Mint manager or executor          | Configure or execute mint policy                             | Can it exceed Core supply, bypass counters, or select an unintended recipient? |
+| Randomness controller or provider | Configure, request, or fulfill randomness                    | What can it bias, delay, retry, abandon, or strand?                            |
+| Governance proposer               | Publish a delayed action                                     | Who may propose value-bearing or permanent actions?                            |
+| Governance canceller or guardian  | Cancel or veto a scheduled action                            | Can it stop harm without authoring a replacement action?                       |
+| Governance executor               | Execute an action after its delay                            | Are target, calldata, native value, and timing fixed in advance?               |
+| Artist                            | Approve a particular collection state or artistic commitment | Which actions still proceed without the artist's current signature?            |
+| Collector                         | Mint, bid, withdraw, transfer, and burn                      | Which mutable states or external services affect the result?                   |
+| Permissionless caller             | Settle or trigger a maintenance path                         | Can the caller choose any value that was not already committed?                |
+
+The point of this separation is not to create more titles. It is to keep one
+compromised or mistaken actor from inheriting every protocol power.
+
+## Current administrative layer
+
+The current rehearsal includes
+[`StreamAdmins.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamAdmins.sol).
+It supports:
+
+- an owner;
+- a global administrator;
+- administrators scoped to a target contract and function selector;
+- a pause guardian;
+- an unpause administrator;
+- assignment and removal of administrative authority.
+
+Function-scoped authority is materially narrower than giving every operator
+every power. It still requires a complete selector inventory. Reviewers must
+check aliases and alternate module paths, not only the function whose name
+appears in the grant.
+
+Pause and unpause are intentionally different capabilities. A guardian can stop
+a configured domain quickly without automatically receiving the power to
+restart it. Each domain still needs a public policy covering what stops, which
+reads and exits remain available, who may resume, and what incident evidence is
+required. A pause that strands bids, refunds, mints, withdrawals, or randomness
+can create a second failure while trying to contain the first.
+
+## Signed authorization
+
+Signed Drops depend on a configured signer and signer epoch. The signer does not
+move tokens directly. It authorizes a contract call whose typed payload binds
+the intended action. Rotation changes the epoch so an authorization from an old
+signing era cannot be treated as current merely because its signature still
+verifies.
+
+That makes signer custody an important operational trust boundary. Failure modes
+include:
+
+- theft of a signing key;
+- a signer service authorizing values the community did not approve;
+- use of the wrong chain or verifying contract;
+- authorizations with deadlines that are too generous;
+- delayed rotation after compromise;
+- changed ERC-1271 validation behavior in a contract wallet;
+- monitoring that fails to notice unexpected authorizations.
+
+The public record should identify the signer, signer type, epoch, rotation
+authority, emergency-revocation process, and the exact typed-data software used
+to construct authorizations. No private key, seed, or recovery secret belongs in
+that record.
+
+## Governance actors
+
+The source includes
+[`StreamRoleRegistry.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRoleRegistry.sol)
+and
+[`StreamGovernanceExecutor.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamGovernanceExecutor.sol).
+They separate proposing, cancelling, guardian intervention, and execution. The
+executor can publish actions, enforce delays, execute matured calls, expire or
+cancel actions, support guardian vetoes, and freeze selected selectors.
+
+Those contracts are source implementations, not part of the current rehearsal's
+deployed contract set. Their exact candidate roles, target catalog, delays,
+selector classes, native-value limits, and bootstrap cutover remain readiness
+questions. The [Governance, Pausing, and
+Successors](./governance-pausing-and-successors) page explains how those powers
+are intended to change over time.
+
+## Artist authority
+
+The Core stores the artist address and can verify an artist signature over a
+specific collection state. That approval binds the artist address, current
+collection-freeze manifest hash, maximum collection purchases, total supply,
+and final-supply delay.
+
+It is not a universal artist veto. In the reviewed source, an administrator with
+the relevant authority can call `freezeCollection` without the freeze function
+itself demanding a fresh artist signature. Other metadata, preservation, and
+finality records can have their own writers and approval rules.
+
+That separation needs an explicit policy. Reviewers should decide which of these
+actions require:
+
+- the artist's current signature;
+- protocol governance;
+- a public delay;
+- a guardian veto window;
+- more than one of those protections.
+
+Artist consent is only meaningful when the artist can inspect the human-readable
+state behind a hash before signing it.
+
+## Record-family authorization
+
+The source replaces broad whole-selector writer grants with
+[`StreamRecordFamilyRegistry`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRecordFamilyRegistry.sol#L17-L285).
+A selector-level permission asks whether an actor may call a function. The
+record-family check also asks whether that actor may write this exact admitted
+record type for this collection and subject.
+
+The source defines eight authorization classes:
+
+| Class                      | Source authority                            |
+| -------------------------- | ------------------------------------------- |
+| Artist signer              | Live authority provider                     |
+| Owner signer               | Live authority provider                     |
+| Curator signer             | Family grant                                |
+| Institution signer         | Live authority provider                     |
+| Independent attestor       | Direct, self-attributed write by any caller |
+| Preservation administrator | Family grant                                |
+| Metadata administrator     | Family grant                                |
+| Global administrator       | Family grant                                |
+
+Fourteen closed family groups cover artist, owner, independent, curator,
+institution, rights, archive, fixity, C2PA, IIIF, media relationship, identity
+display, snapshot, and agent records. Artist, owner, independent, and
+institution families reject administrator grants. An exact record type is
+admitted once and cannot later be remapped.
+
+Live authority providers are code-hash pinned and fail closed when a call fails,
+returns malformed data, or no longer has the expected runtime code
+([`_providerAuthorizes`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRecordFamilyRegistry.sol#L298-L323)).
+
+These classes answer **who may write**. They do not prove that a rights claim,
+archive location, credential, or other record is true. An independent record is
+self-attributed evidence from its caller, not endorsement by the artist, 6529,
+or the protocol. [Metadata, Scripts, and
+Dependencies](./metadata-scripts-and-dependencies#collection-metadata-separates-claims-by-purpose-and-authority) explains
+each family in ordinary language.
+
+The source check is meaningful, but it is not a candidate configuration. The
+authoritative readiness page tracks the still-missing admission set, live
+providers, grants, runtime code hashes, rotation and revocation exercises, and
+independent review.
+
+## Module and successor authority
+
+Stream does not use an ordinary proxy to rewrite the permanent Core's
+implementation in place. Replaceable duties can move to new immutable contracts
+through explicit module and successor records. The old contract and its history
+remain visible.
+
+That turns an opaque upgrade question into a set of reviewable authority
+questions:
+
+- who can register a module;
+- which code hash and interface are required;
+- who can change its status;
+- who may declare a successor;
+- which delay and veto rules apply;
+- which liabilities remain with the predecessor;
+- whether a successor can affect a supposedly frozen or permanent surface.
+
+The accepted revenue-resolver validation adapter is a deliberate private
+implementation dependency, not a registered module or authority boundary. It
+would own no state, funds, roles, or events. Replacing it would require a new
+resolver, continuity proof, Registry V2 registration, and governed Core-pointer
+change. This prevents a hidden adapter setter from becoming an undeclared
+upgrade path.
+
+## Permissionless callers
+
+Some operations are safer when anyone can trigger them after every sensitive
+value is already fixed. Auction settlement after the end time is an example.
+
+Permissionless does not mean consequence-free. The caller must not be able to
+select a recipient, amount, manifest, implementation, or other value that was
+not already committed. Reviewers should trace every caller-supplied argument and
+every mutable storage read used during execution.
+
+## External trust boundaries
+
+Important powers remain outside Solidity:
+
+- community curation and TDH calculation;
+- authorization construction and signer custody;
+- randomness coordinators, controllers, accounts, and funding;
+- RPC nodes and chain indexing;
+- source and artifact publication;
+- content storage and gateways;
+- browsers and JavaScript runtimes;
+- Safe owners and recovery procedures;
+- deployment operators;
+- monitoring and incident response;
+- marketplaces deciding whether to honor royalty information.
+
+Each dependency needs an owner, failure signal, recovery path, and public
+evidence requirement. Putting a hash onchain can make a result verifiable; it
+cannot make the underlying service honest or continuously available.
+
+## Why this authority model exists
+
+A protocol meant to preserve art for decades cannot assume that one operator,
+module, provider, or service will remain correct forever. Stream's authority
+model is sophisticated because it tries to make each power narrow, visible,
+revocable where appropriate, and permanent only where permanence serves the
+artwork.
+
+The complexity should still be challenged. But removing a role boundary does
+not remove the underlying responsibility. It usually combines that power into a
+broader key, hides it in an operational service, or leaves the failure case
+undefined.
+
+The final system should publish one machine-readable authority view containing
+the permanent Core, current modules, predecessors and successors, code hashes,
+active roles, pending actions, pause state, signer epochs, and permanently
+frozen selectors.
+
+## What can fail
+
+- a role reaches more functions than its name suggests;
+- an alternate module bypasses a selector-scoped restriction;
+- a signer authorizes a payload that differs from the community decision;
+- an artist signature covers fewer facts than the product implies;
+- an authority provider recognizes the wrong wallet or changes code;
+- an administrator writes a record family it should not control;
+- a guardian can author changes instead of only stopping them;
+- a permissionless caller supplies a value that was supposed to be fixed;
+- predecessor and successor modules accept the same authorization or liability;
+- an external service fails without a visible owner or recovery path.
+
+## Questions for reviewers
+
+1. Which global roles should be eliminated before deployment?
+2. Which actions require a delay, and how long should each delay be?
+3. Which actions need both artist approval and protocol governance?
+4. Can the pause system preserve bidder, minter, and withdrawal rights during an
+   incident?
+5. Is record-family authorization enforced for every high-impact mutation?
+6. Should any governance executor be allowed to hold or send native value?
+7. What public evidence should be mandatory before a successor module becomes
+   active?
+8. Which authority boundary can be simplified without combining powers or
+   moving them into an opaque offchain service?

--- a/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/security-testing-and-known-limitations.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/security-testing-and-known-limitations.md
@@ -1,0 +1,491 @@
+# Current Implementation and Readiness
+
+Stream is an incomplete, undeployed, pre-audit candidate under active public
+review. There is no live Stream contract and there are no funds in it.
+
+The source reviewed on these pages is the exact Git commit
+[`513bd7e079eafe109df6ae1ae21bfbca6fec6786`](https://github.com/6529-Collections/6529Stream/tree/513bd7e079eafe109df6ae1ae21bfbca6fec6786),
+with Git tree `b50ec53109f5f8d6b4f4b07f4cb6fd3c1d0e3100`. Every
+implementation, test, limitation, and readiness statement below refers to that
+snapshot. A later commit requires a new review version.
+
+This is the authoritative page for what is in the current path, what exists in
+source but is not connected, which accepted designs remain unimplemented, which
+ideas are still proposals, and what evidence must exist before release. The
+topical pages explain why the mechanisms exist and how they behave.
+
+## Five implementation states
+
+Implementation state and evidence are different questions. A contract can
+compile and have strong local tests without being connected into the candidate
+that users would actually call.
+
+| State                    | Meaning                                                                                                                                            |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Current path**         | Constructed and connected by the current rehearsal in the user-facing path being described. This is rehearsal wiring, not a live deployment.       |
+| **Connected foundation** | Constructed by the rehearsal and connected to some protocol components, but not called by the current user-facing sale or mint path.               |
+| **Source implemented**   | Solidity exists at the pinned commit, but the current rehearsal does not establish complete candidate wiring, addresses, grants, or configuration. |
+| **Accepted target**      | The architecture is accepted for pre-genesis work, but complete conforming source and integration evidence do not yet exist.                       |
+| **Proposed or deferred** | The material is open design work or intentionally outside the current candidate. It is not current contract behavior.                              |
+
+These states are deliberately public. Calling every contract in the repository
+"implemented" would conceal the most important integration question: which
+contracts actually form one supported path?
+
+## A separate evidence dimension
+
+Evidence describes the strength and scope of proof, not the ambition of the
+design.
+
+| Evidence                           | What it establishes                                                                                                                         | What it does not establish                                                        |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| **Pinned source**                  | The Solidity or artifact exists at the exact reviewed commit.                                                                               | That it is connected, configured, safe, or intended for release.                  |
+| **Local tests**                    | Named unit, fuzz, invariant, state-machine, or composition cases passed in the repository's test environment.                               | That every composition is covered or that live infrastructure behaves like mocks. |
+| **Candidate binding**              | Exact addresses, runtime code hashes, roles, grants, parameters, and module relationships match one release candidate.                      | That external providers or marketplaces work correctly.                           |
+| **Non-local evidence**             | Intended coordinators, contract wallets, public RPCs, marketplaces, storage, retrieval, and operational processes work outside local mocks. | That the complete protocol is secure.                                             |
+| **External audit and remediation** | Independent experts reviewed the exact candidate and recorded dispositions and fixes.                                                       | A permanent guarantee against defects or future operational failure.              |
+
+The current repository supplies substantial pinned source and local test
+evidence. Candidate-bound, non-local, deployment, and external-audit evidence
+remain incomplete.
+
+## Current path
+
+The current rehearsal constructs a real multi-contract baseline:
+
+| Area                                    | Current behavior                                                                                                                                                                                                                                                                                                              |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Permanent token and collection identity | [`StreamCore.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol) stores shared ERC-721 identity, collection records, global token IDs, collection-local serials, supply, artist approval, metadata state, burn history, and Core freeze state. |
+| Signed fixed-price Drop                 | `StreamDrops` verifies the EIP-712 authorization and calls the legacy `StreamMinter`, which calls the legacy Core mint entry.                                                                                                                                                                                                 |
+| Signed English auction                  | The rehearsal connects `StreamDrops`, the legacy minter, and `AuctionContract`; auction registration mints into auction custody before bidding.                                                                                                                                                                               |
+| Native fixed-price accounting           | `StreamDrops` selects its own token, collection, or contract-default split and creates poster, protocol, and curator-reserve credits.                                                                                                                                                                                         |
+| Native auction accounting               | `AuctionContract` maintains its own bidder, poster, protocol, and curator credits.                                                                                                                                                                                                                                            |
+| Royalty information                     | Core returns one receiver and `690` basis points for every token through ERC-2981. It does not call the current revenue resolver.                                                                                                                                                                                             |
+| Administration and pauses               | `StreamAdmins` supplies owner, global, target/function, pause-guardian, and unpause authority for the current baseline.                                                                                                                                                                                                       |
+| Core and preservation                   | Core and `StreamPreservationRecords` are included in the current rehearsal.                                                                                                                                                                                                                                                   |
+
+The exact sale and foundation construction is visible in
+[`RehearseDeployment.s.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/script/RehearseDeployment.s.sol#L169-L270).
+
+This baseline already supports meaningful behavior. "Current path" does not mean
+audited, deployed, or final. It means the rehearsal proves these contracts are
+the path selected at this commit.
+
+## Connected foundations
+
+The rehearsal also constructs significant systems that are not called by the
+current signed Drop or Auction path.
+
+### Mint manager and durable ledger
+
+[`StreamMintManager.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMintManager.sol)
+and
+[`StreamMintLedger.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMintLedger.sol)
+provide phases, executors, gates, time windows, supply constraints, policy
+hashes, prepared Core execution, and durable counters.
+
+The rehearsal connects the manager to Core and authorizes it as a ledger writer.
+It still passes the legacy minter to `StreamDrops`. The manager/ledger system and
+the signed Drop are therefore two source-implemented mint lanes, not one
+end-to-end path. [Tokens, Collections, and
+Minting](./tokens-collections-and-minting#the-two-source-mint-lanes)
+explains the behavioral difference.
+
+### Revenue, split, asset-policy, and settlement foundation
+
+The rehearsal deploys:
+
+- [`StreamRevenueResolver.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRevenueResolver.sol);
+- [`StreamSplitFactory.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamSplitFactory.sol);
+- [`StreamSplitWallet.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamSplitWallet.sol);
+- [`StreamAssetPolicyRegistry.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamAssetPolicyRegistry.sol);
+- [`StreamPrimarySaleSettlement.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamPrimarySaleSettlement.sol).
+
+The native Drop and Auction paths do not call this foundation, and the rehearsal
+does not configure a settlement caller. Current sale credits, the resolver and
+split-wallet system, and fixed Core royalties remain parallel accounting lanes.
+[Revenue, Splits, and
+Royalties](./revenue-splits-and-royalties) explains each accounting model.
+
+## Source-implemented systems
+
+These mechanisms exist in Solidity at the reviewed commit. Source presence is
+not a claim that the current rehearsal or a production candidate uses them.
+
+| System                              | Source behavior                                                                                                                                    | Candidate status                                                                                                                     |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Governance V2                       | Role registry, delayed executor, cancellation, expiry, guardian veto, selector freezes, action classes, and one-way bootstrap sealing.             | Not in the current rehearsal's deployed contract set; target catalog, roles, parameters, and cutover evidence remain unbound.        |
+| Module and successor registry       | Records module identity, code hashes, interfaces, status, and explicit successor relationships.                                                    | Complete candidate module graph and continuity evidence remain unavailable.                                                          |
+| Artwork finality                    | Schedules terminal finality, supports delay, cancellation or veto, component manifests, and terminal state.                                        | Not in the current rehearsal's deployed set; complete payload binding and terminal writer inventory are not yet proven.              |
+| Record-family authorization         | Classifies exact metadata and preservation record types and checks writer class, collection, and subject.                                          | Admission set, live providers, grants, runtime code hashes, rotation/revocation evidence, and independent review remain unavailable. |
+| Raise-only governed parameters      | Enforces delayed, strictly higher, maximum-2x changes with no lowering or emergency mutation path.                                                 | Complete candidate parameter catalog and proposal-to-execution binding remain unavailable.                                           |
+| Collection metadata snapshots       | Publishes immutable snapshot records with exact covered record types and fresh authority checks.                                                   | Exact candidate record admissions and writers remain unbound.                                                                        |
+| Mint gates and durable counters     | Binds gate lifecycle, interface, code hash, metadata hash, gas limit, authorizer, quantities, and counter scopes.                                  | The current signed Drop does not call this lane; nonempty nullifier arrays are rejected.                                             |
+| Prepared mint execution             | Manager validates policy and counters, then calls Core prepare and complete entries atomically.                                                    | The current signed Drop uses the legacy Core mint route instead.                                                                     |
+| Randomness lifecycle                | Stores pending, fulfilled, stale, and failed-post-processing states; binds provider and epoch; derives one seed; retries the same seed.            | Live provider configuration, funding, callbacks, monitoring, stale policy, and recovery evidence remain outstanding.                 |
+| Metadata rendering and dependencies | Supports onchain and offchain modes, scripts, token data, dependency versions, images, attributes, and ERC-4906 mutation-triggered refresh events. | Public-RPC, marketplace, browser, maximum-response, and long-term retrieval evidence remain outstanding.                             |
+
+The detailed governance and authority behavior is explained on [Governance,
+Pausing, and Successors](./governance-pausing-and-successors) and [Roles and
+Trust](./roles-and-trust).
+
+## Accepted targets not yet implemented
+
+An accepted target is more than an idea, but less than code that can be credited
+to the candidate.
+
+### Revenue-resolver validation adapter
+
+The accepted revenue architecture adds one immutable, exact-code validation
+adapter to resolver write paths. The adapter owns no state, authority, roles,
+funds, or events. It may make only approved caller-insensitive, read-only calls
+to pinned dependencies.
+
+The registered resolver remains the sole state owner, writer, Core royalty
+pointer target, and normative event emitter. It authenticates the request,
+checks adapter and dependency identities, validates the complete returned
+result, and only then changes state. The Core-facing royalty read uses resolver
+storage and pure computation; it never reaches the adapter.
+
+The boundary fails closed. A revert, out-of-gas result, changed code hash, or
+malformed answer reverts before lasting state change. Recovery requires a new
+resolver, continuity proof, Registry V2 registration, and governed Core-pointer
+replacement.
+
+That architecture is accepted for pre-genesis work, but complete conforming
+resolver and adapter source are not present at this commit. Implementation
+remains gated on an independently approved normative interface appendix and
+freeze commit.
+
+### Satellite-triggered metadata refresh
+
+Core currently emits ERC-4906 refresh events as part of its own mutations. The
+accepted launch target adds restricted single-token and batch helpers so
+authorized satellite contracts can emit standard refresh signals with
+Stream-native context.
+
+No such public or external helper exists in the reviewed Solidity. Caller
+checks, lifecycle and range bounds, context binding, abuse analysis,
+implementation, and tests remain outstanding. [Metadata, Scripts, and
+Dependencies](./metadata-scripts-and-dependencies#refresh-events-tell-consumers-that-state-changed) explains the
+current events and the target.
+
+### Genesis role inventory
+
+The release artifacts describe a thirty-seven-role genesis inventory. It is an
+architecture requirement and review target, not a concrete deployment manifest.
+The final candidate must bind every role to exact accounts, contracts,
+selectors, scopes, delays, and revocation conditions.
+
+## Proposed or deferred work
+
+The following material is review input, not implemented protection:
+
+| Proposal or deferred area             | Current position                                                                                                                                                                                                                                               |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Artist-registry validation adapter    | ADR 0022 proposes an immutable, stateless, unregistered validation adapter while the registry remains the sole authority and state owner. The ADR authorizes no implementation.                                                                                |
+| Payer-bound ERC-20 orchestration      | A proposed sale adapter would verify a payer-signed `PaymentIntent` and be the only protocol contract allowed to pull allowance; the settlement contract would record and route value without pulling the payer. The verifier and top-level path do not exist. |
+| Batch operation-root replay ownership | ADR 0018 proposes making the ledger the durable batch replay owner and joining ledger accounting to per-token prepared-mint events. It is not accepted or implemented.                                                                                         |
+| Stale-randomness recovery             | A proposal would add an objective delay and one bounded recovery transition. The current stale state is terminal for that token.                                                                                                                               |
+| Append-only artwork-finality recovery | ADR 0020 proposes a companion that preserves the original finality record while appending a governed recovery lineage. It is not accepted or implemented.                                                                                                      |
+| Broader artist authority and recovery | Collaborators, delegated roles, guardians, estate instructions, sanctions, disputes, and recovery remain broader design work rather than a complete production artist registry.                                                                                |
+| Additional sale profiles              | Dutch auctions, private sales, refund windows, sealed bids, raffles, burn-to-mint, ERC-20 bidding, and other profiles are proposed or deferred unless present in reviewed source and tests.                                                                    |
+| `RandomizerNXT` production use        | Source remains in the repository, but the reviewed release policy does not approve it as a production provider.                                                                                                                                                |
+
+No topical explanation should present these ideas as protections already
+provided by the candidate.
+
+## Test evidence
+
+The repository contains:
+
+- ordinary unit tests;
+- fuzz tests;
+- invariant tests;
+- state-machine tests;
+- adversarial multi-contract composition tests;
+- focused tests for EIP-712, auction timing, mint accounting, burn behavior,
+  metadata events, randomness state and retry behavior, governance, and
+  preservation.
+
+The generated Technical Reference compiles the complete Solidity corpus at the
+pinned commit and inventories protocol contracts, interfaces, libraries, test
+contracts, deployment scripts, definitions, functions, events, errors,
+signatures, selectors, and source ranges.
+
+This is meaningful engineering evidence. It does not prove the absence of:
+
+- missing assertions;
+- an untested composition;
+- a wrong specification encoded consistently in implementation and test;
+- deployment or initialization mistakes;
+- live-provider differences;
+- economic attacks;
+- key-management failure;
+- long-term storage, browser, RPC, or marketplace failure.
+
+In particular, tests of both mint lanes do not establish a signed-Drop-to-
+MintManager integration that the rehearsal does not contain. Tests of individual
+revenue contracts do not create one unified settlement path.
+
+## Static analysis
+
+The pinned
+[`SLITHER_BASELINE.json`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/ops/SLITHER_BASELINE.json)
+contains `30` open High or Medium findings: `3` High and `27` Medium.
+
+A count alone does not establish exploitability, and static-analysis tools can
+produce false positives. It does establish that the candidate is not
+static-analysis clean. Every finding needs one of:
+
+- a source-backed fix and regression test;
+- a demonstrated false-positive analysis;
+- an explicit accepted-risk decision with scope and owner;
+- removal from the release surface.
+
+The final register should preserve tool version, configuration, raw output,
+normalization rules, source commit, and disposition evidence.
+
+## Known limitations and unresolved blockers
+
+This register centralizes release state. The linked topical page owns the fuller
+behavioral explanation.
+
+| Area                            | Current limitation                                                                                                                                                                                                                            | Best detailed explanation                                                                                                                                                                                                                       |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Zero-mint final supply          | `setFinalSupply` stores `0` when no token has minted; `setCollectionData` also treats `0` as uninitialized, so an unfrozen collection can be given a new nonzero cap and minting can reopen. There is no separate final-supply flag or event. | [Final supply](./freezing-preservation-and-artwork-finality#final-supply-is-a-supply-promise)                                                                                                                                                   |
+| Core bytecode margin            | The pinned proof records `StreamCore` deployed bytecode at `24,152` bytes: `424` bytes below EIP-170. It passes the interim `384`-byte margin by `40` bytes but misses the normative `2,000`-byte margin by `1,576` bytes.                    | [Contract bytecode size](#contract-bytecode-size)                                                                                                                                                                                               |
+| Governance record families      | `RISK-GOV-002` remains open for candidate admissions, providers, grants, runtime bindings, rotation/revocation evidence, and independent review.                                                                                              | [Record-family authorization](./roles-and-trust#record-family-authorization)                                                                                                                                                                    |
+| Governance native value         | `RISK-GOV-003` records that executor native-value authority is too broad or insufficiently constrained.                                                                                                                                       | [Native-value authority](./governance-pausing-and-successors#native-value-authority)                                                                                                                                                            |
+| Governed parameter binding      | `RISK-GOV-004` records incomplete end-to-end evidence that every governed action binds every sensitive parameter.                                                                                                                             | [Governed parameter binding](./governance-pausing-and-successors#governed-parameter-binding)                                                                                                                                                    |
+| Parallel mint lanes             | Signed Drops and the current auction use legacy `StreamMinter`; manager/ledger behavior is separate.                                                                                                                                          | [The two source mint lanes](./tokens-collections-and-minting#the-two-source-mint-lanes)                                                                                                                                                         |
+| Parallel accounting lanes       | Drop, Auction, curator pool, resolver, split-wallet, settlement, and fixed Core royalty accounting are not one unified value path or ledger.                                                                                                  | [One accountable value path](./revenue-splits-and-royalties#one-wei-should-have-one-accountable-path)                                                                                                                                           |
+| Auction terms                   | Bid-increment percentage and extension time are mutable global values, not per-auction snapshots. They have no bound, delay, or change event and can change during active auctions.                                                           | [The minimum next bid](./fixed-price-sales-and-auctions#the-minimum-next-bid-is-exact) and [anti-sniping](./fixed-price-sales-and-auctions#anti-sniping-needs-a-reproducible-clock-rule)                                                        |
+| Manager nullifiers              | The gate interface defines nullifiers, but the current manager and ledger reject every nonempty nullifier array.                                                                                                                              | [Gate security inputs](./tokens-collections-and-minting#gates-carry-security-inputs-not-descriptive-metadata)                                                                                                                                   |
+| Manager replay ownership        | The manager derives a batch root and token operation IDs after consuming ledger state, while the ledger does not store the root and Core retains an unbounded lifetime token-operation mapping.                                               | [Durable replay ownership](./tokens-collections-and-minting#replay-protection-needs-one-durable-owner)                                                                                                                                          |
+| Randomness stale state          | An authorized admin can mark a newly pending request stale without an onchain elapsed-time check. `Stale` is terminal and prevents another request for that token.                                                                            | [The current stale state](./randomness#the-current-stale-state-is-immediate-and-terminal)                                                                                                                                                       |
+| Randomness provider replacement | A `FailedPostProcessing` request no longer counts as pending, so a provider can be replaced before retry; the old provider/epoch then fails the implemented retry checks.                                                                     | [Provider migration](./randomness#provider-migration-is-prospective-not-retroactive-recovery)                                                                                                                                                   |
+| Randomness providers            | Live subscription/controller funding, callbacks, permissions, stale policy, monitoring, and raw-word retrieval are not proven by mocks. `RandomizerNXT` is not approved for production use.                                                   | [Provider trust models](./randomness#two-providers-do-not-mean-one-trust-model)                                                                                                                                                                 |
+| Shared collection identity      | A Stream collection has no separate ERC-721 contract address. Marketplace and indexer handling of Core-native collection identity remains a non-local launch gate. There is no dormant per-collection facade in this Core.                    | [One permanent identity surface](./tokens-collections-and-minting#one-permanent-identity-surface-for-many-collections)                                                                                                                          |
+| Metadata refresh                | Mutation-triggered Core events exist, but the accepted satellite-callable helper does not. Current collection batch refresh covers a deliberate superset of globally interleaved token IDs.                                                   | [Refresh events](./metadata-scripts-and-dependencies#refresh-events-tell-consumers-that-state-changed)                                                                                                                                          |
+| Metadata and RPC size           | Local acceptance of long strings or token URIs does not prove that public RPCs, wallets, indexers, or marketplaces will process the result.                                                                                                   | [Size limits](./metadata-scripts-and-dependencies#size-limits-protect-more-than-gas)                                                                                                                                                            |
+| Artwork finality                | Scheduling and veto mechanisms exist in source, but complete payload binding and the terminal selector/writer inventory are not yet proven for a candidate.                                                                                   | [Delayed finality](./freezing-preservation-and-artwork-finality#terminal-finality-is-delayed-for-a-reason) and [terminal writer inventory](./freezing-preservation-and-artwork-finality#terminal-means-every-effective-writer-is-accounted-for) |
+| Preservation availability       | A valid content hash proves equality when bytes are retrieved; it does not keep the bytes, dependencies, browser, RPC, or rendering environment available. Independent package recovery has not been demonstrated.                            | [Append-only preservation history](./freezing-preservation-and-artwork-finality#preservation-records-keep-history-append-only)                                                                                                                  |
+
+## Contract bytecode size
+
+The pinned
+[`bytecode release proof`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/release-artifacts/latest/bytecode-release-proof.json)
+records the exact Core measurement above. The narrow margin matters because
+small compiler or source changes can cross the chain limit, emergency fixes
+become harder, and optimizer and metadata settings are part of the result.
+"It deploys today" is not the same as having a durable engineering margin.
+
+The accepted revenue architecture also imposes independent future limits on the
+resolver and adapter: each must be no larger than `22,576` bytes of deployed
+runtime and `47,152` bytes of full initcode, including encoded constructor
+arguments. Those values preserve a `2,000`-byte margin under EIP-170 and
+EIP-3860 respectively.
+
+Neither accepted future contract is implemented at this commit. Only a final,
+canonical isolated build can supply release evidence; issue-worktree or
+aggregate-build measurements are diagnostic.
+
+## Candidate-bound evidence still required
+
+The release needs a generated, machine-readable candidate manifest covering:
+
+- exact source and artifact hashes;
+- compiler and optimizer settings;
+- contract addresses, chain, creation transactions, and runtime code hashes;
+- constructor and initializer arguments;
+- Core pointers and complete module graph;
+- role holders, scopes, signer addresses, and signer epochs;
+- record-family admissions, authority providers, and grants;
+- governed parameter values and action classes;
+- pause, unpause, and guardian configuration;
+- randomness providers, accounts, funding, callbacks, and monitoring;
+- revenue, settlement, split, royalty, and liability paths;
+- ownership transfers, renunciations, and one-way bootstrap sealing;
+- explorer verification;
+- independent readback of every critical invariant.
+
+Local deployment scripts do not prove a correct live deployment. A second party
+must be able to reconstruct and verify the ceremony without trusting the
+deployer's notes.
+
+The staging review currently resolves to Wave
+`19d4bbf5-86ec-4053-a5f2-bb28d7a2f780`, titled **Stream review (staging)**.
+That is the verified staging-only destination.
+
+The user-designated future production destination is Wave
+`06e69198-eea7-40c5-95d3-7c1bf5051aba`. That is an intended mapping only:
+production review routes remain disabled, and this staging release does not
+enable or mutate the production destination. Any future production activation
+must bind that exact Wave through the reviewed environment configuration and
+independently read the mapping back before accepting feedback.
+
+## Non-local evidence still required
+
+The current candidate does not contain complete evidence for:
+
+- fork or public-testnet execution against intended infrastructure;
+- live VRF and arRNG requests and callbacks;
+- production-style signing and ERC-1271 contract-wallet verification;
+- marketplace handling of shared collection identity, metadata, and royalties;
+- public-RPC handling of maximum token URI responses;
+- independent retrieval and reconstruction of preservation packages;
+- long-duration auction operation and failure recovery;
+- signer and authority-provider rotation and revocation;
+- successor discovery and continuity readback.
+
+Mocks are valuable for deterministic tests. They cannot reproduce real service
+limits, permissions, latency, billing, availability, or operational failure.
+
+## External audit
+
+There is no completed independent external audit and remediation record for this
+candidate. Community review can improve the specification and find serious
+issues. It is not a substitute for expert audit.
+
+The audit must cover the exact release candidate and deployment configuration,
+not an earlier design branch. Any material post-audit change needs an explicit
+delta review. Findings need source-backed dispositions, fix commits, regression
+evidence, and a record of remaining risk.
+
+## Release blockers
+
+At minimum, release to production should remain blocked until:
+
+- all High findings and every material Medium finding are fixed or formally
+  resolved;
+- the zero-mint final-supply promise is repaired or accurately redefined;
+- governance record-family authorization and action binding are proven;
+- native-value executor authority is constrained and tested;
+- the chosen signed-sale mint lane is explicit and its callers, counters, replay
+  state, and Core entry are tested end to end;
+- native Drop and Auction accounting is deliberately retained or replaced by
+  resolver/settlement integration, with no ambiguous parallel path;
+- current fixed royalties are deliberately retained or replaced by the accepted
+  resolver-backed target, with marketplace behavior verified;
+- the Core meets the adopted bytecode margin or the design is deliberately
+  revised;
+- the accepted revenue adapter architecture has an independently approved
+  interface freeze, reconciled specification, conforming implementation,
+  independent review, per-contract size proof, and adapter-first deployment
+  evidence;
+- every production randomness provider has candidate-bound non-local evidence
+  and a reviewed stale/failure policy;
+- the finality payload and every terminal writer are proven bound;
+- exact deployment, bootstrap, rollback, and successor-cutover ceremonies are
+  rehearsed and independently read back;
+- preservation packages are independently recovered using only published
+  instructions and commitments;
+- any future production review activation binds and independently verifies the
+  designated production feedback Wave without reusing the staging destination;
+- external audit and remediation are complete;
+- the final public review version matches the exact deployment commit and
+  configuration.
+
+This list can grow as public review discovers new facts. A removed blocker needs
+evidence of resolution, not a more reassuring label.
+
+## Threat model
+
+The protocol must assume interaction with:
+
+- malicious buyers, bidders, recipients, and contract wallets;
+- compromised or mistaken privileged accounts;
+- stale, replayed, or partially bound signatures;
+- unavailable or adversarial randomness infrastructure;
+- hostile ETH and token recipients, reentrancy, and forced value;
+- malformed metadata and very large return values;
+- registries or modules configured in the wrong order;
+- front-running, chain reorganization, timestamp variation, and transaction
+  censorship;
+- disappearing storage, RPC, browser, marketplace, and indexing services;
+- governance proposals whose visible description differs from executable
+  bytes.
+
+The threat model also includes honest mistakes. An artist approving the wrong
+manifest, an operator selecting the wrong address, or a governance action
+binding an incomplete payload can create permanent damage without an attacker.
+
+## Review priorities
+
+### Economic and accounting review
+
+Reviewers should reconstruct every liability across sales, auctions, refunds,
+randomness reserves, split wallets, settlement, and emergency surplus. They
+should prove:
+
+- credits cannot exceed value received;
+- the same funds are not promised twice;
+- rounding dust has an explicit owner;
+- reverting recipients cannot block unrelated users;
+- emergency withdrawal excludes all liabilities;
+- successor cutover cannot duplicate or abandon balances;
+- contract wallets and self-referential recipients do not break accounting.
+
+Invariant tests should combine sale, bid, refund, withdrawal, pause, burn, and
+successor sequences.
+
+### Signature review
+
+Every signed action should bind chain, verifying contract, action type,
+collection, relevant participants, economic terms, quantity, replay identifier,
+signer epoch, and deadline.
+
+Reviewers should compare the human-readable UI, typed-data payload, Solidity
+type hash, recovered signer, replay storage, and emitted event. A value omitted
+from one layer can let the user approve a different action from the one
+executed.
+
+### Metadata and preservation review
+
+Security includes the artwork experience. Test malformed strings, untrusted
+HTML and JavaScript, oversized responses, missing dependencies, wrong hashes,
+unavailable storage, and future browser behavior.
+
+A contract can remain secure while its artwork becomes unavailable. Release
+criteria need both smart-contract security and preservation evidence.
+
+## Public findings
+
+The current configured disclosure policy permits possible exploitable
+vulnerabilities to be reported in the public review Wave while this candidate is
+in its validated predeployment state. That permission comes from the explicit
+review state and policy, not merely from the absence of a deployment.
+
+[How to participate in the community
+review](./community-review#public-conduct-and-sensitive-information) contains the
+authoritative reporting and sensitive-information guidance. Every substantive
+disposition should link a source commit, test, or documented decision. A status
+label without evidence is not a resolution.
+
+## Design position
+
+Stream is ambitious because the problem is ambitious: preserve artistic intent
+and token identity while allowing sale infrastructure, randomness providers,
+metadata services, governance, and other replaceable systems to survive change.
+
+That sophistication increases the need for an exact readiness ledger. It does
+not make the architecture suspect by default, and it does not make local source
+or tests sufficient. The right question is whether every mechanism protects a
+real requirement, whether its authority is bounded, and whether the complete
+system can be independently reconstructed.
+
+The standard for release is evidence, not confidence.
+
+## Questions for reviewers
+
+1. Does the implementation-state inventory classify any component too strongly?
+2. Does the threat model omit an actor, asset, trust boundary, or failure mode?
+3. Which current static-analysis findings become exploitable in composition?
+4. Is the adopted Core bytecode margin adequate for a permanent contract?
+5. Which governance paths still lack complete parameter or record-family
+   binding?
+6. What non-local evidence must exist before audit and before deployment?
+7. Which properties need independent economic or formal verification?
+8. Which accepted target is essential for genesis, and which can safely move to
+   an explicit successor without weakening the permanent artwork promise?

--- a/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/tokens-collections-and-minting.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-27.1/editorial/tokens-collections-and-minting.md
@@ -1,0 +1,363 @@
+# Tokens, collections, and minting
+
+This review covers an incomplete, undeployed candidate; [Current Implementation and Readiness](./security-testing-and-known-limitations) is the authoritative record of what is connected, implemented, proposed, and still required.
+
+A minimal ERC-721 can assign a token ID to an owner. Stream is trying to
+protect a larger set of facts: which collection the token belongs to, its
+serial within that collection, how many works may ever exist, which
+distribution policy admitted the mint, which limits were consumed, and what
+history remains after a burn or module replacement.
+
+Those protections explain why minting is more than one public function. The
+important review question is not whether Stream could use fewer contracts. It
+is whether a smaller design would preserve the same identity, supply, replay,
+and accounting guarantees—or quietly move them into a website or private
+database.
+
+## One permanent identity surface for many collections
+
+The reviewed Core stores a collection record and associates every token with a
+collection. Token IDs are globally sequential across the shared ERC-721
+contract. The Core also records a collection-local serial, so the same work can
+be identified both as a global Stream token and as an item within its own
+collection.
+
+This is a deliberate alternative to deploying a separate ERC-721 contract for
+every artist or project. It gives all Stream works a common permanent surface
+for ownership, approvals, transfers, identity reads, and shared invariants.
+Collection identity does not have to be reconstructed from a private index.
+
+The tradeoff is real. A defect or governance failure in the shared Core can
+affect many collections, and an artist's collection does not receive its own
+ERC-721 contract address. Ethereum has no native subcollection identity
+standard, so address-only marketplaces may present one Stream contract rather
+than one contract per artist.
+
+The accepted design addresses that presentation problem with Core collection
+reads, per-collection metadata, and `properties.stream.collection` fields in
+token JSON. Marketplace and indexer support still requires external evidence.
+The launch Core contains no dormant facade that can later turn each collection
+into a separate ERC-721 address. See the accepted
+[`collection identity decision`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/docs/adr/0015-collection-identity-and-facade-readiness.md#L21-L66)
+and
+[`Core-native-only decision`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/docs/adr/0016-core-native-only-erc721.md#L27-L50).
+
+## Supply is several facts, not one number
+
+Stream distinguishes:
+
+- the configured maximum supply;
+- the number of tokens minted over the collection's lifetime;
+- the live supply after burns;
+- the final supply;
+- the remaining capacity of a phase or authorization.
+
+These values answer different questions. Burning a token changes live supply
+but does not erase mint history, make its token ID reusable, or necessarily
+restore someone's lifetime mint allowance. A collection-level cap does not say
+whether an individual phase, wallet, recipient, or signed authorization still
+has capacity.
+
+A superficially simpler design can keep only the current token count. That
+works until a burn is mistaken for permission to mint again, a replaced minter
+forgets prior usage, or two distribution paths each believe they own the same
+remaining supply.
+
+## Why mint policy lives outside the Core
+
+The Core should enforce the invariants that every mint path must respect:
+token identity, collection identity, supply, freeze state, and non-reuse of
+permanent operation identifiers. It should not permanently embed every future
+allowlist, claim, sale, airdrop, or eligibility mechanism.
+
+The newer manager-and-ledger design therefore separates:
+
+- **Core**, which allocates and records permanent token identity;
+- **StreamMintManager**, which applies phase and execution policy;
+- **StreamMintLedger**, which retains durable usage and replay accounting;
+- **executors**, which drive an approved mint path; and
+- **gates**, which can evaluate additional eligibility policy.
+
+This is purposeful modularity. Different distributions can evolve without
+changing what an existing token is. The security condition is that no module
+may exceed Core supply, rewrite identity, bypass freeze, or discard durable
+limits.
+
+## The two source mint lanes
+
+The pinned source contains two distinct lanes, and they should not be described
+as one integrated flow.
+
+The signed Drop and current auction route call the legacy
+[`StreamMinter`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMinter.sol).
+That minter applies its own collection time and supply checks before calling
+the legacy Core mint entry. It does not consume `StreamMintLedger` counters.
+
+The separately deployed
+[`StreamMintManager`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMintManager.sol)
+and
+[`StreamMintLedger`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMintLedger.sol)
+implement phases, gates, policy hashes, durable counters, and prepared Core
+execution. The rehearsal installs the manager in Core, but gives the legacy
+minter to `StreamDrops`.
+
+The distinction is visible in
+[`StreamDrops._executeFixedPriceDrop`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L609-L632),
+[`StreamMinter.mint`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMinter.sol#L130-L175),
+[`StreamMintManager.mintPrepared`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMintManager.sol#L241-L299),
+and the
+[`rehearsal wiring`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/script/RehearseDeployment.s.sol#L218-L269).
+
+Parallel lanes are not themselves a virtue. They are current candidate state
+that must be reconciled into one explicit launch path. The lasting design value
+is the separation between permanent identity and replaceable distribution
+policy.
+
+## Phases make distribution policy inspectable
+
+A manager phase can bind:
+
+- collection and phase identity;
+- opening and closing time;
+- maximum phase supply;
+- per-wallet, per-recipient, or other scoped limits;
+- an executor and optional gate;
+- a policy hash;
+- whether the phase is paused;
+- the counters consumed by each mint.
+
+That structure exists because "eligible to mint" is not one universal rule. A
+one-of-one sale, fixed edition, free claim, allowlist, and airdrop can need
+different timing and accounting without changing the ERC-721 Core.
+
+Every supported phase should make these facts visible before a user acts:
+
+- phase identifier and collection;
+- opening and closing time;
+- maximum phase supply;
+- per-wallet or per-recipient limits;
+- executor and optional gate;
+- whether transfers or burns affect counters;
+- which role can edit, pause, or freeze the phase;
+- what happens to pending or prepared work at closure.
+
+An extension point is not proof that every imaginable policy is safe. The
+genesis release still needs an explicit list of supported and tested profiles.
+
+## Gates carry security inputs, not descriptive metadata
+
+An active gate registration binds lifecycle status, interface ID, semantic
+version, runtime code hash, metadata hash, and a per-call gas limit. The
+registry rechecks active status, interface support, and code identity.
+
+A gate result can include:
+
+- an **authorization ID**, intended as a one-use identifier;
+- **nullifiers**, intended as domain-separated replay keys;
+- an **authorizer**, whose identity or entitlement was accepted;
+- a **maximum quantity**;
+- a **gate hash** committing to the validation result and policy context.
+
+The current ledger scopes an authorization ID to the calling mint manager and
+rejects a second consumption by that manager. The current manager and ledger
+reject every nonempty nullifier array, so this candidate does not yet support
+nullifier-backed gates. A `bytes32[]` interface would not provide privacy by
+itself in any case.
+
+The gate hash improves auditability, but it does not prove that an offchain
+eligibility process was correct. Reviewers still need to trace every external
+call, return value, code-hash check, reentrancy boundary, and rollback rule.
+Moving code outside the Core does not make it harmless.
+
+See
+[`StreamMintModuleRegistry`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMintModuleRegistry.sol#L9-L100)
+and
+[`IStreamMintGate`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/IStreamMintGate.sol#L6-L29).
+
+## Durable counters survive more than one transaction
+
+`StreamMintLedger` can apply counters to wallets, recipients, tokens, contexts,
+or other keys. That flexibility is needed because several apparently similar
+limits have different meanings:
+
+- A payer limit is not a recipient limit when sponsored mints are possible.
+- A live-balance limit is not a minted-ever limit.
+- A burn should not automatically restore a lifetime allowance.
+- A reverted mint should not permanently consume capacity.
+- Replacing the mint manager should not erase historical usage.
+
+If these counters exist only in a website, users must trust the website to
+apply them consistently. If they live only inside one replaceable minter, a
+module cutover can reset the policy's memory. A separate durable ledger makes
+continuity an explicit protocol responsibility.
+
+## Editions and signed Drop quantity
+
+The shared Core can represent a one-of-one, a fixed edition, or a larger
+collection by minting distinct ERC-721 tokens into one collection.
+
+That collection capability must not be confused with the current signed Drop
+payload. `DropAuthorization` contains `quantity`, but
+[`StreamDrops._validateAuthorization`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L561-L581)
+requires `quantity == 1`. The fixed-price path constructs one-element arrays
+and mints one token through
+[`_executeFixedPriceDrop`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L609-L632).
+
+An edition can still contain many tokens, but the current signed Drop lane
+needs a separate authorization for each one. The manager lane has different
+quantity and batch rules. Documentation and interfaces must name the lane
+rather than imply that the signed field currently enables a batch.
+
+## Prepared execution keeps cross-module state atomic
+
+The manager lane crosses policy, counter, identity, and mint state. It therefore
+uses a preparation sequence:
+
+1. validate the request and phase policy;
+2. consume the required ledger counters;
+3. derive a batch operation root and per-token operation IDs;
+4. prepare identity in Core;
+5. complete the mint in Core;
+6. emit execution evidence.
+
+Preparation and completion occur within one transaction. A revert restores the
+transaction rather than leaving a long-lived half-mint for a user to complete
+later. Core also contains a manager-only abort hook for the most recently
+prepared allocation, although the current `mintPrepared` path relies on atomic
+transaction rollback rather than calling it.
+
+The required invariant is:
+
+> After any revert, every supply reservation, replay identifier, counter,
+> payment credit, and pending token state is either fully committed or fully
+> restored.
+
+A direct call may look simpler, but it does not remove this problem when policy,
+accounting, and identity live in different modules. It merely makes partial
+execution harder to see.
+
+## Replay protection needs one durable owner
+
+Core retains lifetime operation-ID replay state so an old prepared operation
+cannot be accepted again.
+
+The current manager derives one batch operation root and distinct token
+operation IDs, but it consumes the ledger before deriving that root. The ledger
+does not store the root or token operation ID, while Core retains an unbounded
+lifetime mapping of prepared-token operation IDs.
+
+The proposed repair would make the ledger the durable batch-replay owner and
+provide an exact join between ledger accounting and prepared-token events. It
+is not accepted or implemented. See
+[`ADR 0018`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/docs/adr/0018-batch-operation-root-and-token-identity.md#L3-L33).
+
+This is a good example of complexity that should be reduced: one invariant
+should have one unambiguous owner.
+
+## Every minted token receives durable identity
+
+On successful allocation, a token receives:
+
+- a global token ID;
+- a collection ID;
+- a collection-local serial;
+- an owner;
+- mint history and, where supplied by the selected lane, operation identity;
+- the metadata and randomness state required by the collection.
+
+Reviewers should verify event reconstructability separately for each mint lane.
+A third party should be able to distinguish a legacy mint from a prepared
+manager mint and rebuild collection creation, allocation, transfer, burn, and
+finality from public state and events.
+
+## Burning ends ownership, not history
+
+Burn removes ERC-721 ownership and ordinary token behavior. Core retains burn
+audit reads, and the token ID is not minted again.
+
+That permanence matters because "nonexistent" and "burned" are not the same
+historical state. Other modules still need explicit rules for:
+
+- pending randomness;
+- unsettled sale or credit state;
+- metadata and preservation evidence;
+- supply finalization;
+- curator or revenue accounting;
+- artwork finality;
+- offchain indexes.
+
+The repository includes Core burn, randomness, metadata, and supply-invariant
+tests. Cross-module burn composition remains a critical review area.
+
+## Mint closure must close every lane
+
+For a collection with at least one mint, `setFinalSupply` lowers the configured
+cap to minted-ever supply. The zero-mint case contains a current exception:
+`0` also means uninitialized supply to `setCollectionData`, so a function admin
+can later set a nonzero cap while the collection remains unfrozen.
+
+There is no separate final-supply flag or final-supply event in the pinned
+candidate. A zero-minted, unfrozen collection can therefore be reopened after
+`setFinalSupply`. See the line-by-line explanation in
+[Freezing, preservation, and artwork finality](./freezing-preservation-and-artwork-finality#final-supply-is-a-supply-promise).
+
+An accepted mint-closure design should prove that:
+
+- finalization is monotonic even when minted-ever supply is zero;
+- every phase and executor is closed or exhausted;
+- signed Drops and auctions cannot mint later;
+- no successor module can bypass the final state;
+- any required delay has elapsed;
+- an event records the final value;
+- authorizations prepared before finalization have defined behavior.
+
+## What a simpler design would externalize
+
+Removing the manager, ledger, gates, operation identities, or collection-local
+identity does not automatically remove the requirements they serve. It can
+instead make a website responsible for:
+
+- deciding eligibility;
+- remembering lifetime limits;
+- distinguishing payer from recipient;
+- preventing replay;
+- coordinating supply across sale paths;
+- retaining history through burns and replacements;
+- explaining which collection a shared-contract token belongs to.
+
+That may be an acceptable tradeoff for a disposable mint page. It is a much
+larger trust assumption for a protocol intended to carry valuable artworks
+over decades.
+
+The right simplification test is precise: identify the requirement that can be
+dropped, or show a smaller mechanism that preserves it. Complexity that only
+duplicates ownership of one invariant should be removed. Complexity that makes
+a lasting promise explicit should be judged against the risk it replaces.
+
+## What can fail
+
+- Two mint lanes enforce different supply or replay assumptions.
+- Overlapping phases exceed intended supply.
+- Payer and recipient counters are confused.
+- A gate reenters or returns ambiguous data.
+- A manager transaction leaves counters and token state inconsistent.
+- A replay identifier is consumed too early or too late.
+- Burning restores an allowance unintentionally.
+- Manager replacement loses durable limits.
+- Final supply is recorded while another mint path remains open.
+
+## Questions for reviewers
+
+1. Which identity and mint invariants must remain in the permanent Core?
+2. Are global token IDs plus collection-local serials the right shared identity
+   model?
+3. Which genesis distribution profiles actually require onchain phases, gates,
+   and counters?
+4. Do counters handle sponsored mints, transfers, burns, and manager succession
+   correctly?
+5. Can every partial execution return all affected modules to a clean state?
+6. Which single component should own lifetime replay evidence?
+7. Is the long-term storage cost of durable counters and operation IDs justified
+   by the guarantees they preserve?
+8. Does the final launch path remove ambiguity between the legacy and manager
+   mint lanes?


### PR DESCRIPTION
## Issue

The staging artifact packager requires the immutable 2026-07-27.1 editorial manifest to exist in the trusted base before the independently generated Solidity snapshot can land.

## Fix

Preload only the 15-file Stream review editorial directory for version `2026-07-27.1`. These files remain unreferenced by the active review configuration until the subsequent snapshot and activation changes land.

## Notable changes

- Adds the complete plain-English editorial corpus for the new immutable review version.
- Adds its manifest and page topology.
- Makes no runtime, route, component, configuration, or generated snapshot changes.

## Validation

- Verified exact 15-file scope under the versioned editorial directory.
- Verified manifest version, source provenance, and page topology.
- Scoped whitespace check is clean.

## Dependency

This is the prerequisite for snapshot PR #3486 and combined Stream review PR #3475.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive public review for Stream version 2026-07-27.1.
  * Documented artwork lifecycle, artist approvals, minting, token identity, metadata, randomness, sales, auctions, revenue, royalties, governance, and preservation.
  * Added guidance on authority, trust boundaries, security testing, known limitations, and community participation.
  * Included reviewer checklists, failure scenarios, readiness considerations, and questions across the protocol lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->