### PR TITLE
fix: make release bus composition idempotent

### DIFF
--- a/.github/workflows/release-bus-v2-compose.yml
+++ b/.github/workflows/release-bus-v2-compose.yml
@@ -36,7 +36,7 @@ jobs:
           [[ "$TRAIN_ID" =~ ^[A-Za-z0-9._-]{1,100}$ ]]
           [[ "$OPERATION_KEY" =~ ^rb2:[A-Za-z0-9:._-]+:a[1-9][0-9]*$ ]]
           [[ "$RELEASE_BRANCH" =~ ^release-bus-v2/(staging|production|qualification)-train-[A-Za-z0-9._-]+$ ]]
-          jq -e 'type == "array" and length > 0 and all(.[]; test("^[a-f0-9]{40}$"))' <<< "$CANDIDATE_SHAS"
+          jq -e 'type == "array" and all(.[]; test("^[a-f0-9]{40}$"))' <<< "$CANDIDATE_SHAS"
       - name: Authorize exact v2 operation
         env:
           EXPECTED_SHA: ${{ inputs.expected_sha }}
@@ -88,7 +88,12 @@ jobs:
           excluded='[]'
           while IFS= read -r sha; do
             git fetch --no-tags origin "$sha"
+            if git merge-base --is-ancestor "$sha" HEAD; then
+              echo "Candidate $sha is already included in the composition."
+              continue
+            fi
             if git merge --no-ff --no-commit "$sha"; then
+              git rev-parse --verify --quiet MERGE_HEAD >/dev/null
               git -c core.hooksPath=/dev/null commit -s \
                 -m "Release Bus v2 train $TRAIN_ID: merge frontend candidate" \
                 -m "Candidate-SHA: $sha" \

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -120,9 +120,7 @@ describe("release bus staging artifact transfer", () => {
     expect(deployStep.run).toContain(
       "public-review-discussion-destinations.json"
     );
-    expect(deployStep.run).toContain(
-      "PUBLIC_REVIEW_DISCUSSION_DESTINATIONS:"
-    );
+    expect(deployStep.run).toContain("PUBLIC_REVIEW_DISCUSSION_DESTINATIONS:");
     expect(deployStep.run).toContain(
       '> "$release_dir/public-review-discussion-destinations.json"'
     );
@@ -360,6 +358,205 @@ describe("release bus v2 E2E callbacks", () => {
     expect(stagingE2E).toContain("failure_phase=staging_e2e_setup");
     expect(stagingE2E).toContain("failure_class=E2E");
     expect(stagingE2E).toContain("failure_phase=staging_e2e");
+  });
+});
+
+describe("release bus v2 frontend composition", () => {
+  const workflow = YAML.parse(
+    fs.readFileSync(
+      path.join(process.cwd(), ".github/workflows/release-bus-v2-compose.yml"),
+      "utf8"
+    )
+  );
+  const composeScript = workflow.jobs.compose.steps.find(
+    (step: { name?: string }) =>
+      step.name === "Compose deterministic candidate set"
+  ).run;
+  const validateScript = workflow.jobs.compose.steps.find(
+    (step: { name?: string }) => step.name === "Validate immutable inputs"
+  ).run;
+
+  function runCompositionScenario(
+    setup: string,
+    candidates: string,
+    assertions: string
+  ) {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "release-bus-v2-compose-")
+    );
+    try {
+      childProcess.execFileSync("bash", ["-s"], {
+        cwd: tempDir,
+        env: {
+          ...process.env,
+          GIT_CONFIG_NOSYSTEM: "1",
+        },
+        input: `
+set -euo pipefail
+# The Windows jq binary writes CRLF even inside Git Bash. Normalize its output
+# so this fixture exercises the workflow's Ubuntu line semantics locally too.
+jq_executable="$(command -v jq)"
+jq() {
+  "$jq_executable" "$@" | tr -d '\\r'
+}
+git init --bare origin.git >/dev/null
+git init seed >/dev/null
+cd seed
+git config user.name "Fixture Author"
+git config user.email "fixture@example.com"
+printf 'base\\n' > shared.txt
+git add shared.txt
+git commit -m base >/dev/null
+base_sha="$(git rev-parse HEAD)"
+git branch -M main
+git remote add origin "$OLDPWD/origin.git"
+git push origin main >/dev/null
+${setup}
+cd ..
+git clone --no-checkout origin.git work >/dev/null
+cd work
+git checkout --detach "$base_sha" >/dev/null
+mkdir -p runner-temp
+export BASE_SHA="$base_sha"
+export CANDIDATE_SHAS="$(jq -nc ${candidates})"
+export RELEASE_BRANCH="release-bus-v2/staging-train-fixture"
+export RELEASE_BUS_GIT_EMAIL="release-bus@example.com"
+export RELEASE_BUS_GIT_NAME="Release Bus Fixture"
+export RUNNER_TEMP="$PWD/runner-temp"
+export TRAIN_ID="fixture"
+(
+${composeScript}
+)
+${assertions}
+`,
+        stdio: "pipe",
+      });
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+
+  it("accepts a base-only composition with an empty candidate set", () => {
+    expect(validateScript).toContain(
+      'type == "array" and all(.[]; test("^[a-f0-9]{40}$"))'
+    );
+    expect(validateScript).not.toContain("length > 0");
+
+    runCompositionScenario(
+      "",
+      "'[]'",
+      `
+test "$(jq -r '.reused' "$RUNNER_TEMP/composition.json")" = false
+test "$(jq -c '.excluded_shas' "$RUNNER_TEMP/composition.json")" = '[]'
+test "$(jq -r '.composed_sha' "$RUNNER_TEMP/composition.json")" = "$base_sha"
+test "$(git rev-parse HEAD)" = "$base_sha"
+`
+    );
+  });
+
+  it("commits candidates only from an active merge state", () => {
+    const merge = composeScript.indexOf(
+      'if git merge --no-ff --no-commit "$sha"; then'
+    );
+    const mergeHead = composeScript.indexOf(
+      "git rev-parse --verify --quiet MERGE_HEAD >/dev/null"
+    );
+    const commit = composeScript.indexOf(
+      "git -c core.hooksPath=/dev/null commit -s"
+    );
+
+    expect(merge).toBeGreaterThan(-1);
+    expect(mergeHead).toBeGreaterThan(merge);
+    expect(commit).toBeGreaterThan(mergeHead);
+    expect(composeScript).not.toContain("--allow-empty");
+  });
+
+  it("accepts ancestor and repeated candidate SHAs without empty commits", () => {
+    runCompositionScenario(
+      `
+printf 'candidate\\n' > candidate.txt
+git add candidate.txt
+git commit -m candidate >/dev/null
+candidate_sha="$(git rev-parse HEAD)"
+git push origin HEAD:refs/heads/candidate >/dev/null
+`,
+      '--arg base "$base_sha" --arg candidate "$candidate_sha" \'[$base, $candidate, $candidate]\'',
+      `
+test "$(jq -r '.reused' "$RUNNER_TEMP/composition.json")" = false
+test "$(jq -c '.excluded_shas' "$RUNNER_TEMP/composition.json")" = '[]'
+composed_sha="$(jq -r '.composed_sha' "$RUNNER_TEMP/composition.json")"
+test "$composed_sha" = "$(git rev-parse HEAD)"
+git merge-base --is-ancestor "$base_sha" "$composed_sha"
+git merge-base --is-ancestor "$candidate_sha" "$composed_sha"
+test "$(git rev-list --merges --count "$base_sha..$composed_sha")" = 1
+test "$(git log --format=%B "$base_sha..$composed_sha" | grep -c "Candidate-SHA: $candidate_sha")" = 1
+`
+    );
+  });
+
+  it("reuses an existing immutable branch and reports candidates outside it", () => {
+    runCompositionScenario(
+      `
+git switch -c existing "$base_sha" >/dev/null
+printf 'existing\\n' > existing.txt
+git add existing.txt
+git commit -m existing >/dev/null
+existing_sha="$(git rev-parse HEAD)"
+git push origin HEAD:refs/heads/release-bus-v2/staging-train-fixture >/dev/null
+git switch -c outside "$base_sha" >/dev/null
+printf 'outside\\n' > outside.txt
+git add outside.txt
+git commit -m outside >/dev/null
+outside_sha="$(git rev-parse HEAD)"
+git push origin HEAD:refs/heads/outside >/dev/null
+`,
+      '--arg existing "$existing_sha" --arg outside "$outside_sha" \'[$existing, $outside]\'',
+      `
+test "$(jq -r '.reused' "$RUNNER_TEMP/composition.json")" = true
+test "$(jq -r '.composed_sha' "$RUNNER_TEMP/composition.json")" = "$existing_sha"
+test "$(jq -r '.excluded_shas | length' "$RUNNER_TEMP/composition.json")" = 1
+test "$(jq -r '.excluded_shas[0]' "$RUNNER_TEMP/composition.json")" = "$outside_sha"
+`
+    );
+  });
+
+  it("continues with a compatible candidate after excluding a conflict", () => {
+    runCompositionScenario(
+      `
+git switch -c first "$base_sha" >/dev/null
+printf 'first\\n' > shared.txt
+git commit -am first >/dev/null
+first_sha="$(git rev-parse HEAD)"
+git push origin HEAD:refs/heads/first >/dev/null
+git switch -c conflicting "$base_sha" >/dev/null
+printf 'conflicting\\n' > shared.txt
+git commit -am conflicting >/dev/null
+conflicting_sha="$(git rev-parse HEAD)"
+git push origin HEAD:refs/heads/conflicting >/dev/null
+git switch -c following "$first_sha" >/dev/null
+printf 'following\\n' > following.txt
+git add following.txt
+git commit -m following >/dev/null
+following_sha="$(git rev-parse HEAD)"
+git push origin HEAD:refs/heads/following >/dev/null
+`,
+      '--arg first "$first_sha" --arg conflicting "$conflicting_sha" --arg following "$following_sha" \'[$first, $conflicting, $following]\'',
+      `
+test "$(jq -r '.reused' "$RUNNER_TEMP/composition.json")" = false
+test "$(jq -r '.excluded_shas | length' "$RUNNER_TEMP/composition.json")" = 1
+test "$(jq -r '.excluded_shas[0]' "$RUNNER_TEMP/composition.json")" = "$conflicting_sha"
+composed_sha="$(jq -r '.composed_sha' "$RUNNER_TEMP/composition.json")"
+git merge-base --is-ancestor "$first_sha" "$composed_sha"
+git merge-base --is-ancestor "$following_sha" "$composed_sha"
+if git merge-base --is-ancestor "$conflicting_sha" "$composed_sha"; then
+  exit 1
+fi
+test -z "$(git ls-files --unmerged)"
+test "$(cat shared.txt)" = first
+test "$(cat following.txt)" = following
+test "$(git rev-list --merges --count "$base_sha..$composed_sha")" = 2
+`
+    );
   });
 });
 


### PR DESCRIPTION
## Issue

Release Bus v2 composition treated `git merge --no-ff --no-commit` success as proof that Git had opened a merge. When a candidate SHA was already an ancestor of the current composition, Git returned success with “already up to date,” and the following signed commit failed with “nothing to commit.” The operation then retried as infrastructure failure instead of completing idempotently.

## Fix

Treat an already-included candidate as a successful no-op before merging. For a non-ancestor candidate, require an active `MERGE_HEAD` before creating the signed merge commit. Keep merge conflicts on the existing strict abort-and-exclude path. Also allow the documented empty candidate array so a base-only/candidate-free composition can complete.

## Changes

- accept base-only composition with `candidate_shas: []`
- skip ancestor and repeated candidate SHAs without creating empty commits
- require `MERGE_HEAD` before committing a successful non-ancestor merge
- add real temporary-repository coverage for empty sets, ancestor/repeated SHAs, immutable-branch reuse, conflict exclusion, and a compatible candidate after a conflict

## Validation

- `seize run test:no-coverage --runInBand --runTestsByPath __tests__/scripts/deployment-bus.test.ts __tests__/scripts/release-bus-v2-compose-workflow.test.ts __tests__/scripts/release-bus-install-dependencies.test.ts` — 75 tests passed
- `seize run lint:changed` — passed
- `seize run typecheck:changed` — passed
- `seize run typecheck:jest` — ratchet passed
- `actionlint .github/workflows/release-bus-v2-compose.yml` — passed
- changed-file whitespace check — passed

The aggregate `quality:changed` command was not used as a pass signal: its mutating formatter compared against a stale local `main`, touched unrelated files, and then surfaced an unrelated existing lint failure. All unintended formatter changes were restored and the final delta against current `main` contains only the workflow and two release-bus test files described above.

## Risk

Low and isolated to frontend train composition. Immutable branch reuse, exact-SHA ancestry checks, signed merge commits, conflict exclusion, and publish-once behavior remain intact. No release controls, staging state, or production state are changed by this PR.

## Review Notes

Please focus on the empty-set/base-only case, ancestor idempotency, the `MERGE_HEAD` invariant, and strict cleanup before processing a post-conflict candidate.