### PR TITLE
Make About page body text easier to read

### DIFF
--- a/components/about/AboutMemes.tsx
+++ b/components/about/AboutMemes.tsx
@@ -130,7 +130,7 @@ export default function AboutMemes() {
             </h2>
           </header>
           <div className="tw-max-w-3xl">
-            <p className="tw-m-0 tw-text-pretty tw-text-lg tw-font-light tw-leading-7 tw-text-iron-100 sm:tw-text-xl sm:tw-leading-8">
+            <p className="tw-m-0 tw-text-pretty tw-text-lg tw-font-normal tw-leading-7 tw-text-iron-100 sm:tw-text-xl sm:tw-leading-8">
               {t(DEFAULT_LOCALE, "about.memes.intro")}
             </p>
             <p className="tw-m-0 tw-mt-5 tw-text-pretty tw-text-base tw-leading-6 tw-text-iron-300 sm:tw-mt-6 sm:tw-text-lg sm:tw-leading-7">

--- a/components/about/AboutMinting.tsx
+++ b/components/about/AboutMinting.tsx
@@ -113,7 +113,7 @@ function MintingHeader() {
           >
             {m("about.minting.summary.label")}
           </h2>
-          <div className="tw-mt-2 tw-space-y-2 tw-text-base tw-font-light tw-leading-7 tw-text-iron-400">
+          <div className="tw-mt-2 tw-space-y-2 tw-text-base tw-font-normal tw-leading-7 tw-text-iron-400">
             <p className="tw-m-0">
               Meme Cards are minted (primary sale) when the art for the next
               Meme Card is ready.
@@ -249,7 +249,7 @@ function MintingOverview() {
         ))}
       </ul>
 
-      <p className="tw-mb-0 tw-mt-6 tw-max-w-4xl tw-text-base tw-font-light tw-leading-7 tw-text-iron-400">
+      <p className="tw-mb-0 tw-mt-6 tw-max-w-4xl tw-text-base tw-font-normal tw-leading-7 tw-text-iron-300">
         The Memes generally mint using an allowlist model. The purpose of the
         allowlist is to avoid gas wars / bot wars and to give as broad a range
         of people as possible a chance to mint.
@@ -295,7 +295,7 @@ function MintingOverview() {
         </aside>
       </div>
 
-      <p className="tw-mb-0 tw-mt-5 tw-text-sm tw-font-light tw-italic tw-leading-6 tw-text-iron-500">
+      <p className="tw-mb-0 tw-mt-5 tw-text-sm tw-font-normal tw-italic tw-leading-6 tw-text-iron-400">
         There is quite a bit of thought that goes into the allowlist process.
         Read below to learn more.
       </p>
@@ -381,7 +381,7 @@ function MintingPhilosophy() {
         >
           {m("about.minting.philosophy.title")}
         </h2>
-        <p className="tw-mb-0 tw-mt-2 tw-text-base tw-font-light tw-leading-7 tw-text-iron-400">
+        <p className="tw-mb-0 tw-mt-2 tw-text-base tw-font-normal tw-leading-7 tw-text-iron-400">
           Mints for well-known collections where demand may exceed supply are
           very difficult to manage effectively. The main approaches and our
           views on them are highlighted below.

--- a/components/about/AboutMintingReference.tsx
+++ b/components/about/AboutMintingReference.tsx
@@ -68,7 +68,7 @@ function AllowlistBackground({ locale }: { readonly locale: SupportedLocale }) {
         >
           {m(locale, "about.minting.background.title")}
         </h2>
-        <p className="tw-mb-0 tw-mt-2 tw-text-base tw-font-light tw-leading-7 tw-text-iron-400">
+        <p className="tw-mb-0 tw-mt-2 tw-text-base tw-font-normal tw-leading-7 tw-text-iron-400">
           It might be useful to understand how we imagine the allowlist process.
           The analogy below is imperfect, but still helpful.
         </p>
@@ -199,7 +199,7 @@ function AllowlistCurrentPractices({
         >
           {m(locale, "about.minting.current.title")}
         </h2>
-        <p className="tw-mb-0 tw-mt-2 tw-text-base tw-font-light tw-leading-7 tw-text-iron-400">
+        <p className="tw-mb-0 tw-mt-2 tw-text-base tw-font-normal tw-leading-7 tw-text-iron-400">
           This is the current process for allowlists at The Memes as of February
           2023. It is certain that the process will change in the future, as it
           has in the past, in response to new challenges.

--- a/components/about/AboutSubscriptions.tsx
+++ b/components/about/AboutSubscriptions.tsx
@@ -131,7 +131,7 @@ function Overview({ locale }: { readonly locale: SupportedLocale }) {
         >
           {m(locale, "about.subscriptions.overview.title")}
         </h2>
-        <p className="tw-mb-0 tw-mt-2 tw-text-base tw-font-light tw-leading-7 tw-text-iron-400">
+        <p className="tw-mb-0 tw-mt-2 tw-text-base tw-font-normal tw-leading-7 tw-text-iron-400">
           {m(locale, "about.subscriptions.overview.intro")}
         </p>
       </div>


### PR DESCRIPTION
## Issue

- Body copy on the Minting and Subscription Minting About pages uses a light font weight and inconsistent neutral text colors, making longer paragraphs look thin and less cohesive.
- The Memes About page contains one additional light-weight intro paragraph.

## Fix

- Use normal font weight for all affected body paragraphs.
- Keep longer body copy on `iron-300` and shorter lead-ins, notes, and secondary copy on `iron-400`, following the hierarchy already used by the Network reference pages.

## Changes

- Updated `/about/minting` body, lead-in, and note utilities.
- Updated `/about/subscriptions` overview lead-in weight.
- Removed the stray light weight from `/about/the-memes` while preserving its intentionally prominent intro color.
- Scanned `app/about` and `components/about`; no `tw-font-light` instances remain.
- No headings, links, list markers, layout, behavior, copy, dependencies, or generated files changed.

## Validation

- `6529 run react-doctor:diff` — passed, 100/100 with no issues across all four changed files.
- `git diff --check` — passed.
- Focused source scan confirmed no remaining `tw-font-light` in the About routes/components.
- `6529 run lint:changed` was attempted twice (including an explicit four-file ESLint invocation) but both local processes remained silent and were stopped after five minutes without diagnostics.
- `6529 run typecheck:changed` was stopped after eight silent minutes without diagnostics; PR CI is the authoritative type/lint gate.
- The app started successfully against the staging API on a unique local port at the exact branch SHA. Protected routes redirected to `/access` because no staging access key is available in the local environment.
- Pixel-level desktop/mobile screenshots were not collected: the packaged in-app browser runtime failed before navigation with `Cannot redefine property: process`.

## Risk

- Level: Low
- Why: utility-only typography changes in four About components; no runtime logic, data flow, or interaction behavior changed.
- Rollback: revert the single commit to restore the prior font weight and color utilities.

## Review Notes

- Please focus on the visual hierarchy: normal-weight long copy should read as `iron-300`, while lead-ins and smaller incidental copy remain `iron-400`.
- Loading, error, permission, focus, hover, touch, and keyboard behavior are unaffected because the PR changes only static text utilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved readability across About page content by adjusting font weights and text colors.
  * Updated typography for introductory, minting, allowlist, and subscription descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->