### PR TITLE
Restore Release Bus frontend production release notes

### DIFF
--- a/.github/workflows/release-bus-deploy-production.yml
+++ b/.github/workflows/release-bus-deploy-production.yml
@@ -332,4 +332,5 @@ jobs:
           CI_PIPELINES_SHA: ${{ inputs.expected_sha }}
           CI_RELEASE_TRAIN_ID: ${{ inputs.release_train_id }}
           CI_RELEASE_CONTRIBUTORS: ${{ inputs.release_contributors }}
+          CI_RELEASE_NOTES_PROMPT_PATH: ops/release-notes/release-notes.prompt.md
         run: node .ci-wave-notifier/scripts/notify-ci-wave.mjs

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -316,6 +316,18 @@ describe("release bus contributor notifications", () => {
           CI_RELEASE_CONTRIBUTORS: "${{ inputs.release_contributors }}",
         });
       }
+      expect(failure.env).not.toHaveProperty("CI_RELEASE_NOTES_PROMPT_PATH");
+      if (_environment === "production") {
+        expect(success.env).toMatchObject({
+          CI_PIPELINES_TARGET_ENV: "prod",
+          CI_PIPELINES_STATUS: "success",
+          CI_PIPELINES_SERVICE: "web",
+          CI_RELEASE_NOTES_PROMPT_PATH:
+            "ops/release-notes/release-notes.prompt.md",
+        });
+      } else {
+        expect(success.env).not.toHaveProperty("CI_RELEASE_NOTES_PROMPT_PATH");
+      }
     }
   );
 

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -325,6 +325,11 @@ describe("release bus contributor notifications", () => {
           CI_RELEASE_NOTES_PROMPT_PATH:
             "ops/release-notes/release-notes.prompt.md",
         });
+        expect(
+          fs.existsSync(
+            path.join(process.cwd(), success.env.CI_RELEASE_NOTES_PROMPT_PATH)
+          )
+        ).toBe(true);
       } else {
         expect(success.env).not.toHaveProperty("CI_RELEASE_NOTES_PROMPT_PATH");
       }

--- a/__tests__/scripts/notify-ci-wave.test.ts
+++ b/__tests__/scripts/notify-ci-wave.test.ts
@@ -97,6 +97,26 @@ describe("notify-ci-wave Release Train metadata", () => {
     });
   });
 
+  it("adds the autonomous release-note contract for frontend production", async () => {
+    const result = await runNotifier({
+      CI_RELEASE_NOTES_PROMPT_PATH: "ops/release-notes/release-notes.prompt.md",
+    });
+
+    expect(result).toMatchObject({
+      code: 0,
+      stderr: "",
+      payload: {
+        release_notes_prompt_path: "ops/release-notes/release-notes.prompt.md",
+        release_group_id: "6529-Collections/6529seize-frontend:123",
+        release_group_services: ["web"],
+      },
+    });
+    expect(result.payload?.deployed_at).toEqual(expect.any(String));
+    expect(Number.isNaN(Date.parse(String(result.payload?.deployed_at)))).toBe(
+      false
+    );
+  });
+
   it("rejects contributors without a train id", async () => {
     const result = await runNotifier({
       CI_RELEASE_CONTRIBUTORS: JSON.stringify(["GelatoGenesis"]),

--- a/__tests__/scripts/notify-ci-wave.test.ts
+++ b/__tests__/scripts/notify-ci-wave.test.ts
@@ -95,6 +95,9 @@ describe("notify-ci-wave Release Train metadata", () => {
         sha: expectedSha,
       },
     });
+    expect(result.payload).not.toHaveProperty("release_notes_prompt_path");
+    expect(result.payload).not.toHaveProperty("release_group_id");
+    expect(result.payload).not.toHaveProperty("deployed_at");
   });
 
   it("adds the autonomous release-note contract for frontend production", async () => {

--- a/__tests__/scripts/notify-ci-wave.test.ts
+++ b/__tests__/scripts/notify-ci-wave.test.ts
@@ -114,10 +114,10 @@ describe("notify-ci-wave Release Train metadata", () => {
         release_group_services: ["web"],
       },
     });
-    expect(result.payload?.deployed_at).toEqual(expect.any(String));
-    expect(Number.isNaN(Date.parse(String(result.payload?.deployed_at)))).toBe(
-      false
-    );
+    expect(result.payload?.["deployed_at"]).toEqual(expect.any(String));
+    expect(
+      Number.isNaN(Date.parse(String(result.payload?.["deployed_at"])))
+    ).toBe(false);
   });
 
   it("rejects contributors without a train id", async () => {

--- a/pr-reports/3498.md
+++ b/pr-reports/3498.md
@@ -1,0 +1,69 @@
+# PR Report: Restore Release Bus Frontend Production Release Notes
+
+PR: [Frontend PR #3498](https://github.com/6529-Collections/6529seize-frontend/pull/3498)
+
+Branch: `agent-prxt/release-bus-production-release-notes` -> `main`
+
+Related PRs: None
+
+## Summary
+
+Successful frontend Release Bus production deployments will once again request
+autonomous release-note generation through the existing signed CI notification
+contract. Staging and failed deployment notifications remain ineligible.
+
+## What Changed
+
+- The successful `Release Bus - Deploy Frontend Production` notification now
+  supplies the reviewed frontend release-notes prompt path.
+- The existing deployed SHA, Release Train ID, contributor list, and `web`
+  service metadata remain unchanged.
+- Regression coverage verifies that only successful production notifications
+  carry the prompt path and that the notifier produces the prompt path, `web`
+  release group, deterministic group ID, and deployment timestamp required by
+  the autonomous pipeline.
+
+## Historical Root Cause
+
+Frontend release notes were introduced through the separate manual
+`Web Deploy - PROD` workflow by
+[frontend PR #3262](https://github.com/6529-Collections/6529seize-frontend/pull/3262)
+and its autonomous backend pipeline in
+[backend PR #1750](https://github.com/6529-Collections/6529seize-backend/pull/1750).
+That workflow supplied the reviewed prompt path and could enqueue notes after a
+successful production notification.
+
+[Frontend PR #3418](https://github.com/6529-Collections/6529seize-frontend/pull/3418)
+introduced the Release Bus v2 production workflow without a CI-wave notifier.
+[Frontend PR #3451](https://github.com/6529-Collections/6529seize-frontend/pull/3451)
+later added Release Train success and failure notifications with exact SHA,
+train, contributor, and service metadata, but omitted the prompt path. Because
+the notifier and backend receiver both require that field before enqueueing,
+Release Bus production deployments have never requested frontend release notes.
+Older notes came from the separate manual production workflow rather than from
+Release Bus.
+
+## Frontend Impact
+
+- Routes/views: Not affected.
+- Components: Not affected.
+- Generated API/client: Not affected.
+- User-visible behavior: Future successful frontend Release Bus production
+  deployments can produce autonomous release notes after the existing backend
+  pipeline processes the signed notification.
+
+## Config / Env
+
+- `CI_RELEASE_NOTES_PROMPT_PATH` is a pre-existing optional notifier input,
+  owned by the frontend production workflow and backend release-note contract.
+  The successful Release Bus production step now sets it to the allowlisted
+  repository path `ops/release-notes/release-notes.prompt.md`. It is not a
+  secret or operator-provided GitHub variable. When absent, the notifier omits
+  all release-note fields and the backend does not enqueue generation.
+
+## Release Notes
+
+Future successful frontend production releases performed through Release Bus
+can publish the same autonomous, repository-reviewed release notes previously
+available only through the manual production workflow. This change does not
+backfill or manually publish historical notes.


### PR DESCRIPTION
## Issue

Successful `Release Bus - Deploy Frontend Production` runs post a signed CI notification without `CI_RELEASE_NOTES_PROMPT_PATH`. The notifier deliberately omits autonomous release-note fields unless a successful production notification supplies that prompt path, and the backend receiver returns without enqueueing release notes when the field is absent.

## Root Cause

Frontend release notes previously worked through the separate manual `Web Deploy - PROD` path. Frontend [PR #3262](https://github.com/6529-Collections/6529seize-frontend/pull/3262), paired with backend [PR #1750](https://github.com/6529-Collections/6529seize-backend/pull/1750), added the reviewed prompt-path contract to that legacy workflow in July 2026.

Release Bus v2 arrived in frontend [PR #3418](https://github.com/6529-Collections/6529seize-frontend/pull/3418). Its production workflow initially had no CI-wave notifier. Frontend [PR #3451](https://github.com/6529-Collections/6529seize-frontend/pull/3451) later added signed Release Train notifications, including the exact deployed SHA, train ID, and contributors, but did not carry the release-notes prompt path into the successful production step.

Therefore this is a recent path regression, but not a regression within a once-working Release Bus implementation: autonomous frontend notes worked through `Web Deploy - PROD`; they have never been requested by the Release Bus production workflow.

## Fix

Add the allowlisted frontend prompt path to the successful Release Bus production notification. The existing notifier then supplies the complete frontend release-note contract: the prompt path, the default `web` release group, a deterministic run-scoped group ID, and an ISO deployment timestamp.

## Changes

- Set `CI_RELEASE_NOTES_PROMPT_PATH` only on the successful Release Bus production notification.
- Preserve the deployed SHA, Release Train ID, contributor metadata, and `web` service metadata.
- Keep staging and failed deployment notifications ineligible for release-note generation.
- Add workflow regression coverage for the environment gate.
- Add payload coverage for the prompt path, `web` release group, and deployment timestamp.

## Validation

- Focused notifier and Release Bus workflow suites: 76 tests passed.
- Committed changed-file quality checks passed.
- Scoped diff lint and formatting checks passed.
- The full build completed generation and repository-wide lint, then stopped at Next.js configuration because the isolated validation environment did not provide the required runtime endpoint variables. No application or build configuration is changed by this PR.

## Risk

- Level: Low
- Why: one existing, allowlisted environment field is added to the already-successful production-only notification; deployment execution is unchanged.
- Rollback: remove the single workflow environment entry.

## Review Notes

Please verify the prompt-path field remains exclusive to successful production notifications. This PR does not deploy, backfill, or manually publish release notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Successful production frontend deployments now automatically provide the information needed to generate release notes.
  * Release-note metadata includes the relevant service, release grouping, and deployment timestamp.

* **Documentation**
  * Documented the production-only behavior and clarified that historical deployments are not backfilled.
  * Staging and failed deployments remain excluded from release-note generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->