### PR TITLE
docs: preload Stream review editorial 2026-07-28.1

### DIFF
--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/artwork-lifecycle.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/artwork-lifecycle.md
@@ -1,0 +1,441 @@
+# Artwork lifecycle
+
+This page follows one artwork from its first collection record to its final
+state. Stream breaks that journey into visible steps so an artist or collector
+can tell what has happened, what can still change, who can act next, and which
+outside service could still stop progress.
+
+## A 1/1 journey in plain language
+
+Consider one generative 1/1:
+
+1. The artist receives a collection identity in Stream's shared token contract,
+   called the Core. It follows ERC-721, the standard contract interface for
+   recording NFT ownership.
+2. The work's scripts, images, data, dependencies, randomness policy, sale
+   terms, and recipients are assembled.
+3. The artist signs a specific collection state.
+4. A community curation process produces an exact sale authorization.
+5. The authorized mint or auction creates the token and its permanent ID.
+6. If the work uses randomness, a named provider fulfills one recorded request.
+7. Metadata combines the stored artwork inputs into a description a viewer can
+   use.
+8. Sale value becomes credits owed to specific people rather than an
+   unexplained contract balance.
+9. Supply closes, the shared token contract's collection configuration freezes,
+   and preservation evidence is checked.
+10. A delayed finality ceremony closes the remaining artwork-changing paths.
+11. If replaceable infrastructure later becomes obsolete, a visible successor
+    can take over future duties without rewriting the token's Core history.
+
+“Minted,” “sold,” “randomized,” “preserved,” “frozen,” and “final” are
+different facts. The machinery exists because collapsing them into one
+“immutable” state would hide important powers and failure cases.
+
+## What this lifecycle protects
+
+The sequence is designed to protect four things:
+
+- **Identity:** a token keeps the same Core identity even when surrounding
+  modules change.
+- **Consent:** an artist or sale signer approves exact values, not a vague
+  future action.
+- **Coherence:** mint supply, one-use authorization state, payment credits,
+  randomness, and metadata should either move together or roll back together.
+- **Finality:** irreversible claims should name the precise state they close and
+  give people time to inspect it.
+
+The lifecycle cannot make every dependency self-sufficient. Signers can be
+compromised, randomness providers can fail, committed files can disappear,
+browsers can change, and governance can use powers that the community later
+decides were too broad. Stream's aim is to expose those boundaries and preserve
+evidence about them.
+
+## 1. The collection receives an identity
+
+The Core is Stream's shared ERC-721 token contract. An authorized caller creates
+a collection through
+[`StreamCore.createCollection`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L336).
+The Core assigns the collection ID and records the artist address, supply
+information, and other collection state. Additional collection data is set
+through
+[`setCollectionData`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L379).
+
+Creating the record does not open minting. Sale authorization, mint policy,
+metadata, randomness, and revenue configuration are separate decisions.
+
+Stream uses one shared ERC-721 Core for many native collections. A token later
+receives both a globally sequential ID and a collection-local serial. That lets
+the work remain part of one common Stream identity surface while still being
+identified inside its artist collection.
+
+## 2. The artwork package is assembled
+
+The artist-facing package can include:
+
+- collection information;
+- token-specific data;
+- scripts and their execution order;
+- images, animation, and attributes;
+- dependency names, versions, bytes, and locations;
+- metadata mode;
+- randomness provider and failure policy;
+- maximum supply and mint rules;
+- sale terms;
+- revenue recipients;
+- preservation and finality manifests.
+
+Different modules hold different parts because those parts have different
+lifespans. Token identity belongs in the permanent Core. A sale mechanism,
+browser dependency, renderer, or randomness provider may need a successor.
+
+Writer identity matters too. An artist statement, owner statement,
+institutional attestation, independent observation, rights record, and archive
+record should not all inherit the same authority merely because they are
+“metadata.”
+
+## 3. The artist approves a specific state
+
+The current artist-approval mechanism supports ordinary account signatures and
+ERC-1271 signatures from contract wallets. Its typed domain binds the chain and
+Core contract. The signed state binds:
+
+- artist address;
+- collection-freeze manifest hash;
+- maximum collection purchases;
+- collection total supply;
+- final-supply delay.
+
+The fields are defined in
+[`StreamArtistApprovals`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamArtistApprovals.sol#L8-L21)
+and assembled from Core state in
+[`_hashArtistApproval`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L1631-L1639).
+
+If a bound field changes, the earlier signature describes an older state. This
+protects the artist from having one approval silently attached to different
+bound terms.
+
+The approval is not a universal artist veto. Different administrative and
+governance paths still have their own authority. Reviewers must decide which
+later steps—supply closure, Core freeze, preservation, and terminal
+finality—also require fresh artist consent.
+
+## 4. A distribution policy is chosen
+
+The same Core can support a one-of-one sale, fixed edition, free claim,
+airdrop, or another reviewed distribution policy without placing every future
+sale profile in the permanent token contract.
+
+The reviewed source contains two mint lanes:
+
+- The signed Drop and current auction route use `StreamMinter`, which applies
+  its own collection time and supply checks before calling the legacy Core mint
+  entry.
+- `StreamMintManager` and `StreamMintLedger` provide phases, executors, optional
+  gates, policy hashes, time windows, supply constraints, and durable counters.
+
+The signed path is visible in
+[`StreamDrops._executeFixedPriceDrop`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L609-L632)
+and
+[`StreamMinter.mint`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMinter.sol#L130-L175).
+The manager and durable ledger are in
+[`StreamMintManager`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMintManager.sol)
+and
+[`StreamMintLedger`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMintLedger.sol).
+
+These are not one combined path. The exact connected, source-only, accepted,
+and proposed states are centralized on [Current Implementation and
+Readiness](./security-testing-and-known-limitations). Every supported sale must
+name one caller sequence, one counter model, and one Core entry.
+
+## 5. Curation becomes an exact authorization
+
+For a 6529 drop, an offchain process applies the relevant curation or Total Days
+Held (TDH) rules. TDH is 6529's time-weighted holding measure. A service then
+constructs an EIP-712 authorization—a standard typed message whose named fields
+can be inspected before signing—and the configured signer signs it.
+
+The authorization binds values including:
+
+- chain and verifying contract;
+- signer epoch;
+- collection;
+- payer and token recipient;
+- quantity;
+- price or auction terms;
+- token-data hash;
+- deadline;
+- sale mode;
+- a one-use replay identifier that prevents the authorization from being used
+  again.
+
+Solidity verifies the signed result. It does not calculate TDH, choose the
+artist, or decide whether the community process was fair.
+
+This separation protects the authorized action from drifting after the social
+decision. A valid authorization can drive a fixed-price execution or register
+an English auction, depending on its sale mode.
+
+## 6. Mint execution must stay coherent
+
+The legacy lane checks its pause state, collection time window, and supply
+before calling Core.
+
+The manager lane has a more explicit cross-module sequence. It validates the
+phase, executor, optional gate, policy hash, and counters, then calls:
+
+- [`prepareMintFromManager`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L492-L518);
+- [`completePreparedMintFromManager`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L520-L550).
+
+[`StreamMintManager.mintPrepared`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMintManager.sol#L241-L299)
+consumes counters and calls those entries in one transaction. If a later check
+fails, transaction rollback restores the earlier changes.
+
+The real invariant is larger than “no token was minted.” After a revert, supply
+reservations, counters, replay identifiers, credits, and token state must all
+return to one coherent result.
+
+## 7. The token receives an identity that is never reused
+
+The Core allocates a global token ID, associates it with the collection, and
+records its collection-local serial. Supply is tracked as minted-ever history,
+not merely as the number of tokens currently held.
+
+This protects provenance after a burn. A token ID that once represented a work
+is not returned to the allocation pool.
+
+## 8. Randomness becomes a recorded process
+
+If the collection uses randomness, minting creates a request bound to the token,
+collection, provider address, and provider epoch.
+
+The request can be:
+
+1. pending;
+2. fulfilled;
+3. marked stale;
+4. left with failed post-processing after provider output was accepted.
+
+The lifecycle stores the provider request ID, request and fulfillment times,
+derived seed, hash of the raw provider output, failure hash, and retry count.
+The final seed binds the provider, request, collection, token, epoch, and raw
+output commitment.
+
+If the provider result was accepted but writing the seed into Core failed, the
+retry path uses the same derived seed. It does not ask for new randomness. This
+protects technical recovery from becoming a selective redraw.
+
+Provider delay, stale handling, post-processing failure, migration, and burn can
+still interact badly. A provider remains an external operational dependency,
+and the current stale and migration limitations are recorded on the readiness
+page.
+
+## 9. Metadata turns state into an artwork description
+
+`tokenURI` is produced from the collection's metadata mode and the token's
+current state. Depending on the work, it can combine collection information,
+scripts, token data, dependencies, images, attributes, and randomness output.
+
+Metadata availability and artwork finality are different:
+
+- Randomness can leave metadata pending.
+- A data URI can contain JSON while the JSON points to external bytes.
+- A script can be onchain while its browser or dependencies remain external.
+- A content hash can verify retrieved bytes without making them retrievable.
+
+The protocol therefore needs both accurate token metadata and a wider package
+describing how to reconstruct the artwork.
+
+## 10. Sale value becomes named obligations
+
+A paid fixed-price sale and an English auction both place value under contract
+control. Stream uses credits and pull withdrawals so sale progress does not
+depend on every recipient accepting ETH during the same transaction.
+
+In the current native fixed-price path, `StreamDrops` selects a token,
+collection, or contract-default proceeds split and creates poster, protocol,
+and curator-reserve credits. The auction contract separately accounts for
+poster, protocol, curator, and bidder credits.
+
+The fixed-price credit path is in
+[`_creditFixedPriceProceeds`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L635-L680).
+Auction proceeds are handled by
+[`AuctionContract._creditAuctionProceeds`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol#L471-L508).
+
+The source also contains a revenue resolver, split-wallet factory, split
+wallets, asset-policy registry, and primary-sale settlement contract. Their
+purpose is to make revenue precedence, recipients, supported assets, and
+settlement identity explicit outside the sale modules.
+
+Whichever path is used, every credited unit must have one source, one owner, and
+sufficient backing. Emergency recovery must treat only balance beyond all
+liabilities as surplus.
+
+## 11. An auction reaches one final outcome
+
+Auction registration mints the token into contract custody. Bids establish a
+leader and amount. A displaced bidder receives a withdrawal credit instead of
+an inline refund that could block the next bid.
+
+After the end time, any caller may trigger settlement because the caller cannot
+choose the winner, price, recipient, or proceeds. Those values are already
+fixed by state.
+
+With a winner, settlement credits proceeds and transfers the token from
+custody. With no bids, the token returns to the poster or follows the
+contract-poster claim path. Cancellation is available only within the defined
+pre-bid boundary.
+
+The protection is terminality: an auction should finish as settled with a
+winner, settled without a bid, or cancelled. No path should settle, refund, or
+transfer it twice.
+
+## 12. Burn ends ownership, not history
+
+[`StreamCore.burn`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L631)
+removes the live ERC-721 ownership record. The token ID remains consumed and
+the protocol retains burn audit information.
+
+Reviewers must trace burn across:
+
+- pending or fulfilled randomness;
+- sale settlement and credits;
+- minted-ever and live supply;
+- metadata and preservation records;
+- curator and revenue accounting;
+- finality;
+- offchain indexes.
+
+A future reader should be able to distinguish “never existed” from “minted and
+later burned.”
+
+## 13. Supply closes
+
+Supply closure is intended to establish that no further tokens can enter the
+collection. It is based on minted-ever history and is separate from whether
+scripts, metadata, or other artwork state can still change.
+
+Closing supply must cover every mint route, phase, executor, authorization, and
+auction path. A signed action prepared before closure must not become a hidden
+way to mint afterward.
+
+The final value should be visible in state and events, including when a
+collection closes before minting any token. The current zero-mint exception is
+an explicit release blocker detailed on [Current Implementation and
+Readiness](./security-testing-and-known-limitations#known-limitations-and-unresolved-blockers).
+
+## 14. The permanent Core boundary freezes
+
+[`freezeCollection`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L827)
+checks collection existence, required data, timing, supply, and pending metadata
+conditions. It records a freeze-manifest commitment and permanently rejects the
+Core mutations within its freeze boundary.
+
+Core freeze closes minting, burn, artist-approval changes, randomizer changes,
+and covered live-token or collection metadata mutations. Ordinary ERC-721
+transfers remain possible. Append-only preservation records and some
+post-freeze evidence operations remain separate.
+
+This protects a defined Core boundary. It does not prove that every shared or
+successor module has become terminal, which is why a generic “collection
+frozen” label is not enough.
+
+## 15. Preservation evidence can continue to grow
+
+Preservation records can commit hashes, locations, manifests, signatures, and
+other typed evidence about the materials needed to understand or reconstruct
+the work.
+
+They are append-only rather than overwriteable. An old record remains in
+history even when a later record becomes the current `latest` record for its
+type and subject. A future archive or institution can therefore add recovery
+evidence without rewriting the artist's original final package.
+
+A commitment is not storage. Long-term preservation still requires the bytes,
+independent retrieval, functioning storage providers, and enough runtime
+information to execute the work.
+
+## 16. Artwork finality becomes a visible ceremony
+
+[`StreamArtworkFinalityRegistry`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamArtworkFinalityRegistry.sol)
+defines a delayed finality process with scheduling, execution windows,
+cancellation or veto, component manifests, and terminal state.
+
+During the delay, the artist, collectors, guardians, and independent reviewers
+should be able to inspect:
+
+- exact collection and one-of-one manifests;
+- files, dependencies, and content hashes;
+- proposed execution time and expiry;
+- artist approval;
+- every mutation path the terminal state is expected to close.
+
+Execution should apply the same payload that was visible during the waiting
+period. A guardian can stop a suspicious proposal but should not be able to
+replace its artistic commitments. A cancelled or expired proposal should
+require a new identity and fresh approval.
+
+The ceremony protects against a surprise irreversible transaction. It still
+depends on a complete writer inventory and on people monitoring the schedule.
+
+## 17. Successors carry future duties without rewriting history
+
+Over decades, a renderer, storage route, randomness integration, or operational
+module may fail or become obsolete. Stream's long-term model records module
+identity, code hashes, interfaces, status, and successor relationships.
+
+A successor does not rewrite the predecessor or the token's Core history. It
+changes which replaceable module is recognized for a future duty.
+
+A safe transition must answer:
+
+- Which new actions route to the successor?
+- Which liabilities and pending work remain with the predecessor?
+- Which state is read, shared, migrated, or intentionally left behind?
+- Can both modules act at once?
+- Do signatures, nonces, counters, or replay keys cross the boundary?
+- Which old artwork commitments remain binding?
+
+This final step protects continuity without pretending that surrounding
+infrastructure can remain unchanged forever.
+
+## What should remain visible to a reader
+
+A collector should not need transaction traces to understand the lifecycle.
+The product should show whether a token is awaiting randomness, whether
+metadata is complete, whether supply is closed, whether the Core boundary is
+frozen, which preservation package applies, and whether terminal artwork
+finality has occurred.
+
+Stream's sophistication is useful only if these states become easier for
+artists and collectors to understand—not merely more detailed in Solidity.
+
+## Failure modes reviewers should test
+
+- a collection is created with the wrong artist, supply, or module pointers;
+- an artist signs a readable package that does not match the hashed state;
+- a sale authorization is stolen, stale, replayed, or assembled incorrectly;
+- a mint failure restores the token but not counters, replay state, or credits;
+- overlapping phases or executors exceed intended supply;
+- a randomness provider delays, fails, or leaves a token unrecoverable;
+- metadata is correctly hashed but unavailable or impossible to execute;
+- sale liabilities become unbacked or a hostile recipient blocks withdrawal;
+- burn erases provenance or restores an allowance;
+- supply closes while another mint path remains open;
+- Core freeze leaves an alternate mutation path;
+- finality binds the wrong manifest or rereads mutable values at execution;
+- a successor duplicates authority, replay state, or liabilities.
+
+## Questions for reviewers
+
+1. Is every stage necessary, and is its purpose understandable without Solidity
+   knowledge?
+2. Which transitions require an artist signature in addition to protocol
+   governance?
+3. Which failures should revert atomically, and which should enter a visible
+   recoverable state?
+4. Are supply closure, Core freeze, preservation, and artwork finality separated
+   clearly enough?
+5. Which burn and provenance records must remain readable forever?
+6. What evidence must be published before terminal finality can be scheduled?
+7. What invariants must hold before a successor module becomes current?

--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/community-review.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/community-review.md
@@ -1,0 +1,381 @@
+# How to participate in the community review
+
+This page explains how to turn a question, design objection, artist concern,
+test gap, bug, or possible vulnerability into a public report tied to the exact
+Stream code and explanation it examined. The goal is to improve the protocol
+before its permanent boundaries are fixed, not to collect endorsements.
+
+## A concrete example
+
+Suppose you are reading the Randomness page and notice that a request can become
+stale before enough time has passed.
+
+1. Open the feedback composer on that page.
+2. Choose **Protocol design** or **Implementation bug**, depending on what you
+   found.
+3. Choose an initial severity, or **Not assessed** if you are unsure.
+4. Explain what you expected, what the pinned code does, who can trigger it, and
+   what happens to the artwork.
+5. Attach the exact function from the compiler-generated code index called the
+   Technical Reference.
+6. Submit the report to the public Stream review discussion.
+7. Use the resulting discussion link to add a reproduction, answer questions,
+   or point to another affected module.
+
+The site records the review version, page, section, and optional code reference
+with the report. A later reader can therefore recover the context without
+guessing which candidate or paragraph you meant.
+
+## Why the review record has structure
+
+Stream is a multi-contract system. A useful comment may involve an artist
+workflow, an offchain signer, two Solidity modules, a browser assumption, and a
+deployment setting at the same time.
+
+The review machinery exists to protect:
+
+- **Context:** a report remains attached to the exact source and explanation it
+  examined.
+- **History:** a later candidate does not overwrite the earlier review record.
+- **Accountability:** an official decision about a report—its disposition—
+  identifies who made it and what evidence supports it.
+- **Auditability:** reports can be filtered, exported, reproduced, and handed
+  to auditors without reconstructing their meaning from an unstructured feed.
+- **Open participation:** a non-Solidity reader can report an unclear promise or
+  unacceptable authority with the same durable context as a code-linked bug.
+
+Structure does not make a report correct. A `NEW` record is not a confirmed
+finding, a severity is not a verdict, and a generated source inventory is not
+an audit. Human review and reproducible evidence remain necessary.
+
+## Confirm the source before commenting
+
+The reviewed source is
+[`513bd7e079eafe109df6ae1ae21bfbca6fec6786`](https://github.com/6529-Collections/6529Stream/tree/513bd7e079eafe109df6ae1ae21bfbca6fec6786).
+The review version is `2026-07-28.1`.
+
+Check both values before submitting. A comment about another commit may still
+be useful, but it must say which code it examined.
+
+[Current Implementation and
+Readiness](./security-testing-and-known-limitations) is the authoritative
+inventory of what the pinned rehearsal connects, what exists only in source,
+which accepted targets remain unfinished, and what evidence is still required.
+
+## Who should comment
+
+This review needs different kinds of expertise:
+
+- **Artists** can decide whether approvals, mutation boundaries, preservation,
+  recovery, and finality fit a real artistic practice.
+- **Collectors** can test whether ownership, artwork access, sale terms, trust,
+  and long-term state are understandable.
+- **Solidity engineers** can trace authorization, accounting, state changes,
+  unexpected re-entry during external calls (reentrancy), repeated use of a
+  one-time authorization (replay), and rules that must stay true across
+  multiple contracts.
+- **Protocol designers** can challenge the permanent Core token-contract
+  boundary, modules, governance, pauses, and successors.
+- **Auditors and security researchers** can build hypotheses, reproduce
+  failures, and identify missing evidence.
+- **Frontend and product reviewers** can find cases where the interface might
+  cause a person to approve or pay for something different from what the
+  contract executes.
+- **Storage, browser, metadata, indexing, and infrastructure engineers** can
+  test assumptions that Solidity cannot establish.
+- **Accessibility and localization reviewers** can identify explanations or
+  workflows that exclude people.
+- **Community members** can ask whether the architecture matches 6529's values
+  and whether its complexity is justified.
+
+You do not need to read Solidity to identify an unclear promise, unfair
+workflow, missing recovery case, unacceptable authority, or term that an
+ordinary reader would interpret differently.
+
+## Start from the page you are reading
+
+Each review page has a feedback composer. Submitting from that page records the
+page and review context automatically.
+
+When a page links to generated code, feedback can reference a contract,
+interface, function, event, error, or source range. Technical references use
+stable semantic keys derived from the pinned source rather than positions in a
+list.
+
+The discussion is written to the Stream review subwave. It is a public part of
+the review record, not a private support ticket.
+
+If a report spans several modules, submit it from the page representing the
+primary issue and link the other relevant code or pages. Important failures
+often occur between two individually reasonable modules.
+
+## Choose the closest feedback type
+
+- **Question** — something is unclear or needs an authoritative answer.
+- **Documentation** — an explanation is inaccurate, incomplete, or difficult
+  to understand.
+- **Artist workflow** — approval, metadata, preservation, sale, recovery, or
+  finality does not work for an artist's real process.
+- **Product or UX** — an interaction, state, consequence, or recovery path is
+  confusing.
+- **Protocol design** — a role, boundary, invariant, lifecycle, or permanent
+  choice should change.
+- **Implementation bug** — the Solidity appears not to implement the stated
+  behavior.
+- **Possible exploitable security vulnerability** — a path may permit theft,
+  unauthorized mutation, permanent lock, manipulation, takeover, or another
+  security failure.
+- **Testing or evidence gap** — an important property lacks a reproducible test
+  or operational proof.
+- **Accessibility or localization** — the review or intended product excludes
+  a class of users.
+
+Choose the best fit. The report can explain how the issue crosses categories.
+
+## Assess likely impact
+
+Severity is a starting signal, not a final judgment:
+
+- **Critical** — credible loss of all or substantial assets, permanent
+  unauthorized artwork change, protocol-wide takeover, or comparable impact.
+- **High** — serious asset, authorization, availability, or finality failure
+  with a plausible path.
+- **Medium** — meaningful failure with narrower impact, stronger preconditions,
+  or a practical workaround.
+- **Low** — limited impact or a defense-in-depth issue.
+- **Informational** — clarification, convention, maintainability, or evidence
+  improvement.
+- **Not assessed** — use this when the impact is uncertain.
+
+Describe the facts, assumptions, and uncertainty. Reviewers and maintainers can
+revise the assessment after reproduction and discussion.
+
+## Write a useful report
+
+Answer as many of these questions as you can:
+
+1. What did you expect?
+2. What does the pinned code or review page do instead?
+3. Which collection, token, role, module, field, or lifecycle state is involved?
+4. What must an actor control or do?
+5. What is the likely consequence?
+6. Can you reproduce it with a call sequence, transaction, test, or example?
+7. Is the issue prevented or reduced elsewhere?
+8. Which assumptions remain uncertain?
+9. What fix or design alternative should be considered?
+
+Short reports are welcome. A precise question can expose a missing
+specification before it becomes a code defect.
+
+For a product or documentation issue, include the wording or screen state that
+created the misunderstanding and the conclusion a reasonable reader might
+draw. For an artist-workflow issue, describe the actual studio, collaborator,
+signing, preservation, or estate process the design fails to serve.
+
+## Reference code precisely
+
+Prefer a generated Technical Reference link because it carries the review
+version and semantic declaration identity.
+
+If you use GitHub, link to the exact reviewed commit rather than `main`. For a
+cross-contract issue:
+
+- link every important function or definition;
+- describe the order of calls;
+- identify storage or accounting that crosses the boundary;
+- state which steps revert together and which survive;
+- include the test, script, or configuration needed to reproduce the path.
+
+A report about an upgrade, successor, pause, or finality bypass should include
+every alternate contract function—identified onchain by its four-byte
+selector—or module that can reach the same effect.
+
+## The exact structured fields
+
+Each submission carries exactly four machine-readable fields, in this order:
+
+- `review_schema` — schema version used to decode the report;
+- `type` — feedback category;
+- `severity` — submitter's initial impact assessment;
+- `context` — review, version, page, section, submission, and optional code
+  references.
+
+The visible comment remains ordinary human language. The fields make reports
+filterable, exportable, deduplicable, and traceable.
+
+For review schema version `1`, the allowed values are:
+
+- `type`: `question`, `documentation`, `artist-workflow`, `product-or-ux`,
+  `protocol-design`, `implementation-bug`,
+  `possible-exploitable-security-vulnerability`,
+  `testing-or-evidence-gap`, or `accessibility-or-localization`;
+- `severity`: `critical`, `high`, `medium`, `low`, `informational`, or
+  `not-assessed`.
+
+`context` is canonical JSON. Optional properties are omitted when they do not
+apply rather than filled with placeholder values.
+
+Page identifiers are the IDs in this review version's editorial manifest. The
+possible-exploit type remains in the same public review Wave while the
+published disclosure policy permits public reporting.
+
+## What happens after submission
+
+Every new top-level structured report enters the ledger in a deterministic
+`NEW` state. Replies remain in the linked Wave discussion.
+
+`NEW` means the report exists. It does not mean accepted, rejected, confirmed,
+fixed, or assigned a final severity.
+
+The initial ledger does not infer an official disposition from free-form
+conversation. A future official resolution should identify:
+
+- disposition;
+- person or body making it and their authority;
+- source commit or design decision resolving the report;
+- regression test or other verification;
+- remaining risk;
+- review version containing the resolution.
+
+This protects the difference between a community hypothesis, reproduced
+finding, accepted design change, and verified fix.
+
+## When the source changes
+
+The active review points to one exact commit. A later candidate receives a new
+immutable review-data bundle and version-specific routes. Earlier explanations,
+source links, and reports remain available.
+
+For each new candidate, the review system should:
+
+1. compile and inventory the exact new Git tree;
+2. validate declarations against compiler output;
+3. publish a new immutable bundle;
+4. retain the older version and source links;
+5. attach new feedback to the version it examined;
+6. record which earlier reports still apply, were fixed, or need review again.
+
+Automated structural diffs and formal carry-forward dispositions are not
+available in this first review version. Until they are, compare pinned versions
+directly and state which code each conclusion examined.
+
+## What the generated reference establishes
+
+The generated Technical Reference compiles the pinned Solidity corpus and
+extracts the definitions, functions, events, errors, signatures, selectors,
+source ranges, and documentation visible to the compiler.
+
+It establishes that the published inventory corresponds to the pinned source.
+It does not establish that:
+
+- implementation matches the intended specification;
+- a function is safe when composed with other modules;
+- a deployment is initialized correctly;
+- an external provider operates reliably;
+- an economic or governance assumption is acceptable.
+
+The inventory supports human review, static analysis, tests, and audit. It does
+not replace them.
+
+## What remains outside the review machinery
+
+The platform can preserve a report and its context. It cannot:
+
+- decide whether a claim is true merely because it was submitted;
+- turn discussion replies into an authoritative resolution;
+- guarantee that every affected code path was linked;
+- reproduce an external provider or marketplace from a local mock;
+- replace independent security audit;
+- make an unclear artistic or governance choice acceptable.
+
+That is why strong reports include evidence and why official dispositions must
+name their authority and verification.
+
+## What to review
+
+Useful feedback can address:
+
+- artist identity, consent, delegation, recovery, and estates;
+- curation, Total Days Held (TDH), authorization construction, signer custody,
+  and replay;
+- shared collection identity, supply, mint phases, gates, and counters;
+- fixed-price sales, auction custody, bids, extensions, refunds, and settlement;
+- collaborators, split profiles, curator rewards, accounting, and royalties;
+- randomness providers, failures, retries, migration, and reserves;
+- metadata modes, scripts, dependencies, encoding, and browser behavior;
+- preservation, manifests, Core freeze, and artwork finality;
+- roles, pauses, governance binding, guardians, and successors;
+- threat model, tests, deployment evidence, and release criteria;
+- whether the system is more complex than its requirements justify;
+- whether the explanations make that complexity legible.
+
+Do not assume complexity is proof of sophistication or proof of failure. Ask
+what each mechanism protects, whether that protection belongs onchain, and
+whether a smaller authority or state surface can preserve the same guarantee.
+
+## Public conduct and sensitive information
+
+Be direct about code and design, and civil toward people. Disagreement about
+severity, architecture, and permanence is expected.
+
+Do not post:
+
+- private keys, seed phrases, credentials, cookies, or API keys;
+- personal information unnecessary to the report;
+- secrets from unrelated systems;
+- instructions or data for attacking a live system outside this review;
+- copyrighted material not needed to establish the issue.
+
+Under this review version's published disclosure policy, a possible exploitable
+vulnerability in Stream may be described publicly in the review Wave. If the
+same technique affects another live protocol, limit the Stream report to Stream
+and coordinate the separate disclosure responsibly.
+
+## For auditors
+
+The review is designed to be exported without scraping meaning from rendered
+pages. The immutable generated bundle, editorial manifest, structured Wave
+metadata, pinned source, and review ledger form the audit-support package.
+
+Auditors should be able to:
+
+- reproduce the compiler inventory;
+- enumerate every code-linked report;
+- filter by module, declaration, type, severity, and disposition;
+- identify reports that cross review versions;
+- distinguish community hypotheses from validated findings;
+- verify official replies, source changes, and regression evidence;
+- recover the exact explanation shown when a comment was submitted.
+
+Public review can improve the specification, reveal assumptions, and find
+important defects. It does not replace independent expert audit of the exact
+release candidate and deployment configuration.
+
+## Closing the review
+
+At closeout, the team should publish:
+
+- final candidate commit and Git tree;
+- every review version and available structural diff;
+- feedback counts by type and disposition;
+- unresolved questions and accepted risks;
+- fix commits and regression evidence;
+- audit reports and remediation status;
+- deployment-blocker checklist;
+- machine-readable archive of the review record.
+
+Closing feedback marks the boundary used to prepare a release candidate. It
+does not erase the discussion or detach a report from the source it examined.
+
+## Questions for reviewers
+
+1. Can an artist or collector identify the right place to comment without
+   understanding the contract structure?
+2. Are the feedback types and severity choices sufficient?
+3. What context should be captured automatically with every code reference?
+4. Which official dispositions and authority rules should the ledger support?
+5. How should unresolved reports carry forward when the source commit changes?
+6. What export format would be most useful to auditors?
+7. Which explanation remains too technical for a non-Solidity reader?
+8. Does this process invite genuine disagreement about whether Stream's
+   complexity is justified?

--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/curation-and-tdh-authorization.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/curation-and-tdh-authorization.md
@@ -1,0 +1,341 @@
+# Community curation, TDH, and signed authorization
+
+Stream turns a community decision made outside Ethereum into one exact action
+that a smart contract can verify.
+
+Imagine the community approves a fixed-price mint for a particular collection,
+buyer, recipient, price, and deadline. A service writes those terms into a
+standard typed message. The configured signer signs it. When the message is
+submitted, Stream checks that the signature is from the current signing era,
+that the terms have not changed, that the deadline has not passed, and that the
+authorization has not already been used or cancelled. Only then can the mint
+proceed.
+
+The contract does **not** choose the artist or decide whether the community
+rules were applied fairly. When its other checks also pass, it executes the
+signed result.
+
+**TDH means Total Days Held.** It is 6529’s time-weighted measure of how long
+eligible assets have been held. TDH is neither a token nor a value stored by
+Stream. The [TDH guide](/network/tdh) explains its calculation and categories.
+Stream does not measure TDH, hold an onchain TDH vote, or decide that a work
+crossed a community threshold.
+
+## From a community decision to a contract call
+
+A typical flow is:
+
+1. an offchain process applies the published curation or TDH rules;
+2. a service constructs the exact mint or auction authorization;
+3. the configured signer signs the authorization as EIP-712 typed data, a
+   standard structured message whose named fields can be inspected before
+   signing;
+4. the payer or another caller submits that signed payload to Stream;
+5. Stream verifies the signature, signer epoch, deadline, whether the
+   authorization was already used or cancelled, and the other bound values;
+6. Stream executes only the sale mode and parameters in the authorization.
+
+The first two steps are social and operational. The signature is the bridge.
+The remaining steps are cryptographic and contractual.
+
+This split lets community judgment evolve without making the resulting onchain
+action vague. It also makes the signer and authorization-building service
+important trust boundaries. Artists and collectors should be able to inspect
+both.
+
+## Why the signed bridge exists
+
+A simpler design could let an operator call a sale contract with whatever
+values happen to be current. That would move important decisions into a private
+database, admin dashboard, or transaction script. The collection, recipient,
+price, deadline, or sale type could drift between community approval and
+execution.
+
+Stream instead signs the outcome. The machinery is justified only to the extent
+that it prevents this drift:
+
+- a payload for one chain or contract should not work on another;
+- a fixed-price decision should not become an auction;
+- a copied transaction should not redirect the token or charge another payer;
+- token data should not be substituted;
+- an old or cancelled authorization should not execute;
+- a successful authorization should not be replayed.
+
+The signature does not prove that the earlier social decision was correct. It
+protects the handoff from that decision to the contract.
+
+## What the authorization cannot establish
+
+Stream can verify that the configured signer authorized the exact typed
+payload. It cannot establish that:
+
+- the offchain TDH calculation was correct;
+- the curation policy was applied fairly;
+- the community intended the payload produced by the service;
+- the signer was not mistaken, coerced, or compromised;
+- the artist saw an accurate rendering of the terms;
+- an operator retained the evidence supporting the decision.
+
+Those claims require transparent offchain records, reproducible calculations,
+operational controls, and accountable signers. This is not a gap that can be
+closed by adding one more Solidity field. It is the boundary between community
+judgment and contractual execution.
+
+## The exact authorization
+
+The signed Drop path in
+[`StreamDrops.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L24-L60)
+uses EIP-712 typed data. Its domain binds the chain ID and verifying contract.
+The signed `DropAuthorization` contains:
+
+| Field                 | What it fixes                                                    |
+| --------------------- | ---------------------------------------------------------------- |
+| `dropId`              | The authorization identity consumed or cancelled by the contract |
+| `poster`              | The sale poster and current native-sale proceeds recipient       |
+| `recipient`           | The account that receives the token                              |
+| `payer`               | The account allowed to fund the execution                        |
+| `collectionId`        | The collection that may be minted or auctioned                   |
+| `saleMode`            | Fixed price or auction                                           |
+| `tokenDataHash`       | The hash of the token data supplied at execution                 |
+| `price`               | The fixed-price amount                                           |
+| `quantity`            | The authorized quantity                                          |
+| `auctionReservePrice` | The minimum auction price                                        |
+| `auctionEndTime`      | The intended auction end                                         |
+| `salt`                | Additional signed uniqueness                                     |
+| `nonce`               | Signer-scoped sequence input used to derive the drop identity    |
+| `deadline`            | The last valid execution time                                    |
+| `signerEpoch`         | The signing-key era that must still be current                   |
+
+Reviewers should compare the typed-data definition, Solidity encoding, offchain
+construction code, wallet display, and emitted events byte for byte. A field
+present in only one layer can create a gap between what the community approved,
+what the signer signed, what the payer saw, and what the contract executed.
+
+## Why each field exists
+
+### Chain and verifying contract
+
+The EIP-712 domain prevents a payload intended for one Stream deployment from
+being accepted on another chain or by another contract.
+
+### Signer epoch
+
+A signer epoch gives key rotation a clear boundary. A payload from an earlier
+signing era should not become current merely because the old public key still
+verifies it.
+
+Epochs also make incident response legible. When a signer is replaced,
+reviewers can ask whether older payloads expire immediately, survive for a
+grace period, or remain valid only after another explicit action.
+
+### Payer and recipient
+
+The account providing funds and the account receiving the token may differ.
+Binding both supports sponsored or delegated purchases without letting a copied
+transaction redirect the artwork or charge an unintended payer.
+
+### Collection and token data
+
+An authorization for one collection must not mint into another. The
+`tokenDataHash` binds the supplied token data so execution cannot substitute a
+different artwork input while retaining the rest of the signed terms.
+
+### Quantity
+
+The structure contains a quantity field, but current Drop validation requires
+`quantity == 1`. One consumed Drop authorization therefore authorizes one token,
+not a multi-token batch.
+
+See
+[`StreamDrops._validateAuthorization`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L561-L581).
+
+An edition can contain many tokens, but this path needs a separate authorization
+for each one. The interface should describe the execution path instead of
+implying batch support from the mere presence of a field.
+
+### Price and sale mode
+
+A fixed-price authorization must not become an auction registration, and a free
+claim must not become a paid sale. The current signed paths use native ETH; the
+authorization has no token-address field. A future token-denominated path would
+need to bind the asset as well as the amount.
+
+### Auction terms
+
+The reserve and intended end time connect the curation decision to the initial
+auction state. They do not replace the auction contract’s later custody, bid,
+extension, cancellation, refund, and settlement rules.
+
+### Deadline
+
+A deadline limits how long a signed action remains useful. A generous deadline
+improves operational reliability but increases exposure if a payload leaks or
+the community decision changes.
+
+### Replay identity
+
+A successful authorization must not be reusable for an unintended second sale.
+The replay identity, cancellation state, signer epoch, and transaction rollback
+must continue to agree under failed execution, rotation, and concurrent
+submission.
+
+## Fixed-price execution
+
+A valid fixed-price authorization can describe a free or paid mint. Before
+minting, the current path checks:
+
+- Drop pause state;
+- replay and cancellation state;
+- token-data hash;
+- deadline;
+- payer and recipient;
+- quantity;
+- sale mode;
+- native payment;
+- mint time and supply rules;
+- Core freeze state.
+
+Signature validity does not override those checks. If execution fails, the
+transaction reverts rather than leaving a partly consumed authorization and a
+partly minted token.
+
+A free authorization still needs identity, recipient, replay, deadline, phase,
+and supply protection. Removing payment does not remove policy.
+
+## Auction registration
+
+An auction-mode authorization registers the intended auction parameters. The
+auction contract then owns custody and governs bidding, extensions,
+cancellation, refunds, and settlement.
+
+The signed payload bridges the curation decision to the initial auction state.
+It is not a bid, and it should not remain replayable as a second auction.
+
+Once registered, the auction has its own state. Rotating a signer or cancelling
+an unused authorization does not decide what should happen to a token already
+in auction custody or to bids already placed.
+
+## Ordinary accounts and contract-wallet signers
+
+The signing system supports ordinary ECDSA accounts and ERC-1271 contract
+wallets. ERC-1271 lets a Safe or another smart account authorize the payload,
+which can improve key management and shared control.
+
+It also adds an assumption: a contract wallet’s owners, threshold, and
+validation behavior can change.
+
+The public signing record should identify:
+
+- signing address;
+- whether it is an ordinary account or contract wallet;
+- Safe threshold and owner policy where applicable;
+- current signer epoch;
+- rotation and emergency-revocation procedure;
+- monitoring for unexpected authorizations;
+- software version that constructed the typed data.
+
+Private keys, seed phrases, and recovery secrets never belong in that record.
+
+## Cancellation, consumption, and rotation
+
+The protocol includes authorization cancellation and signer-epoch rotation.
+The complete lifecycle should make the following observable:
+
+- who may cancel;
+- whether cancellation applies to one authorization, one drop identity, or a
+  broader set;
+- when consumed state is written;
+- whether a failed transaction consumes anything;
+- how rotation affects already issued payloads;
+- whether old-epoch payloads have a grace period;
+- what happens to an auction registered before rotation;
+- which events reconstruct every cancellation and epoch change.
+
+Cancellation is part of the public promise. Hiding a payload on a website is not
+equivalent to cancelling it onchain.
+
+## Transaction ordering and maximal extractable value (MEV)
+
+The repository includes MEV-timing and EIP-712 tests. Binding payer, recipient,
+collection, price, quantity, mode, deadline, and token data limits what a copied
+transaction can change.
+
+It does not remove every ordering effect. A public mempool can still affect:
+
+- who submits first;
+- when a transaction is observed;
+- whether it lands before a deadline;
+- whether another bid arrives first;
+- which block timestamp applies.
+
+The payload should bind every sensitive outcome that copying or relaying must
+not change. The product should not promise ordering guarantees Ethereum does
+not provide.
+
+## The authorization receipt
+
+Every authorized Drop should have a public, human-readable receipt containing:
+
+- curation rule and version;
+- relevant offchain decision identifier;
+- collection and artist identity;
+- typed payload in readable and canonical machine form;
+- signer address and epoch;
+- chain and verifying contract;
+- payer and recipient rules;
+- price, asset, quantity, deadline, and sale mode;
+- token-data hash and authorization identity;
+- transaction and emitted events after execution;
+- cancellation, expiry, or exception record where applicable.
+
+The receipt lets an artist, collector, auditor, or community member compare the
+decision, signature, execution, and public explanation without trusting a
+private service database.
+
+## Design position
+
+Keeping curation outside Solidity is reasonable only when the boundary is
+explicit. The public experience should never suggest that an onchain vote
+selected a work when a configured signer actually authorized the result of an
+offchain process.
+
+The architecture is valuable when it does two things at once:
+
+1. preserves room for human judgment and evolving community rules; and
+2. prevents the resulting onchain action from changing after approval.
+
+That is the standard against which the signer, payload, interface, replay
+storage, and public receipt should be reviewed. Extra ceremony that does not
+improve this binding or its evidence should be challenged.
+
+## Failure modes reviewers should test
+
+- TDH or curation input is wrong;
+- the authorization service constructs different terms from the approved
+  decision;
+- the human-readable display omits or misstates a signed field;
+- a signer key or Safe is compromised;
+- signer rotation leaves an old payload valid unexpectedly;
+- domain separator, type hash, or field encoding differs across implementations;
+- a replay or cancellation marker is written too early or too late;
+- a copied transaction changes an incompletely bound field;
+- a deadline, chain, asset, or sale mode is misunderstood;
+- auction registration and later signer cancellation produce inconsistent
+  expectations;
+- a failed execution consumes an authorization without completing the intended
+  action.
+
+## Questions for reviewers
+
+1. Does the typed payload bind every value that could harm an artist, payer,
+   recipient, or collector if changed?
+2. Can a non-technical reader compare the curation decision with the exact
+   action they are asked to sign or submit?
+3. What public evidence should prove the offchain curation result?
+4. Who may rotate or revoke a signer, and how quickly?
+5. Should issued authorizations survive signer rotation?
+6. Are cancellation and replay rules clear under every revert path?
+7. Which parts of the TDH and curation process should be independently
+   reproducible?
+8. What should happen to a registered auction when the signer or underlying
+   community decision later changes?

--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/curation-and-tdh-authorization.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/curation-and-tdh-authorization.md
@@ -92,8 +92,8 @@ The signed `DropAuthorization` contains:
 | --------------------- | ---------------------------------------------------------------- |
 | `dropId`              | The authorization identity consumed or cancelled by the contract |
 | `poster`              | The sale poster and current native-sale proceeds recipient       |
-| `recipient`           | The account that receives the token                              |
-| `payer`               | The account allowed to fund the execution                        |
+| `recipient`           | Fixed price: the token recipient. Auction: must be zero           |
+| `payer`               | Paid fixed price: the caller funding the mint. Free or auction: must be zero |
 | `collectionId`        | The collection that may be minted or auctioned                   |
 | `saleMode`            | Fixed price or auction                                           |
 | `tokenDataHash`       | The hash of the token data supplied at execution                 |
@@ -105,6 +105,12 @@ The signed `DropAuthorization` contains:
 | `nonce`               | Signer-scoped sequence input used to derive the drop identity    |
 | `deadline`            | The last valid execution time                                    |
 | `signerEpoch`         | The signing-key era that must still be current                   |
+
+For an auction, the eventual bidder and winner are not known when this payload
+is signed. Bidders later fund the separate auction contract, and settlement
+sends the token to the winner. The signed auction's `payer` and `recipient`
+fields are therefore both zero; they do not stand for that later bidder or
+winner.
 
 Reviewers should compare the typed-data definition, Solidity encoding, offchain
 construction code, wallet display, and emitted events byte for byte. A field
@@ -130,9 +136,12 @@ grace period, or remain valid only after another explicit action.
 
 ### Payer and recipient
 
-The account providing funds and the account receiving the token may differ.
-Binding both supports sponsored or delegated purchases without letting a copied
-transaction redirect the artwork or charge an unintended payer.
+For a paid fixed-price mint, the signed payer must submit the transaction, while
+the separately signed recipient receives the token. This supports sponsored or
+delegated purchases without letting a copied transaction redirect the artwork
+or charge an unintended payer. A free fixed-price mint keeps the recipient but
+requires the payer to be zero. An auction requires both fields to be zero
+because its later bidder and winner come from the auction state.
 
 ### Collection and token data
 
@@ -199,8 +208,9 @@ Signature validity does not override those checks. If execution fails, the
 transaction reverts rather than leaving a partly consumed authorization and a
 partly minted token.
 
-A free authorization still needs identity, recipient, replay, deadline, phase,
-and supply protection. Removing payment does not remove policy.
+A free fixed-price authorization requires the payer to be zero, but it still
+needs identity, recipient, replay, deadline, collection-time, mint-pause,
+supply, and Core-freeze protection. Removing payment does not remove policy.
 
 ## Auction registration
 
@@ -283,7 +293,9 @@ Every authorized Drop should have a public, human-readable receipt containing:
 - signer address and epoch;
 - chain and verifying contract;
 - payer and recipient rules;
-- price, asset, quantity, deadline, and sale mode;
+- price, quantity, deadline, and sale mode from the typed payload;
+- native ETH as the current execution route's currency, clearly distinguished
+  from the signed fields because the payload has no currency or token address;
 - token-data hash and authorization identity;
 - transaction and emitted events after execution;
 - cancellation, expiry, or exception record where applicable.

--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/fixed-price-sales-and-auctions.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/fixed-price-sales-and-auctions.md
@@ -63,14 +63,15 @@ binds the chain and verifying contract. Its payload binds:
 
 - authorization identity and replay inputs;
 - poster;
-- token recipient;
-- payer;
+- token recipient for fixed price, which must be zero for auction;
+- payer for paid fixed price, which must be zero for free fixed price and
+  auction;
 - collection;
 - fixed-price or auction mode;
 - token-data hash;
-- fixed price;
+- fixed price, which must be zero for auction;
 - quantity;
-- auction reserve and end time;
+- auction reserve and end time, which must be zero for fixed price;
 - deadline;
 - signer epoch.
 
@@ -79,13 +80,16 @@ contract does not reproduce Total Days Held (TDH), 6529's time-weighted holding
 measure, or the curation process; it verifies that the signed result cannot
 quietly become a different sale.
 
-Without the domain binding, the signature could be replayed elsewhere. Without
-separate payer and recipient fields, a copied transaction could redirect the
-work or charge the wrong account. Without the mode, amount, token-data hash,
-deadline, signer epoch, and one-use identity, one valid signature could
-authorize more than its signer intended.
+Without the domain binding, the signature could be replayed elsewhere. On a
+paid fixed-price mint, separate payer and recipient fields stop a copied
+transaction from redirecting the work or charging the wrong account. A free
+fixed-price mint requires the payer to be zero. An auction requires both payer
+and recipient to be zero because bidders later fund the auction contract and
+the winner receives the token only at settlement. Without the mode, amount,
+token-data hash, deadline, signer epoch, and one-use identity, one valid
+signature could authorize more than its signer intended.
 
-Signature validity is only the first gate. Supply, mint policy, pause state,
+Signature validity is only the first gate. Supply, collection-time, pause state,
 payment, freeze, and sale-specific checks still apply.
 
 The current authorization has no currency or token-address field. These Drop
@@ -124,11 +128,12 @@ not a batch mint.
 
 ## Payer and recipient are intentionally different
 
-The account funding a mint and the account receiving the token can differ. That
-supports gifts and sponsored actions without leaving the beneficiary
-ambiguous.
+For a paid fixed-price mint, the account funding the mint and the account
+receiving the token can differ. That supports gifts and sponsored actions
+without leaving the beneficiary ambiguous. A free mint still names its
+recipient but requires its payer to be zero.
 
-Both addresses are signed. Someone may copy a public transaction, but the copy
+Both fields are signed. Someone may copy a public transaction, but the copy
 cannot change the recipient or charge another payer. This does not promise
 private order flow or first inclusion; it limits what a copied payload can do.
 
@@ -148,18 +153,20 @@ Core-entry behavior as one composition.
 
 An auction authorization opens a longer state machine:
 
-1. The authorization registers the approved collection, token, poster, reserve,
-   and end time with
-   [`AuctionContract.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol).
-2. Registration mints the token into auction custody and confirms that custody
-   before bidding becomes active.
-3. A valid first bid meets the reserve. Each later valid bid meets the current
+1. The authorization approves the collection and token-data inputs, poster,
+   reserve, and end time. It does not name an existing token ID.
+2. The legacy minter allocates the Core's next token ID and mints that new token
+   into auction custody.
+3. `StreamDrops` registers the newly allocated token and approved terms with
+   [`AuctionContract.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol),
+   which confirms custody before bidding becomes active.
+4. A valid first bid meets the reserve. Each later valid bid meets the current
    minimum and becomes the new leader.
-4. The displaced bidder receives a withdrawable credit; the new bid is not
+5. The displaced bidder receives a withdrawable credit; the new bid is not
    allowed to depend on an immediate refund succeeding.
-5. A qualifying late bid extends the end time.
-6. After the end, any address may trigger the already-determined settlement.
-7. If no one bid, the contract returns or makes the token claimable by the
+6. A qualifying late bid extends the end time.
+7. After the end, any address may trigger the already-determined settlement.
+8. If no one bid, the contract returns or makes the token claimable by the
    poster. A cancellation is possible only before any bid and before the
    auction has ended.
 

--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/fixed-price-sales-and-auctions.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/fixed-price-sales-and-auctions.md
@@ -1,0 +1,349 @@
+# Fixed-price sales and auctions
+
+Stream's sales contracts turn approved terms into one of two outcomes: a
+fixed-price mint or an English auction. They are responsible not only for
+receiving ETH, but also for enforcing the exact terms the configured signer
+authorized, placing the work in the right custody, accounting for every
+liability, and reaching a final state that anyone can inspect.
+
+That is more machinery than a bare payable mint. The extra state exists because
+a sale can otherwise change between the screen and the transaction, a copied
+signature can do more than intended, a hostile bidder can block refunds, or
+ownership and payment can finish in different states.
+
+## The sale flow at a glance
+
+Both sale modes start from the same signed instruction and then take different
+paths:
+
+1. An approved signer creates a signed instruction describing the exact sale.
+2. The sale contract verifies its signature, deadline, current signing-key
+   epoch, used-or-cancelled state, participants, collection, token data,
+   quantity, and sale terms.
+3. A fixed-price authorization mints one token to its signed recipient and
+   records the resulting payment credits.
+4. An auction authorization mints the token into auction custody and opens a
+   state machine for bids, refunds, extensions, and settlement.
+5. Recipients withdraw recorded credits rather than being paid inside the
+   mint, bid, or settlement transaction.
+6. The terminal record must show whether the work was sold, returned after no
+   bids, or cancelled before any bid.
+
+## Why the machinery exists
+
+A marketplace or operator can perform much of this work offchain. That can make
+the Solidity shorter, but it leaves another system responsible for:
+
+- proving that the displayed terms match execution;
+- preventing a copied approval from changing the payer or recipient;
+- holding the work safely while bids are open;
+- refunding displaced bidders;
+- deciding and disclosing time extensions;
+- handling contract-wallet recipients;
+- keeping all credits solvent through settlement;
+- producing a public terminal record.
+
+That may be a valid trust model for a particular sale. It is not the same
+guarantee. Stream's design should be judged by whether each mechanism protects
+one of these responsibilities and whether overlapping mechanisms can be
+removed.
+
+The contracts cannot establish that the offchain curation decision was fair,
+that the configured signer was honest or uncompromised, that a user understood
+the terms, or that every recipient will withdraw successfully. They can bind
+the signer's exact instruction to execution and keep custody, liabilities, and
+terminal states inspectable.
+
+## The signed instruction fixes the sale
+
+Both paths begin with
+[`DropAuthorization`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L24-L61).
+It uses EIP-712, a standard format for structured typed signatures. Its domain
+binds the chain and verifying contract. Its payload binds:
+
+- authorization identity and replay inputs;
+- poster;
+- token recipient;
+- payer;
+- collection;
+- fixed-price or auction mode;
+- token-data hash;
+- fixed price;
+- quantity;
+- auction reserve and end time;
+- deadline;
+- signer epoch.
+
+This is the bridge from an offchain curation decision to an onchain action. The
+contract does not reproduce Total Days Held (TDH), 6529's time-weighted holding
+measure, or the curation process; it verifies that the signed result cannot
+quietly become a different sale.
+
+Without the domain binding, the signature could be replayed elsewhere. Without
+separate payer and recipient fields, a copied transaction could redirect the
+work or charge the wrong account. Without the mode, amount, token-data hash,
+deadline, signer epoch, and one-use identity, one valid signature could
+authorize more than its signer intended.
+
+Signature validity is only the first gate. Supply, mint policy, pause state,
+payment, freeze, and sale-specific checks still apply.
+
+The current authorization has no currency or token-address field. These Drop
+and auction paths use native ETH, so the execution path fixes the currency. A
+future token-denominated authorization would also need to bind the asset
+address, not just an amount.
+
+## The fixed-price flow
+
+A fixed-price authorization can describe either a paid mint or a free claim:
+
+1. `StreamDrops` verifies the signed instruction and its one-use identity.
+2. It checks the collection, quantity, recipient, token data, deadline, mint
+   capacity, freeze state, and the other applicable policy conditions.
+3. For a paid mint, submitted ETH must match the authorized economics. The
+   frontend does not get to supply a different executable price.
+4. The legacy `StreamMinter` calls the legacy Core mint entry and delivers the
+   token to the signed recipient.
+5. The Drop contract selects a proceeds split in token, collection, then
+   contract-default order.
+6. It records separate poster, protocol, and curator-reserve credits for later
+   withdrawal.
+
+The split lookup is visible in
+[`proceedsSplitFor`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L542-L558),
+and the crediting logic in
+[`_creditFixedPriceProceeds`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L635-L680).
+
+A zero price removes payment, not policy. Replay, collection, quantity,
+recipient, token data, deadline, mint capacity, and freeze checks still matter.
+"Free" must not mean "any caller may mint anything."
+
+The signed Drop requires `quantity == 1`; one authorization mints one token.
+Stream can represent editions at the collection level, but this signed path is
+not a batch mint.
+
+## Payer and recipient are intentionally different
+
+The account funding a mint and the account receiving the token can differ. That
+supports gifts and sponsored actions without leaving the beneficiary
+ambiguous.
+
+Both addresses are signed. Someone may copy a public transaction, but the copy
+cannot change the recipient or charge another payer. This does not promise
+private order flow or first inclusion; it limits what a copied payload can do.
+
+## Current signed sales use the legacy mint lane
+
+The signed Drop and auction paths call the legacy `StreamMinter`, not
+`StreamMintManager`. The rehearsal installs the manager in Core separately but
+passes the legacy minter to both current sale contracts. See
+[`RehearseDeployment.s.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/script/RehearseDeployment.s.sol#L218-L269).
+
+The distinction matters because these sale calls do not consume the manager
+lane's durable counters or prepared-mint records. A release candidate must name
+one supported end-to-end path and prove its supply, replay, payment, and
+Core-entry behavior as one composition.
+
+## The auction flow
+
+An auction authorization opens a longer state machine:
+
+1. The authorization registers the approved collection, token, poster, reserve,
+   and end time with
+   [`AuctionContract.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol).
+2. Registration mints the token into auction custody and confirms that custody
+   before bidding becomes active.
+3. A valid first bid meets the reserve. Each later valid bid meets the current
+   minimum and becomes the new leader.
+4. The displaced bidder receives a withdrawable credit; the new bid is not
+   allowed to depend on an immediate refund succeeding.
+5. A qualifying late bid extends the end time.
+6. After the end, any address may trigger the already-determined settlement.
+7. If no one bid, the contract returns or makes the token claimable by the
+   poster. A cancellation is possible only before any bid and before the
+   auction has ended.
+
+Minting into custody first protects bidders from paying into an auction whose
+contract does not hold the work. Minting to an operator and asking for a later
+transfer is simpler, but it makes custody and operator failure offchain trust
+assumptions.
+
+## Bids create liabilities as well as a leader
+
+Each bid puts ETH under contract control. The auction records the highest
+bidder and amount, enforces the next minimum, and keeps displaced bids as
+withdrawable credits.
+
+This pull-refund model stops a bidder contract that rejects ETH or attempts
+reentrancy from blocking the next valid bid. It also creates a strict solvency
+rule: every bidder credit must remain backed and must never be treated as
+emergency surplus.
+
+Synchronous refunds need less accounting state, but let an arbitrary recipient
+decide whether the auction can continue.
+
+## The minimum next bid is exact
+
+The first bid must meet the reserve. Later bids must equal or exceed:
+
+`current highest bid + floor(current highest bid * 5 / 100)`
+
+The percentage starts at 5%. After a 1 ETH bid, the default next minimum is
+1.05 ETH. At very small values, integer rounding can make the percentage
+component zero. The authoritative read is
+[`minimumNextBid`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol#L251-L265);
+the same calculation is enforced by
+[`participateToAuction`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol#L279-L312).
+
+One global `incPercent` applies when a bid arrives. A function-scoped or global
+admin can change it while auctions are active, with no bound, delay, dedicated
+change event, or per-auction snapshot. See
+[`updatePercentAndExtensionTime`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol#L549-L558).
+
+Review must cover reserve equality, the exact next minimum, one wei below it,
+small-value rounding, large values and multiplication bounds, zero or extreme
+percentages, mid-auction changes, bidder replacement, and bids at the time
+boundary. Reviewers should decide whether the visible terms must be fixed when
+an auction starts.
+
+## Anti-sniping needs a reproducible clock rule
+
+The extension time begins at 300 seconds. When a valid bid arrives with five
+minutes or less remaining, the contract adds a full five minutes to the
+recorded end time. It adds to the old end time, not the current block time.
+Every qualifying late bid can extend again, with no current cap on extension
+count or total duration.
+
+`AuctionExtended` records the old and new times. The auction ends only after
+`block.timestamp` is greater than the recorded end, so a bid included at the
+exact end timestamp can still qualify and extend.
+
+`extensionTime` is also one mutable global value. A function-scoped or global
+admin can change it during an active auction without a bound, delay, or
+dedicated change event; later bids use the live value.
+
+The rule protects bidders from an auction ending before they can answer a
+last-second bid. It cannot guarantee transaction inclusion during congestion.
+Removing timing state means choosing a different fairness model, not obtaining
+fairness for free.
+
+## Winner settlement is permissionless but not discretionary
+
+After the end time, any address may call
+[`claimAuction`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol#L371-L388).
+The caller does not choose the winner, price, or proceeds. Auction state already
+fixed them.
+
+Settlement must:
+
+1. confirm that settlement is allowed;
+2. use the recorded winning bid and bidder;
+3. transfer the escrowed token exactly once;
+4. select the token, collection, or default proceeds split;
+5. create poster, protocol, and curator credits;
+6. preserve bidder and seller accounting;
+7. emit a reconstructable record;
+8. prevent cancellation or a second settlement.
+
+The contract transfers the token from auction custody and creates
+Auction-local credits through
+[`_creditAuctionProceeds`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol#L471-L508).
+It does not use the separately deployed revenue resolver or split wallets.
+
+Permissionless settlement is safe only because the trigger carries no
+sensitive choice: the consequences were committed earlier.
+
+## No-bid settlement still has a token to resolve
+
+The auction minted its token before bidding, so a no-bid result does not undo
+the mint or restore supply. It decides where the existing token goes.
+
+For an ordinary poster address, `claimAuction` returns the token and records
+`SettledNoBid`. For a contract poster, it records a pending claimant rather
+than attempting an immediate safe transfer. Only that exact contract may call
+[`claimNoBidAuctionToken`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol#L390-L407)
+and choose a nonzero recipient. The claim is then cleared, the token
+transferred, and the auction made terminal. See
+[`_settleNoBidAuction`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol#L438-L454).
+
+This extra state prevents a contract wallet that rejects or mishandles an
+ERC-721 transfer from stranding the token or blocking terminal settlement.
+Reviewers should still decide whether a contract poster may name any recipient
+and whether returning an already-minted work is the right supply and collector
+outcome.
+
+## Cancellation must respect custody and bidder rights
+
+The poster, or an admin authorized for `cancelAuction`, may cancel only while
+the auction is active and has no highest bid. Once a bid exists or the auction
+has ended, this path is closed.
+
+Cancellation makes the auction terminal and returns the token to the poster.
+The function does not check the bidding or settlement pause. See
+[`cancelAuction`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/AuctionContract.sol#L409-L426).
+
+A broader emergency-cancel path would give an operator power over a bidder's
+acquired expectation. If cancellation after a bid is ever required, its
+refund, consent, timing, and evidence rules must be explicit.
+
+## Liabilities, surplus, and hostile recipients
+
+Auction and Drop contracts hold funds owed to other people. Recoverable surplus
+is balance minus liabilities, never raw balance. Liabilities include:
+
+- active highest-bid escrow;
+- refundable outbid credits;
+- seller proceeds;
+- protocol and curator credits;
+- every other accounted entitlement.
+
+Both contracts expose liability-aware surplus information. Only
+`AuctionContract` exposes `emergencyWithdraw` at this commit, and it caps the
+withdrawal at calculated surplus. `StreamDrops` exposes surplus views but no
+emergency-withdrawal function. Forced ETH and rounding residuals do not change
+the rule.
+
+External transfers must update state first, use reentrancy protection where
+needed, preserve credits after failed withdrawals, support alternate recipients
+where permitted, and account for every effect. No path should assume that every
+wallet is an ordinary address or rely on gas-stipend folklore.
+
+## Additional sale mechanics need their own review
+
+The sales specifications discuss Dutch auctions, private sales, refund windows,
+sealed bids, raffles, burn-to-mint, ERC-20 bidding, and other profiles. Those
+mechanics are not protections supplied by the sale path described here.
+
+Each could change custody, pricing, ordering, refund, eligibility, replay, and
+finality assumptions. The permanent Core should not absorb speculative sale
+mechanics. Any added profile should be an explicit reviewed module with bounded
+authority over token identity and supply.
+
+## What can still fail
+
+- A signed participant, asset, quantity, price, or sale mode is not completely
+  bound.
+- A replay registers or settles twice.
+- The sale reaches a mint lane with different limits than reviewers expect.
+- A global parameter change silently changes an active auction.
+- A refund or proceeds credit becomes unbacked.
+- Different clients implement extension or rounding rules differently.
+- Settlement leaves token custody and funds out of sync.
+- No-bid handling strands a token or creates an unfair supply outcome.
+- Cancellation violates bidder expectations.
+- Emergency withdrawal treats liabilities as surplus.
+- A hostile recipient blocks progress or reenters.
+
+## Questions for reviewers
+
+1. Does the authorization bind every participant, economic term, asset, and
+   replay input needed by the current sale?
+2. Should bid increment and extension rules be fixed per auction?
+3. Are the exact boundary-time and rounding rules understandable to bidders?
+4. Is direct auction custody the right model for the work before settlement?
+5. Should any cancellation path exist after a valid bid?
+6. Is no-bid behavior fair to the artist and potential collector?
+7. Can every liability and terminal state be reconstructed from public storage
+   and events?
+8. Which additional sale profiles, if any, are important enough to justify
+   genesis audit surface?

--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/for-artists.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/for-artists.md
@@ -1,0 +1,451 @@
+# For artists
+
+Stream is designed to let an artist define the life of a digital artwork, not
+just mint its token. It can make the work's identity, materials, supply, sale,
+revenue, randomness, mutable state, preservation package, and final state
+visible as connected commitments.
+
+## What publishing a 1/1 could look like
+
+For an artist, the intended journey is:
+
+1. **Create the collection identity.** Confirm the artist address and the
+   collection record in Stream's shared token contract, called the Core, that
+   will permanently identify the work.
+2. **Assemble the artwork.** List the exact files, scripts, token data,
+   dependencies, images, attributes, and runtime assumptions.
+3. **Choose the edition and audience.** Set the maximum supply, mint policy,
+   sale path, eligibility rules, and recipient behavior.
+4. **Choose the economics.** Confirm the price, currency, collaborators,
+   curator allocation, protocol allocation, withdrawal rules, and royalty
+   information.
+5. **Choose the randomness policy.** If the work uses randomness, identify the
+   provider, cost, failure states, retry rules, and recovery limits.
+6. **Approve one readable state.** Compare the wallet signature with a
+   human-readable package showing exactly what the signed hash commits to.
+7. **Publish and observe.** Watch the mint or auction, token identity,
+   randomness result, metadata, payments, and any burn history.
+8. **Close supply.** Confirm that every mint path is closed, not only the one
+   visible in the main interface.
+9. **Freeze the Core boundary.** Verify the exact fields and functions that
+   become unchangeable.
+10. **Preserve and finalize the artwork.** Retrieve the materials independently,
+    inspect collection and token-specific manifests, wait through the finality
+    delay, and verify the terminal state.
+
+The machinery exists so these choices do not remain private operator settings.
+Its value depends on whether the artist can understand the choices before
+signing and independently check the result afterward.
+
+## What the system is trying to protect
+
+For artists, Stream is trying to protect:
+
+- **Identity:** the work should not receive a new identity when a sale,
+  renderer, or other replaceable module changes.
+- **Specific consent:** a signature for one state should not approve a later
+  state with different bound terms.
+- **Attribution:** an artist statement should remain distinguishable from an
+  owner, curator, institution, administrator, or independent observer.
+- **Complete artwork materials:** the protocol should describe more than a
+  thumbnail or mutable URL.
+- **Economic clarity:** recipients, percentages, liabilities, and royalty
+  limits should be visible before a sale.
+- **Deliberate finality:** “finished” should name the exact supply, data,
+  preservation, and mutation promises being made.
+
+It cannot remove every outside dependency. The artist still depends on
+curation services, signers, randomness providers, storage, browsers,
+marketplaces, governance, and the quality of the human-readable interface.
+Those boundaries should be named rather than hidden behind “trustless” or
+“immutable.”
+
+## Your collection has a durable identity
+
+Stream uses one shared ERC-721 Core—the standard kind of contract that records
+NFT ownership—for many native collections. The Core stores the collection
+record and its artist address. Each token receives both a global Stream token
+ID and a collection-local serial.
+
+A Stream collection therefore does not receive a separate ERC-721 contract
+address. Its identity comes from the Core collection record, collection reads,
+and token metadata.
+
+This protects continuity: the artwork does not acquire a new identity when a
+sale module, renderer, randomness integration, or other replaceable component
+changes. The tradeoff is that Core correctness and governance affect every
+collection, and marketplaces or indexers must understand Stream's native
+collection identity instead of grouping only by contract address.
+
+The collection can refer to:
+
+- artist identity;
+- maximum and current supply;
+- mint policy;
+- token data, scripts, images, and attributes;
+- dependency versions;
+- metadata mode;
+- randomness provider;
+- sale and revenue configuration;
+- freeze and preservation commitments.
+
+The artist should be able to see which contract owns each value, who may change
+it, and what closes that mutation path.
+
+## You approve a specific state
+
+The current artist-approval mechanism in
+[`StreamArtistApprovals.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamArtistApprovals.sol#L8-L21)
+computes a collection-state hash and verifies the artist's signature.
+
+The typed domain binds the chain and Core contract. The signed state binds:
+
+- artist address;
+- current collection-freeze manifest hash;
+- maximum collection purchases;
+- collection total supply;
+- final-supply delay.
+
+The signature can come from an ordinary account or an ERC-1271 contract wallet
+such as a Safe.
+
+If a bound field changes, the old signature describes the earlier state. This
+protects the artist from having one approval silently reused for new bound
+terms.
+
+The wallet still shows a hash. The product must translate that hash into a
+readable package with the collection, source version, files, supply, sale
+rules, recipients, randomness provider, mutable fields, and irreversible
+actions. A technically valid signature is not meaningful artistic consent when
+the artist cannot inspect what it means.
+
+## Approval is not total control
+
+The current artist approval is not a universal veto. Administrative and
+governance paths can still act within their own authority. The current
+Core-freeze call, for example, does not itself demand a new artist signature.
+
+The practical question is which actions become impossible without current
+artist consent. Important candidates include:
+
+- initial collection state;
+- maximum and final supply;
+- sale and revenue terms;
+- randomness-provider selection;
+- collection and one-of-one manifests;
+- Core freeze;
+- terminal artwork finality;
+- a recovery or successor action that changes what viewers receive.
+
+Some actions may reasonably require both artist approval and protocol
+governance. A guardian may be able to stop a suspicious action without gaining
+power to author a different artwork payload.
+
+## Statements made in your name
+
+Collection metadata and preservation records can carry different kinds of
+claims. Stream's record-family design distinguishes artist, owner, independent,
+curator, institution, rights, archive, fixity evidence (checks showing whether
+retrieved bytes changed), C2PA (Coalition for Content Provenance and
+Authenticity) credentials, IIIF (International Image Interoperability
+Framework) media records, media-relationship, identity-display, snapshot, and
+agent records.
+
+This prevents an owner statement from appearing to be an artist statement, an
+archive location from appearing to be a rights grant, or a permissionless
+observation from appearing to be protocol endorsement.
+
+In the current source, artist, owner, institution, and independent families
+reject ordinary administrative grants. Artist authority comes through an
+artist-authority provider, and an exact record type can be admitted to only one
+family.
+
+The implementation is in
+[`StreamRecordFamilyRegistry`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRecordFamilyRegistry.sol#L17-L285).
+
+The artist-facing interface should show:
+
+- record family and exact type;
+- authoring address;
+- wallet or provider that established authority;
+- collection or token concerned;
+- whether the record can be revised, locked, superseded, or only supplemented;
+- whether Stream checked authorship only or also validated the contents.
+
+A recorded statement can prove who submitted it under the configured authority
+model. It does not automatically make a rights claim, archive location,
+institutional attestation, or provenance credential true.
+
+## The artwork is more than its metadata URL
+
+Stream can represent a work through collection information, scripts,
+token-specific data, images, attributes, dependency records, metadata modes,
+and randomness output.
+
+For generative and executable work, `tokenURI` alone may not reveal:
+
+- exact script bytes and execution order;
+- library names, versions, and bytes;
+- image, font, codec, or data-file dependencies;
+- which values are onchain and which must be retrieved elsewhere;
+- which browser or runtime assumptions affect the result.
+
+Before approval or finality, the artist should receive a dependency bill of
+materials showing:
+
+1. every file and exact byte hash;
+2. every script and its execution order;
+3. every external dependency and version;
+4. each retrieval location;
+5. token data and randomness inputs;
+6. reconstruction instructions;
+7. browser, font, codec, and runtime assumptions;
+8. reference outputs where visual equivalence matters.
+
+A hash proves that retrieved bytes match a commitment. It does not upload the
+file, keep it available, operate a gateway, or preserve the software needed to
+execute it.
+
+## One-of-ones and editions
+
+The shared Core can represent a one-of-one, fixed edition, or another supported
+collection pattern through supply and mint policy.
+
+One-of-one work receives special treatment where a collection-wide record is
+not enough. A token can require its own materials and manifest so the finality
+package binds that exact work rather than only a shared collection description.
+
+For any collection, the artist should be able to inspect:
+
+- maximum possible supply;
+- minted-ever supply;
+- live supply after burns;
+- collection-local serials;
+- every phase or authorization that can still mint;
+- who may change a time window or supply setting;
+- what closes supply;
+- whether a successor can reopen a path represented as closed.
+
+Minted-ever and live supply answer different questions. Burning a token should
+not erase its mint history or automatically restore a lifetime allowance.
+
+## Choosing who can mint
+
+Stream separates collection identity from distribution policy. Mint phases can
+describe:
+
+- opening and closing times;
+- phase supply;
+- executors;
+- optional eligibility gates;
+- per-wallet, per-recipient, or other durable limits;
+- policy hashes;
+- authorizers and one-use authorization safeguards, also called replay
+  protection.
+
+That allows distribution rules to change without putting every future sale
+mechanism into the permanent Core.
+
+The signed Drop path binds a sale to a payer, recipient, collection, quantity,
+price, deadline, sale mode, token-data hash, signer epoch, and a one-use replay
+identifier that prevents the authorization from being executed twice.
+In that path, `quantity` is currently required to equal `1`, so one
+authorization mints one token. An edition can use multiple authorizations or
+another configured mint lane; the existence of a quantity field does not make
+this path a batch mint.
+
+See
+[`StreamDrops._validateAuthorization`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L561-L581)
+and
+[`_executeFixedPriceDrop`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L609-L632).
+
+The exact current, connected, source-only, accepted, and proposed paths are
+centralized on [Current Implementation and
+Readiness](./security-testing-and-known-limitations).
+
+## Curation and TDH
+
+Total Days Held (TDH) is 6529's time-weighted holding measure. TDH and curation
+are calculated outside Solidity. Stream does not choose the artist or run an
+onchain TDH vote. A service constructs the authorized action, a configured
+signer signs it, and the contract checks the payload.
+
+This protects the approved result by binding the collection, participants,
+price, quantity, timing, and sale mode. It does not prove that the curation
+rules were fair, the TDH calculation was correct, or the signer was not
+compromised.
+
+Artists still depend on published curation rules, correct authorization
+construction, signer security, visible rotation, and public evidence of the
+offchain decision. The complete typed payload should be readable before the
+sale, not only after execution.
+
+## Fixed-price sales and auctions
+
+A sale can be a free or paid fixed-price mint or an English auction.
+
+For a fixed-price sale, the artist should see:
+
+- collection and token data;
+- price and currency;
+- payer and token recipient;
+- deadline;
+- proceeds recipients and percentages;
+- curator and protocol allocation;
+- withdrawal behavior;
+- cancellation and replay state.
+
+For an auction, the artist should additionally see:
+
+- reserve price;
+- start and end conditions;
+- minimum next-bid calculation;
+- late-bid extension rule;
+- token custody;
+- bidder refund method;
+- cancellation boundary;
+- winner and no-bid settlement;
+- treatment of the already-minted token if no one bids.
+
+The contract uses pull credits for proceeds and refunds so a recipient cannot
+block sale progress by rejecting an inline ETH transfer. That also creates an
+accounting duty: every bidder, artist, curator, and protocol credit must remain
+fully backed.
+
+Future sale profiles can use new modules rather than expanding the permanent
+Core. Each still needs its own custody, pricing, refund, replay, and settlement
+review.
+
+## Revenue, collaborators, and royalties
+
+An artist may need to divide primary-sale value among collaborators, a curator,
+an institution, the protocol, an estate, or other recipients.
+
+Before approving a sale, the artist should receive one readable revenue
+statement identifying:
+
+- every recipient and share;
+- token, collection, and default-profile precedence;
+- when the profile can change;
+- supported currencies;
+- rounding direction and residual owner;
+- withdrawal behavior;
+- curator allocation and claim method;
+- emergency-surplus boundaries;
+- royalty receiver and rate;
+- which claims Stream enforces and which depend on marketplaces.
+
+The source contains native Drop and Auction credit accounting as well as a
+separate resolver, split-wallet, asset-policy, and primary-settlement
+foundation. Those are distinct value paths, so the sale interface must name the
+one it actually uses.
+
+Core also exposes ERC-2981 royalty information. ERC-2981 tells a marketplace
+what royalty the contract reports; it does not force every marketplace to pay.
+
+## Randomness
+
+If the work uses randomness, the artist should know the provider and failure
+policy before minting.
+
+Stream can bind a request to the token, collection, provider address, and
+provider epoch. It stores a hash of the raw provider output, derives a
+context-bound seed, and exposes pending, fulfilled, stale, and
+failed-post-processing states.
+
+If the provider output was accepted but the Core write failed, retry uses the
+same derived seed instead of requesting a new result. That protects a technical
+recovery from becoming a reroll.
+
+The artist should be able to answer:
+
+- Can I reject the provider before minting?
+- Who can change it?
+- What happens to pending or failed requests?
+- When may a request be declared stale?
+- Can a stale token recover without creating selective rerolls?
+- Can a token be burned while randomness is pending?
+- Which fees or subscriptions must remain funded?
+- Which provider settings can change without a new Core epoch?
+
+The selected provider remains an outside trust and availability dependency.
+
+## Freezing the work
+
+Stream separates:
+
+- **Final supply:** whether more tokens can be minted.
+- **Core freeze:** whether covered collection and live-token fields in the
+  permanent contract can change.
+- **Preservation records:** what evidence exists about the materials needed to
+  understand or reconstruct the work.
+- **Artwork finality:** whether the remaining artwork-affecting paths for the
+  defined scope are terminal.
+
+Before freeze or finality, the artist should:
+
+1. Verify collection identity and artist address.
+2. Verify maximum, minted-ever, live, and intended final supply.
+3. Verify every open mint phase, executor, gate, sale, and authorization.
+4. Verify every live token's randomness and metadata state.
+5. Verify scripts, token data, images, attributes, dependency versions, and
+   hashes.
+6. Retrieve every required file from the published locations.
+7. Reconstruct the work independently.
+8. Verify recipients, percentages, currencies, curator allocation, and royalty
+   information.
+9. Verify burn and provenance records.
+10. Inspect exact collection and one-of-one manifests.
+11. Inspect what Core freeze closes and what remains outside it.
+12. Sign only the intended state.
+13. Preserve an independent copy of the approval and finality package.
+
+The finality delay should provide time to find a missing file, wrong hash,
+incorrect manifest, or unexpected remaining writer before the action becomes
+terminal.
+
+## Collaborators, recovery, and estates
+
+The current artist-state approval is narrower than a complete lifetime artist
+authority system.
+
+A broader model would need to address:
+
+- collaborators with narrow responsibilities;
+- delegated signing;
+- key rotation and loss;
+- contract-wallet ownership changes;
+- guardians and recovery;
+- disputes and sanctions;
+- estate instructions;
+- boundaries among artist, owner, institution, and protocol authority.
+
+One proposal would keep artist authority and history in a single registry while
+delegating only narrow validation to a stateless helper. Replacing that helper
+would require the full successor process. Artists should decide whether that
+recovery and delegation model is understandable and worthy of permanence.
+
+## Design position
+
+Artists should not need transaction traces to understand what they are
+signing. The approval experience should name the work, exact source, materials,
+supply, sale terms, recipients, randomness provider, mutable fields, other
+actors with power, and irreversible actions.
+
+The strongest version of Stream is not merely a contract that records an artist
+address. It is a system in which artistic consent is readable,
+version-specific, and carried through the full life of the work.
+
+## Questions for artists
+
+1. Which actions must be impossible without your current signature?
+2. Which actions should require both artist approval and protocol governance?
+3. Should collaborators receive narrow onchain roles, or should the artist
+   remain the only signing identity?
+4. What recovery and estate process is credible over a fifty-year horizon?
+5. Is the approval package understandable enough to sign without Solidity
+   knowledge?
+6. What preservation evidence would make you comfortable freezing a work?
+7. Which sale, revenue, and royalty settings must become permanent, and when?
+8. Would the finality ceremony make you more confident, or does it place too
+   much operational burden on the artist?

--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/freezing-preservation-and-artwork-finality.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/freezing-preservation-and-artwork-finality.md
@@ -1,0 +1,396 @@
+# Freezing, preservation, and artwork finality
+
+The reviewed Solidity separates "finished" into four mechanisms: final supply,
+a selected configuration freeze in `StreamCore`—called Core here—the permanent
+token and collection identity contract, append-only preservation records, and a
+delayed artwork-finality registry. Each protects a different boundary; complete
+terminal closure is not yet proven for a candidate.
+
+Those are different promises. Combining them into one `frozen = true` flag
+would be shorter, but could hide a live mint route, mutable dependency,
+replaceable renderer, missing file, or administrative writer. The layers exist
+so an artist and collector can tell exactly what became irreversible.
+
+## The closing flow at a glance
+
+A careful close proceeds in this order:
+
+1. Confirm the number of works that may exist and close every mint lane.
+2. Build a reproducible manifest—a machine-readable inventory—of the collection
+   state, then freeze the defined Core boundary.
+3. Publish append-only preservation records for the artwork materials, their
+   hashes, locations, and context.
+4. Build collection-wide and, where needed, token-specific finality manifests.
+5. Bind artist approval to the exact human-readable payload.
+6. Schedule terminal finality, wait through the review and veto period, and
+   cancel or let the action expire if the package is wrong.
+7. Execute only the payload that was reviewed.
+8. Have an independent reader verify the terminal state and recover the
+   preservation package from published instructions.
+
+## Four completion promises
+
+Stream distinguishes:
+
+1. **Final supply** — no more tokens should be mintable for the collection.
+2. **Core freeze** — selected collection configuration in the permanent token
+   contract can no longer change.
+3. **Preservation records** — append-only evidence identifies artwork
+   materials, hashes, locations, and context.
+4. **Artwork finality** — a delayed terminal action is intended to close the
+   remaining artwork-affecting paths for a defined scope.
+
+The relevant source contracts include
+[`StreamCore.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol),
+[`StreamPreservationRecords.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamPreservationRecords.sol),
+and
+[`StreamArtworkFinalityRegistry.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamArtworkFinalityRegistry.sol).
+
+The promises complement rather than replace one another. Minting can stop while
+metadata remains editable. Core can freeze while preservation evidence
+continues to grow. Exact file hashes can exist while the software or service
+needed to retrieve and run those files disappears.
+
+## Why the layers exist
+
+A single flag and content hash would leave external actors to answer:
+
+- Did every mint path actually close?
+- Which metadata and module fields remained mutable?
+- Which exact encoding did the hash cover?
+- Was every token-specific artifact included?
+- Are the committed bytes still available?
+- Can a current browser execute them?
+- Did a replacement renderer change the work?
+- Did the artist approve this exact terminal state?
+- Can another administrative path still mutate it?
+
+A deliberately narrow token may accept those external assumptions. Stream's
+source is attempting a stronger, independently verifiable artwork promise. The
+added machinery is justified only when each layer has one precise meaning and
+no unbound path can bypass it.
+
+## Final supply is a supply promise
+
+When a collection has minted at least one token, `setFinalSupply` lowers its cap
+to the number already minted. Future minting then fails at that cap. This action
+says nothing about artwork bytes, scripts, or metadata.
+
+There is a defect in the zero-mint case. With no minted token,
+`setFinalSupply` stores `0`. `setCollectionData` also interprets `0` as
+uninitialized supply. While the collection remains unfrozen, a function admin
+can set a new nonzero cap and reopen minting. See
+[`setFinalSupply`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L888-L907),
+[`_finalizeCollectionSupply`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L1497-L1501),
+and
+[`setCollectionData`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L377-L408).
+
+There is no separate final-supply flag or event in the pinned candidate.
+Calling `setFinalSupply` alone is therefore not irreversible for a zero-minted,
+unfrozen collection. Core freeze closes that route, but Core freeze is a
+different promise.
+
+A durable supply close must prove:
+
+- one monotonic finalized state, including zero supply;
+- closure or exhaustion of every mint phase and executor;
+- defined handling of authorizations, auctions, and reservations created
+  before finalization;
+- an event carrying the final value;
+- no successor route that bypasses the final state.
+
+Using one sentinel saves storage but makes "zero authorized works"
+indistinguishable from "supply not initialized." A permanent promise should not
+depend on that ambiguity.
+
+## Core freeze fixes a defined boundary
+
+Core freeze is consequential because Core is intended to preserve token and
+collection identity. At the pinned commit, it:
+
+- finalizes supply;
+- stores a freeze-manifest hash;
+- blocks legacy and manager mint entries;
+- blocks burning live tokens;
+- blocks changing the collection randomizer;
+- blocks artist-approval changes;
+- blocks token-data, image, and attribute changes;
+- blocks new or revised collection-metadata records;
+- blocks reserved collection-metadata lock changes.
+
+See
+[`freezeCollection`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L826-L841),
+the
+[`mint entries`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L445-L503),
+[`burn`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L628-L640),
+and
+[`artist approval`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L734-L761).
+
+Core freeze deliberately does not stop everything. It leaves:
+
+- ordinary ERC-721 transfers and approvals;
+- append-only preservation records;
+- post-burn randomness audit evidence for an already burned token;
+- collection-metadata snapshot publication if snapshot locks remain open;
+- nonreserved record-specific locks;
+- shared contract-level metadata changes;
+- reads, exports, and historical event reconstruction;
+- global module, successor, or governance actions unless another terminal rule
+  blocks them.
+
+The ordinary transfer posture is visible
+[`in Core`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L1008-L1011).
+Collection-record revisions check Core freeze, while snapshot publication does
+not and nonreserved record locks remain available. See the
+[`metadata mutation checks`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCollectionMetadata.sol#L363-L397).
+
+The product must enumerate this boundary. "Collection frozen" is misleading if
+readers infer that presentation, preservation history, and every successor
+module are immutable too.
+
+## A freeze manifest gives the boundary one identity
+
+Core stores a hash of the relevant freeze state. Another party can compare an
+independently reconstructed package with the state that was actually frozen.
+
+That hash is useful only when its preimage is canonical and inspectable.
+Reviewers need to know which fields and versions enter it, how values are
+serialized, how live, burned, and unminted tokens are handled, which dependency
+and randomness facts are covered, how a readable package maps to the hash, and
+which mutable surfaces remain outside it.
+
+A generic hash with no reproducible preimage does not tell an artist what was
+approved or a collector what became fixed.
+
+## Preservation records keep history append-only
+
+[`StreamPreservationRecords`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamPreservationRecords.sol)
+records typed evidence about materials needed to understand or reproduce a
+work. A useful record identifies:
+
+- collection or token scope;
+- record type and subject;
+- the authorized submitter;
+- digest algorithm and bytes;
+- URI or location context;
+- effective time;
+- relationship to earlier evidence;
+- exact record hash.
+
+The contract supports Keccak-256, SHA-256, BLAKE3, multihash, IPFS CID, and
+Arweave transaction references. It bounds URI and digest sizes and stores
+complete records behind their hashes.
+
+Records remain appendable after Core freeze. An old record is never overwritten,
+but a later record can move the collection/type/subject `latest` pointer.
+`Latest` means most recently recorded onchain, not greatest `effectiveAt`.
+
+This lets conservators add a storage location, fixity check, or format note
+without claiming that the original final package changed. It also means
+"append-only" does not mean "one final preservation record." Readers must
+distinguish:
+
+- the package associated with finality;
+- later preservation evidence;
+- the current latest pointer;
+- each record's author and authority class;
+- a signature hash from a signature independently verified elsewhere.
+
+The preservation contract stores signature-related commitments but does not
+verify a signature itself. See
+[`IStreamPreservationRecords`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/IStreamPreservationRecords.sol#L106-L126).
+
+## Integrity is not availability
+
+A valid hash proves that retrieved bytes match a commitment. It does not:
+
+- recover missing bytes;
+- pay storage providers;
+- keep a domain or gateway online;
+- preserve an RPC service;
+- preserve a browser, font, codec, GPU, or JavaScript runtime;
+- prove that an external location is independently controlled.
+
+The preservation promise should state both the onchain integrity commitment and
+the operational availability guarantee. A hash is not "permanent storage."
+
+## One-of-one materials need token-specific commitments
+
+A one-of-one work may have source, media, or authenticity evidence that does
+not fit a collection-wide package. The finality design therefore includes
+token-specific manifest handling.
+
+Reviewers should prove that every token needing an individual manifest is
+covered, one token's manifest cannot substitute for another's, encoding and
+hashing are unambiguous, shared edition materials are not duplicated without
+need, and burned and unminted cases are defined.
+
+This does not make Stream one-of-one-only; editions remain part of the shared
+protocol.
+
+The release artifacts also distinguish a 1/1 provenance manifest from a
+collector-verifiable permanence package. Provenance carries artist, story, and
+authenticity context. A permanence package binds renderer, dependencies, source
+archives, replay instructions, output hashes, browser proof, and storage
+assumptions. Neither proves ownership, marketplace acceptance, or royalty
+enforcement.
+
+## Terminal finality is delayed for a reason
+
+Artwork finality is scheduled rather than immediate. The delay gives artists,
+guardians, reviewers, and independent retrievers time to find:
+
+- a wrong file, digest, manifest, collection, or token;
+- missing dependencies;
+- premature artist approval;
+- an unaccounted writer;
+- a route that cannot be reproduced.
+
+The source registry supports scheduling, a veto floor, execution window,
+cancellation, expiry, staged manifest bytes, component expectations, and
+collection or scoped finality records. See
+[`StreamArtworkFinalityRegistry.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamArtworkFinalityRegistry.sol#L39-L81)
+and its
+[`schedule and finalization entries`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamArtworkFinalityRegistry.sol#L297-L589).
+
+A delay protects only the payload that reviewers can see. The scheduled record
+must bind the complete action, and execution must not reread a mutable value and
+finalize something different.
+
+Without complete payload binding and writer coverage across every terminal
+path, scheduling and veto code alone are not proof of a terminal guarantee.
+
+## Artist approval must cover readable facts
+
+Finality is an artistic decision and a protocol transition. The artist's
+approval should bind:
+
+- chain and verifying contract;
+- collection or token scope;
+- exact manifests and component commitments;
+- nonce and deadline;
+- finality action identity.
+
+A signature over an unexplained hash is not meaningful consent. The artist
+needs a readable package whose fields deterministically produce the signed
+commitment.
+
+If contract-wallet artists are supported, they need a documented ERC-1271 path.
+Key-loss recovery also needs an explicit rule; losing an artist key should not
+quietly make the platform administrator the artist.
+
+Core's current artist approval binds a narrower collection state and is not a
+universal veto. The relationship among artist approval, Core freeze,
+preservation, and terminal finality remains a critical design decision.
+
+## A guardian may stop finality, not author it
+
+The guardian veto is a safety brake:
+
+- the proposal supplies the payload;
+- artist approval confirms the artistic commitment;
+- the guardian may stop execution;
+- execution applies the already-bound payload;
+- expiry closes an abandoned proposal.
+
+A guardian should not replace manifests, substitute components, or choose a new
+work. A cancelled or expired action should require a new identifier and fresh
+approvals; reusing an old signature would defeat the review period.
+
+## Terminal means every effective writer is accounted for
+
+After terminal artwork finality, each artwork-affecting path must be impossible
+or explicitly outside the promise. The selector- and effect-level inventory
+must cover:
+
+- token and collection metadata writes;
+- scripts, token data, images, animation, and attributes;
+- dependency versions and pointers;
+- renderer inputs;
+- randomizer provider and final seed;
+- preservation records and refresh helpers;
+- module or renderer successors;
+- global routes that reach the same mutation through another contract.
+
+Testing a function named `setMetadata` is not enough if a module, registry,
+executor, or fallback path can produce the same effect.
+
+Record-family authorization exists in source, but it identifies the real writer
+set only when admitted types, provider addresses, grants, runtime code hashes,
+rotation, and revocation are bound and independently reviewed. A terminal
+writer-inventory proof must use those candidate bindings, not an intended role
+diagram.
+
+## Recovery after finality would change the promise
+
+The repository contains a proposal for an append-only recovery companion when a
+frozen renderer, dependency, or serving route later fails. It is neither
+accepted nor implemented.
+
+The proposal would keep the original finality record unchanged, make Governance
+V2 the sole scheduler and executor, append a separate recovery lineage, and
+bind scope, predecessor, old route, replacement, manifest, and reason. A route
+change would count as changing artwork bytes unless a later accepted
+equivalence verifier proved otherwise. Artist and owner evidence would come
+from independently owned append-only sources, and a metadata router would serve
+the recovery only after exact pointer, interface, and route checks.
+
+That may restore access while changing what viewers receive. It is not routine
+maintenance. Review must address artist consent, owner notice, guardian veto,
+objection time, competing recoveries, and whether any byte-changing recovery
+should exist.
+
+See
+[`ADR 0020 status and blockers`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/docs/adr/0020-executor-only-finality-recovery.md#L3-L24)
+and its
+[`proposed decision`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/docs/adr/0020-executor-only-finality-recovery.md#L75-L138).
+
+## Irreversible actions deserve separate ceremonies
+
+An artist-facing workflow should make each irreversible choice explicit:
+
+1. confirm maximum and final supply;
+2. close every mint path;
+3. inspect and freeze Core configuration;
+4. retrieve and independently verify preservation materials;
+5. inspect collection-wide and one-of-one manifests;
+6. compare the readable package with the signed payload;
+7. wait through the review and veto period;
+8. execute terminal finality;
+9. verify the result through an independent reader.
+
+Each step should produce a machine-readable receipt. An artist should not need
+to decode calldata or trust a block explorer to understand the consequence.
+The ceremony is not complete until someone who did not prepare the package
+recovers and replays it using only published instructions and commitments.
+
+## What can still fail
+
+- Final supply leaves another mint lane open.
+- A broad freeze label hides mutable fields or modules.
+- A freeze or finality manifest binds the wrong encoding, scope, or token.
+- Required bytes disappear despite a valid hash.
+- Finality execution rereads values changed after scheduling.
+- An old artist approval is replayed for another action.
+- A guardian can shape the payload instead of only vetoing it.
+- A metadata, preservation, refresh, governance, or successor route bypasses
+  terminal state.
+- A later recovery changes the bytes but is presented as preserving them.
+
+## Questions for reviewers
+
+1. Are final supply, Core freeze, preservation, and artwork finality each
+   defined narrowly enough to verify?
+2. Does mint closure cover every current and successor lane, including the
+   zero-mint case?
+3. Which exact Core and satellite fields enter each manifest?
+4. Is the finality delay long enough for independent retrieval and replay?
+5. Should current artist approval be expanded, or should terminal finality use
+   a separate exact artist signature?
+6. Can a guardian only veto, or can any path let it shape the final payload?
+7. Does the terminal writer inventory include every indirect mutation route?
+8. Which independent storage locations and runtime artifacts are mandatory?
+9. What receipt lets an artist and collector verify the terminal state without
+   trusting the current website?
+10. Should any byte-changing recovery exist after finality, and what evidence
+    would distinguish recovery from replacement?

--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/governance-pausing-and-successors.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/governance-pausing-and-successors.md
@@ -1,0 +1,393 @@
+# Governance, pausing, and successors
+
+`StreamCore`—called Core here—is the permanent token and collection identity
+contract. It is not a conventional upgradeable proxy, so governance cannot
+silently replace its bytecode while keeping the same address. The reviewed
+source instead separates powers that can be paused, scheduled, permanently
+surrendered, or moved to a separately visible successor contract.
+
+Under the Governance V2 source design, consider a randomness module that must
+eventually be replaced. The new contract can be published with its code and
+interface visible. Governance can schedule a successor declaration, giving
+reviewers time to compare old and new behavior. A guardian can veto the pending
+action, but cannot substitute a different module. After the delay, anyone can
+trigger the already fixed action. The old contract, its bytecode, and its
+history remain onchain.
+
+That is the intended source model. The current rehearsal uses `StreamAdmins` for
+its administrative and pause layer. It does not deploy Governance V2, its role
+registry, delayed executor, selector freezes, or successor machinery.
+
+## Why governance is explicit
+
+Artwork identity may need to last longer than any provider, operator, or piece
+of infrastructure. Pretending nothing will ever change would push future change
+into abandoned interfaces, emergency keys, or unrecorded social coordination.
+Using a proxy would make change easy but could replace behavior beneath the same
+address.
+
+The source design instead separates:
+
+- permanent identity that should not be rewritten;
+- duties that may move to a visible successor;
+- rapid intervention that can stop harm without creating policy;
+- delayed actions whose complete effects can be inspected;
+- powers that can be surrendered permanently.
+
+This does not eliminate governance risk. It makes the actor, action, delay, and
+new code easier to inspect.
+
+The simplification test is the effective authority surface, not the number of
+contracts. A smaller design is better if it preserves the same artistic,
+operational, and security guarantees. A hidden upgrade, unbounded emergency
+multisig, or private coordination process is not less governance; it is less
+visible governance.
+
+## What the source model protects—and what remains unresolved
+
+The source mechanisms are designed to:
+
+- keep bootstrap authority from becoming a permanent alternate governor;
+- bind the complete meaning of delayed actions before the waiting period;
+- separate proposing, vetoing, cancelling, and executing;
+- pause only the affected domain while preserving safe exits;
+- make selected powers permanently unavailable;
+- preserve predecessor history during successor cutover.
+
+The current evidence does not yet prove a complete candidate configuration.
+Open work includes exact role and contract-function inventories, native-value
+constraints, per-function parameter binding, module and code-hash catalogs,
+guardian monitoring, pause semantics across both mint lanes, and independently
+rehearsed bootstrap and successor ceremonies. The exact source sections below
+use Solidity’s term *selector* for a contract function’s compact identifier.
+
+[Roles and Trust](./roles-and-trust) explains who holds each capability. This
+page explains how those capabilities change over time.
+
+## From bootstrap to governed operation
+
+A new system needs temporary authority to deploy contracts, bind dependencies,
+assign roles, and prove that the intended graph exists. That bootstrap power
+should not remain as another governor.
+
+The intended transition is:
+
+1. deploy the immutable contracts;
+2. bind the expected role registry, Governance Root, Core, system-manifest
+   satellite, code hashes, guardian set, trigger set, manifest, and inventory
+   root;
+3. independently verify that configuration;
+4. seal the system manifest;
+5. transfer executor ownership to the Governance Root;
+6. leave no hidden route back to the bootstrap authority.
+
+The source implements this one-way lifecycle in
+[`StreamGovernanceManifest`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamGovernanceManifest.sol#L12-L54)
+and
+[`bindSystemManifestBootstrap` / `sealSystemManifestBootstrap`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamGovernanceExecutor.sol#L807-L893).
+
+A wrong address, code hash, guardian set, or inventory root can become
+authoritative when sealing succeeds. Exact bindings should therefore be read
+back independently during a non-local sealing ceremony.
+
+## Module registration
+
+The module registry records recognized contracts and lifecycle status. A
+registration can bind runtime code hash and interface expectations, so directing
+clients to an unrelated address leaves evidence.
+
+Reviewers should verify:
+
+- when the code hash is measured;
+- whether a target can be a proxy or metamorphic contract;
+- which interface check is required;
+- whether an inactive or deprecated module remains reachable another way;
+- whether status changes are delayed;
+- whether historical module records remain queryable;
+- how clients discover the current module without a private index.
+
+A matching code hash proves which runtime bytecode occupied an address at the
+measured time. It does not prove that the code is safe, correctly initialized,
+or connected to the intended dependencies.
+
+## Scheduled actions
+
+The Governance V2 executor source can publish a proposed call, enforce its
+delay, permit cancellation or guardian intervention, and allow execution after
+the delay. Execution is safe only if the reviewed action and the applied action
+are the same.
+
+For every governed selector, the scheduled record must commit to:
+
+- target;
+- native value;
+- calldata, including selector and every argument;
+- predecessor or ordering requirements;
+- scope;
+- old-state and new-state commitments where required;
+- earliest execution time;
+- expiry;
+- governing epoch or configuration;
+- reason and manifest;
+- a unique salt or nonce.
+
+Execution must use that exact record. It must not accept a fresh recipient,
+value, address, or calldata fragment that was invisible during review.
+
+The current source binds target, native value, selector, calldata hash, scope,
+old-state hash, new-state hash, earliest execution, expiry, reason, and manifest.
+It publishes the calldata preimage onchain. Authorized actors schedule or
+cancel; execution is permissionless inside the committed window. See the
+[`scheduled-call binding`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamGovernanceExecutor.sol#L305-L403).
+
+Without complete binding for every governed selector, the reviewed action can
+differ from the executed one.
+
+## Action classes and minimum delays
+
+Governance V2 classifies actions by consequence:
+
+| Class                 |  ID | Minimum delay |
+| --------------------- | --: | ------------: |
+| Immediate tightening  |   0 |             0 |
+| Delayed loosening     |   1 |      48 hours |
+| Terminal freeze       |   2 |      72 hours |
+| Pointer replacement   |   3 |      48 hours |
+| Funds recovery        |   4 |       14 days |
+| Successor declaration |   5 |       30 days |
+
+Numeric IDs are append-only. Former class `6` is retired and cannot be reused.
+Delayed classes also require an open execution window. The constants and delay
+rules are visible in the
+[`action-class interface`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/IStreamGovernanceExecutor.sol#L69-L79)
+and
+[`delay function`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamGovernanceBootstrap.sol#L299-L311).
+
+The categories express different risks:
+
+- removing authority may be safe immediately;
+- expanding authority should be visible before it takes effect;
+- terminal freeze needs time to inspect the exact boundary;
+- pointer replacement must expose old and new contracts;
+- funds recovery needs proof that liabilities are not withdrawn;
+- successor declaration changes the protocol’s long-term interpretation and
+  receives the longest default review.
+
+## Native-value authority
+
+The source risk register identifies governance-executor native-value authority
+as open High risk `RISK-GOV-003`. A generic executor that can send ETH controls
+more than configuration. It can fund payable calls, move unaccounted balances,
+or interact with targets in ways a selector label does not reveal.
+
+The final design needs a precise answer for:
+
+- which balances the executor may receive or control;
+- whether native value is included in the action commitment;
+- whether value is capped, class-limited, or target-restricted;
+- how bidder, seller, curator, randomness, and other liabilities are excluded;
+- what event proves the transfer;
+- whether an emergency path has the same power;
+- how residual ETH is recovered without a general withdrawal key.
+
+This is a code and accounting boundary, not merely an operational policy.
+
+## Governed parameter binding
+
+For each governed selector, reviewers should compare:
+
+1. values visible when the action is scheduled;
+2. values included in the action identifier;
+3. values checked at execution;
+4. mutable storage read again at execution;
+5. values emitted in events.
+
+If a mutable registry, global default, or caller argument fills a gap during
+execution, the delayed action can mean something different from what reviewers
+saw.
+
+The accepted policy for launch gas and time parameters is deliberately one-way:
+
+- only a Governance V2 `DELAYED_LOOSENING` action may change a value;
+- the minimum delay is 48 hours;
+- the new value must be strictly higher;
+- one action may raise it by no more than 2x;
+- there is no lowering, emergency raise, probe repair, or permissionless
+  mutation path;
+- zero governance authority makes the host immutable;
+- permanent governance loss leaves values readable but unchangeable;
+- tightening later requires a reviewed successor host or deployment line.
+
+This trades recovery flexibility for a smaller, more auditable authority
+surface. The source hosts implement the rule, but without a complete parameter
+catalog and proposal-to-execution proof, that rule does not establish the
+candidate’s effective authority surface. See
+[`ADR 0017`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/docs/adr/0017-raise-only-parameter-governance.md#L48-L71)
+and its
+[`governance-loss consequence`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/docs/adr/0017-raise-only-parameter-governance.md#L140-L153).
+
+## Guardian intervention
+
+The guardian is a rapid defensive role. It can stop or veto a defined
+operation, especially during a timelock. It should not become a second governor.
+
+Where practical, guardian actions should only move toward safety:
+
+- pause a domain;
+- veto a pending action;
+- prevent a suspicious successor cutover.
+
+Resuming operations, replacing modules, moving funds, or changing artwork should
+normally require the full governance path. A guardian veto should stop a
+proposed payload, not substitute another one.
+
+This role creates an operational obligation. Someone must monitor scheduled
+actions, understand their complete effect, and act within the veto window. An
+unwatched veto power is only theoretical.
+
+## Pause domains
+
+`StreamAdmins` defines six pause domains in the current source. The owner or a
+registered pause guardian can pause. The owner or a registered unpause
+administrator can resume.
+
+| Domain             | Stops                                                                                               | Does not stop                                                              |
+| ------------------ | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Drop execution     | New signed Drop execution                                                                           | Withdrawals and unrelated reads                                            |
+| Mint               | Legacy `StreamMinter.mint` and `mintAndAuction`                                                     | Existing ownership and the separate manager unless its phase is paused     |
+| Auction bid        | New bids                                                                                            | Auction-credit withdrawals                                                 |
+| Auction settlement | Winner and no-bid settlement entries                                                                | Bidder and seller credit withdrawals                                       |
+| Metadata mutation  | Core, contract-metadata, collection-metadata, and preservation writes that consult the shared check | Existing metadata reads                                                    |
+| Randomness request | New requests in the current randomizer adapters                                                     | Existing request reads and provider callbacks governed by their own checks |
+
+The identifiers are in
+[`StreamPauseDomains`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamPauseDomains.sol#L5-L12).
+Pause and resume authority are implemented in
+[`StreamAdmins.setPaused`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamAdmins.sol#L137-L157)
+and its
+[`authority checks`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamAdmins.sol#L223-L229).
+
+`StreamMintManager` has a separate per-phase pause and does not consult global
+`MINT`. Any cutover must decide whether that distinction is intentional and
+present it explicitly.
+
+Pauses should preserve withdrawals and other safe exits wherever possible.
+Otherwise incident control can trap the users it is meant to protect.
+
+## Permanent selector freezes
+
+The Governance V2 source can make selected operations permanently unavailable.
+A selector freeze is stronger than a pause and must cover the complete
+effective call surface, including aliases and module paths that reach the same
+state change.
+
+Freezing a selector in one executor does not help if another privileged module
+can perform the same write directly. Final freeze evidence should enumerate all
+equivalent mutation paths and prove they are closed.
+
+## Signer epochs
+
+Signed authorizations are tied to signer epochs. Rotation can invalidate prior
+authorizations without confusing them with signatures from the new signer.
+
+Reviewers should establish:
+
+- which signatures become invalid after rotation;
+- whether an epoch can ever be reused;
+- how ERC-1271 contract-wallet signatures are checked;
+- whether auctions registered under the prior epoch remain valid;
+- what happens during emergency compromise;
+- how the public learns which signer and epoch were active.
+
+Epochs make a change visible. They do not prove that the new signer is correctly
+controlled or that its service applies community policy.
+
+## Explicit successor modules
+
+In the Governance V2 source, a successor is a new immutable contract recognized
+as following an older module. The predecessor, bytecode, and history remain
+onchain. Governance records the transition instead of rewriting the old
+implementation behind a proxy address.
+
+A collector can therefore distinguish:
+
+- the contract that originally acted;
+- the later contract recognized for future duties;
+- the governance decision that connected them;
+- commitments and liabilities that stayed with the predecessor.
+
+A safe cutover must answer:
+
+- which new actions route to the successor;
+- which reads and liabilities remain with the predecessor;
+- whether state is read, copied, or recomputed;
+- whether both contracts can act concurrently;
+- which signatures, nonces, counters, and balances are shared;
+- how clients discover the current module;
+- whether permanent Core can reject an incompatible successor;
+- what evidence proves continuity before the pointer changes.
+
+A successor should not rewrite token history or silently relax an artwork
+commitment. If it changes served bytes, mint authority, value flow, or
+authoritative metadata, that consequence must be stated directly.
+
+Successor declaration has a 30-day minimum delay in the source action classes.
+The delay makes cutover a separate ceremony with before-and-after invariants,
+independent readback, and a published continuity record.
+
+## Emergency actions
+
+Emergency authority is still authority. A faster path should have a narrower
+effect, stronger monitoring, and a clear route back to ordinary governance.
+
+The code and public catalog should enumerate exactly what emergency actors can
+pause, veto, rotate, or withdraw. Saying that a multisig “can fix things” is not
+a security model.
+
+Emergency recovery must not become:
+
+- a shortcut around action delays;
+- an unbounded native-value transfer;
+- a hidden module replacement;
+- a way to alter an artist-approved payload;
+- a route that strands user withdrawals or refunds.
+
+## Why this governance is intentionally explicit
+
+Over a long artwork horizon, providers fail and technical or operational
+assumptions change. The source design records how replaceable duties move while
+keeping permanent identity and historical contracts visible.
+
+The safest governance action is one whose complete effect can be simulated from
+published bytes before its delay begins. That standard also exposes
+unnecessary complexity: if two paths can perform the same sensitive action, if
+a scheduled action rereads mutable inputs, or if a guardian can author policy,
+the boundary has failed.
+
+## What can fail
+
+- bootstrap authority remains an alternate governor after sealing;
+- the system manifest binds a wrong address, code hash, or inventory root;
+- a role reaches more selectors than its name suggests;
+- a module is registered with wrong code or initialization;
+- a scheduled action omits native value or another sensitive field;
+- execution rereads mutable state and changes the reviewed meaning;
+- a guardian can author a replacement instead of only vetoing;
+- a pause blocks user exits or misses an alternate call path;
+- a selector freeze has an alias bypass;
+- a predecessor and successor accept the same authorization or spend the same
+  liability;
+- clients follow a new module without verifying the governed continuity record.
+
+## Questions for reviewers
+
+1. Is every effective role expressible as a selector-level capability list?
+2. Should the governance executor ever be able to send native value?
+3. Are all action parameters fixed and visible at scheduling time?
+4. Which pause domains must preserve withdrawals and refunds?
+5. What invariants must hold before a successor becomes current?
+6. Which governance powers should become permanently unavailable after launch?
+7. Is 30 days enough notice for a successor that changes an artwork-affecting
+   duty?
+8. Which governance mechanism can be removed without creating an opaque upgrade,
+   emergency, or offchain coordination path?

--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/governance-pausing-and-successors.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/governance-pausing-and-successors.md
@@ -140,6 +140,18 @@ It publishes the calldata preimage onchain. Authorized actors schedule or
 cancel; execution is permissionless inside the committed window. See the
 [`scheduled-call binding`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamGovernanceExecutor.sol#L305-L403).
 
+The schedule path takes the executor's current nonce, includes it in the action
+ID, and then increments it. The action ID also binds the chain, executor
+address, and action class. See
+[`nonce consumption`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamGovernanceExecutor.sol#L938-L977)
+and
+[`action-identity hashing`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamGovernanceBootstrap.sol#L73-L108).
+The current generic record has no separate predecessor field or governing
+configuration epoch. Any ordering or configuration dependency must therefore
+be encoded in the call, scope, old-state, new-state, or manifest commitments for
+that selector. Complete selector-by-selector evidence for those dependencies
+remains a release requirement.
+
 Without complete binding for every governed selector, the reviewed action can
 differ from the executed one.
 

--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/manifest.json
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/manifest.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "review_id": "6529-stream",
+  "review_version": "2026-07-28.1",
+  "locale": "en-US",
+  "source_repository": "https://github.com/6529-Collections/6529Stream",
+  "source_commit": "513bd7e079eafe109df6ae1ae21bfbca6fec6786",
+  "pages": [
+    {
+      "id": "overview",
+      "title": "Overview",
+      "file": "overview.md"
+    },
+    {
+      "id": "artwork-lifecycle",
+      "title": "Artwork Lifecycle",
+      "file": "artwork-lifecycle.md"
+    },
+    {
+      "id": "for-artists",
+      "title": "For Artists",
+      "file": "for-artists.md"
+    },
+    {
+      "id": "roles-and-trust",
+      "title": "Roles and Trust",
+      "file": "roles-and-trust.md"
+    },
+    {
+      "id": "curation-and-tdh-authorization",
+      "title": "Curation and TDH Authorization",
+      "file": "curation-and-tdh-authorization.md"
+    },
+    {
+      "id": "tokens-collections-and-minting",
+      "title": "Tokens, Collections, and Minting",
+      "file": "tokens-collections-and-minting.md"
+    },
+    {
+      "id": "fixed-price-sales-and-auctions",
+      "title": "Fixed-Price Sales and Auctions",
+      "file": "fixed-price-sales-and-auctions.md"
+    },
+    {
+      "id": "revenue-splits-and-royalties",
+      "title": "Revenue, Splits, and Royalties",
+      "file": "revenue-splits-and-royalties.md"
+    },
+    {
+      "id": "randomness",
+      "title": "Randomness",
+      "file": "randomness.md"
+    },
+    {
+      "id": "metadata-scripts-and-dependencies",
+      "title": "Metadata, Scripts, and Dependencies",
+      "file": "metadata-scripts-and-dependencies.md"
+    },
+    {
+      "id": "freezing-preservation-and-artwork-finality",
+      "title": "Freezing, Preservation, and Artwork Finality",
+      "file": "freezing-preservation-and-artwork-finality.md"
+    },
+    {
+      "id": "governance-pausing-and-successors",
+      "title": "Governance, Pausing, and Successors",
+      "file": "governance-pausing-and-successors.md"
+    },
+    {
+      "id": "security-testing-and-known-limitations",
+      "title": "Current Implementation and Readiness",
+      "file": "security-testing-and-known-limitations.md"
+    },
+    {
+      "id": "community-review",
+      "title": "Community Review",
+      "file": "community-review.md"
+    }
+  ]
+}

--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/metadata-scripts-and-dependencies.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/metadata-scripts-and-dependencies.md
@@ -1,0 +1,435 @@
+# Metadata, scripts, and dependencies
+
+At the pinned commit, Stream’s Solidity describes what an artwork is and what
+is needed to reconstruct it. For a simple image, that may be JSON plus one
+media file. For a generative work, it may include token data, ordered scripts,
+exact library versions, randomness, images, attributes, content hashes, and
+instructions for the software that executes them.
+
+Most of the machinery on this page is source-implemented rather than a proven
+current path. The rehearsal includes `StreamCore`—called Core here—the permanent
+token and collection identity contract. It does not establish the renderer,
+dependency registry, record-family admissions, or snapshot configuration as a
+release candidate.
+
+Consider a generative token in one mode supported by the source renderer. A
+viewer reads `tokenURI()`, decodes the JSON, loads the collection’s scripts in
+order, combines them with token data and the stored randomness result, resolves
+the named dependency version, and runs the work in a browser. If one script
+chunk is missing, the dependency silently changes, or the required browser
+behavior disappears, the token may still exist while the artwork no longer
+renders as intended.
+
+The source design tries to make every part of that chain inspectable. It cannot
+guarantee that offchain bytes, gateways, browsers, fonts, codecs, or
+marketplaces will remain available.
+
+## Why this machinery exists
+
+A `baseURI` and mutable JSON server would be much smaller onchain. They would
+also let a server operator, domain owner, gateway, package resolver, or mutable
+dependency decide what collectors see. That may be a legitimate design when the
+trust model is explicit, but the complexity has moved outside the protocol.
+
+The source design instead separates several responsibilities:
+
+- token rendering and collection configuration;
+- byte-exact scripts and versioned dependencies;
+- claims made by artists, owners, institutions, curators, and others;
+- snapshots and locks;
+- shared contract presentation;
+- notifications that metadata changed;
+- preservation evidence for bytes and execution assumptions.
+
+The goal is durable attribution and verifiability, not maximum contract surface.
+Duplicate writers or representations should still be consolidated. A mechanism
+that does not improve integrity, provenance, authority, or reconstruction should
+not survive merely because metadata is important.
+
+## What it protects—and what remains outside Ethereum
+
+The source mechanisms can help answer:
+
+- which bytes and versions were intended;
+- who was allowed to make a particular claim;
+- whether retrieved bytes match a stored commitment;
+- which records were included in a snapshot;
+- which fields were mutable at a given point;
+- when consumers were told that metadata changed.
+
+It cannot by itself keep external bytes online, pay storage providers, preserve
+a domain, force a wallet to parse a large response, make a rights claim true, or
+freeze browser behavior. “Onchain,” “content-addressed,” “available,” and
+“reproducible” are different promises.
+
+## The first question is: where are the bytes?
+
+The source renderer can represent:
+
+- artwork assembled entirely from onchain inputs;
+- artwork whose metadata or media lives at external locations;
+- generative work combining token data, collection scripts, randomness, and
+  versioned dependencies;
+- hybrid work with commitments onchain and some bytes elsewhere.
+
+The principal rendering logic is in
+[`StreamMetadataRenderer.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMetadataRenderer.sol).
+Collection-level records are in
+[`StreamCollectionMetadata.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCollectionMetadata.sol),
+shared contract presentation is in
+[`StreamContractMetadata.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamContractMetadata.sol),
+and reusable libraries are in
+[`DependencyRegistry.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/DependencyRegistry.sol).
+
+“Onchain metadata” is too vague on its own. It may mean:
+
+- `tokenURI()` returns encoded JSON;
+- the JSON embeds an image or HTML document;
+- the JSON points to an onchain script that imports other dependencies;
+- the JSON or media points to IPFS, Arweave, HTTPS, or another external
+  location.
+
+Reviewers should follow every layer. A data URI at the first layer does not
+prove that the entire work is self-contained.
+
+## Metadata modes express different preservation promises
+
+The renderer builds a token URI from collection configuration and token state.
+Depending on the selected mode, it can return or assemble different
+combinations of JSON, media, scripts, and external locations.
+
+The flexibility is useful because artworks have different media and storage
+models. It must not be collapsed into one visual “onchain” badge.
+
+An artist and collector should be able to tell:
+
+- whether token JSON is generated onchain;
+- whether image or animation bytes are embedded or referenced;
+- whether scripts are stored in chunks or fetched elsewhere;
+- which dependency versions are required;
+- whether URLs can change;
+- which hashes cover which representation;
+- which parts remain mutable;
+- what a third party needs to reconstruct the work.
+
+An honest guarantee can be strong without claiming that everything is onchain.
+Precision is stronger than a badge.
+
+## String construction is a security boundary
+
+The renderer constructs values that wallets, marketplaces, indexers, RPC
+clients, and browsers parse as JSON, URIs, HTML, or JavaScript.
+
+Every artist-controlled value needs encoding for the context where it is used.
+Valid JSON escaping is not automatically safe in JavaScript. HTML-attribute
+escaping is not automatically safe in a URI. A string can pass one parser and
+close a tag or change meaning in the next.
+
+The current renderer contains:
+
+- JSON-string escaping;
+- HTML-attribute escaping;
+- JavaScript single-quoted-string escaping;
+- script-end-tag handling;
+- UTF-8 validation;
+- URI policy checks;
+- structured raw-attribute validation;
+- explicit limits for collection text, token data, images, attributes, script
+  chunks, chunk counts, and generated token URIs.
+
+See the validation and encoding surface in
+[`StreamMetadataRenderer.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMetadataRenderer.sol#L453-L925).
+
+Reviewers should still test:
+
+- quotes, backslashes, newlines, null bytes, and control characters;
+- valid and invalid UTF-8;
+- combining characters and right-to-left text;
+- closing script and HTML tags;
+- very long text, attributes, media, and URLs;
+- data-URI media types and base64 boundaries;
+- numeric and boolean attributes that must remain typed;
+- return values near RPC and consumer limits.
+
+Contract-valid output can still be refused or truncated by ordinary consumers.
+Compatibility needs evidence from those consumers.
+
+## Scripts are ordered, byte-exact artwork inputs
+
+In the source renderer, collections can store or reference scripts and
+token-specific data used to render generative work. Script order, chunk order,
+encoding, and exact bytes all matter.
+
+The renderer hashes script chunks and their positions rather than treating an
+unordered set of strings as equivalent. That protects against rearrangement or
+partial reconstruction.
+
+The point at which scripts become immutable matters too. Authorized editing
+before freeze may be part of the artist’s process. After the relevant
+commitment, a collector should not have to trust an operator to remember which
+draft was final.
+
+A hash gives integrity:
+
+> If these bytes are available, do they match the committed work?
+
+It does not give availability:
+
+> Can anyone still obtain these bytes?
+
+An external URI plus a hash needs both answers. The hash does not pay a storage
+provider, renew a domain, or preserve a browser runtime.
+
+## Versioned dependencies prevent silent library replacement
+
+Generative artwork often depends on a shared library. The
+[`DependencyRegistry`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/DependencyRegistry.sol)
+records dependencies by name and version, with:
+
+- ordered script chunks;
+- per-chunk hashes;
+- a content hash for the assembled script;
+- provenance text;
+- creator and creation context;
+- deprecation state;
+- explicit size and chunk-count limits.
+
+Publishing a new library should create a new version, not change what an old
+version means. Deprecation can warn against new use without erasing the source
+needed by existing artwork.
+
+Reviewers should establish:
+
+- who can create a dependency name;
+- who can add a version;
+- when byte content and chunk order become fixed;
+- whether a location can change;
+- which hash covers a chunk and which covers the assembled dependency;
+- how consumers detect a missing, duplicated, or reordered chunk;
+- what deprecation changes and what it leaves intact;
+- where every version is retained outside the contract.
+
+The simpler alternative is an ordinary CDN or package name. That is convenient,
+but it lets mutable hosting and version resolution decide what old art executes.
+
+## Collection metadata separates claims by purpose and authority
+
+The source collection-metadata system can carry artist statements, rights,
+preservation locations, fixity evidence, institutional records, media
+relationships, and presentation context.
+
+These records are separated so one broad “metadata admin” does not inherit every
+artwork-adjacent power. Permission to update a public description should not
+also authorize script replacement, supply changes, revenue policy, or a
+statement attributed to the artist.
+
+The pinned source provides a closed family-to-writer model:
+
+| Record family      | Purpose                                                                        | Allowed source classes                                  | Why the distinction matters                                                    |
+| ------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Artist             | Statement attributed to the recognized artist                                  | Artist signer only                                      | Separates the artist’s words from platform or third-party commentary           |
+| Owner              | Statement attributed to the recognized current owner                           | Owner signer only                                       | Shows owner authorship without implying artist endorsement                     |
+| Independent        | Self-attributed third-party observation or analysis                            | Any independent attestor                                | Permissionless evidence is attributable, not protocol-approved                 |
+| Curator            | Selection, interpretation, or exhibition context                               | Curator signer or global admin                          | Identifies the source of curatorial framing                                    |
+| Institution        | Museum, archive, university, or other recognized institution attestation       | Institution signer only                                 | Separates institutional evidence from artist and owner claims                  |
+| Rights             | Copyright, license, usage, or permissions information                          | Metadata admin or global admin                          | Affects use and display, but is not legal advice merely because it is recorded |
+| Archive            | Location of preservation materials or manifests                                | Preservation admin or global admin                      | A location record does not guarantee continued availability                    |
+| Fixity             | Checksums, sizes, or other alteration-detection evidence                       | Institution signer, preservation admin, or global admin | Tests retrieved bytes when those bytes remain available                        |
+| C2PA               | Content-provenance credential context                                          | Institution signer, preservation admin, or global admin | Recording a credential does not make its assertions true                       |
+| IIIF               | Interoperable cultural-heritage presentation or retrieval context              | Preservation admin, metadata admin, or global admin     | Helps compatible viewers find and present high-resolution media                |
+| Media relationship | Master, derivative, thumbnail, soundtrack, or alternate-rendering relationship | Preservation admin or metadata admin                    | Prevents a preview or derivative from being mistaken for the canonical work    |
+| Identity display   | Preferred names, credits, and attribution presentation                         | Metadata admin or global admin                          | Changes display, not the underlying authority identity                         |
+| Snapshot           | Immutable commitment to selected metadata records at one time                  | Metadata admin or global admin                          | Lets later readers compare a known bundle with newer records                   |
+| Agent              | Record of an automated service or machine-produced action                      | Metadata admin or global admin                          | Makes automation visible without proving it was safe                           |
+
+The registry controls who may write an admitted record type. It does not
+validate the truth of a rights claim, archive location, credential, IIIF
+response, or agent statement.
+
+Artist, owner, independent, and institution families reject admin grants. An
+independent record is directly self-attributed by its caller, not endorsed by
+the artist, 6529, or the protocol. Each exact record type is admitted once and
+cannot later be remapped. See
+[`StreamRecordFamilyRegistry`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRecordFamilyRegistry.sol#L85-L228).
+
+The family model determines real authority only when its admitted record types,
+live authority providers, grants, runtime code hashes, and rotation or
+revocation evidence are published. Without those bindings, it does not prove
+that a future deployment recognizes the correct wallets.
+
+## Snapshots preserve a view without freezing all future context
+
+A collection snapshot is an immutable record with its own identifier, record
+hash, and hash of the covered record-type list.
+
+Publication requires:
+
+1. an admitted snapshot-family record type;
+2. authority to write that snapshot type;
+3. a nonempty, strictly ascending list of exact covered record types;
+4. fresh authorization for every covered record type;
+5. an unlocked snapshot path.
+
+A snapshot is not a permission shortcut. The contract emits authorization
+evidence for every covered record type. A later snapshot can become `latest`,
+and underlying records can continue to change until their own lock or Core
+freeze.
+
+Snapshot publication itself does not check Core collection freeze. An
+authorized writer can therefore snapshot already-frozen record state while
+snapshot locks remain open. Nonreserved record-specific locks can also be added
+after Core freeze. Those actions are narrower than revising frozen records, but
+they belong in any accurate explanation of freeze.
+
+See
+[`publishCollectionSnapshot`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCollectionMetadata.sol#L124-L180)
+and
+[`_requireSnapshotFamilyIntersection`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCollectionMetadata.sol#L504-L524).
+
+## Shared contract metadata is not an artist's token identity
+
+Contract-level metadata describes the shared Stream ERC-721 surface. It can
+affect the marketplace-facing name, description, image, and links for every
+collection.
+
+The current
+[`updateContractURI`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamContractMetadata.sol#L109-L145)
+checks metadata pause and function-admin authority but does not consult an
+individual collection’s Core freeze.
+
+A frozen artwork collection and the shared contract’s presentation are
+different states. A label can change without changing ownership, token
+identity, or the collection’s frozen artwork inputs. Shared presentation still
+matters; its authority and promise simply need accurate names.
+
+## Refresh events tell consumers that state changed
+
+Core implements ERC-4906 refresh signals for particular mutations:
+
+- token-data and image/attribute changes emit `MetadataUpdate(tokenId)`;
+- live-token randomness fulfillment emits `MetadataUpdate(tokenId)`;
+- collection-info and metadata-mode changes emit
+  `BatchMetadataUpdate(1, lastAllocatedTokenId)` when tokens exist.
+
+The broad range is an intentional superset because tokens from different Stream
+collections can interleave in the global ID sequence.
+
+See the
+[`token-level emissions`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L786-L823),
+[`randomness emission`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L844-L883),
+and
+[`collection helper`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L1035-L1044).
+
+These events are notifications, not enforcement. A consumer can ignore them,
+cache longer than expected, or interpret a broad range differently.
+
+The accepted launch target also calls for restricted Core helpers through which
+authorized satellite contracts can emit standard ERC-4906 signals plus
+Stream-native context. No public or external helper exists in the pinned
+Solidity. Caller checks, lifecycle and range bounds, abuse analysis,
+implementation, and tests remain target work. See the
+[`launch target`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/docs/launch-v1-target-architecture.md#L320-L333).
+
+## Size limits protect more than gas
+
+Onchain strings and chunks cost gas to write and can produce large `eth_call`
+responses. Limits matter at several layers:
+
+- transaction and block gas;
+- deployed bytecode;
+- RPC response size;
+- wallet and marketplace parsers;
+- browser memory and execution time.
+
+A unit test that accepts a maximum value does not prove that public RPC
+providers or consumer applications can retrieve and render it. Maximum-size
+evidence should exercise the real delivery path.
+
+## The browser is part of the artwork's environment
+
+Generative HTML and JavaScript execute in software Stream does not control.
+Browser engines, security policies, APIs, fonts, codecs, GPUs, timing,
+randomness APIs, and cross-origin rules change.
+
+Where reproducibility matters, source code alone may be insufficient. A useful
+preservation package can need:
+
+- exact dependency and asset bytes;
+- browser or runtime version;
+- fonts and codecs;
+- build and replay instructions;
+- expected metadata and animation hashes;
+- a reference output or browser proof.
+
+The contract can remain secure while the artwork stops rendering. Smart-
+contract security and artwork preservation are related but distinct release
+requirements.
+
+## Every collection needs a dependency bill of materials
+
+A human-readable package should state:
+
+- which bytes are onchain;
+- which bytes are content-addressed;
+- which locations are conventional URLs;
+- which dependencies and versions are required;
+- which values can still change;
+- who can change each one;
+- which hashes cover each representation;
+- which software assumptions remain;
+- how an independent party reconstructs the work without the current website.
+
+“Fully onchain” should be the conclusion of that evidence, with a defined
+scope—not a publisher-selected marketing badge.
+
+## What a simpler design would externalize
+
+A base URI and mutable JSON server can remove much of this contract surface. It
+also lets external operators determine:
+
+- which image or animation a token displays;
+- which script and dependency version executes;
+- whether historical bytes remain available;
+- which statements came from the artist, owner, institution, or third party;
+- whether a collection was reconstructed completely;
+- whether visible content changed after a supposed freeze.
+
+Stream’s metadata complexity exists because it tries to make more of those
+responsibilities durable, attributable, and independently verifiable. The right
+simplification is to consolidate duplicate writers and representations while
+preserving exact provenance and authority—not to replace them with an opaque
+server.
+
+## What can fail
+
+- Artist-controlled text breaks or changes constructed JSON, HTML, JavaScript,
+  SVG, or URI meaning.
+- A dependency version is mutable or incompletely hashed.
+- An external asset disappears despite a valid onchain hash.
+- Chunk order or completeness is ambiguous.
+- A metadata writer has authority over the wrong record family.
+- Deployed authority providers or grants do not match the reviewed model.
+- A snapshot or lock is mistaken for a broader freeze than it provides.
+- A refresh helper targets unrelated tokens or creates excessive indexer work.
+- An RPC, wallet, indexer, marketplace, or browser cannot process the output.
+- Future software renders the same source differently.
+
+## Questions for reviewers
+
+1. Which exact bytes must be present before any Stream collection can be called
+   fully onchain?
+2. Are all artist-controlled values encoded for every context where they
+   appear?
+3. Do dependency records make chunk order, content identity, provenance, and
+   deprecation unambiguous?
+4. Which metadata writes require direct artist authority?
+5. Are the record families narrow enough to prevent one role from making claims
+   in another actor's name?
+6. Which snapshot and lock actions remain valid after Core freeze, and are they
+   presented clearly?
+7. Does the protocol need external refresh helpers, and if so who may signal
+   which token or range?
+8. What maximum sizes have been tested through real RPC and consumer
+   infrastructure?
+9. What must be preserved outside Ethereum for each supported artwork mode to
+   remain reproducible?

--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/overview.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/overview.md
@@ -1,0 +1,287 @@
+# 6529 Stream: public review
+
+Stream is our attempt to build what we believe may be the most sophisticated
+and complete artist-centered contract system yet designed for serious 1/1
+digital art. It treats the artwork as more than a token ID: the artist's
+approval, exact materials, sale, revenue, randomness, dependencies,
+preservation, finality, and future stewardship all belong to the same public
+history.
+
+## A concrete 1/1 journey
+
+Imagine an artist publishing one generative artwork.
+
+1. **The work receives an identity.** A collection is created in Stream's
+   shared token contract, called the Core, and the token will receive both a
+   global Stream ID and a serial inside that collection.
+2. **The artist assembles the work.** Scripts, token data, images, attributes,
+   dependency versions, randomness policy, supply, sale terms, and revenue
+   recipients are recorded or committed.
+3. **The artist approves a specific state.** The signature is tied to the chain,
+   Core contract, artist, freeze manifest, supply, purchase limit, and final-
+   supply delay. It is not a reusable “I approve Stream” message.
+4. **A community decision becomes an exact sale.** Curation and Total Days Held
+   (TDH), 6529's time-weighted holding measure, remain offchain, but the
+   resulting signed authorization fixes the collection, payer, recipient,
+   price, quantity, timing, sale mode, signer era, and a one-use identifier that
+   prevents the authorization from being executed twice.
+5. **The token is minted and sold.** A fixed-price mint or English auction
+   applies the authorized terms, updates supply, and records the resulting
+   payment obligations.
+6. **Randomness follows a visible lifecycle.** The request identifies its
+   provider and era. Fulfillment stores evidence, and a failed Core write retries
+   the same accepted seed rather than drawing again.
+7. **The artwork can be reconstructed.** Metadata can combine onchain state,
+   token data, scripts, images, attributes, randomness, and named dependency
+   versions.
+8. **The artist closes the work deliberately.** Supply closure, Core freeze,
+   preservation records, and terminal artwork finality answer different
+   questions and happen as separate commitments.
+9. **Infrastructure can outlive its first implementation.** If a replaceable
+   module later fails or becomes obsolete, an explicit successor can take over
+   future duties without rewriting the permanent Core or erasing the old
+   contract's history.
+
+Not every artwork needs every step. Stream's purpose is to make the relevant
+steps explicit, inspectable, and attributable instead of leaving them scattered
+across a website, marketplace settings, private databases, and operator
+promises.
+
+## Why Stream goes beyond a mint contract
+
+A minimal ERC-721 can assign a token ID to an owner. That is useful, but it does
+not answer many of the questions that matter to an artwork expected to last for
+decades:
+
+- What exactly did the artist approve?
+- Which files, scripts, libraries, and runtime assumptions make up the work?
+- Who may still change them?
+- How was a community curation decision translated into this sale?
+- Which payer funded the mint, and which address received the token?
+- What happens if a randomness provider is late or a callback partly fails?
+- How are artists, collaborators, curators, and the protocol paid?
+- Which liabilities must remain available for withdrawal?
+- What does “frozen” cover?
+- How can surrounding infrastructure change without changing the artwork's
+  identity?
+
+Stream takes those questions into the protocol design. That creates more
+contracts and more state, but it also makes responsibilities visible that would
+otherwise still exist offchain.
+
+## Why this complexity exists
+
+Complexity should earn its place. The useful question is not whether Stream has
+many components, but which real requirement each component addresses and where
+that responsibility would go if the component were removed.
+
+| Requirement | Stream response | What simplification would externalize |
+| --- | --- | --- |
+| Keep an artwork's identity stable | A permanent shared Core records token and collection identity | Identity becomes dependent on one sale contract, renderer, website, or later migration |
+| Let infrastructure improve without silently rewriting the art | Replaceable modules and explicit successor records surround the non-proxy Core | Either old infrastructure can never change, or an upgradeable proxy can replace behavior beneath the same address |
+| Make artist consent specific | Typed state approval with ordinary-account and contract-wallet signature support | Consent becomes a vague message, operator assertion, or private workflow |
+| Connect community curation to exact execution | A signed authorization binds the chain, contract, signer era, collection, participants, economics, timing, and sale mode | The offchain decision and onchain action can drift apart |
+| Support different distribution policies safely | Mint phases, executors, gates, policy hashes, and durable counters live outside the permanent token layer | Every new distribution rule either bloats the Core or depends on a private eligibility database |
+| Handle generative randomness without reroll ambiguity | Requests bind provider and era; fulfillment stores evidence; failed Core writes retry the same derived seed | Provider delay, callback failure, retries, and migration become informal operator decisions |
+| Preserve executable artwork, not only a token URI | Scripts, token data, dependencies, content commitments, manifests, and preservation records describe what the work needs | Critical materials and runtime assumptions remain scattered across mutable services |
+| Say exactly what “final” means | Supply finalization, Core freeze, preservation evidence, and terminal artwork finality are separate states | One “immutable” badge conceals remaining mutation paths, dependencies, and operational duties |
+| Represent real artistic economics | Sale accounting, split profiles, curator allocations, refunds, asset policy, and royalty information are distinct concerns | Collaborator payments, curator rewards, refunds, rounding, and royalty policy move into private accounting |
+| Survive organizational and technical change | Bound delayed actions, guardians, module registration, permanently disabled contract functions, and successors make change visible | Future operators either have no recovery path or rely on opaque emergency authority |
+| Respond to incidents without freezing everything | Pause domains separate minting, bidding, settlement, metadata, and randomness, with distinct pause and resume powers | A single emergency switch either misses the affected path or strands unrelated users |
+
+This table is also an invitation to simplify. A reviewer who thinks a mechanism
+is unnecessary should identify the requirement that can be dropped, narrowed,
+moved offchain, or served by a smaller design. “Too complex” begins the
+analysis; it does not finish it.
+
+## A permanent center with replaceable edges
+
+The Core is intended to hold the smallest common set of facts that should
+survive changes in sale mechanics, randomness providers, metadata
+infrastructure, and governance operations. It records shared ERC-721 ownership,
+native Stream collections, globally sequential token IDs, collection-local
+serials, supply, artist approval, metadata state, burn history, and Core freeze.
+
+The surrounding modules handle concerns with different lifespans:
+
+- mint phases, gates, executors, and counters;
+- fixed-price sales and English auctions;
+- revenue resolution, split wallets, curator claims, and settlement;
+- metadata, scripts, dependencies, and preservation records;
+- randomness providers and request recovery;
+- roles, pauses, delayed governance, finality, and successors.
+
+Stream does not use a conventional upgradeable proxy for the permanent Core.
+A replacement module is a new visible contract, not new bytecode hidden behind
+the old Core address. The predecessor remains onchain with its code, events,
+liabilities, and history.
+
+That protects the artwork's identity, but it moves the key governance questions
+to the boundary:
+
+- Which facts must remain in Core?
+- Which duties may move to a successor?
+- Who can authorize the change?
+- Which delay, veto, code-hash, interface, and continuity evidence is required?
+- Which signatures, counters, balances, and old commitments remain binding?
+
+## Artist-centered means inspectable consent
+
+The current artist-approval mechanism signs a collection-state hash using
+EIP-712, a standard for typed messages whose named fields can be inspected
+before signing. Its signing domain binds the chain and Core contract. The
+signed state binds the artist address, collection-freeze manifest hash, maximum
+collection purchases, total supply, and final-supply delay. A change to a bound
+field makes the earlier approval describe an older state.
+
+The mechanism accepts ordinary account signatures and ERC-1271 signatures from
+contract wallets such as a Safe.
+
+This protects an artist from having one approval silently reused for different
+bound terms. It does not yet give the artist a universal veto over every
+administrative, preservation, governance, or finality action. Reviewers must
+decide which irreversible steps require a current artist signature, protocol
+governance, a waiting period, or more than one of those.
+
+The human experience matters as much as the hash. An approval package should
+show the collection, source version, artwork materials, supply, sale rules,
+revenue recipients, randomness provider, mutable fields, other actors with
+power, and irreversible actions before the artist signs.
+
+## Social decisions become bound actions
+
+Stream does not calculate TDH or choose artists inside Solidity. Community
+curation remains a human and operational process.
+
+Once that process reaches a result, the signed Drop authorization binds values
+including the chain, verifying contract, signer epoch, collection, payer,
+recipient, quantity, price, deadline, sale mode, token-data hash, and replay
+identifier—a one-use value that prevents the authorization from being executed
+twice. The contract can then verify that the submitted transaction matches the
+authorized action.
+
+This protects the result from quietly changing between community approval and
+execution. It cannot prove that the offchain curation rule was fair, the TDH
+calculation was correct, or the signer was not mistaken or compromised. Those
+claims require transparent offchain records and operational controls.
+
+## Art that depends on code and infrastructure
+
+Stream can describe artwork assembled entirely from onchain inputs, artwork
+whose files live elsewhere, and generative work that combines token data,
+scripts, images, randomness, and versioned dependencies.
+
+These modes carry different preservation promises:
+
+- A content hash proves that retrieved bytes match a commitment. It does not
+  make missing bytes available.
+- An onchain script can remain readable while its browser, font, codec, library,
+  or external asset changes.
+- A named dependency version identifies the intended library only if its exact
+  bytes and ordering can still be recovered.
+- A preservation record creates public history. It does not operate a storage
+  service or make every recorded claim true.
+
+Stream therefore separates token metadata, collection metadata, reusable
+dependencies, preservation records, Core freeze, and artwork finality.
+“Onchain,” “permanent,” and “immutable” should describe exact properties, not
+serve as broad badges.
+
+## Finality is a sequence, not a switch
+
+Stream distinguishes four questions:
+
+1. Can more tokens still be minted?
+2. Can the permanent collection configuration still change?
+3. Can future readers retrieve and verify the materials needed to understand or
+   reconstruct the work?
+4. Can any remaining artwork-affecting path still act?
+
+Final supply, Core freeze, preservation records, and artwork finality answer
+those questions separately. The finality design uses a scheduled process with a
+waiting period, exact manifests, cancellation or guardian veto, and terminal
+execution. One-of-one works can carry token-specific manifest commitments
+instead of relying only on a collection-wide package.
+
+The machinery protects against a surprise irreversible call and gives artists,
+collectors, and independent reviewers time to find a wrong hash, missing file,
+incorrect manifest, or unexpected writer.
+
+It still depends on a complete inventory of every mutation path and on people
+watching the schedule. A finality label is only as strong as the code paths it
+actually closes.
+
+## What the chain can and cannot promise
+
+Stream can make important claims verifiable:
+
+- a configured signer authorized a particular typed payload;
+- a token belongs to a particular Stream collection;
+- a stored hash commits to particular bytes;
+- a randomness seed was derived from recorded provider output and context;
+- a governance action was scheduled with specified call data;
+- an old module has a recorded successor;
+- a collection crossed defined freeze or finality states.
+
+Other claims remain partly or entirely external:
+
+- whether TDH or curation was calculated fairly;
+- whether an artist saw an accurate human-readable approval package;
+- whether committed artwork bytes remain retrievable;
+- whether a future browser renders a script identically;
+- whether a randomness provider remains funded and available;
+- whether a marketplace honors ERC-2981 royalty information;
+- whether signers, guardians, administrators, and governance participants act
+  wisely.
+
+The protocol is strongest when it names these boundaries instead of hiding them
+behind words such as “trustless.”
+
+## Exact source and current state
+
+The source is pinned to
+[`513bd7e079eafe109df6ae1ae21bfbca6fec6786`](https://github.com/6529-Collections/6529Stream/tree/513bd7e079eafe109df6ae1ae21bfbca6fec6786),
+with Git tree
+`b50ec53109f5f8d6b4f4b07f4cb6fd3c1d0e3100`. Every code link in this review
+points to that commit. A later candidate receives a new review version so its
+code, explanation, and feedback remain historically reproducible.
+
+[Current Implementation and
+Readiness](./security-testing-and-known-limitations) is the single inventory of
+what the pinned rehearsal connects, what exists in source, which accepted
+targets still need implementation, which ideas remain proposals, and what
+evidence is required before release.
+
+The generated Technical Reference is compiled from the same pinned source. It
+inventories the contracts, interfaces, libraries, functions, events, errors,
+signatures, selectors, and source ranges seen by the compiler. It supports
+navigation and completeness checks; it does not decide whether the design or
+implementation is correct.
+
+## Design position
+
+A permanent art protocol should be judged by more than whether it can mint a
+token. It should make artist consent legible, keep token identity stable, expose
+the trust it still requires, preserve the materials needed to understand the
+work, and let supporting infrastructure evolve without quietly rewriting the
+artwork.
+
+Stream is ambitious because the problem is ambitious. The purpose of this
+review is to decide whether every part of that ambition is necessary, coherent,
+bounded, and safe enough to deserve permanence.
+
+## Questions for reviewers
+
+1. Does Stream take responsibility for the right parts of a serious 1/1
+   artwork's lifecycle?
+2. Which mechanisms solve a real long-term requirement, and which should be
+   removed or narrowed?
+3. Is a shared, multi-collection permanent Core the right long-term identity
+   model?
+4. Is the boundary between permanent and replaceable components clear enough?
+5. Which powers should require an artist signature, a delay, a guardian veto,
+   or more than one of those?
+6. Which external dependencies are acceptable for artwork intended to remain
+   usable for decades?
+7. Does the design make complexity inspectable, or merely distribute it across
+   more contracts?

--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/overview.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/overview.md
@@ -22,15 +22,19 @@ Imagine an artist publishing one generative artwork.
    supply delay. It is not a reusable “I approve Stream” message.
 4. **A community decision becomes an exact sale.** Curation and Total Days Held
    (TDH), 6529's time-weighted holding measure, remain offchain, but the
-   resulting signed authorization fixes the collection, payer, recipient,
-   price, quantity, timing, sale mode, signer era, and a one-use identifier that
-   prevents the authorization from being executed twice.
+   resulting signed authorization fixes the collection, token data, quantity,
+   timing, sale mode, signer era, and a one-use identifier. For fixed price it
+   also binds the recipient, payer, and price: a paid mint names the payer and
+   exact price, while a free mint sets its payer and price to zero. For auction,
+   payer, recipient, and fixed price must be zero; later bids determine the
+   bidder and winner.
 5. **The token is minted and sold.** A fixed-price mint or English auction
    applies the authorized terms, updates supply, and records the resulting
    payment obligations.
 6. **Randomness follows a visible lifecycle.** The request identifies its
-   provider and era. Fulfillment stores evidence, and a failed Core write retries
-   the same accepted seed rather than drawing again.
+   provider and era. Fulfillment stores evidence, and a failed Core write can
+   retry the same accepted seed while that provider and era remain current,
+   rather than drawing again.
 7. **The artwork can be reconstructed.** Metadata can combine onchain state,
    token data, scripts, images, attributes, randomness, and named dependency
    versions.
@@ -82,7 +86,7 @@ that responsibility would go if the component were removed.
 | Make artist consent specific | Typed state approval with ordinary-account and contract-wallet signature support | Consent becomes a vague message, operator assertion, or private workflow |
 | Connect community curation to exact execution | A signed authorization binds the chain, contract, signer era, collection, participants, economics, timing, and sale mode | The offchain decision and onchain action can drift apart |
 | Support different distribution policies safely | Mint phases, executors, gates, policy hashes, and durable counters live outside the permanent token layer | Every new distribution rule either bloats the Core or depends on a private eligibility database |
-| Handle generative randomness without reroll ambiguity | Requests bind provider and era; fulfillment stores evidence; failed Core writes retry the same derived seed | Provider delay, callback failure, retries, and migration become informal operator decisions |
+| Handle generative randomness without reroll ambiguity | Requests bind provider and era; fulfillment stores evidence; failed Core writes can retry the same derived seed while that provider and era remain current | Provider delay, callback failure, retries, and migration become informal operator decisions |
 | Preserve executable artwork, not only a token URI | Scripts, token data, dependencies, content commitments, manifests, and preservation records describe what the work needs | Critical materials and runtime assumptions remain scattered across mutable services |
 | Say exactly what “final” means | Supply finalization, Core freeze, preservation evidence, and terminal artwork finality are separate states | One “immutable” badge conceals remaining mutation paths, dependencies, and operational duties |
 | Represent real artistic economics | Sale accounting, split profiles, curator allocations, refunds, asset policy, and royalty information are distinct concerns | Collaborator payments, curator rewards, refunds, rounding, and royalty policy move into private accounting |
@@ -153,12 +157,17 @@ power, and irreversible actions before the artist signs.
 Stream does not calculate TDH or choose artists inside Solidity. Community
 curation remains a human and operational process.
 
-Once that process reaches a result, the signed Drop authorization binds values
-including the chain, verifying contract, signer epoch, collection, payer,
-recipient, quantity, price, deadline, sale mode, token-data hash, and replay
-identifier—a one-use value that prevents the authorization from being executed
-twice. The contract can then verify that the submitted transaction matches the
-authorized action.
+Once that process reaches a result, the signed Drop authorization binds shared
+values including the chain, verifying contract, signer epoch, collection,
+quantity, deadline, sale mode, token-data hash, and replay identifier—a one-use
+value that prevents the authorization from being executed twice. A fixed-price
+authorization also binds its recipient, payer, and price. A paid mint names its
+payer and exact price; a free mint sets payer and price to zero. An auction
+authorization instead requires payer, recipient, and fixed price to be zero and
+binds its reserve and end time. Those zero addresses are not the later bidder
+and winner, which the auction determines through bids and settlement. The
+contract can then verify that the submitted transaction matches the authorized
+action.
 
 This protects the result from quietly changing between community approval and
 execution. It cannot prove that the offchain curation rule was fair, the TDH

--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/randomness.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/randomness.md
@@ -23,8 +23,10 @@ One request moves through these steps:
 4. Stream verifies the request context, hashes the raw words, and derives one
    seed bound to that provider, request, collection, token, and epoch.
 5. It tries to write the seed to Core exactly once.
-6. If that Core write fails, an authorized retry reuses the same accepted seed;
-   it never asks for fresh randomness.
+6. If that Core write fails, an authorized retry may reuse the same accepted
+   seed while the original provider and provider epoch remain current; it never
+   asks for fresh randomness. Replacing the provider or changing the epoch can
+   strand this retry path.
 7. The request record remains as provenance even if the token is later burned.
 
 ## Why the lifecycle exists

--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/randomness.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/randomness.md
@@ -1,0 +1,277 @@
+# Randomness
+
+For generative art, a random value can help determine the work itself. At the
+pinned commit, Stream's Solidity implements a randomness lifecycle designed to
+preserve the full provenance of that value: which provider produced it, which
+request and token it belonged to, which provider era authorized it, what
+happened if delivery failed, and why a retry cannot become a reroll.
+
+A one-shot callback is shorter. It also leaves delays, provider changes,
+failures, retries, and disputed outputs to an operator or private database. The
+source lifecycle instead records states that artists and collectors can inspect.
+
+## The randomness flow at a glance
+
+One request moves through these steps:
+
+1. A collection is assigned one randomizer provider, and `StreamCore`—called
+   Core here—the permanent token and collection identity contract, increments a
+   counter—the provider epoch—that identifies this provider era.
+2. The provider adapter creates a request and records the token, collection,
+   provider address, provider request ID, and current epoch.
+3. The external provider returns raw words through its authenticated callback.
+4. Stream verifies the request context, hashes the raw words, and derives one
+   seed bound to that provider, request, collection, token, and epoch.
+5. It tries to write the seed to Core exactly once.
+6. If that Core write fails, an authorized retry reuses the same accepted seed;
+   it never asks for fresh randomness.
+7. The request record remains as provenance even if the token is later burned.
+
+## Why the lifecycle exists
+
+Without persistent request state, another system must explain:
+
+- which request belonged to which token;
+- whether an output came from the current provider era;
+- whether the provider returned nothing;
+- whether a callback was accepted but Core storage failed;
+- whether a retry reused the accepted seed;
+- whether a result was abandoned legitimately;
+- whether anyone had an opportunity to reroll;
+- where the raw provider output can be found.
+
+For generative art, these are part of the manipulation-resistance and
+provenance story. The right simplification is a smaller complete state machine,
+not an absent one.
+
+## Two providers do not mean one trust model
+
+The common state machine is in
+[`StreamRandomizerLifecycle.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRandomizerLifecycle.sol).
+This review covers two adapters:
+
+- [`RandomizerVRF.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/RandomizerVRF.sol)
+  requests Chainlink VRF through a configured coordinator and subscription;
+- [`RandomizerRNG.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/RandomizerRNG.sol)
+  pays a configured amount of ETH to an external arRNG controller and receives
+  its authorized callback later.
+
+The VRF adapter depends on a coordinator, subscription ID, key hash, callback
+gas limit, confirmation count, and word count. The arRNG adapter depends on a
+controller fixed at construction and a mutable per-request ETH cost.
+
+The lifecycle pins the provider address and Core epoch to each request. It does
+not prove that a subscription stays funded, a controller stays available and
+honest, or mutable provider settings are appropriate. A common record format
+does not make the providers equivalent or trustless.
+
+## Provider assignment creates an authorization era
+
+A collection has one configured randomizer. Core's assignment path records a
+new address and increments the collection's randomizer epoch. Replacement
+reverts while the old provider reports a pending request for that collection.
+See
+[`StreamCore.addRandomizer`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L411-L443).
+
+Every request stores the provider and current epoch. Fulfillment checks that
+the collection still points to both before accepting output. An old callback
+therefore cannot be mistaken for a current result after provider migration.
+
+The epoch has a narrow meaning. It changes when Core assigns a provider.
+Changing settings inside the same adapter—VRF callback gas, key hash,
+subscription, confirmations, word count, or arRNG cost—does not increment it.
+The product should not imply that every provider configuration change creates a
+new authorization era.
+
+## Each request has an explicit state
+
+The lifecycle distinguishes five states:
+
+1. `None` — no request record exists.
+2. `Pending` — the request exists and may be fulfilled.
+3. `Fulfilled` — output was accepted, a seed was derived, and the Core write
+   succeeded.
+4. `Stale` — an authorized admin marked a pending request stale.
+5. `FailedPostProcessing` — output was accepted and the seed derived, but the
+   Core write failed.
+
+The
+[`RandomnessRequest`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRandomizerLifecycle.sol#L13-L36)
+record stores:
+
+- collection and token;
+- provider and provider request ID;
+- Core randomizer epoch;
+- request and fulfillment times;
+- derived seed;
+- `rawOutputHash`;
+- failure hash;
+- post-processing retry count.
+
+"No final seed" can therefore mean no request, a pending provider, a failed
+Core write, or a deliberately abandoned request. Those states must not all look
+like zero.
+
+## Fulfillment binds the output to one work
+
+A callback is accepted only for a known `Pending` request. The lifecycle checks
+the token's collection, recorded provider, live Core provider, and epoch before
+deriving the seed.
+
+The raw word array is not stored. Stream stores:
+
+`keccak256(abi.encode(randomWords))`
+
+See
+[`_hashRawRandomWords`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRandomizerLifecycle.sol#L480-L502).
+
+This commitment lets a reviewer compare independently retrieved words with the
+onchain record without paying to store the full array. It proves integrity
+after retrieval; it does not preserve or retrieve the words. Provider and
+release operations must retain the raw evidence if later verification matters.
+
+The final seed is:
+
+`keccak256(abi.encode(typehash, provider, requestId, collectionId, tokenId, randomizerEpoch, rawOutputHash))`
+
+See
+[`_deriveRandomnessSeed`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRandomizerLifecycle.sol#L484-L502).
+
+The exact domain string, ABI encoding, request-ID uniqueness, and callback
+authentication are part of the artwork's provenance. They should be reviewed
+byte for byte.
+
+Together, these checks prevent an unknown request, wrong token, obsolete
+provider era, already-terminal request, or mismatched collection assignment
+from accepting output. Calling the right callback function is not enough; the
+entire request context must still match.
+
+## A failed Core write must not become a reroll
+
+The lifecycle first accepts and derives the seed, then attempts the Core write.
+If that write fails, the request becomes `FailedPostProcessing`.
+
+An authorized admin may retry at most three times. Each attempt reuses the
+stored `derivedSeed` and `rawOutputHash`; it does not call the provider, request
+new words, or derive another seed. See
+[`_prepareRandomnessPostProcessingRetry`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRandomizerLifecycle.sol#L360-L405),
+the
+[`VRF retry`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/RandomizerVRF.sol#L116-L135),
+and the
+[`arRNG retry`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/RandomizerRNG.sol#L115-L134).
+
+Retrying delivery of an accepted seed is a reliability action. Requesting new
+randomness after seeing an outcome is a reroll and can become a selection
+mechanism.
+
+The repository tests successful fulfillment, empty-word rejection, wrong
+provider and epoch handling, failed Core writes, same-seed retries, retry
+success, repeated failure, the three-attempt limit, unauthorized retry, burned
+tokens, and lifecycle invariants. Focused cases are in
+[`StreamRandomizerRetry.t.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/test/StreamRandomizerRetry.t.sol).
+
+These are local tests. They do not prove live provider behavior on the intended
+network.
+
+## The current stale state is immediate and terminal
+
+Both adapters expose an admin-authorized `markStaleRequest` with no elapsed-time
+or block-delay check. An authorized caller can mark a newly pending request
+stale immediately. See
+[`RandomizerVRF.markStaleRequest`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/RandomizerVRF.sol#L109-L114),
+[`RandomizerRNG.markStaleRequest`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/RandomizerRNG.sol#L108-L113),
+and
+[`_markRandomnessRequestStale`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRandomizerLifecycle.sol#L454-L472).
+
+`Stale` is terminal. A late callback fails because the request is no longer
+pending. The token-to-request binding remains, and
+[`_recordRandomnessRequest`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRandomizerLifecycle.sol#L178-L217)
+rejects a second request for the token.
+
+Marking stale reduces the provider's pending count. That may allow Core to
+assign another provider for the collection, but it does not clear the affected
+token or make it eligible for a new request.
+
+A different policy could require an objective waiting period and one tightly
+bounded recovery transition. It would need to define who may act, the delay and
+its clock, whether the provider is reused or replaced, how selective rerolls
+are prevented, and which events preserve the full lineage. That is not the
+behavior described above.
+
+## Provider migration is prospective, not retroactive recovery
+
+Replacement governs new requests. A fulfilled seed cannot be rewritten because
+Core accepts a token hash only once. Pending requests block replacement until
+they are fulfilled, marked stale, or fail during post-processing and no pending
+requests remain.
+
+`FailedPostProcessing` no longer counts as pending. Core can therefore replace
+the provider while an accepted seed still needs its same-seed retry. After
+replacement, retry preparation rejects the old provider or epoch, which can
+strand the request.
+
+There is no separate guard or recovery transition for that ordering. Provider
+migration must not be described as recovery for stale or failed tokens. The
+lifecycle needs one unambiguous answer for every ordering between replacement
+and unresolved accepted work.
+
+## Burn does not erase randomness evidence
+
+A token may be burned while its request is pending. The lifecycle record stays.
+A later callback can preserve post-burn audit evidence without recreating the
+token or emitting a live-token metadata update.
+
+That keeps one historical question answerable: did the provider eventually
+return output for this burned token's request? Burn, callback, retry, provider
+accounting, and metadata behavior still need composition review. Treating
+"burned" as "never existed" can erase request or liability state.
+
+## Provider funding is part of correctness
+
+VRF depends on a funded external subscription. arRNG reserves native value for
+payable requests. These obligations must stay separate from:
+
+- sale proceeds;
+- auction bids and refunds;
+- recipient credits;
+- accidental or recoverable surplus.
+
+Operational evidence must identify the real coordinator or controller,
+configuration, funded accounts, callback permissions, request health, failure
+alerts, and replenishment process.
+
+`RandomizerNXT.sol` remains in the source tree but is not approved by the
+reviewed release policy as a production provider. Source presence is not
+operating evidence.
+
+## What can still fail
+
+- Mutable provider settings change without a new Core epoch.
+- An authorized admin marks a healthy request stale immediately.
+- Terminal stale state leaves a token permanently unresolved.
+- Provider replacement strands a `FailedPostProcessing` request.
+- A callback is accepted for the wrong request, token, collection, provider, or
+  epoch.
+- A failed Core write exhausts all same-seed retries.
+- A late result overwrites or attempts to reopen a terminal state.
+- Raw provider words cannot be retrieved to verify `rawOutputHash`.
+- A subscription, reserve, coordinator, controller, or operational account
+  fails.
+- Burn leaves request or reserve accounting inconsistent.
+
+## Questions for reviewers
+
+1. Which provider properties and configuration changes must create a new Core
+   epoch?
+2. Should stale marking require a minimum elapsed time, and how should that time
+   be measured?
+3. Should a stale token have exactly one recovery route, or is permanent
+   unresolved state intentional?
+4. Can provider replacement occur while any accepted seed still needs
+   post-processing?
+5. Is three the right maximum for deterministic same-seed Core-write retries?
+6. Where must raw provider output remain available so its hash can be checked?
+7. Which provider funding, callback, monitoring, and failure-drill evidence must
+   block production use?
+8. Does every supported provider give artists and collectors an equally clear
+   provenance record even though its trust model differs?

--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/revenue-splits-and-royalties.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/revenue-splits-and-royalties.md
@@ -1,0 +1,347 @@
+# Revenue, splits, and royalties
+
+Stream's revenue system is meant to answer a simple but demanding question:
+after a sale receives value, who is entitled to every unit of it? The answer may
+include an artist, collaborator, poster, protocol, curator, institution, or
+estate. It also has to survive rounding, failed recipients, refunds, contract
+replacement, and emergency recovery.
+
+Writing down percentages is the easy part. The real work is proving which
+profile applied, recording each entitlement once, keeping every credit backed,
+and describing royalties without promising enforcement that ERC-2981, the
+marketplace royalty-reporting standard, does not provide.
+
+## The money flow at a glance
+
+For the native-ETH Drop and Auction paths described in this review, value moves
+in this order:
+
+1. A fixed-price mint or auction settlement receives ETH.
+2. The sale contract selects a token-specific, collection, or default proceeds
+   rule, in that priority order.
+3. It records local credits for the relevant poster, protocol, curator reserve,
+   or bidder instead of paying arbitrary recipients inline.
+4. Each recipient withdraws its credit separately.
+5. Emergency recovery may reach only balance that is not owed to anyone.
+6. Public reads and events should let another person reconstruct the full path.
+
+Stream also defines a separate accounting foundation for choosing an approved
+asset and economic profile, ensuring one sale is settled once, routing its
+value to a split wallet with a predictable address, and letting recipients
+withdraw. [Current Implementation and
+Readiness](./security-testing-and-known-limitations) records which revenue path
+the present rehearsal actually uses.
+
+## Why the machinery exists
+
+Sending every payment to one operator is smaller. It also asks artists,
+collaborators, curators, collectors, and auditors to trust that operator to:
+
+- apply the agreed split;
+- keep enough funds for every claimant;
+- handle recipients that cannot receive value;
+- reconcile refunds, rounding, and residuals;
+- preserve historical split identities;
+- survive key loss, succession, or organizational change;
+- describe secondary royalties honestly.
+
+Stream moves those obligations into inspectable state. That is valuable only
+when each invariant has one clear owner. Parallel routes that account for the
+same kind of value must be deliberately reconciled, not celebrated as extra
+features.
+
+No contract can make a marketplace pay a reported royalty, prove that an
+offchain curator allocation was fair, or guarantee that a recipient retains
+its keys. The onchain machinery can make the selected rule, recorded
+liabilities, withdrawals, residuals, and successor boundary inspectable.
+
+## One wei should have one accountable path
+
+Every sale should answer:
+
+- Which sale created the value?
+- Which asset and amount arrived?
+- Which revenue rule won, and by what precedence?
+- Which accounts became entitled?
+- How did division and residual units work?
+- Where is the value before withdrawal?
+- Which liabilities are excluded from emergency recovery?
+- Which reads and events reconstruct every later movement?
+
+These are protocol invariants. A contract can compile while crediting the same
+wei twice, omitting a liability from surplus, or selecting a different profile
+at settlement from the one the artist approved.
+
+## The native-ETH flow
+
+Signed fixed-price ETH runs through `StreamDrops`; English-auction ETH runs
+through `AuctionContract`. Each contract:
+
+1. receives value through its own sale path;
+2. checks token, collection, then contract-default split configuration;
+3. calculates the poster, protocol, curator, and where applicable bidder
+   liabilities;
+4. stores those liabilities as local pull credits;
+5. lets each claimant withdraw from that same contract.
+
+`StreamDrops` creates poster, protocol, and curator-reserve credits.
+`AuctionContract` creates poster, protocol, curator, and bidder credits.
+
+Local pull credits and the resolver-and-settlement foundation are distinct
+accounting paths. A release must select and fully specify one coherent route
+rather than leave overlapping paths whose liabilities cannot be reconciled.
+
+## Pull credits keep one recipient from blocking everyone
+
+Paying every recipient during mint or settlement looks direct, but the entire
+sale then depends on every recipient contract accepting the transfer.
+
+Pull accounting records the entitlement first and moves value later. This
+means:
+
+- a recipient that rejects ETH does not block the sale;
+- a failed withdrawal can leave the credit intact;
+- state can be updated before the external call;
+- liabilities stay visible between sale and withdrawal;
+- a compatible alternate recipient can be used where permitted.
+
+The complexity moves into explicit credit and solvency state. It does not
+disappear. Credits plus reserves must never exceed the contract's held value.
+
+There is no single protocol-wide credit ledger. Drop recipients withdraw
+Drop-local credits, auction recipients and displaced bidders withdraw
+Auction-local credits, and split-wallet recipients withdraw wallet-local
+allocations after funding. Reviewers therefore need cross-contract solvency and
+cutover evidence, not just isolated withdrawal tests.
+
+## The settlement foundation flow
+
+The separately deployed
+[`StreamPrimarySaleSettlement.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamPrimarySaleSettlement.sol#L96-L145)
+records and settles primary-sale value. Its intended sequence is:
+
+1. an owner-approved settlement caller submits one typed settlement;
+2. the settlement key binds the sale identity so it cannot be officially
+   consumed twice;
+3. the requested asset must be active in the asset-policy registry;
+4. the revenue assignment resolves from the approved policy context;
+5. value reaches the selected split wallet;
+6. the settlement record becomes the public accounting identity for that sale.
+
+A settlement record is intended to bind sale identity, token or collection
+context, payer and other participants, asset, amount, revenue class, selected
+profile or template, and policy context.
+
+"Already paid" cannot safely live only in a private database. Retries,
+successor callers, and alternate sale adapters must reach the same answer about
+whether one sale identity has been consumed.
+
+This foundation is designed to sit behind sale adapters. The status page owns
+the exact candidate-wiring claim; the important accounting rule here is that
+every adapter must reach the same answer about whether a sale identity has
+already been settled.
+
+## Resolution separates the sale from its economic policy
+
+[`StreamRevenueResolver.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRevenueResolver.sol#L170-L279)
+can select a token rule before a collection rule, and a collection rule before
+defaults.
+
+That creates a useful boundary:
+
+- the sale adapter decides how and when a sale happens;
+- the resolver decides which approved economic profile applies.
+
+Without this separation, every sale type can duplicate split selection and
+freeze semantics, then disagree about who should be paid. With it, precedence
+and profile identity can be inspected once—provided every supported sale
+actually uses it.
+
+An artist needs to see the selected assignment, every higher-priority override,
+whether the assignment can still change, and when it becomes fixed. A label
+such as "artist split" is not enough when token, collection, and default rules
+can compete.
+
+A narrow validation-adapter design can extend this boundary without adding a
+second state owner. Such an adapter would own no state, authority, roles, funds,
+or normative events. Resolver writes would fail closed when exact validation
+could not complete, while Core royalty reads would use resolver storage and
+pure computation rather than call the adapter. The registered resolver would
+remain the only state owner, writer, Core royalty pointer target, and normative
+event source.
+
+## Immutable split profiles make collaboration inspectable
+
+A split profile identifies recipients and shares.
+[`StreamSplitFactory`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamSplitFactory.sol)
+canonicalizes the profile and can deploy its
+[`StreamSplitWallet`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamSplitWallet.sol)
+at a deterministic address.
+
+The profile itself is immutable. To change participants or shares, the system
+creates a new profile and changes the resolver assignment subject to its
+mutability and freeze rules. The old profile keeps its meaning and the boundary
+of the change stays visible.
+
+Reviewers should verify that:
+
+- every recipient is valid;
+- shares total the exact denominator;
+- duplicate recipients are rejected or combined deterministically;
+- canonical ordering produces one profile identity;
+- the expected wallet address cannot deploy different code;
+- the wallet's stored entries match its profile;
+- profile changes have an explicit effective boundary;
+- artists can inspect exact recipients and shares before approval.
+
+A spreadsheet expresses the same percentages with less Solidity. It does not
+prove which profile a sale used, preserve historical identity, or let a
+recipient withdraw without trusting its operator.
+
+## Approved ERC-20 settlement is deliberately strict
+
+The settlement foundation accepts only asset contracts marked active in the
+deployment-wide
+[`StreamAssetPolicyRegistry`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamAssetPolicyRegistry.sol#L7-L83).
+Unknown, inactive, deprecated, or unsupported assets fail closed. Each policy
+decision includes an evidence hash and effective timestamp.
+
+Settlement requires a successful boolean-returning transfer and exact
+before-and-after balances for the payer, settlement contract, and split wallet.
+The
+[`StreamPrimarySaleSettlement`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamPrimarySaleSettlement.sol#L124-L145)
+path rejects:
+
+- missing or false return values;
+- fee-on-transfer behavior;
+- no-op transfers;
+- failed balance reads;
+- unexpected balance changes.
+
+The pinned
+[`settlement tests`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/test/StreamPrimarySaleSettlement.t.sol#L778-L1043)
+exercise the supported standard-token path and these rejection cases.
+
+ERC-20 contracts do not all behave alike. A bare `transferFrom` can record more
+value than arrived, accept a meaningless return, or expose recipient
+accounting to token-specific behavior. The actual registry state—not a
+frontend allowlist—defines the accepted assets.
+
+## A payer-bound token sale needs a separate authorization
+
+A safer token-sale architecture separates:
+
+1. a sale adapter that verifies a payer-signed `PaymentIntent` and is the only
+   protocol contract allowed to use the payer's allowance;
+2. `StreamPrimarySaleSettlement`, which resolves policy, consumes the
+   settlement key, routes value, and records the official settlement without
+   pulling from the payer.
+
+This would bind one token payment to one sale and keep allowance authority out
+of the accounting recorder. Its exact payment fields, signer-scoped replay,
+revocation, escrow fallback, and top-level orchestration still need a complete
+design. See
+[`ADR 0019`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/docs/adr/0019-payment-intent-orchestration.md#L3-L82).
+
+## Rounding and surplus have owners
+
+Integer division can leave residual units. The contract and public economic
+statement should identify the denominator, rounding direction, residual owner,
+whether dust accumulates, how it can be withdrawn, and whether repeated small
+payments bias one participant.
+
+"Approximately" is not a split rule. Tiny residuals become material across
+many payments, and an unspecified owner becomes an emergency-recovery dispute.
+
+For every ETH-holding path, reviewers should also prove:
+
+- `msg.value` matches the required amount;
+- value is never allocated twice;
+- credits and reserves remain backed;
+- forced ETH does not create a false liability;
+- failed withdrawals preserve entitlement;
+- emergency recovery uses balance minus liabilities.
+
+A contract's balance says how much ETH it holds, not how much it owns.
+
+## Curator rewards bind an external allocation to onchain claims
+
+Drop and Auction create curator-reserve credits for the configured
+`StreamCuratorsPool`. An authorized release moves the reserve to the pool. The
+pool publishes a collection Merkle root and uses pull credits for claims.
+
+The proof shows that a claimant belongs to the committed allocation without
+storing every leaf. It does not prove that the offchain process which built the
+root was fair or used correct inputs.
+
+Reviewers should establish who builds and publishes the root, which data and
+policy version it represents, whether it can be replaced, how claims prevent
+replay, how proofs are encoded, what happens to unclaimed value, and whether
+anyone can reproduce and contest the allocation.
+
+The commitment makes an external decision inspectable; it does not make the
+decision onchain.
+
+## ERC-2981 reports royalties; it does not enforce them
+
+At the pinned commit, Core's
+[`royaltyInfo`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol#L1013-L1027)
+returns:
+
+- receiver `0xC8ed02aFEBD9aCB14c33B5330c803feacAF01377`;
+- `690` basis points out of `10,000`;
+- `salePrice * 690 / 10_000`;
+- the same answer for arbitrary token IDs;
+- no runtime setter or per-token override.
+
+Core does not call `StreamRevenueResolver` for this read.
+
+ERC-2981 tells a marketplace what the contract reports. It cannot compel
+payment. Honest product language is "royalty information" or "royalty signal,"
+not "guaranteed royalty." Transfer-restricting enforcement would be a
+different protocol and collector tradeoff.
+
+## Every value movement should be reconstructable
+
+Public reads and events should let an independent reviewer rebuild:
+
+- sale identity and gross value;
+- selected assignment and precedence;
+- split profile and every allocation;
+- every credit and withdrawal;
+- curator reserve, root, and claims;
+- royalty configuration;
+- rounding residuals;
+- emergency or surplus movements.
+
+If reconstruction needs a private database, the public accounting record is
+incomplete.
+
+## What can still fail
+
+- Native-sale accounting and the separate foundation remain ambiguous parallel
+  paths.
+- The wrong token, collection, or default profile wins precedence.
+- A sale or settlement key is consumed twice.
+- Shares or rounding allocate the wrong amount.
+- Liabilities exceed held value or emergency recovery withdraws reserved funds.
+- A fee-on-transfer or other nonstandard asset creates a false record.
+- A split wallet's code or stored profile differs from its expected identity.
+- A curator root is valid but built from wrong inputs.
+- Successor cutover duplicates or abandons credits.
+- A marketplace ignores ERC-2981.
+
+## Questions for reviewers
+
+1. Should genesis retain the current local native-sale accounting, or connect
+   every sale to the resolver and settlement foundation?
+2. Can artists see exactly which assignment wins before approving a sale?
+3. When should a split or royalty assignment become immutable?
+4. Which assets belong in the initial onchain asset policy?
+5. Who receives rounding residuals, and can repeated dust create bias?
+6. Can aggregate liabilities be proven across every value-holding contract?
+7. Is the curator-root process reproducible and contestable?
+8. What continuity proof is required before a successor can inherit accounting
+   duties?
+9. Is every public royalty statement explicit that ERC-2981 does not compel
+   marketplace payment?

--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/revenue-splits-and-royalties.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/revenue-splits-and-royalties.md
@@ -11,7 +11,14 @@ profile applied, recording each entitlement once, keeping every credit backed,
 and describing royalties without promising enforcement that ERC-2981, the
 marketplace royalty-reporting standard, does not provide.
 
-## The money flow at a glance
+## Two source-described money paths, and which one is wired
+
+These are alternative paths in the pinned source, not one reconciled accounting
+system. In the present rehearsal, signed Drops and Auctions use their own
+native-ETH credit accounting. The rehearsal also deploys the separate resolver,
+split-wallet, asset-policy, and settlement foundation, but those sale paths do
+not call it and no settlement caller is configured. [Current Implementation and
+Readiness](./security-testing-and-known-limitations) records that exact wiring.
 
 For the native-ETH Drop and Auction paths described in this review, value moves
 in this order:
@@ -25,12 +32,10 @@ in this order:
 5. Emergency recovery may reach only balance that is not owed to anyone.
 6. Public reads and events should let another person reconstruct the full path.
 
-Stream also defines a separate accounting foundation for choosing an approved
-asset and economic profile, ensuring one sale is settled once, routing its
-value to a split wallet with a predictable address, and letting recipients
-withdraw. [Current Implementation and
-Readiness](./security-testing-and-known-limitations) records which revenue path
-the present rehearsal actually uses.
+The separate foundation is designed to choose an approved asset and economic
+profile, ensure one sale is settled once, route its value to a split wallet with
+a predictable address, and let recipients withdraw. It is implemented in source,
+but it is not the accounting path used by the rehearsed Drop and Auction flow.
 
 ## Why the machinery exists
 

--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/roles-and-trust.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/roles-and-trust.md
@@ -1,0 +1,338 @@
+# Roles and trust
+
+Stream’s authority system answers a practical question: **who can make each
+kind of change?** It separates routine administration, emergency stops, signed
+sale approval, artist consent, governed change, and permissionless execution.
+The aim is not to create impressive-sounding titles. It is to keep one mistaken
+or compromised actor from inheriting every protocol power.
+
+Consider an incident during an auction. A pause guardian can stop new bids in
+the affected domain. That does not automatically let the guardian restart the
+auction, move bidder funds, replace a module, or change the artwork. A separate
+unpause authority can resume activity after review, while withdrawals remain a
+different path. This is the basic pattern throughout Stream: give each actor
+only the capability needed for its job.
+
+Smart contracts do not remove trust. They can make a power visible, narrow it,
+delay it, make it revocable, or make it permanent. People and external systems
+still calculate Total Days Held (TDH), 6529's time-weighted holding measure,
+hold signing keys, operate randomness services, preserve files, monitor
+incidents, and decide whether marketplaces honor royalties.
+
+## Why not use one administrator?
+
+One owner or multisig would be easier to describe. It would also combine powers
+that fail in different ways:
+
+- stopping harm and restarting service;
+- authorizing a sale and approving an artwork;
+- editing a description and speaking in the artist’s name;
+- proposing a governed change and executing it;
+- replacing infrastructure and changing permanent token identity.
+
+Stream keeps these responsibilities separate so a stolen signing key cannot
+also rewrite metadata, a pause guardian cannot become a governor, and a
+metadata operator cannot make an artist-attributed claim.
+
+The right test for simplification is concrete: which responsibility can be
+removed, or which smaller mechanism preserves the same boundary? Deleting a
+role name while handing its powers to a broader key is not simplification. It
+moves the risk.
+
+## A concrete authority flow
+
+A signed fixed-price mint shows several roles working together:
+
+1. an offchain curation process reaches a decision;
+2. the configured authorization signer signs the exact sale payload for its
+   current signer epoch;
+3. a caller submits the payload;
+4. the Drop contract verifies the signature and bound terms;
+5. the configured minter checks supply and mint rules;
+6. Core records the token’s permanent identity;
+7. if an incident occurs, a pause guardian can stop the relevant domain without
+   receiving unrelated powers;
+8. in the Governance V2 design, a later policy change must use its own visible
+   process rather than borrowing the signer or guardian role.
+
+No single role proves that the whole flow is correct. The safety claim comes
+from the boundaries between them and from public evidence that the deployed
+grants match the reviewed design.
+
+## What this model protects—and what it does not
+
+The model is designed to:
+
+- scope authority to particular contracts, functions, collections, subjects,
+  or record families;
+- separate rapid defensive action from policy-making;
+- make signer rotation and authorization eras visible;
+- distinguish artist consent from protocol administration;
+- preserve old module history when a successor takes over;
+- allow safe actions to be triggered permissionlessly after every sensitive
+  value is fixed.
+
+It does not prove that an authorized person is honest, that an external service
+is available, that a rights claim is true, or that a future deployment uses the
+correct grants. A complete candidate still needs exact addresses, selectors,
+code hashes, scopes, delays, revocation rules, and independent readback.
+
+## Authority is a capability, not a title
+
+In Solidity, a function selector is the compact identifier for a contract
+function. Stream can scope an administrator to one selector on one target
+instead of granting authority over the whole contract.
+
+The useful question is not “is this account an admin?” It is:
+
+- which exact function or record family can the account reach;
+- on which contract, collection, token, or subject;
+- whether the action is immediate or delayed;
+- whether another party can veto it;
+- whether the actor can grant itself or someone else more authority;
+- how the authority expires, freezes, rotates, or is revoked;
+- what public evidence reconstructs its use.
+
+A reassuring role name is not a security boundary. Effective authority comes
+from every reachable selector, registry check, executor, fallback, module
+relationship, and external service.
+
+## Actor matrix
+
+| Actor                             | Principal capability                                          | Trust question                                                                 |
+| --------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Core owner                        | Bootstrap and ownership duties                                | When is this authority removed, transferred, or constrained?                   |
+| Global administrator              | Broad protocol administration                                 | Is any global role necessary after launch?                                     |
+| Target/function administrator     | Call a specific selector on a specific target                 | Does the selector grant more power than its name suggests?                     |
+| Pause guardian                    | Stop a configured domain                                      | Can it limit damage without becoming a censorship key?                         |
+| Unpause administrator             | Resume a paused domain                                        | What evidence is required before restart?                                      |
+| Signer manager                    | Rotate authorization signers and epochs                       | Can a stolen or mistaken signer be removed quickly and visibly?                |
+| TDH authorization signer          | Authorize a specific Drop action                              | Does the signed payload bind every fact that matters?                          |
+| Mint manager or executor          | Configure or execute mint policy                              | Can it exceed Core supply, bypass counters, or select an unintended recipient? |
+| Randomness controller or provider | Configure, request, or fulfill randomness                     | What can it bias, delay, retry, abandon, or strand?                            |
+| Governance proposer               | Publish a delayed action                                      | Who may propose value-bearing or permanent actions?                            |
+| Governance canceller or guardian  | Cancel or veto a scheduled action                             | Can it stop harm without authoring a replacement action?                       |
+| Governance executor               | Execute an action after its delay                             | Are target, calldata, native value, and timing fixed in advance?               |
+| Artist                            | Approve a specific collection state or artistic commitment    | Which actions still proceed without the artist’s current signature?            |
+| Collector                         | Mint, bid, withdraw, transfer, and burn                       | Which mutable states or external services affect the result?                   |
+| Permissionless caller             | Settle or trigger a maintenance path                          | Can the caller choose any value that was not already committed?                |
+
+## Current administrative layer
+
+The current rehearsal includes
+[`StreamAdmins.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamAdmins.sol).
+It supports:
+
+- an owner;
+- a global administrator;
+- administrators scoped to a target contract and function selector;
+- a pause guardian;
+- an unpause administrator;
+- assignment and removal of administrative authority.
+
+Function-scoped authority is narrower than giving every operator every power.
+It still requires a complete selector inventory. Reviewers must check aliases
+and alternate module paths, not only the function named in a grant.
+
+Pause and unpause are intentionally separate. A guardian can stop a configured
+domain quickly without automatically receiving the power to restart it. Each
+domain still needs a public policy covering what stops, which reads and exits
+remain available, who may resume, and what incident evidence is required. A
+pause that strands bids, refunds, mints, withdrawals, or randomness can create
+a second failure while trying to contain the first.
+
+## Signed authorization
+
+Signed Drops depend on a configured signer and signer epoch. The signer does not
+move tokens directly. It authorizes a contract call whose typed payload binds
+the intended action. Rotation changes the epoch, so an authorization from an
+old signing era cannot be treated as current merely because its signature still
+verifies.
+
+Signer custody is therefore an important operational trust boundary. Failure
+modes include:
+
+- theft of a signing key;
+- a signer service authorizing values the community did not approve;
+- use of the wrong chain or verifying contract;
+- authorizations with deadlines that are too generous;
+- delayed rotation after compromise;
+- changed ERC-1271 validation behavior in a contract wallet;
+- monitoring that fails to notice unexpected authorizations.
+
+The public record should identify the signer, signer type, epoch, rotation
+authority, emergency-revocation process, and exact typed-data software. It must
+never contain a private key, seed, or recovery secret.
+
+## Artist authority
+
+Core stores the artist address and can verify an artist signature over a
+specific collection state. That approval binds the artist address, current
+collection-freeze manifest hash, maximum collection purchases, total supply,
+and final-supply delay.
+
+This is not a universal artist veto. In the reviewed source, an administrator
+with the relevant authority can call `freezeCollection`; that function does not
+itself demand a fresh artist signature. Metadata, preservation, and finality
+records can also have their own writers and approval rules.
+
+Reviewers should decide which irreversible actions require the artist’s current
+signature, protocol governance, a public delay, a guardian veto window, or more
+than one of those protections. Consent is meaningful only when the artist can
+inspect the human-readable state behind the hash before signing.
+
+## Record-family authorization
+
+The source replaces broad whole-selector writer grants with
+[`StreamRecordFamilyRegistry`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRecordFamilyRegistry.sol#L17-L285).
+A selector-level permission asks whether an actor may call a function. The
+record-family check also asks whether that actor may write this exact admitted
+record type for this collection and subject.
+
+The source defines eight authorization classes:
+
+| Class                      | Source authority                            |
+| -------------------------- | ------------------------------------------- |
+| Artist signer              | Live authority provider                     |
+| Owner signer               | Live authority provider                     |
+| Curator signer             | Family grant                                |
+| Institution signer         | Live authority provider                     |
+| Independent attestor       | Direct, self-attributed write by any caller |
+| Preservation administrator | Family grant                                |
+| Metadata administrator     | Family grant                                |
+| Global administrator       | Family grant                                |
+
+Fourteen closed family groups cover artist, owner, independent, curator,
+institution, rights, archive, fixity, C2PA, IIIF, media relationship, identity
+display, snapshot, and agent records. Artist, owner, independent, and
+institution families reject administrator grants. An exact record type is
+admitted once and cannot later be remapped.
+
+Live authority providers are code-hash pinned. They fail closed when a call
+fails, returns malformed data, or no longer has the expected runtime code
+([`_providerAuthorizes`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRecordFamilyRegistry.sol#L298-L323)).
+
+These checks answer **who may write**. They do not prove that a rights claim,
+archive location, credential, or other record is true. An independent record is
+self-attributed evidence from its caller, not endorsement by the artist, 6529,
+or the protocol. [Metadata, Scripts, and
+Dependencies](./metadata-scripts-and-dependencies#collection-metadata-separates-claims-by-purpose-and-authority)
+explains each family in ordinary language.
+
+The rules exist in source, but they are not yet a candidate configuration. The
+still-missing evidence includes the admitted record types, live providers,
+grants, runtime code hashes, rotation and revocation exercises, and independent
+review.
+
+## Governance actors
+
+The source includes
+[`StreamRoleRegistry.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRoleRegistry.sol)
+and
+[`StreamGovernanceExecutor.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamGovernanceExecutor.sol).
+They separate proposing, cancelling, guardian intervention, and execution. The
+executor can publish actions, enforce delays, execute matured calls, expire or
+cancel actions, support guardian vetoes, and freeze selected selectors.
+
+These are source implementations, not part of the current rehearsal’s deployed
+contract set. Exact candidate roles, target catalog, delays, selector classes,
+native-value limits, and bootstrap cutover remain readiness questions. The
+[Governance, Pausing, and
+Successors](./governance-pausing-and-successors) page explains how those powers
+are intended to change over time.
+
+## Module and successor authority
+
+Stream does not use an ordinary proxy to rewrite the permanent Core in place.
+Replaceable duties can move to new immutable contracts through explicit module
+and successor records. The old contract and its history remain visible.
+
+That makes the authority questions reviewable:
+
+- who can register a module;
+- which code hash and interface are required;
+- who can change its status;
+- who may declare a successor;
+- which delay and veto rules apply;
+- which liabilities remain with the predecessor;
+- whether a successor can affect a supposedly frozen or permanent surface.
+
+The accepted revenue-resolver validation adapter would be a private implementation
+dependency, not a registered module or authority boundary. It would own no
+state, funds, roles, or events. Replacing it would require a new resolver,
+continuity proof, Registry V2 registration, and governed Core-pointer change.
+That design would prevent a hidden adapter setter from becoming an undeclared
+upgrade path.
+
+## Permissionless callers
+
+Some operations are safer when anyone can trigger them after every sensitive
+value is fixed. Auction settlement after the end time is one example.
+
+Permissionless does not mean consequence-free. The caller must not be able to
+choose a recipient, amount, manifest, implementation, or other value that was
+not already committed. Reviewers should trace every caller-supplied argument
+and every mutable storage read used during execution.
+
+## External trust boundaries
+
+Important powers remain outside Solidity:
+
+- community curation and TDH calculation;
+- authorization construction and signer custody;
+- randomness coordinators, controllers, accounts, and funding;
+- RPC nodes and chain indexing;
+- source and artifact publication;
+- content storage and gateways;
+- browsers and JavaScript runtimes;
+- Safe owners and recovery procedures;
+- deployment operators;
+- monitoring and incident response;
+- marketplaces deciding whether to honor royalty information.
+
+Each dependency needs an owner, failure signal, recovery path, and public
+evidence requirement. Putting a hash onchain can make a result verifiable; it
+cannot make the underlying service honest or continuously available.
+
+## Why this authority model exists
+
+A protocol meant to preserve art for decades cannot assume that one operator,
+module, provider, or service will remain correct forever. Stream’s authority
+model tries to make each power narrow, visible, revocable where appropriate,
+and permanent only where permanence serves the artwork.
+
+Removing a boundary usually combines the power into a broader key, hides it in
+an operational service, or leaves the failure case undefined. The final system
+should publish one machine-readable authority view containing the permanent
+Core, current modules, predecessors and successors, code hashes, active roles,
+pending actions, pause state, signer epochs, and permanently frozen selectors.
+
+Deliberate separation should not excuse unresolved complexity. Duplicate paths,
+unclear grants, or two components owning one invariant should be consolidated.
+
+## What can fail
+
+- a role reaches more functions than its name suggests;
+- an alternate module bypasses a selector-scoped restriction;
+- a signer authorizes a payload that differs from the community decision;
+- an artist signature covers fewer facts than the product implies;
+- an authority provider recognizes the wrong wallet or changes code;
+- an administrator writes a record family it should not control;
+- a guardian can author changes instead of only stopping them;
+- a permissionless caller supplies a value that was supposed to be fixed;
+- predecessor and successor modules accept the same authorization or liability;
+- an external service fails without a visible owner or recovery path.
+
+## Questions for reviewers
+
+1. Which global roles should be eliminated before deployment?
+2. Which actions require a delay, and how long should each delay be?
+3. Which actions need both artist approval and protocol governance?
+4. Can the pause system preserve bidder, minter, and withdrawal rights during an
+   incident?
+5. Is record-family authorization enforced for every high-impact mutation?
+6. Should any governance executor be allowed to hold or send native value?
+7. What public evidence should be mandatory before a successor module becomes
+   active?
+8. Which authority boundary can be simplified without combining powers or
+   moving them into an opaque offchain service?

--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/security-testing-and-known-limitations.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/security-testing-and-known-limitations.md
@@ -313,7 +313,9 @@ The release needs a generated, machine-readable manifest containing:
 - chain, addresses, creation transactions, and runtime code hashes;
 - constructor and initializer arguments;
 - Core pointers and the complete module graph;
-- role holders, scopes, signer addresses, and signer epochs;
+- role holders and scopes;
+- signer addresses, signer types, signer epochs, rotation authority,
+  emergency-revocation process, and exact typed-data software;
 - record-family admissions, authority providers, and grants;
 - governed parameters and action classes;
 - pause, unpause, and guardian configuration;
@@ -322,6 +324,11 @@ The release needs a generated, machine-readable manifest containing:
 - ownership transfers, renunciations, and one-way bootstrap sealing;
 - explorer verification;
 - independent readback of every critical invariant.
+
+The signer fields above are the public operational record required by [Roles
+and Trust](./roles-and-trust#signed-authorization). Independent readback must
+cover those fields as well as the onchain address and epoch; the manifest must
+never contain signing secrets.
 
 A local deployment script does not prove a live deployment is correct. Someone
 other than the deployer must be able to reconstruct and verify the ceremony

--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/security-testing-and-known-limitations.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/security-testing-and-known-limitations.md
@@ -1,0 +1,499 @@
+# Current Implementation and Readiness
+
+Stream is an incomplete, undeployed, pre-audit candidate under active public
+review; there is no live Stream contract and no funds in it.
+
+This page is the single readiness ledger for the review. It answers four
+questions:
+
+1. Which contracts form the user-facing path in the current rehearsal?
+2. Which other systems are connected, present only in source, accepted but not
+   built, or still proposals?
+3. What evidence supports each claim, and what evidence is still missing?
+4. Which limitations and release blockers prevent production?
+
+The topical pages explain what each mechanism does and why it exists. This page
+classifies what is done and not done so readers do not have to reconstruct
+status from scattered caveats.
+
+Every statement refers to exact Git commit
+[`513bd7e079eafe109df6ae1ae21bfbca6fec6786`](https://github.com/6529-Collections/6529Stream/tree/513bd7e079eafe109df6ae1ae21bfbca6fec6786)
+and Git tree `b50ec53109f5f8d6b4f4b07f4cb6fd3c1d0e3100`. A later
+commit requires a new review version.
+
+## How to read this page
+
+Start with a system's **implementation state**. That tells you whether a user
+would reach it in the rehearsed path, whether it is merely connected nearby,
+or whether it exists only as source or design.
+
+In this review, the **rehearsal** is the repository's repeatable deployment
+script for constructing and wiring a candidate locally. It is evidence about
+composition, not a live-chain deployment.
+
+Then check its **evidence**. Source and local tests can strongly support a
+mechanism without proving its candidate wiring, live infrastructure, economic
+safety, or audit status.
+
+Finally, read the **known limitations**, **missing evidence**, and **release
+blockers**. A system remains unready when a required proof is missing even if
+its code exists and its unit tests pass.
+
+## Five implementation states
+
+| State                    | What it means                                                                                                                                        | What a reader should conclude                                                                 |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| **Current path**         | The current rehearsal constructs and connects it in the user-facing path being described.                                                            | This is the path selected by the rehearsal, not a live, audited, or final deployment.          |
+| **Connected foundation** | The rehearsal constructs it and connects it to some protocol components, but the current user-facing sale or mint path does not call it.             | It is more than loose source, but less than an end-to-end supported path.                       |
+| **Source implemented**   | Solidity exists at the pinned commit, but the rehearsal does not prove complete candidate addresses, grants, configuration, or use.                  | Its behavior can be reviewed; its inclusion and production configuration cannot be assumed.   |
+| **Accepted target**      | The architecture is accepted for pre-genesis work, but complete conforming source, integration, and evidence do not yet exist.                       | It is a committed direction, not protection the candidate supplies today.                      |
+| **Proposed or deferred** | The material remains open design work or is intentionally outside the candidate.                                                                     | It must not be described as current contract behavior or release protection.                   |
+
+Implementation state is not a quality score. A well-tested contract may still
+be source-only, while a current-path contract may still contain a blocker. The
+states expose the most important integration fact: which contracts actually
+compose one supported path?
+
+## Evidence is a separate dimension
+
+| Evidence                           | What it establishes                                                                                                                         | What it does not establish                                                         |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| **Pinned source**                  | The Solidity or artifact exists at the exact reviewed commit.                                                                               | That it is connected, configured, safe, or intended for release.                   |
+| **Local tests**                    | Named unit, fuzz, invariant, state-machine, or composition cases passed in the repository environment.                                      | That every composition is covered or live infrastructure behaves like mocks.      |
+| **Candidate binding**              | Exact addresses, runtime code hashes, roles, grants, parameters, and module relationships match one release candidate.                      | That external providers or marketplaces behave correctly.                         |
+| **Non-local evidence**             | Intended coordinators, contract wallets, public RPCs, marketplaces, storage, retrieval, and operations work outside local mocks.            | That the complete protocol is secure.                                              |
+| **External audit and remediation** | Independent experts reviewed the exact candidate and recorded findings, dispositions, fixes, and remaining risk.                            | A permanent guarantee against defects or future operational failure.               |
+
+The repository supplies substantial pinned-source and local-test evidence.
+Candidate binding, non-local operation, deployment proof, and external audit
+remain incomplete.
+
+## Current path
+
+The rehearsal selects this multi-contract baseline:
+
+| Area                                    | What the rehearsed path does                                                                                                                                                                                                                                                                                                   |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Permanent token and collection identity | [`StreamCore.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamCore.sol) stores shared ERC-721 identity—the NFT ownership standard—collection records, global token IDs, collection-local serials, supply, artist approval, metadata state, burn history, and Core freeze state. |
+| Signed fixed-price Drop                 | `StreamDrops` verifies an EIP-712 structured typed authorization and calls the legacy `StreamMinter`, which calls the legacy Core mint entry.                                                                                                                                                                                    |
+| Signed English auction                  | `StreamDrops`, the legacy minter, and `AuctionContract` register the approved sale and mint the token into auction custody before bidding.                                                                                                                                                                                       |
+| Native fixed-price accounting           | `StreamDrops` selects its own token, collection, or contract-default split and creates poster, protocol, and curator-reserve credits.                                                                                                                                                                                            |
+| Native auction accounting               | `AuctionContract` maintains its own bidder, poster, protocol, and curator credits.                                                                                                                                                                                                                                               |
+| Royalty information                     | Core reports one receiver and `690` basis points (`6.9%`) for every token through ERC-2981, the marketplace royalty-reporting standard; it does not call the revenue resolver.                                                                                                                                                     |
+| Administration and pauses               | `StreamAdmins` supplies owner, global, target/function, pause-guardian, and unpause authority for the baseline.                                                                                                                                                                                                                   |
+| Core and preservation                   | Core and `StreamPreservationRecords` are included in the rehearsal.                                                                                                                                                                                                                                                              |
+
+The construction is visible in
+[`RehearseDeployment.s.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/script/RehearseDeployment.s.sol#L169-L270).
+
+This is meaningful functionality. "Current path" means the rehearsal selects
+these contracts at this commit. It does not mean deployed, audited, final, or
+free of blockers.
+
+## Connected foundations
+
+The rehearsal also constructs substantial systems outside the current signed
+Drop and Auction call path.
+
+### Mint manager and durable ledger
+
+[`StreamMintManager.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMintManager.sol)
+and
+[`StreamMintLedger.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMintLedger.sol)
+provide phases, executors, gates, time windows, supply constraints, policy
+hashes, prepared Core execution, and durable counters.
+
+The rehearsal connects the manager to Core and authorizes it as a ledger
+writer. It still gives the legacy minter to `StreamDrops`. The manager/ledger
+and signed Drop are therefore two separate mint lanes rather than one
+end-to-end sale path. [Tokens, Collections, and
+Minting](./tokens-collections-and-minting#the-two-source-mint-lanes) explains
+the difference.
+
+### Revenue, split, asset-policy, and settlement foundation
+
+The rehearsal deploys:
+
+- [`StreamRevenueResolver.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamRevenueResolver.sol);
+- [`StreamSplitFactory.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamSplitFactory.sol);
+- [`StreamSplitWallet.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamSplitWallet.sol);
+- [`StreamAssetPolicyRegistry.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamAssetPolicyRegistry.sol);
+- [`StreamPrimarySaleSettlement.sol`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamPrimarySaleSettlement.sol).
+
+The native Drop and Auction paths do not call this foundation, and the
+rehearsal configures no settlement caller. Current sale credits, resolver and
+split-wallet accounting, and fixed Core royalties remain parallel lanes.
+[Revenue, Splits, and Royalties](./revenue-splits-and-royalties) explains their
+behavior.
+
+## Source-implemented systems
+
+These systems exist in Solidity. Source presence does not mean the rehearsal or
+a production candidate uses them.
+
+| System                              | What exists in source                                                                                                                               | What is not yet established for the candidate                                                                                         |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Governance V2                       | Role registry, delayed executor, cancellation, expiry, guardian veto, selector freezes, action classes, and one-way bootstrap sealing.              | Inclusion in the rehearsal; exact target catalog, roles, parameters, and cutover evidence.                                            |
+| Module and successor registry       | Module identities, code hashes, interfaces, status, and explicit successor relationships.                                                           | A complete candidate module graph and continuity evidence.                                                                            |
+| Artwork finality                    | Delayed scheduling, cancellation or veto, component manifests, and terminal state.                                                                  | Inclusion in the rehearsal; complete payload binding and terminal-writer proof.                                                       |
+| Record-family authorization         | Exact metadata and preservation record-type classes with checks for writer class, collection, and subject.                                          | Admissions, provider addresses, grants, runtime hashes, rotation and revocation evidence, and independent review.                     |
+| Raise-only governed parameters      | Delayed, strictly higher, maximum-2x changes with no lowering or emergency mutation path.                                                           | A complete candidate parameter catalog and proposal-to-execution binding.                                                             |
+| Collection metadata snapshots       | Immutable snapshot records with exact covered record types and fresh authority checks.                                                              | Exact candidate record admissions and writers.                                                                                         |
+| Mint gates and durable counters     | Gate lifecycle, interface, code hash, metadata hash, gas limit, authorizer, quantity, and counter-scope binding.                                     | Use by the current signed Drop; support for nonempty nullifier arrays, which the manager and ledger reject.                           |
+| Prepared mint execution             | Manager policy and counter validation followed by atomic Core prepare and complete entries.                                                         | Use by the current signed Drop, which takes the legacy Core route.                                                                     |
+| Randomness lifecycle                | Pending, fulfilled, stale, and failed-post-processing states; provider and epoch binding; one derived seed; same-seed retries.                      | Live provider configuration, funding, callbacks, monitoring, stale policy, and recovery evidence.                                    |
+| Metadata rendering and dependencies | Onchain and offchain modes, scripts, token data, dependency versions, images, attributes, and mutation-triggered ERC-4906 refresh events.           | Public-RPC, marketplace, browser, maximum-response, and long-term retrieval evidence.                                                  |
+
+[Governance, Pausing, and Successors](./governance-pausing-and-successors) and
+[Roles and Trust](./roles-and-trust) explain the authority systems in detail.
+
+## Accepted targets not yet implemented
+
+An accepted target is a committed architecture direction, not code that can be
+credited to this candidate.
+
+### Revenue-resolver validation adapter
+
+The accepted revenue architecture adds one immutable, exact-code,
+implementation-private validation adapter to resolver write paths. The adapter
+owns no state, authority, roles, funds, or events and may make only approved
+caller-insensitive, read-only calls to pinned dependencies.
+
+The registered resolver stays the sole state owner, writer, Core royalty
+pointer target, and normative event emitter. It authenticates the request,
+checks adapter and dependency identities, validates the complete answer, and
+only then changes state. The Core-facing royalty read uses resolver storage and
+pure computation rather than calling the adapter.
+
+The boundary fails closed: revert, out-of-gas, changed code hash, or malformed
+output stops the write before lasting state change. Recovery requires a new
+resolver, continuity proof, Registry V2 registration, and governed Core-pointer
+replacement.
+
+Complete conforming resolver and adapter source are not present at this commit.
+Implementation remains gated on an independently approved normative interface
+appendix and freeze commit.
+
+### Satellite-triggered metadata refresh
+
+Core currently emits ERC-4906 refresh events during its own mutations. The
+accepted target adds restricted single-token and batch helpers so authorized
+satellite contracts can emit standard refresh signals with Stream-native
+context.
+
+No such public or external helper exists in the reviewed Solidity. Caller
+checks, lifecycle and range bounds, context binding, abuse analysis,
+implementation, and tests remain outstanding. [Metadata, Scripts, and
+Dependencies](./metadata-scripts-and-dependencies#refresh-events-tell-consumers-that-state-changed)
+explains the present events and target.
+
+### Genesis role inventory
+
+Release artifacts describe a thirty-seven-role genesis inventory. It is an
+architecture requirement and review target, not a concrete deployment
+manifest. The candidate must bind every role to exact accounts, contracts,
+selectors, scopes, delays, and revocation conditions.
+
+## Proposed or deferred work
+
+The following items are review input, not protection this candidate supplies:
+
+| Area                                  | Position                                                                                                                                                                                                                                                       |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Artist-registry validation adapter    | ADR 0022 proposes an immutable, stateless, unregistered validation adapter while the registry remains the sole authority and state owner. The ADR authorizes no implementation.                                                                                |
+| Payer-bound ERC-20 orchestration      | A sale adapter would verify a payer-signed `PaymentIntent` and alone pull allowance; settlement would record and route the value without pulling the payer. The verifier and top-level path do not exist.                                                     |
+| Batch operation-root replay ownership | ADR 0018 proposes making the ledger the durable batch replay owner and joining ledger accounting to per-token prepared-mint events. It is not accepted or implemented.                                                                                         |
+| Stale-randomness recovery             | A proposal would add an objective delay and one bounded recovery transition. The current stale state is terminal for that token.                                                                                                                               |
+| Append-only artwork-finality recovery | ADR 0020 proposes a companion that preserves the original finality record and appends a governed recovery lineage. It is not accepted or implemented.                                                                                                         |
+| Broader artist authority and recovery | Collaborators, delegated roles, guardians, estate instructions, sanctions, disputes, and recovery remain broader design work rather than a complete production artist registry.                                                                              |
+| Additional sale profiles              | Dutch auctions, private sales, refund windows, sealed bids, raffles, burn-to-mint, ERC-20 bidding, and other profiles are proposed or deferred unless present in reviewed source and tests.                                                                    |
+| `RandomizerNXT` production use        | The source remains in the repository, but reviewed release policy does not approve it as a production provider.                                                                                                                                               |
+
+No topical explanation should present these items as current protection.
+
+## Evidence available today
+
+The repository contains:
+
+- unit tests;
+- fuzz tests;
+- invariant tests;
+- state-machine tests;
+- adversarial multi-contract composition tests;
+- focused tests for EIP-712, auction timing, mint accounting, burn behavior,
+  metadata events, randomness states and retries, governance, and preservation.
+
+The generated Technical Reference compiles the complete Solidity corpus at the
+pinned commit and inventories protocol contracts, interfaces, libraries, test
+contracts, deployment scripts, definitions, functions, events, errors,
+signatures, selectors, and source ranges.
+
+That is substantial engineering evidence. It does not rule out:
+
+- a missing assertion or untested composition;
+- a wrong specification implemented and tested consistently;
+- deployment or initialization mistakes;
+- live-provider differences;
+- economic attacks;
+- key-management failure;
+- long-term storage, browser, RPC, or marketplace failure.
+
+Tests of two mint lanes do not create a signed-Drop-to-MintManager integration
+that the rehearsal lacks. Tests of individual revenue contracts do not create
+one unified settlement path.
+
+## Static analysis
+
+The pinned
+[`SLITHER_BASELINE.json`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/ops/SLITHER_BASELINE.json)
+contains `30` open High or Medium findings: `3` High and `27` Medium.
+
+The count alone does not prove exploitability, and static analyzers produce
+false positives. It does prove the candidate is not static-analysis clean.
+Every finding needs one of:
+
+- a source-backed fix and regression test;
+- a demonstrated false-positive analysis;
+- an explicit accepted-risk decision with scope and owner;
+- removal from the release surface.
+
+The final register should retain tool version, configuration, raw output,
+normalization rules, source commit, and disposition evidence.
+
+## Known limitations and unresolved blockers
+
+This is the central status register. Linked topical pages provide the fuller
+behavioral explanation.
+
+| Area                            | Current limitation                                                                                                                                                                                                                       | Detailed explanation                                                                                                                                                                                                                             |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Zero-mint final supply          | `setFinalSupply` stores `0` when no token has minted; `setCollectionData` also treats `0` as uninitialized, so an unfrozen collection can receive a new nonzero cap and minting can reopen. There is no separate final-supply flag or event. | [Final supply](./freezing-preservation-and-artwork-finality#final-supply-is-a-supply-promise)                                                                                                                                                     |
+| Core bytecode margin            | The pinned proof records `StreamCore` deployed bytecode at `24,152` bytes: `424` bytes below EIP-170. It passes the interim `384`-byte margin by `40` bytes but misses the normative `2,000`-byte margin by `1,576` bytes.               | [Contract bytecode size](#contract-bytecode-size)                                                                                                                                                                                                |
+| Governance record families      | `RISK-GOV-002` remains open for candidate admissions, providers, grants, runtime bindings, rotation and revocation evidence, and independent review.                                                                                      | [Record-family authorization](./roles-and-trust#record-family-authorization)                                                                                                                                                                     |
+| Governance native value         | `RISK-GOV-003` records that executor native-value authority is too broad or insufficiently constrained.                                                                                                                                  | [Native-value authority](./governance-pausing-and-successors#native-value-authority)                                                                                                                                                             |
+| Governed parameter binding      | `RISK-GOV-004` records incomplete end-to-end evidence that every governed action binds every sensitive parameter.                                                                                                                        | [Governed parameter binding](./governance-pausing-and-successors#governed-parameter-binding)                                                                                                                                                     |
+| Parallel mint lanes             | Signed Drops and the current auction use legacy `StreamMinter`; manager and ledger behavior is separate.                                                                                                                                 | [The two source mint lanes](./tokens-collections-and-minting#the-two-source-mint-lanes)                                                                                                                                                          |
+| Parallel accounting lanes       | Drop, Auction, curator pool, resolver, split wallet, settlement, and fixed Core royalty accounting are not one unified value path or ledger.                                                                                             | [One accountable value path](./revenue-splits-and-royalties#one-wei-should-have-one-accountable-path)                                                                                                                                            |
+| Auction terms                   | Bid-increment percentage and extension time are mutable globals, not per-auction snapshots. They have no bound, delay, or change event and can change during active auctions.                                                            | [Minimum next bid](./fixed-price-sales-and-auctions#the-minimum-next-bid-is-exact) and [anti-sniping](./fixed-price-sales-and-auctions#anti-sniping-needs-a-reproducible-clock-rule)                                                           |
+| Manager nullifiers              | The gate interface defines nullifiers, but the manager and ledger reject every nonempty nullifier array.                                                                                                                                 | [Gate security inputs](./tokens-collections-and-minting#gates-carry-security-inputs-not-descriptive-metadata)                                                                                                                                    |
+| Manager replay ownership        | The manager derives a batch root and token operation IDs after consuming ledger state, while the ledger does not store the root and Core retains an unbounded lifetime token-operation mapping.                                          | [Durable replay ownership](./tokens-collections-and-minting#replay-protection-needs-one-durable-owner)                                                                                                                                           |
+| Randomness stale state          | An authorized admin can mark a newly pending request stale without an onchain elapsed-time check. `Stale` is terminal and prevents another request for that token.                                                                       | [Current stale state](./randomness#the-current-stale-state-is-immediate-and-terminal)                                                                                                                                                            |
+| Randomness provider replacement | A `FailedPostProcessing` request no longer counts as pending, so the provider can be replaced before retry; old provider or epoch checks then reject that retry.                                                                         | [Provider migration](./randomness#provider-migration-is-prospective-not-retroactive-recovery)                                                                                                                                                    |
+| Randomness providers            | Live subscription or controller funding, callbacks, permissions, stale policy, monitoring, and raw-word retrieval are not proven by mocks. `RandomizerNXT` is not approved for production use.                                           | [Provider trust models](./randomness#two-providers-do-not-mean-one-trust-model)                                                                                                                                                                  |
+| Shared collection identity      | A Stream collection has no separate ERC-721 contract address. Marketplace and indexer handling of Core-native collection identity remains a non-local launch gate. There is no dormant per-collection facade in this Core.               | [One permanent identity surface](./tokens-collections-and-minting#one-permanent-identity-surface-for-many-collections)                                                                                                                           |
+| Metadata refresh                | Mutation-triggered Core events exist, but the accepted satellite-callable helper does not. The current collection batch refresh deliberately covers a superset of globally interleaved token IDs.                                      | [Refresh events](./metadata-scripts-and-dependencies#refresh-events-tell-consumers-that-state-changed)                                                                                                                                           |
+| Metadata and RPC size           | Local acceptance of long strings or token URIs does not prove that public RPCs, wallets, indexers, or marketplaces process the result.                                                                                                  | [Size limits](./metadata-scripts-and-dependencies#size-limits-protect-more-than-gas)                                                                                                                                                             |
+| Artwork finality                | Scheduling and veto mechanisms exist in source, but complete payload binding and the terminal selector and writer inventory are not proven for a candidate.                                                                             | [Delayed finality](./freezing-preservation-and-artwork-finality#terminal-finality-is-delayed-for-a-reason) and [terminal writers](./freezing-preservation-and-artwork-finality#terminal-means-every-effective-writer-is-accounted-for)          |
+| Preservation availability       | A valid content hash proves equality after retrieval; it does not keep bytes, dependencies, browser, RPC, or rendering environment available. Independent package recovery has not been demonstrated.                                    | [Append-only preservation history](./freezing-preservation-and-artwork-finality#preservation-records-keep-history-append-only)                                                                                                                   |
+
+## Contract bytecode size
+
+The pinned
+[`bytecode release proof`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/release-artifacts/latest/bytecode-release-proof.json)
+records the exact Core measurement above. The narrow margin matters because a
+small source or compiler change can cross the chain limit, emergency fixes
+become harder, and optimizer and metadata settings affect the result.
+"Deploys today" is not the same as a durable engineering margin.
+
+The accepted revenue architecture also sets future limits for the resolver and
+adapter: each must be no more than `22,576` bytes of deployed runtime and
+`47,152` bytes of full initcode, including constructor arguments. Those limits
+retain a `2,000`-byte margin under EIP-170 and EIP-3860 respectively.
+
+Neither accepted future contract is implemented at this commit. Only a final,
+canonical isolated build can provide release evidence; issue-worktree and
+aggregate-build measurements are diagnostic.
+
+## Candidate-bound evidence still required
+
+The release needs a generated, machine-readable manifest containing:
+
+- exact source and artifact hashes;
+- compiler and optimizer settings;
+- chain, addresses, creation transactions, and runtime code hashes;
+- constructor and initializer arguments;
+- Core pointers and the complete module graph;
+- role holders, scopes, signer addresses, and signer epochs;
+- record-family admissions, authority providers, and grants;
+- governed parameters and action classes;
+- pause, unpause, and guardian configuration;
+- randomness providers, accounts, funding, callbacks, and monitoring;
+- revenue, settlement, split, royalty, and liability paths;
+- ownership transfers, renunciations, and one-way bootstrap sealing;
+- explorer verification;
+- independent readback of every critical invariant.
+
+A local deployment script does not prove a live deployment is correct. Someone
+other than the deployer must be able to reconstruct and verify the ceremony
+without trusting private notes.
+
+The staging review resolves to Wave
+`19d4bbf5-86ec-4053-a5f2-bb28d7a2f780`, titled **Stream review (staging)**.
+That is the verified staging-only destination.
+
+The user-designated future production destination is Wave
+`06e69198-eea7-40c5-95d3-7c1bf5051aba`. It is an intended mapping only.
+Production review routes remain disabled, and this staging release neither
+enables nor mutates that destination. Any future production activation must
+bind this exact Wave through reviewed environment configuration and
+independently read the mapping back before accepting feedback.
+
+## Non-local evidence still required
+
+The candidate lacks complete evidence for:
+
+- fork or public-testnet execution against intended infrastructure;
+- live VRF and arRNG requests and callbacks;
+- production-style signing and ERC-1271 contract-wallet verification;
+- marketplace handling of shared identity, metadata, and royalties;
+- public-RPC handling of maximum token URI responses;
+- independent retrieval and reconstruction of preservation packages;
+- long-duration auction operation and failure recovery;
+- signer and authority-provider rotation and revocation;
+- successor discovery and continuity readback.
+
+Mocks make tests deterministic. They cannot reproduce live service limits,
+permissions, latency, billing, availability, or operational failure.
+
+## External audit
+
+There is no completed independent audit and remediation record for this
+candidate. Community review can improve the specification and find serious
+issues, but it does not replace expert audit.
+
+The audit must cover the exact release candidate and deployment configuration,
+not an earlier design branch. A material post-audit change needs an explicit
+delta review. Findings need source-backed dispositions, fix commits, regression
+evidence, and a record of remaining risk.
+
+## Release blockers
+
+Production must remain blocked until, at minimum:
+
+- all High findings and every material Medium finding are fixed or formally
+  resolved;
+- the zero-mint final-supply promise is repaired or accurately redefined;
+- governance record-family authorization and action binding are proven;
+- native-value executor authority is constrained and tested;
+- the chosen signed-sale mint lane is explicit and its callers, counters,
+  replay state, and Core entry are tested end to end;
+- native Drop and Auction accounting is deliberately retained or replaced by
+  resolver and settlement integration, with no ambiguous parallel path;
+- fixed Core royalties are deliberately retained or replaced by the accepted
+  resolver-backed target, with marketplace behavior verified;
+- Core meets the adopted bytecode margin or the design is deliberately revised;
+- the accepted revenue-adapter architecture has an independently approved
+  interface freeze, reconciled specification, conforming implementation,
+  independent review, per-contract size proof, and adapter-first deployment
+  evidence;
+- each production randomness provider has candidate-bound non-local evidence
+  and a reviewed stale and failure policy;
+- the finality payload and every terminal writer are proven bound;
+- deployment, bootstrap, rollback, and successor-cutover ceremonies are
+  rehearsed and independently read back;
+- preservation packages are independently recovered using only published
+  instructions and commitments;
+- any future production review activation binds and independently verifies the
+  designated production feedback Wave without reusing the staging destination;
+- external audit and remediation are complete;
+- the final public review version matches the deployment commit and
+  configuration exactly.
+
+Public review may add blockers. Removing one requires evidence of resolution,
+not a more reassuring label.
+
+## Threat model
+
+The protocol must assume:
+
+- malicious buyers, bidders, recipients, and contract wallets;
+- compromised or mistaken privileged accounts;
+- stale, replayed, or partly bound signatures;
+- unavailable or adversarial randomness infrastructure;
+- hostile ETH and token recipients, reentrancy, and forced value;
+- malformed metadata and very large return values;
+- registries or modules configured in the wrong order;
+- front-running, chain reorganizations, timestamp variation, and censorship;
+- disappearing storage, RPC, browser, marketplace, and indexing services;
+- governance descriptions that differ from executable bytes.
+
+Honest mistakes belong in the model too. An artist can approve the wrong
+manifest, an operator can select the wrong address, or governance can bind an
+incomplete payload. No attacker is required for permanent damage.
+
+## Review priorities
+
+### Economic and accounting review
+
+Reconstruct every liability across sales, auctions, refunds, randomness
+reserves, split wallets, settlement, and emergency surplus. Prove:
+
+- credits never exceed received value;
+- the same funds are not promised twice;
+- rounding dust has an explicit owner;
+- reverting recipients cannot block unrelated users;
+- emergency withdrawal excludes every liability;
+- successor cutover cannot duplicate or abandon balances;
+- contract wallets and self-referential recipients do not break accounting.
+
+Invariant tests should combine sale, bid, refund, withdrawal, pause, burn, and
+successor sequences.
+
+### Signature review
+
+Each signed action should bind chain, verifying contract, action type,
+collection, relevant participants, economic terms, quantity, replay identity,
+signer epoch, and deadline.
+
+Compare the readable UI, typed-data payload, Solidity type hash, recovered
+signer, replay storage, and emitted event. A value missing from one layer can
+let the user approve one action while the contract executes another.
+
+### Metadata and preservation review
+
+Security includes the artwork experience. Test malformed strings, untrusted
+HTML and JavaScript, oversized responses, missing dependencies, wrong hashes,
+unavailable storage, and future browser behavior.
+
+The contracts can remain secure while the artwork becomes unavailable. Release
+criteria need both smart-contract security and preservation evidence.
+
+## Public findings
+
+The configured disclosure policy permits possible exploitable vulnerabilities
+to be reported in the public review Wave while the candidate remains in its
+validated predeployment state. That permission comes from explicit review state
+and policy, not merely the absence of a deployment.
+
+[How to participate in the community
+review](./community-review#public-conduct-and-sensitive-information) contains
+the reporting and sensitive-information rules. Each substantive disposition
+should link a source commit, test, or documented decision. A status label
+without evidence is not a resolution.
+
+## Design position
+
+Stream is ambitious because the problem is ambitious: preserve artistic intent
+and token identity while sale infrastructure, randomness providers, metadata
+services, governance, and other replaceable systems survive change.
+
+That sophistication demands an exact readiness ledger. It is not suspect by
+default, and local source or tests are not enough by themselves. The right
+questions are whether each mechanism protects a real requirement, whether its
+authority is bounded, and whether an independent party can reconstruct the
+complete system.
+
+The release standard is evidence, not confidence.
+
+## Questions for reviewers
+
+1. Does the implementation-state inventory classify any component too strongly?
+2. Does the threat model omit an actor, asset, trust boundary, or failure mode?
+3. Which current static-analysis findings become exploitable in composition?
+4. Is the adopted Core bytecode margin adequate for a permanent contract?
+5. Which governance paths still lack complete parameter or record-family
+   binding?
+6. What non-local evidence must exist before audit and before deployment?
+7. Which properties need independent economic or formal verification?
+8. Which accepted target is essential for genesis, and which can safely move to
+   an explicit successor without weakening the permanent artwork promise?

--- a/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/tokens-collections-and-minting.md
+++ b/content/public-reviews/6529-stream/versions/2026-07-28.1/editorial/tokens-collections-and-minting.md
@@ -1,0 +1,377 @@
+# Tokens, collections, and minting
+
+Stream’s minting system gives each artwork a permanent identity while allowing
+different distribution rules around it. The permanent Core token contract
+records the token and collection. Minting modules decide whether a particular
+mint is allowed. Durable accounting is meant to remember limits and prevent
+reuse of old operations even when those modules change.
+
+Consider a five-work edition. The first successful mint receives a global Stream
+token ID and serial `1` inside the artist’s collection. Later mints receive new
+global IDs and collection serials `2` through `5`. If token `2` is burned, its
+ownership ends, but its ID, serial, and mint history are not reused. When the
+collection closes, no sale path or replacement minter should be able to create a
+sixth work.
+
+That simple story requires several facts to agree: collection identity, minted-
+ever supply, live supply, phase limits, wallet or recipient limits, replay
+state, burn history, and final closure.
+
+## Why minting has more than one component
+
+A minimal ERC-721 can assign a token ID to an owner. Stream is trying to protect
+more:
+
+- which collection the token belongs to;
+- its serial within that collection;
+- how many works may ever exist;
+- which distribution policy admitted the mint;
+- which limits the mint consumed;
+- what history survives a burn or module replacement.
+
+Putting every allowlist, sale, airdrop, gate, and future distribution rule in
+the permanent Core would make Core harder to keep small and stable. Keeping all
+of those rules in a website would make supply and eligibility depend on a
+private database. Stream instead separates permanent identity, replaceable
+policy, and durable accounting.
+
+The key security condition is straightforward: no module may exceed Core
+supply, rewrite identity, bypass freeze, discard lifetime limits, or replay an
+old operation.
+
+## What this protects—and what remains unresolved
+
+The architecture is intended to preserve:
+
+- one permanent identity for every token and collection;
+- distinct minted-ever and live-supply histories;
+- explicit phase, wallet, recipient, and authorization limits;
+- atomic execution across policy, counters, and Core;
+- replay evidence that survives module replacement;
+- burn history without token-ID reuse.
+
+The pinned candidate does not yet present one clean launch lane. Signed Drops
+and the current auction use the legacy minter, while the separately connected
+manager and ledger implement the newer phase-and-counter design. Replay
+ownership in the manager lane is also split between the ledger and Core, and
+zero-mint finalization has a current defect. These are unresolved complexity,
+not benefits to defend.
+
+## One permanent identity surface for many collections
+
+The reviewed Core stores many native collections in one shared ERC-721
+contract. Token IDs are globally sequential. Core also records a
+collection-local serial, so an artwork can be identified both as a global
+Stream token and as an item within its artist collection.
+
+This avoids reconstructing collection membership from a private index and gives
+all Stream works one permanent surface for ownership, approvals, transfers,
+identity reads, and shared invariants.
+
+The tradeoff is real. A Core defect or governance failure can affect many
+collections, and an artist’s collection does not receive its own ERC-721
+contract address. Ethereum has no native subcollection identity standard, so
+address-only marketplaces may show one Stream contract rather than one contract
+per artist.
+
+The accepted design addresses presentation through Core collection reads,
+per-collection metadata, and `properties.stream.collection` fields in token
+JSON. Marketplace and indexer support still needs external evidence. The launch
+Core has no dormant facade that can later turn each collection into a separate
+ERC-721 address. See the accepted
+[`collection identity decision`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/docs/adr/0015-collection-identity-and-facade-readiness.md#L21-L66)
+and
+[`Core-native-only decision`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/docs/adr/0016-core-native-only-erc721.md#L27-L50).
+
+## Supply is several facts, not one number
+
+Stream distinguishes:
+
+- configured maximum supply;
+- tokens minted over the collection’s lifetime;
+- live supply after burns;
+- final supply;
+- remaining capacity in a phase or authorization.
+
+These answer different questions. Burning changes live supply, but it does not
+erase mint history, make a token ID reusable, or necessarily restore a lifetime
+mint allowance. A collection cap does not reveal whether a phase, wallet,
+recipient, or signed authorization still has capacity.
+
+A design that stores only the current token count is shorter until a burn is
+mistaken for permission to mint again, a new minter forgets earlier usage, or
+two distribution paths each believe they own the same remaining supply.
+
+## Why mint policy lives outside the Core
+
+Core should enforce rules every mint path must respect: token and collection
+identity, supply, freeze state, and non-reuse of permanent operation IDs. It
+should not permanently embed every future eligibility mechanism.
+
+The newer manager-and-ledger design separates:
+
+- **Core**, which allocates and records permanent token identity;
+- **StreamMintManager**, which applies phase and execution policy;
+- **StreamMintLedger**, which retains durable usage and replay accounting;
+- **executors**, which drive approved mint paths; and
+- **gates**, which evaluate additional eligibility policy.
+
+This lets distribution methods evolve without changing what an existing token
+is. It is deliberate modularity, but only if the boundaries remain coherent.
+
+## The two source mint lanes
+
+The pinned source contains two different lanes. They are not one integrated
+flow.
+
+The signed Drop and current auction route use the legacy
+[`StreamMinter`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMinter.sol).
+It applies its own collection time and supply checks before calling the legacy
+Core mint entry. It does not consume `StreamMintLedger` counters.
+
+The separately deployed
+[`StreamMintManager`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMintManager.sol)
+and
+[`StreamMintLedger`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMintLedger.sol)
+implement phases, gates, policy hashes, durable counters, and prepared Core
+execution. The rehearsal installs the manager in Core and authorizes it as a
+ledger writer, but still gives the legacy minter to `StreamDrops`.
+
+The difference is visible in
+[`StreamDrops._executeFixedPriceDrop`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L609-L632),
+[`StreamMinter.mint`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMinter.sol#L130-L175),
+[`StreamMintManager.mintPrepared`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMintManager.sol#L241-L299),
+and the
+[`rehearsal wiring`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/script/RehearseDeployment.s.sol#L218-L269).
+
+Parallel lanes are current candidate state that must be reconciled into one
+explicit launch path. The lasting design value is the separation between
+permanent identity and replaceable distribution policy—not the duplication.
+
+## Phases make distribution policy inspectable
+
+A manager phase can bind:
+
+- collection and phase identity;
+- opening and closing time;
+- maximum phase supply;
+- per-wallet, per-recipient, or other scoped limits;
+- an executor and optional gate;
+- a policy hash;
+- whether the phase is paused;
+- counters consumed by each mint.
+
+“Eligible to mint” is not one universal rule. A one-of-one sale, fixed edition,
+free claim, allowlist, and airdrop can need different timing and accounting
+without changing ERC-721 Core.
+
+Before a user acts, the public view should show the phase identifier and
+collection, time window, maximum supply, scoped limits, executor, optional gate,
+burn and transfer effects on counters, edit and pause authority, and what
+happens to pending work when the phase closes.
+
+An extension point is not proof that every possible policy is safe. Genesis
+still needs an explicit list of supported and tested distribution profiles.
+
+## Gates carry security inputs, not descriptive metadata
+
+An active gate registration binds lifecycle status, interface ID, semantic
+version, runtime code hash, metadata hash, and a per-call gas limit. The
+registry rechecks active status, interface support, and code identity.
+
+A gate result can include:
+
+- an **authorization ID**, intended as a one-use identifier;
+- **nullifiers**, intended as domain-separated replay keys;
+- an **authorizer**, whose identity or entitlement was accepted;
+- a **maximum quantity**;
+- a **gate hash** committing to the result and policy context.
+
+The current ledger scopes an authorization ID to the calling mint manager and
+rejects a second consumption by that manager. The current manager and ledger
+reject every nonempty nullifier array, so this candidate does not yet support
+nullifier-backed gates. A `bytes32[]` interface would not provide privacy by
+itself.
+
+The gate hash improves auditability but does not prove that an offchain
+eligibility process was correct. Reviewers must still trace external calls,
+return values, code-hash checks, reentrancy boundaries, and rollback. Moving
+code outside Core does not make it harmless.
+
+See
+[`StreamMintModuleRegistry`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamMintModuleRegistry.sol#L9-L100)
+and
+[`IStreamMintGate`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/IStreamMintGate.sol#L6-L29).
+
+## Durable counters survive more than one transaction
+
+`StreamMintLedger` can apply counters to wallets, recipients, tokens, contexts,
+or other keys. The distinctions matter:
+
+- A payer limit is not a recipient limit when sponsored mints are possible.
+- A live-balance limit is not a minted-ever limit.
+- A burn should not automatically restore a lifetime allowance.
+- A reverted mint should not permanently consume capacity.
+- Replacing the mint manager should not erase historical usage.
+
+Website-only counters require trust that the website applies them consistently.
+Counters stored only in one replaceable minter can reset during cutover. A
+separate durable ledger makes continuity an explicit protocol responsibility.
+
+## Prepared execution keeps cross-module state atomic
+
+The manager lane crosses policy, counters, identity, and mint state. It uses this
+sequence:
+
+1. validate the request and phase policy;
+2. consume the required ledger counters;
+3. derive a batch operation root and per-token operation IDs;
+4. prepare identity in Core;
+5. complete the mint in Core;
+6. emit execution evidence.
+
+Preparation and completion happen in one transaction. A revert rolls back the
+transaction instead of leaving a long-lived half-mint. Core also has a
+manager-only abort hook for the most recently prepared allocation, although
+current `mintPrepared` relies on atomic rollback rather than calling it.
+
+The invariant is:
+
+> After any revert, every supply reservation, replay identifier, counter,
+> payment credit, and pending token state is either fully committed or fully
+> restored.
+
+A direct call does not remove this coordination problem when policy, accounting,
+and identity live in different modules. It can only make partial execution
+harder to see.
+
+## Replay protection needs one durable owner
+
+Core retains lifetime operation-ID replay state so an old prepared operation
+cannot be accepted again.
+
+The current manager derives one batch operation root and distinct token
+operation IDs, but consumes the ledger before deriving that root. The ledger
+does not store the root or token operation ID, while Core retains an unbounded
+lifetime mapping of prepared-token operation IDs.
+
+A proposed repair would make the ledger the durable batch-replay owner and
+provide an exact join between ledger accounting and prepared-token events. It
+is not accepted or implemented. See
+[`ADR 0018`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/docs/adr/0018-batch-operation-root-and-token-identity.md#L3-L33).
+
+This is complexity to reduce: one invariant should have one unambiguous owner.
+
+## Editions and signed Drop quantity
+
+Shared Core can represent a one-of-one, fixed edition, or larger collection by
+minting distinct ERC-721 tokens into one collection.
+
+That does not make the current signed Drop a batch path. `DropAuthorization`
+contains `quantity`, but
+[`StreamDrops._validateAuthorization`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L561-L581)
+requires `quantity == 1`. The fixed-price path builds one-element arrays and
+mints one token through
+[`_executeFixedPriceDrop`](https://github.com/6529-Collections/6529Stream/blob/513bd7e079eafe109df6ae1ae21bfbca6fec6786/smart-contracts/StreamDrops.sol#L609-L632).
+
+An edition can still have many tokens, but this lane needs one authorization per
+token. The manager lane has different quantity and batch rules. Documentation
+and interfaces must name the lane instead of implying that the signed field
+currently enables a batch.
+
+## Every minted token receives durable identity
+
+On successful allocation, a token receives:
+
+- a global token ID;
+- a collection ID;
+- a collection-local serial;
+- an owner;
+- mint history and, where supplied by the selected lane, operation identity;
+- metadata and randomness state required by the collection.
+
+Event reconstruction must be checked separately for each mint lane. A third
+party should be able to distinguish a legacy mint from a prepared manager mint
+and rebuild collection creation, allocation, transfer, burn, and finality from
+public state and events.
+
+## Burning ends ownership, not history
+
+Burn removes ERC-721 ownership and ordinary token behavior. Core retains burn
+audit reads, and the token ID is never minted again.
+
+“Nonexistent” and “burned” are therefore different historical states. Other
+modules still need explicit rules for pending randomness, unsettled sale or
+credit state, metadata and preservation evidence, supply finalization, curator
+or revenue accounting, artwork finality, and offchain indexes.
+
+The repository includes Core burn, randomness, metadata, and supply-invariant
+tests. Cross-module burn composition remains a critical review area.
+
+## Mint closure must close every lane
+
+For a collection with at least one mint, `setFinalSupply` lowers the configured
+cap to minted-ever supply. The zero-mint case has a current defect: `0` also
+means uninitialized supply to `setCollectionData`, so a function administrator
+can later set a nonzero cap while the collection remains unfrozen.
+
+There is no separate final-supply flag or event in the pinned candidate. A
+zero-minted, unfrozen collection can therefore reopen after `setFinalSupply`.
+See [Freezing, preservation, and artwork
+finality](./freezing-preservation-and-artwork-finality#final-supply-is-a-supply-promise).
+
+Any closure repair should prove that:
+
+- finalization is monotonic even when minted-ever supply is zero;
+- every phase and executor is closed or exhausted;
+- signed Drops and auctions cannot mint later;
+- no successor module can bypass the final state;
+- any required delay has elapsed;
+- an event records the final value;
+- authorizations prepared before finalization have defined behavior.
+
+## What a simpler design would externalize
+
+Removing the manager, ledger, gates, operation IDs, or collection-local identity
+does not automatically remove the requirements. It can make a website
+responsible for deciding eligibility, remembering lifetime limits,
+distinguishing payer from recipient, preventing replay, coordinating supply
+across sales, retaining burn and replacement history, and explaining which
+collection a shared-contract token belongs to.
+
+That tradeoff may be acceptable for a disposable mint page. It is a larger
+trust assumption for a protocol intended to carry valuable artworks for
+decades.
+
+The right simplification test is precise: identify the requirement that can be
+dropped, or show a smaller mechanism that preserves it. Complexity that
+duplicates ownership of one invariant should be removed. Complexity that makes
+a lasting promise explicit should be judged against the risk it replaces.
+
+## What can fail
+
+- Two mint lanes enforce different supply or replay assumptions.
+- Overlapping phases exceed intended supply.
+- Payer and recipient counters are confused.
+- A gate reenters or returns ambiguous data.
+- A manager transaction leaves counters and token state inconsistent.
+- A replay identifier is consumed too early or too late.
+- Burning restores an allowance unintentionally.
+- Manager replacement loses durable limits.
+- Final supply is recorded while another mint path remains open.
+
+## Questions for reviewers
+
+1. Which identity and mint invariants must remain in the permanent Core?
+2. Are global token IDs plus collection-local serials the right shared identity
+   model?
+3. Which genesis distribution profiles actually require onchain phases, gates,
+   and counters?
+4. Do counters handle sponsored mints, transfers, burns, and manager succession
+   correctly?
+5. Can every partial execution return all affected modules to a clean state?
+6. Which single component should own lifetime replay evidence?
+7. Is the long-term storage cost of durable counters and operation IDs justified
+   by the guarantees they preserve?
+8. Does the final launch path remove ambiguity between the legacy and manager
+   mint lanes?


### PR DESCRIPTION
## Issue

The staging artifact packager requires the immutable `2026-07-28.1` editorial manifest to exist in the trusted base before the independently generated Solidity snapshot and activation changes can land. Review-bot feedback also identified eight places where the prose needed tighter alignment with the pinned Solidity behavior.

## Fix

Preload the 15-file Stream review editorial directory for version `2026-07-28.1`, then apply source-verified accuracy corrections within that directory before publication.

## Changes

- Adds the complete 14-page plain-language editorial corpus and manifest for the new review version.
- Makes payer, recipient, price, and auction semantics explicitly sale-mode-specific.
- Corrects the legacy Drop lane, typed-payload currency boundary, and mint-before-auction-registration descriptions.
- Makes governance binding gaps, randomness retry constraints, active revenue wiring, and signer evidence requirements explicit.
- Makes no runtime, route, component, configuration, or generated snapshot changes.

## Validation

- Verified the PR contains exactly 15 files under the versioned editorial directory; the accuracy follow-up modifies 7 Markdown files only.
- Ran `seize run public-review:check`; verified both retained review versions, 420 active definitions, and 206 active source files offline.
- Verified manifest version, source provenance, 14 unique pages, file topology, and page headings.
- Verified every internal editorial page and rendered H2 fragment, plus the `/network/tdh` route link.
- Verified all 136 Stream repository links are pinned to the manifest source commit and all 133 blob citations resolve to valid source paths and line ranges.
- Ran `codex-diff-check` on the editorial directory; clean.
- Runtime tests were not run because this PR changes versioned editorial content only and introduces no runtime code path.

## Risk

- Level: Low
- Why: additive, versioned editorial content only; no application or generated snapshot behavior changes.
- Rollback: revert the two commits to remove the preloaded directory and its accuracy corrections.

## Review Notes

- This is the prerequisite for #3500 and #3489.
- All eight CodeRabbit accuracy threads were checked against pinned source commit `513bd7e079eafe109df6ae1ae21bfbca6fec6786` and addressed on the latest head.
- Please focus on source provenance, manifest topology, link integrity, and the corrected sale/governance/randomness/revenue descriptions.