### PR TITLE
fix(public-review): separate snapshot trust from publication

### DIFF
--- a/__tests__/lib/public-review/solidityReferenceData.test.ts
+++ b/__tests__/lib/public-review/solidityReferenceData.test.ts
@@ -3,6 +3,7 @@ jest.mock("next/dist/compiled/server-only", () => ({}), { virtual: true });
 import { existsSync } from "node:fs";
 import path from "node:path";
 
+import streamReferenceConfig from "@/config/public-reviews/6529-stream.reference.json";
 import {
   createSolidityReferenceReader,
   SolidityReferenceNotFoundError,
@@ -17,6 +18,7 @@ import {
 } from "@/lib/public-review/solidityReferenceRoutes";
 import type { SolidityReferenceReviewIdentity } from "@/lib/public-review/solidityReferenceTypes";
 import {
+  isStreamReviewVersionPubliclyAvailable,
   STREAM_REVIEW_DEFINITION,
   STREAM_REVIEW_SLUG,
   STREAM_REVIEW_VERSION,
@@ -36,25 +38,42 @@ if (!hasFixture && process.env["CI"]) {
   throw new Error(`Missing Solidity reference fixture: ${FIXTURE_INDEX}`);
 }
 const describeFixture = hasFixture ? describe : describe.skip;
-const REVIEW_VERSION = STREAM_REVIEW_DEFINITION.versions[0];
-if (!REVIEW_VERSION) {
+const ACTIVE_REVIEW_VERSION = STREAM_REVIEW_DEFINITION.versions.find(
+  ({ version }) => version === STREAM_REVIEW_VERSION
+);
+if (!ACTIVE_REVIEW_VERSION) {
   throw new Error("The Stream review fixture version is missing.");
 }
+const PUBLICLY_AVAILABLE_REVIEW_VERSIONS =
+  STREAM_REVIEW_DEFINITION.versions.filter(({ version }) =>
+    isStreamReviewVersionPubliclyAvailable(version)
+  );
+const REFERENCE_ACTIVE_REVIEW_VERSION =
+  PUBLICLY_AVAILABLE_REVIEW_VERSIONS.find(
+    ({ version }) => version === STREAM_REVIEW_VERSION
+  ) ??
+  PUBLICLY_AVAILABLE_REVIEW_VERSIONS.at(-1) ??
+  ACTIVE_REVIEW_VERSION;
+const SOURCE_COMMITS = Object.fromEntries(
+  STREAM_REVIEW_DEFINITION.versions.map(({ source, version }) => [
+    version,
+    source.commit,
+  ])
+);
+SOURCE_COMMITS[streamReferenceConfig.reviewVersion] =
+  streamReferenceConfig.source.commit;
 
 const IDENTITY: SolidityReferenceReviewIdentity = {
-  activeSourceCommit: REVIEW_VERSION.source.commit,
-  activeVersion: STREAM_REVIEW_VERSION,
-  availableVersions: STREAM_REVIEW_DEFINITION.versions.map(
-    (candidate) => candidate.version
+  activeSourceCommit: REFERENCE_ACTIVE_REVIEW_VERSION.source.commit,
+  activeVersion: REFERENCE_ACTIVE_REVIEW_VERSION.version,
+  availableVersions: PUBLICLY_AVAILABLE_REVIEW_VERSIONS.map(
+    ({ version }) => version
   ),
   reviewId: STREAM_REVIEW_SLUG,
-  sourceCommits: Object.fromEntries(
-    STREAM_REVIEW_DEFINITION.versions.map((candidate) => [
-      candidate.version,
-      candidate.source.commit,
-    ])
-  ),
-  sourceRepository: REVIEW_VERSION.source.repository,
+  sourceCommits: SOURCE_COMMITS,
+  sourceIndexActiveVersion: streamReferenceConfig.reviewVersion,
+  sourceIndexAvailableVersions: streamReferenceConfig.output.retainedVersions,
+  sourceRepository: ACTIVE_REVIEW_VERSION.source.repository,
 };
 
 describe("Solidity reference route identities", () => {
@@ -135,11 +154,15 @@ describeFixture("generated Stream Solidity reference fixture", () => {
       STREAM_REVIEW_VERSION
     );
 
-    expect(index.activeVersion).toBe(STREAM_REVIEW_VERSION);
-    expect(versionEntry.commit).toBe(REVIEW_VERSION.source.commit);
+    expect(index.activeVersion).toBe(streamReferenceConfig.reviewVersion);
+    expect(versionEntry.commit).toBe(
+      REFERENCE_ACTIVE_REVIEW_VERSION.source.commit
+    );
     expect(manifest.reviewId).toBe(STREAM_REVIEW_SLUG);
     expect(manifest.reviewVersion).toBe(STREAM_REVIEW_VERSION);
-    expect(manifest.source.repository).toBe(REVIEW_VERSION.source.repository);
+    expect(manifest.source.repository).toBe(
+      ACTIVE_REVIEW_VERSION.source.repository
+    );
     expect(manifest.summary.definitionCount).toBe(
       manifest.definitionIndex.length
     );

--- a/__tests__/lib/public-review/solidityReferenceIndexValidation.test.ts
+++ b/__tests__/lib/public-review/solidityReferenceIndexValidation.test.ts
@@ -3,8 +3,10 @@ jest.mock("next/dist/compiled/server-only", () => ({}), { virtual: true });
 import { assertSolidityReferenceIndex } from "@/lib/public-review/solidityReferenceValidation.server";
 import type { SolidityReferenceReviewIdentity } from "@/lib/public-review/solidityReferenceTypes";
 
+const HISTORICAL_VERSION = "2026-07-26.1";
 const PUBLIC_VERSION = "2026-07-27.1";
 const DRAFT_VERSION = "2026-07-28.1";
+const HISTORICAL_COMMIT = "9".repeat(40);
 const PUBLIC_COMMIT = "a".repeat(40);
 const DRAFT_COMMIT = "b".repeat(40);
 const BUNDLE_SHA256 = `sha256:${"c".repeat(64)}`;
@@ -12,14 +14,19 @@ const BUNDLE_SHA256 = `sha256:${"c".repeat(64)}`;
 const IDENTITY: SolidityReferenceReviewIdentity = {
   activeSourceCommit: PUBLIC_COMMIT,
   activeVersion: PUBLIC_VERSION,
-  availableVersions: [PUBLIC_VERSION],
+  availableVersions: [PUBLIC_VERSION, HISTORICAL_VERSION],
   reviewId: "6529-stream",
   sourceCommits: {
+    [HISTORICAL_VERSION]: HISTORICAL_COMMIT,
     [PUBLIC_VERSION]: PUBLIC_COMMIT,
     [DRAFT_VERSION]: DRAFT_COMMIT,
   },
   sourceIndexActiveVersion: DRAFT_VERSION,
-  sourceIndexAvailableVersions: [PUBLIC_VERSION, DRAFT_VERSION],
+  sourceIndexAvailableVersions: [
+    HISTORICAL_VERSION,
+    PUBLIC_VERSION,
+    DRAFT_VERSION,
+  ],
   sourceRepository: "6529-Collections/6529Stream",
 };
 
@@ -39,6 +46,7 @@ function sourceIndex() {
     reviewId: "6529-stream",
     activeVersion: DRAFT_VERSION,
     versions: [
+      versionEntry(HISTORICAL_VERSION, HISTORICAL_COMMIT),
       versionEntry(PUBLIC_VERSION, PUBLIC_COMMIT),
       versionEntry(DRAFT_VERSION, DRAFT_COMMIT),
     ],
@@ -49,7 +57,10 @@ function publishedIndex() {
   return {
     ...sourceIndex(),
     activeVersion: PUBLIC_VERSION,
-    versions: [versionEntry(PUBLIC_VERSION, PUBLIC_COMMIT)],
+    versions: [
+      versionEntry(HISTORICAL_VERSION, HISTORICAL_COMMIT),
+      versionEntry(PUBLIC_VERSION, PUBLIC_COMMIT),
+    ],
   };
 }
 
@@ -64,6 +75,29 @@ describe("Solidity reference source-index validation", () => {
     expect(() =>
       assertSolidityReferenceIndex(publishedIndex(), IDENTITY)
     ).not.toThrow();
+  });
+
+  it("uses canonical source order instead of public display order", () => {
+    expect(IDENTITY.availableVersions).toEqual([
+      PUBLIC_VERSION,
+      HISTORICAL_VERSION,
+    ]);
+    expect(publishedIndex().versions.map(({ version }) => version)).toEqual([
+      HISTORICAL_VERSION,
+      PUBLIC_VERSION,
+    ]);
+    expect(() =>
+      assertSolidityReferenceIndex(publishedIndex(), IDENTITY)
+    ).not.toThrow();
+  });
+
+  it("rejects a published projection in public display order", () => {
+    const index = publishedIndex();
+    index.versions.reverse();
+
+    expect(() => assertSolidityReferenceIndex(index, IDENTITY)).toThrow(
+      "Invalid Solidity reference index identity"
+    );
   });
 
   it("rejects a public-active index with the full source version list", () => {
@@ -104,7 +138,7 @@ describe("Solidity reference source-index validation", () => {
 
   it("rejects commit drift in the hidden source version", () => {
     const index = sourceIndex();
-    index.versions[1]!.commit = "e".repeat(40);
+    index.versions[2]!.commit = "e".repeat(40);
 
     expect(() => assertSolidityReferenceIndex(index, IDENTITY)).toThrow(
       "Invalid Solidity reference version entry"
@@ -113,7 +147,7 @@ describe("Solidity reference source-index validation", () => {
 
   it("rejects commit drift in the published projection", () => {
     const index = publishedIndex();
-    index.versions[0]!.commit = "e".repeat(40);
+    index.versions[1]!.commit = "e".repeat(40);
 
     expect(() => assertSolidityReferenceIndex(index, IDENTITY)).toThrow(
       "Invalid Solidity reference version entry"
@@ -123,10 +157,10 @@ describe("Solidity reference source-index validation", () => {
   it("rejects a source identity that omits a required public version", () => {
     const identity = {
       ...IDENTITY,
-      availableVersions: ["2026-07-26.1"],
+      availableVersions: ["2026-07-25.1"],
       sourceCommits: {
         ...IDENTITY.sourceCommits,
-        "2026-07-26.1": "f".repeat(40),
+        "2026-07-25.1": "f".repeat(40),
       },
     };
 

--- a/__tests__/lib/public-review/solidityReferenceIndexValidation.test.ts
+++ b/__tests__/lib/public-review/solidityReferenceIndexValidation.test.ts
@@ -45,6 +45,14 @@ function sourceIndex() {
   };
 }
 
+function publishedIndex() {
+  return {
+    ...sourceIndex(),
+    activeVersion: PUBLIC_VERSION,
+    versions: [versionEntry(PUBLIC_VERSION, PUBLIC_COMMIT)],
+  };
+}
+
 describe("Solidity reference source-index validation", () => {
   it("accepts a trusted source-active draft while keeping the public identity pinned", () => {
     expect(() =>
@@ -52,9 +60,42 @@ describe("Solidity reference source-index validation", () => {
     ).not.toThrow();
   });
 
-  it("rejects a source index that activates the wrong version", () => {
+  it("accepts the exact published projection without exposing the hidden draft", () => {
+    expect(() =>
+      assertSolidityReferenceIndex(publishedIndex(), IDENTITY)
+    ).not.toThrow();
+  });
+
+  it("rejects a public-active index with the full source version list", () => {
     const index = sourceIndex();
     index.activeVersion = PUBLIC_VERSION;
+
+    expect(() => assertSolidityReferenceIndex(index, IDENTITY)).toThrow(
+      "Invalid Solidity reference index identity"
+    );
+  });
+
+  it("rejects a source-active index with only the published version list", () => {
+    const index = publishedIndex();
+    index.activeVersion = DRAFT_VERSION;
+
+    expect(() => assertSolidityReferenceIndex(index, IDENTITY)).toThrow(
+      "Invalid Solidity reference index identity"
+    );
+  });
+
+  it("rejects a partial full-source version list", () => {
+    const index = sourceIndex();
+    index.versions = [versionEntry(DRAFT_VERSION, DRAFT_COMMIT)];
+
+    expect(() => assertSolidityReferenceIndex(index, IDENTITY)).toThrow(
+      "Invalid Solidity reference index identity"
+    );
+  });
+
+  it("rejects an extra version in the published projection", () => {
+    const index = publishedIndex();
+    index.versions.push(versionEntry("2026-07-29.1", "e".repeat(40)));
 
     expect(() => assertSolidityReferenceIndex(index, IDENTITY)).toThrow(
       "Invalid Solidity reference index identity"
@@ -64,6 +105,15 @@ describe("Solidity reference source-index validation", () => {
   it("rejects commit drift in the hidden source version", () => {
     const index = sourceIndex();
     index.versions[1]!.commit = "e".repeat(40);
+
+    expect(() => assertSolidityReferenceIndex(index, IDENTITY)).toThrow(
+      "Invalid Solidity reference version entry"
+    );
+  });
+
+  it("rejects commit drift in the published projection", () => {
+    const index = publishedIndex();
+    index.versions[0]!.commit = "e".repeat(40);
 
     expect(() => assertSolidityReferenceIndex(index, IDENTITY)).toThrow(
       "Invalid Solidity reference version entry"

--- a/__tests__/lib/public-review/solidityReferenceIndexValidation.test.ts
+++ b/__tests__/lib/public-review/solidityReferenceIndexValidation.test.ts
@@ -1,0 +1,87 @@
+jest.mock("next/dist/compiled/server-only", () => ({}), { virtual: true });
+
+import { assertSolidityReferenceIndex } from "@/lib/public-review/solidityReferenceValidation.server";
+import type { SolidityReferenceReviewIdentity } from "@/lib/public-review/solidityReferenceTypes";
+
+const PUBLIC_VERSION = "2026-07-27.1";
+const DRAFT_VERSION = "2026-07-28.1";
+const PUBLIC_COMMIT = "a".repeat(40);
+const DRAFT_COMMIT = "b".repeat(40);
+const BUNDLE_SHA256 = `sha256:${"c".repeat(64)}`;
+
+const IDENTITY: SolidityReferenceReviewIdentity = {
+  activeSourceCommit: PUBLIC_COMMIT,
+  activeVersion: PUBLIC_VERSION,
+  availableVersions: [PUBLIC_VERSION],
+  reviewId: "6529-stream",
+  sourceCommits: {
+    [PUBLIC_VERSION]: PUBLIC_COMMIT,
+    [DRAFT_VERSION]: DRAFT_COMMIT,
+  },
+  sourceIndexActiveVersion: DRAFT_VERSION,
+  sourceIndexAvailableVersions: [PUBLIC_VERSION, DRAFT_VERSION],
+  sourceRepository: "6529-Collections/6529Stream",
+};
+
+function versionEntry(version: string, commit: string) {
+  return {
+    version,
+    commit,
+    tree: "d".repeat(40),
+    bundlePath: `/review-data/6529-stream/versions/${version}/reference-manifest.json`,
+    bundleSha256: BUNDLE_SHA256,
+  };
+}
+
+function sourceIndex() {
+  return {
+    schemaVersion: "public-review.solidity-reference-index.v1",
+    reviewId: "6529-stream",
+    activeVersion: DRAFT_VERSION,
+    versions: [
+      versionEntry(PUBLIC_VERSION, PUBLIC_COMMIT),
+      versionEntry(DRAFT_VERSION, DRAFT_COMMIT),
+    ],
+  };
+}
+
+describe("Solidity reference source-index validation", () => {
+  it("accepts a trusted source-active draft while keeping the public identity pinned", () => {
+    expect(() =>
+      assertSolidityReferenceIndex(sourceIndex(), IDENTITY)
+    ).not.toThrow();
+  });
+
+  it("rejects a source index that activates the wrong version", () => {
+    const index = sourceIndex();
+    index.activeVersion = PUBLIC_VERSION;
+
+    expect(() => assertSolidityReferenceIndex(index, IDENTITY)).toThrow(
+      "Invalid Solidity reference index identity"
+    );
+  });
+
+  it("rejects commit drift in the hidden source version", () => {
+    const index = sourceIndex();
+    index.versions[1]!.commit = "e".repeat(40);
+
+    expect(() => assertSolidityReferenceIndex(index, IDENTITY)).toThrow(
+      "Invalid Solidity reference version entry"
+    );
+  });
+
+  it("rejects a source identity that omits a required public version", () => {
+    const identity = {
+      ...IDENTITY,
+      availableVersions: ["2026-07-26.1"],
+      sourceCommits: {
+        ...IDENTITY.sourceCommits,
+        "2026-07-26.1": "f".repeat(40),
+      },
+    };
+
+    expect(() => assertSolidityReferenceIndex(sourceIndex(), identity)).toThrow(
+      "Missing public Solidity reference version"
+    );
+  });
+});

--- a/__tests__/scripts/package-public-review-artifacts.test.ts
+++ b/__tests__/scripts/package-public-review-artifacts.test.ts
@@ -269,10 +269,12 @@ function addHistoricalVersion({
   fixture,
   activeLifecycleState,
   historicalLifecycleState,
+  topLevelLifecycleState = activeLifecycleState,
 }: {
   readonly fixture: ReturnType<typeof createFixture>;
   readonly activeLifecycleState: string;
   readonly historicalLifecycleState: string;
+  readonly topLevelLifecycleState?: string;
 }): {
   readonly historicalBundleFile: string;
   readonly historicalEditorialManifest: string;
@@ -294,7 +296,7 @@ function addHistoricalVersion({
     {
       schemaVersion: "public-review.publication.v2",
       reviewId: REVIEW_ID,
-      lifecycleState: activeLifecycleState,
+      lifecycleState: topLevelLifecycleState,
       versions: [
         {
           version: HISTORICAL_VERSION,
@@ -809,6 +811,70 @@ describe("profile-aware public-review artifact packaging", () => {
     expect(
       packagedIndex.versions.map(({ version }: { version: string }) => version)
     ).toEqual([HISTORICAL_VERSION]);
+  });
+
+  it("keeps the prior public version active while preloading a new draft", () => {
+    const fixture = createFixture();
+    fixtureRoots.push(fixture.repoRoot);
+    addHistoricalVersion({
+      fixture,
+      activeLifecycleState: "DRAFT",
+      historicalLifecycleState: "PUBLIC_REVIEW",
+      topLevelLifecycleState: "PUBLIC_REVIEW",
+    });
+
+    expect(getPublishedReviewIds(fixture.repoRoot)).toEqual(
+      new Set([REVIEW_ID])
+    );
+    expect(
+      prepareProfileBundle({
+        repoRoot: fixture.repoRoot,
+        bundleRoot: fixture.bundleRoot,
+        profile: "staging",
+      })
+    ).toEqual([
+      expect.objectContaining({
+        reviewId: REVIEW_ID,
+        reviewVersion: HISTORICAL_VERSION,
+        sourceCommit: HISTORICAL_COMMIT,
+      }),
+    ]);
+    const packagedIndex = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          fixture.bundleRoot,
+          `public/review-data/${REVIEW_ID}/index.json`
+        ),
+        "utf8"
+      )
+    );
+    expect(packagedIndex.activeVersion).toBe(HISTORICAL_VERSION);
+    expect(
+      packagedIndex.versions.map(({ version }: { version: string }) => version)
+    ).toEqual([HISTORICAL_VERSION]);
+    expect(
+      fs.existsSync(
+        path.join(
+          fixture.bundleRoot,
+          `public/review-data/${REVIEW_ID}/versions/${REVIEW_VERSION}`
+        )
+      )
+    ).toBe(false);
+  });
+
+  it("rejects a preloaded draft when the public fallback lifecycle drifts", () => {
+    const fixture = createFixture();
+    fixtureRoots.push(fixture.repoRoot);
+    addHistoricalVersion({
+      fixture,
+      activeLifecycleState: "DRAFT",
+      historicalLifecycleState: "REVIEW_CLOSED",
+      topLevelLifecycleState: "PUBLIC_REVIEW",
+    });
+
+    expect(() => getPublishedReviewIds(fixture.repoRoot)).toThrow(
+      "fallback publication lifecycle drifted"
+    );
   });
 
   it("omits a retained draft while packaging the public active version", () => {

--- a/__tests__/scripts/package-public-review-artifacts.test.ts
+++ b/__tests__/scripts/package-public-review-artifacts.test.ts
@@ -68,10 +68,13 @@ interface ReviewEvidence {
 const REVIEW_ID = "6529-stream";
 const REVIEW_VERSION = "2026-07-26.1";
 const HISTORICAL_VERSION = "2026-07-25.1";
+const OLDER_HISTORICAL_VERSION = "2026-07-24.1";
 const SOURCE_COMMIT = "b1598aff93693c6fb8610f7a7a8d2fc3e4df8c1c";
 const SOURCE_TREE = "c7075288c27601727f4ab7ef3be6c52e887ca663";
 const HISTORICAL_COMMIT = "816d85ca277b77cf306e6f919fbc6fbe89f0f43a";
 const HISTORICAL_TREE = "a4de94d6df63539e6737c17a4de41f17cc76052f";
+const OLDER_HISTORICAL_COMMIT = "7bc4ba1176a85bd8227c77f04cb329bc88f27b92";
+const OLDER_HISTORICAL_TREE = "3587b159de93c7ac586e99844104d35da32f3c66";
 const SOURCE_REPOSITORY = "6529-Collections/6529Stream";
 const SOURCE_PATH = "smart-contracts/StreamCore.sol";
 const DEFINITION_ID = `${SOURCE_PATH}:StreamCore`;
@@ -418,6 +421,137 @@ function addHistoricalVersion({
     historicalEditorialManifest,
     historicalSourceFile,
   };
+}
+
+function addOlderPublicVersion(
+  fixture: ReturnType<typeof createFixture>
+): void {
+  const configPath = path.join(
+    fixture.repoRoot,
+    `config/public-reviews/${REVIEW_ID}.reference.json`
+  );
+  const config = JSON.parse(fs.readFileSync(configPath, "utf8")) as {
+    output: { retainedVersions: string[] };
+  };
+  config.output.retainedVersions = [
+    OLDER_HISTORICAL_VERSION,
+    HISTORICAL_VERSION,
+    REVIEW_VERSION,
+  ];
+  const configText = `${JSON.stringify(config, null, 2)}\n`;
+  fs.writeFileSync(configPath, configText);
+
+  const publicationPath = path.join(
+    fixture.repoRoot,
+    `config/public-reviews/${REVIEW_ID}.publication.json`
+  );
+  const publication = JSON.parse(fs.readFileSync(publicationPath, "utf8")) as {
+    versions: { version: string; lifecycleState: string }[];
+  };
+  publication.versions.unshift({
+    version: OLDER_HISTORICAL_VERSION,
+    lifecycleState: "REVIEW_CLOSED",
+  });
+  fs.writeFileSync(
+    publicationPath,
+    `${JSON.stringify(publication, null, 2)}\n`
+  );
+
+  const activeBundle = JSON.parse(fs.readFileSync(fixture.bundleFile, "utf8"));
+  activeBundle.generator.configSha256 = sha256Urn(normalizeLf(configText));
+  activeBundle.generator.outputSha256 = null;
+  activeBundle.generator.outputSha256 = bundleOutputSha256(activeBundle);
+  fs.writeFileSync(
+    fixture.bundleFile,
+    `${JSON.stringify(activeBundle, null, 2)}\n`
+  );
+
+  const historicalVersionRoot = path.join(
+    fixture.repoRoot,
+    `public/review-data/${REVIEW_ID}/versions/${HISTORICAL_VERSION}`
+  );
+  const olderVersionRoot = path.join(
+    fixture.repoRoot,
+    `public/review-data/${REVIEW_ID}/versions/${OLDER_HISTORICAL_VERSION}`
+  );
+  fs.cpSync(historicalVersionRoot, olderVersionRoot, { recursive: true });
+  const olderBundlePath = path.join(
+    olderVersionRoot,
+    "reference-manifest.json"
+  );
+  const olderBundle = JSON.parse(fs.readFileSync(olderBundlePath, "utf8"));
+  olderBundle.reviewVersion = OLDER_HISTORICAL_VERSION;
+  olderBundle.source.commit = OLDER_HISTORICAL_COMMIT;
+  olderBundle.source.tree = OLDER_HISTORICAL_TREE;
+  olderBundle.generator.configSha256 = sha256Urn("older historical config");
+  olderBundle.generator.sourceSha256 = sha256Urn("older historical generator");
+  olderBundle.generator.outputSha256 = null;
+  olderBundle.files[0].publicPath =
+    `/review-data/${REVIEW_ID}/versions/${OLDER_HISTORICAL_VERSION}` +
+    `/sources/${SOURCE_PATH}`;
+  olderBundle.definitionIndex[0].shardPath =
+    `/review-data/${REVIEW_ID}/versions/${OLDER_HISTORICAL_VERSION}` +
+    `/definitions/${DEFINITION_KEY}.json`;
+  olderBundle.generator.outputSha256 = bundleOutputSha256(olderBundle);
+  fs.writeFileSync(
+    olderBundlePath,
+    `${JSON.stringify(olderBundle, null, 2)}\n`
+  );
+
+  const historicalEditorialRoot = path.join(
+    fixture.repoRoot,
+    `content/public-reviews/${REVIEW_ID}/versions/${HISTORICAL_VERSION}`
+  );
+  const olderEditorialRoot = path.join(
+    fixture.repoRoot,
+    `content/public-reviews/${REVIEW_ID}/versions/${OLDER_HISTORICAL_VERSION}`
+  );
+  fs.cpSync(historicalEditorialRoot, olderEditorialRoot, { recursive: true });
+  const olderEditorialManifestPath = path.join(
+    olderEditorialRoot,
+    "editorial",
+    "manifest.json"
+  );
+  const olderEditorialManifest = JSON.parse(
+    fs.readFileSync(olderEditorialManifestPath, "utf8")
+  );
+  olderEditorialManifest.review_version = OLDER_HISTORICAL_VERSION;
+  olderEditorialManifest.source_commit = OLDER_HISTORICAL_COMMIT;
+  fs.writeFileSync(
+    olderEditorialManifestPath,
+    `${JSON.stringify(olderEditorialManifest, null, 2)}\n`
+  );
+
+  const indexPath = path.join(
+    fixture.repoRoot,
+    `public/review-data/${REVIEW_ID}/index.json`
+  );
+  const index = JSON.parse(fs.readFileSync(indexPath, "utf8")) as {
+    versions: {
+      version: string;
+      commit: string;
+      tree: string;
+      bundlePath: string;
+      bundleSha256: string;
+    }[];
+  };
+  const activeEntry = index.versions.find(
+    ({ version }) => version === REVIEW_VERSION
+  );
+  if (!activeEntry) {
+    throw new Error("Fixture active review index entry is missing.");
+  }
+  activeEntry.bundleSha256 = activeBundle.generator.outputSha256;
+  index.versions.unshift({
+    version: OLDER_HISTORICAL_VERSION,
+    commit: OLDER_HISTORICAL_COMMIT,
+    tree: OLDER_HISTORICAL_TREE,
+    bundlePath:
+      `/review-data/${REVIEW_ID}/versions/${OLDER_HISTORICAL_VERSION}` +
+      "/reference-manifest.json",
+    bundleSha256: olderBundle.generator.outputSha256,
+  });
+  fs.writeFileSync(indexPath, `${JSON.stringify(index, null, 2)}\n`);
 }
 
 function mirrorTamper(sourcePath: string, repoRoot: string, value: string) {
@@ -827,6 +961,7 @@ describe("profile-aware public-review artifact packaging", () => {
       historicalLifecycleState: "PUBLIC_REVIEW",
       topLevelLifecycleState: "PUBLIC_REVIEW",
     });
+    addOlderPublicVersion(fixture);
 
     expect(getPublishedReviewIds(fixture.repoRoot)).toEqual(
       new Set([REVIEW_ID])
@@ -838,6 +973,11 @@ describe("profile-aware public-review artifact packaging", () => {
         profile: "staging",
       })
     ).toEqual([
+      expect.objectContaining({
+        reviewId: REVIEW_ID,
+        reviewVersion: OLDER_HISTORICAL_VERSION,
+        sourceCommit: OLDER_HISTORICAL_COMMIT,
+      }),
       expect.objectContaining({
         reviewId: REVIEW_ID,
         reviewVersion: HISTORICAL_VERSION,
@@ -856,18 +996,23 @@ describe("profile-aware public-review artifact packaging", () => {
     expect(packagedIndex.activeVersion).toBe(HISTORICAL_VERSION);
     expect(
       packagedIndex.versions.map(({ version }: { version: string }) => version)
-    ).toEqual([HISTORICAL_VERSION]);
+    ).toEqual([OLDER_HISTORICAL_VERSION, HISTORICAL_VERSION]);
     const referenceIdentity: SolidityReferenceReviewIdentity = {
       activeSourceCommit: HISTORICAL_COMMIT,
       activeVersion: HISTORICAL_VERSION,
-      availableVersions: [HISTORICAL_VERSION],
+      availableVersions: [HISTORICAL_VERSION, OLDER_HISTORICAL_VERSION],
       reviewId: REVIEW_ID,
       sourceCommits: {
+        [OLDER_HISTORICAL_VERSION]: OLDER_HISTORICAL_COMMIT,
         [HISTORICAL_VERSION]: HISTORICAL_COMMIT,
         [REVIEW_VERSION]: SOURCE_COMMIT,
       },
       sourceIndexActiveVersion: REVIEW_VERSION,
-      sourceIndexAvailableVersions: [HISTORICAL_VERSION, REVIEW_VERSION],
+      sourceIndexAvailableVersions: [
+        OLDER_HISTORICAL_VERSION,
+        HISTORICAL_VERSION,
+        REVIEW_VERSION,
+      ],
       sourceRepository: SOURCE_REPOSITORY,
     };
     expect(() =>

--- a/__tests__/scripts/package-public-review-artifacts.test.ts
+++ b/__tests__/scripts/package-public-review-artifacts.test.ts
@@ -1,8 +1,13 @@
+jest.mock("next/dist/compiled/server-only", () => ({}), { virtual: true });
+
 import { spawnSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+
+import { assertSolidityReferenceIndex } from "@/lib/public-review/solidityReferenceValidation.server";
+import type { SolidityReferenceReviewIdentity } from "@/lib/public-review/solidityReferenceTypes";
 
 const {
   assertProfileBundle,
@@ -852,6 +857,22 @@ describe("profile-aware public-review artifact packaging", () => {
     expect(
       packagedIndex.versions.map(({ version }: { version: string }) => version)
     ).toEqual([HISTORICAL_VERSION]);
+    const referenceIdentity: SolidityReferenceReviewIdentity = {
+      activeSourceCommit: HISTORICAL_COMMIT,
+      activeVersion: HISTORICAL_VERSION,
+      availableVersions: [HISTORICAL_VERSION],
+      reviewId: REVIEW_ID,
+      sourceCommits: {
+        [HISTORICAL_VERSION]: HISTORICAL_COMMIT,
+        [REVIEW_VERSION]: SOURCE_COMMIT,
+      },
+      sourceIndexActiveVersion: REVIEW_VERSION,
+      sourceIndexAvailableVersions: [HISTORICAL_VERSION, REVIEW_VERSION],
+      sourceRepository: SOURCE_REPOSITORY,
+    };
+    expect(() =>
+      assertSolidityReferenceIndex(packagedIndex, referenceIdentity)
+    ).not.toThrow();
     expect(
       fs.existsSync(
         path.join(

--- a/__tests__/scripts/public-review-snapshot-trust.test.ts
+++ b/__tests__/scripts/public-review-snapshot-trust.test.ts
@@ -19,6 +19,14 @@ type Config = {
   [key: string]: unknown;
 };
 
+type Publication = {
+  schemaVersion: string;
+  reviewId: string;
+  lifecycleState: string;
+  versions: Array<{ version: string; lifecycleState: string }>;
+  [key: string]: unknown;
+};
+
 type GitEntry = {
   mode: string;
   type: string;
@@ -38,6 +46,7 @@ type Run = (
 const {
   CONFIG_PATH,
   GIT_REGULAR_MODE,
+  PUBLICATION_CONFIG_PATH,
   REVIEW_ROOT,
   SOLC_SHA256,
   compareCandidateToRegeneration,
@@ -54,11 +63,13 @@ const {
   validateIdentifiers,
   validateSolcDigest,
   validateTrustedConfigPolicy,
+  validateTrustedPublicationPolicy,
   verifyOfficialStreamInputs,
   verifySnapshotPr,
 } = require("../../scripts/public-reviews/verify-snapshot-pr.cjs") as {
   CONFIG_PATH: string;
   GIT_REGULAR_MODE: string;
+  PUBLICATION_CONFIG_PATH: string;
   REVIEW_ROOT: string;
   SOLC_SHA256: string;
   compareCandidateToRegeneration: (
@@ -93,11 +104,7 @@ const {
   parseNameStatus: (
     buffer: Buffer
   ) => Array<{ status: string; paths: string[] }>;
-  readGitBlob: (
-    repositoryRoot: string,
-    entry: GitEntry,
-    run?: Run
-  ) => Buffer;
+  readGitBlob: (repositoryRoot: string, entry: GitEntry, run?: Run) => Buffer;
   sha256: (buffer: Buffer) => string;
   snapshotChangePolicy: (
     entries: Array<{ status: string; paths: string[] }>
@@ -111,6 +118,12 @@ const {
   validateTrustedConfigPolicy: (
     base: Config,
     candidate: Config,
+    versions: string[] | null
+  ) => void;
+  validateTrustedPublicationPolicy: (
+    base: Publication,
+    candidate: Publication,
+    candidateConfig: Config,
     versions: string[] | null
   ) => void;
   verifyOfficialStreamInputs: (
@@ -169,6 +182,12 @@ function cloneConfig(config: Config): Config {
   return JSON.parse(JSON.stringify(config)) as Config;
 }
 
+function loadPublication(): Publication {
+  return JSON.parse(
+    fs.readFileSync(path.join(process.cwd(), PUBLICATION_CONFIG_PATH), "utf8")
+  ) as Publication;
+}
+
 function treeRecord(
   candidatePath: string,
   mode = GIT_REGULAR_MODE,
@@ -181,28 +200,14 @@ function treeRecord(
 describe("public-review snapshot trust argument and Git parsing", () => {
   it("accepts each required identifier exactly once", () => {
     expect(
-      parseArgs([
-        "--head-sha",
-        shaA,
-        "--pr-number",
-        "3467",
-        "--base-sha",
-        shaB,
-      ])
+      parseArgs(["--head-sha", shaA, "--pr-number", "3467", "--base-sha", shaB])
     ).toEqual({
       prNumber: "3467",
       headSha: shaA,
       baseSha: shaB,
     });
     expect(() =>
-      parseArgs([
-        "--head-sha",
-        shaA,
-        "--head-sha",
-        shaB,
-        "--base-sha",
-        shaC,
-      ])
+      parseArgs(["--head-sha", shaA, "--head-sha", shaB, "--base-sha", shaC])
     ).toThrow("Duplicate verifier argument");
   });
 
@@ -251,24 +256,21 @@ describe("public-review snapshot trust argument and Git parsing", () => {
       { status: "A", paths: [`${REVIEW_ROOT}/index.json`] },
       {
         status: "R100",
-        paths: [
-          `${REVIEW_ROOT}/old.json`,
-          `${REVIEW_ROOT}/new.json`,
-        ],
+        paths: [`${REVIEW_ROOT}/old.json`, `${REVIEW_ROOT}/new.json`],
       },
     ]);
-    expect(() =>
-      parseNameStatus(Buffer.from(`A\0../escape.json\0`))
-    ).toThrow("Unsafe candidate path");
+    expect(() => parseNameStatus(Buffer.from(`A\0../escape.json\0`))).toThrow(
+      "Unsafe candidate path"
+    );
     expect(() => parseNameStatus(Buffer.from(`A10\0${CONFIG_PATH}\0`))).toThrow(
       "Invalid Git status"
     );
-    expect(() =>
-      parseNameStatus(Buffer.from(`A\0${CONFIG_PATH}`))
-    ).toThrow("not NUL-terminated");
-    expect(() =>
-      parseNameStatus(Buffer.from(`A\0${CONFIG_PATH}\0\0`))
-    ).toThrow("empty record");
+    expect(() => parseNameStatus(Buffer.from(`A\0${CONFIG_PATH}`))).toThrow(
+      "not NUL-terminated"
+    );
+    expect(() => parseNameStatus(Buffer.from(`A\0${CONFIG_PATH}\0\0`))).toThrow(
+      "empty record"
+    );
     expect(() =>
       parseNameStatus(Buffer.from(`A\0${REVIEW_ROOT}/bad\tname.json\0`))
     ).toThrow("Unsafe candidate path");
@@ -325,10 +327,8 @@ describe("public-review snapshot trust argument and Git parsing", () => {
       readGitBlob("", { ...regular, mode: "120000" }, () => Buffer.from("x"))
     ).toThrow("non-executable regular Git blob");
     expect(() =>
-      readGitBlob(
-        "",
-        { ...regular, mode: "160000", type: "commit" },
-        () => Buffer.from("x")
+      readGitBlob("", { ...regular, mode: "160000", type: "commit" }, () =>
+        Buffer.from("x")
       )
     ).toThrow("non-executable regular Git blob");
     expect(() =>
@@ -352,10 +352,11 @@ describe("public-review snapshot trust change policy", () => {
     ).toEqual({ touchesSnapshot: false });
   });
 
-  it("allows only config and review data, with no rename or config delete", () => {
+  it("allows only both configs and review data, with no rename or config delete", () => {
     expect(
       snapshotChangePolicy([
         { status: "M", paths: [CONFIG_PATH] },
+        { status: "M", paths: [PUBLICATION_CONFIG_PATH] },
         { status: "A", paths: [`${REVIEW_ROOT}/index.json`] },
       ])
     ).toEqual({ touchesSnapshot: true });
@@ -369,16 +370,26 @@ describe("public-review snapshot trust change policy", () => {
       snapshotChangePolicy([
         {
           status: "R100",
-          paths: [
-            `${REVIEW_ROOT}/old.json`,
-            `${REVIEW_ROOT}/new.json`,
-          ],
+          paths: [`${REVIEW_ROOT}/old.json`, `${REVIEW_ROOT}/new.json`],
         },
       ])
     ).toThrow("renamed or copied");
     expect(() =>
       snapshotChangePolicy([{ status: "D", paths: [CONFIG_PATH] }])
     ).toThrow("never deleted");
+    expect(() =>
+      snapshotChangePolicy([
+        { status: "M", paths: [CONFIG_PATH] },
+        { status: "D", paths: [PUBLICATION_CONFIG_PATH] },
+        { status: "A", paths: [`${REVIEW_ROOT}/index.json`] },
+      ])
+    ).toThrow("modify exactly one");
+    expect(() =>
+      snapshotChangePolicy([
+        { status: "M", paths: [CONFIG_PATH] },
+        { status: "A", paths: [`${REVIEW_ROOT}/index.json`] },
+      ])
+    ).toThrow("modify exactly one");
   });
 
   it.each([
@@ -410,7 +421,9 @@ describe("public-review snapshot trust change policy", () => {
       [`merge-base ${shaB} ${shaA}`, Buffer.from(shaB)],
       [
         `diff --name-status -z --find-renames ${shaB} ${shaA}`,
-        Buffer.from(`M\0${CONFIG_PATH}\0A\0${REVIEW_ROOT}/index.json\0`),
+        Buffer.from(
+          `M\0${CONFIG_PATH}\0M\0${PUBLICATION_CONFIG_PATH}\0A\0${REVIEW_ROOT}/index.json\0`
+        ),
       ],
     ]);
     const run: Run = (_command, args) => {
@@ -481,7 +494,9 @@ describe("public-review snapshot trust change policy", () => {
         return Buffer.from(shaC);
       }
       if (operation === "diff") {
-        return Buffer.from(`M\0${CONFIG_PATH}\0`);
+        return Buffer.from(
+          `M\0${CONFIG_PATH}\0M\0${PUBLICATION_CONFIG_PATH}\0`
+        );
       }
       throw new Error(`Unexpected Git call: ${args.join(" ")}`);
     };
@@ -559,6 +574,139 @@ describe("public-review snapshot trust immutable history", () => {
   });
 });
 
+describe("public-review snapshot trust publication preload", () => {
+  function futureConfig(): Config {
+    const candidate = cloneConfig(loadConfig());
+    candidate.reviewVersion = "2026-07-28.1";
+    candidate.source.commit = shaA;
+    candidate.source.tree = shaB;
+    candidate.output.directory =
+      "public/review-data/6529-stream/versions/2026-07-28.1";
+    candidate.output.retainedVersions = [
+      "2026-07-26.1",
+      "2026-07-27.1",
+      "2026-07-28.1",
+    ];
+    return candidate;
+  }
+
+  function draftPublication(): Publication {
+    const candidate = JSON.parse(
+      JSON.stringify(loadPublication())
+    ) as Publication;
+    candidate.versions.push({
+      version: "2026-07-28.1",
+      lifecycleState: "DRAFT",
+    });
+    return candidate;
+  }
+
+  it("allows exactly one new DRAFT entry while preserving published state", () => {
+    expect(() =>
+      validateTrustedPublicationPolicy(
+        loadPublication(),
+        draftPublication(),
+        futureConfig(),
+        ["2026-07-26.1", "2026-07-27.1"]
+      )
+    ).not.toThrow();
+  });
+
+  it.each([
+    {
+      label: "a non-draft preload",
+      mutate: (candidate: Publication) => {
+        candidate.versions.at(-1)!.lifecycleState = "PUBLIC_REVIEW";
+      },
+      message: "append exactly one DRAFT version",
+    },
+    {
+      label: "a published lifecycle change",
+      mutate: (candidate: Publication) => {
+        candidate.lifecycleState = "REVIEW_CLOSED";
+      },
+      message: "append exactly one DRAFT version",
+    },
+    {
+      label: "a historical lifecycle change",
+      mutate: (candidate: Publication) => {
+        candidate.versions[0]!.lifecycleState = "ARCHIVED";
+      },
+      message: "append exactly one DRAFT version",
+    },
+    {
+      label: "an extra top-level key",
+      mutate: (candidate: Publication) => {
+        candidate["untrusted"] = true;
+      },
+      message: "append exactly one DRAFT version",
+    },
+    {
+      label: "an extra version key",
+      mutate: (candidate: Publication) => {
+        (
+          candidate.versions.at(-1)! as {
+            version: string;
+            lifecycleState: string;
+            untrusted?: boolean;
+          }
+        ).untrusted = true;
+      },
+      message: "append exactly one DRAFT version",
+    },
+    {
+      label: "a changed review identity",
+      mutate: (candidate: Publication) => {
+        candidate.reviewId = "other-review";
+      },
+      message: "append exactly one DRAFT version",
+    },
+  ])("rejects $label", ({ mutate, message }) => {
+    const candidate = draftPublication();
+    mutate(candidate);
+    expect(() =>
+      validateTrustedPublicationPolicy(
+        loadPublication(),
+        candidate,
+        futureConfig(),
+        ["2026-07-26.1", "2026-07-27.1"]
+      )
+    ).toThrow(message);
+  });
+
+  it("rejects publication history that does not match either trusted index", () => {
+    const base = loadPublication();
+    expect(() =>
+      validateTrustedPublicationPolicy(
+        base,
+        draftPublication(),
+        futureConfig(),
+        ["2026-07-26.1"]
+      )
+    ).toThrow("Trusted base publication versions drifted");
+
+    const candidate = draftPublication();
+    candidate.versions.at(-1)!.version = "2026-07-29.1";
+    expect(() =>
+      validateTrustedPublicationPolicy(base, candidate, futureConfig(), [
+        "2026-07-26.1",
+        "2026-07-27.1",
+      ])
+    ).toThrow("must match retained review history");
+  });
+
+  it("rejects a candidate publication without a versions array", () => {
+    expect(() =>
+      validateTrustedPublicationPolicy(
+        loadPublication(),
+        null as unknown as Publication,
+        futureConfig(),
+        ["2026-07-26.1", "2026-07-27.1"]
+      )
+    ).toThrow("Candidate publication config is invalid");
+  });
+});
+
 describe("public-review snapshot trust independent inputs and output", () => {
   function streamTree(config: Config, extra = ""): Buffer {
     return Buffer.from(
@@ -566,9 +714,7 @@ describe("public-review snapshot trust independent inputs and output", () => {
         ...config.source.roots.map((root) =>
           treeRecord(`${root.path}/Fixture.sol`)
         ),
-        ...config.releaseArtifacts.map((artifact) =>
-          treeRecord(artifact.path)
-        ),
+        ...config.releaseArtifacts.map((artifact) => treeRecord(artifact.path)),
         extra,
       ].join("")
     );
@@ -704,10 +850,7 @@ describe("public-review snapshot trust independent inputs and output", () => {
       path.join(os.tmpdir(), "snapshot-trust-files-")
     );
     try {
-      const reviewRoot = path.join(
-        repositoryRoot,
-        ...REVIEW_ROOT.split("/")
-      );
+      const reviewRoot = path.join(repositoryRoot, ...REVIEW_ROOT.split("/"));
       fs.mkdirSync(reviewRoot, { recursive: true });
       fs.writeFileSync(
         path.join(reviewRoot, "index.json"),
@@ -715,10 +858,7 @@ describe("public-review snapshot trust independent inputs and output", () => {
       );
       expect(filesystemBlobMap(repositoryRoot, REVIEW_ROOT)).toEqual(
         new Map([
-          [
-            `${REVIEW_ROOT}/index.json`,
-            Buffer.from('{"trusted":true}\n'),
-          ],
+          [`${REVIEW_ROOT}/index.json`, Buffer.from('{"trusted":true}\n')],
         ])
       );
 
@@ -727,9 +867,9 @@ describe("public-review snapshot trust independent inputs and output", () => {
         path.join(reviewRoot, "linked.json"),
         "file"
       );
-      expect(() =>
-        filesystemBlobMap(repositoryRoot, REVIEW_ROOT)
-      ).toThrow("must not be a regenerated symlink");
+      expect(() => filesystemBlobMap(repositoryRoot, REVIEW_ROOT)).toThrow(
+        "must not be a regenerated symlink"
+      );
     } finally {
       fs.rmSync(repositoryRoot, { recursive: true, force: true });
     }
@@ -760,13 +900,59 @@ describe("public-review snapshot trust orchestration", () => {
     const repositoryRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), "snapshot-trust-orchestration-")
     );
-    const baseConfig = loadInitialConfig();
+    const baseConfig = loadConfig();
     const configPath = path.join(repositoryRoot, ...CONFIG_PATH.split("/"));
     fs.mkdirSync(path.dirname(configPath), { recursive: true });
     fs.writeFileSync(configPath, `${JSON.stringify(baseConfig, null, 2)}\n`);
 
+    const basePublication = loadPublication();
+    const publicationPath = path.join(
+      repositoryRoot,
+      ...PUBLICATION_CONFIG_PATH.split("/")
+    );
+    fs.writeFileSync(
+      publicationPath,
+      `${JSON.stringify(basePublication, null, 2)}\n`
+    );
+    const baseIndexPath = path.join(
+      repositoryRoot,
+      ...`${REVIEW_ROOT}/index.json`.split("/")
+    );
+    fs.mkdirSync(path.dirname(baseIndexPath), { recursive: true });
+    fs.writeFileSync(
+      baseIndexPath,
+      `${JSON.stringify(
+        {
+          reviewId: "6529-stream",
+          versions: baseConfig.output.retainedVersions.map((version) => ({
+            version,
+          })),
+        },
+        null,
+        2
+      )}\n`
+    );
+
+    const futureConfig = cloneConfig(baseConfig);
+    futureConfig.reviewVersion = "2026-07-28.1";
+    futureConfig.output.directory =
+      "public/review-data/6529-stream/versions/2026-07-28.1";
+    futureConfig.output.retainedVersions = [
+      ...baseConfig.output.retainedVersions,
+      futureConfig.reviewVersion,
+    ];
     const candidateConfig = Buffer.from(
-      `${JSON.stringify(baseConfig, null, 2)}\n`
+      `${JSON.stringify(futureConfig, null, 2)}\n`
+    );
+    const candidatePublicationObject = JSON.parse(
+      JSON.stringify(basePublication)
+    ) as Publication;
+    candidatePublicationObject.versions.push({
+      version: futureConfig.reviewVersion,
+      lifecycleState: "DRAFT",
+    });
+    const candidatePublication = Buffer.from(
+      `${JSON.stringify(candidatePublicationObject, null, 2)}\n`
     );
     const candidateBytes =
       options.candidateBytes ?? Buffer.from('{"trusted":true}\n');
@@ -775,6 +961,7 @@ describe("public-review snapshot trust orchestration", () => {
     const configOid = "1".repeat(40);
     const reviewOid = "2".repeat(40);
     const streamOid = "3".repeat(40);
+    const publicationOid = "4".repeat(40);
     const reviewPath = `${REVIEW_ROOT}/index.json`;
     const cleanupOperations: string[] = [];
     let fetchCount = 0;
@@ -835,14 +1022,21 @@ describe("public-review snapshot trust orchestration", () => {
       if (operation === "diff") {
         return options.unrelated
           ? Buffer.from("M\0components/Card.tsx\0")
-          : Buffer.from(`M\0${CONFIG_PATH}\0A\0${reviewPath}\0`);
+          : Buffer.from(
+              `M\0${CONFIG_PATH}\0M\0${PUBLICATION_CONFIG_PATH}\0A\0${reviewPath}\0`
+            );
       }
       if (operation === "ls-tree") {
         if (repository === "/stream.git") {
           return Buffer.from(
             [
               ...baseConfig.source.roots.map((root) =>
-                treeRecord(`${root.path}/Fixture.sol`, GIT_REGULAR_MODE, "blob", streamOid)
+                treeRecord(
+                  `${root.path}/Fixture.sol`,
+                  GIT_REGULAR_MODE,
+                  "blob",
+                  streamOid
+                )
               ),
               ...baseConfig.releaseArtifacts.map((artifact) =>
                 treeRecord(artifact.path, GIT_REGULAR_MODE, "blob", streamOid)
@@ -854,6 +1048,16 @@ describe("public-review snapshot trust orchestration", () => {
         if (requestedPath === CONFIG_PATH) {
           return Buffer.from(
             treeRecord(CONFIG_PATH, GIT_REGULAR_MODE, "blob", configOid)
+          );
+        }
+        if (requestedPath === PUBLICATION_CONFIG_PATH) {
+          return Buffer.from(
+            treeRecord(
+              PUBLICATION_CONFIG_PATH,
+              GIT_REGULAR_MODE,
+              "blob",
+              publicationOid
+            )
           );
         }
         if (requestedPath === REVIEW_ROOT) {
@@ -869,6 +1073,9 @@ describe("public-review snapshot trust orchestration", () => {
         }
         if (oid === reviewOid) {
           return candidateBytes;
+        }
+        if (oid === publicationOid) {
+          return candidatePublication;
         }
         if (oid === streamOid) {
           return Buffer.from("trusted Stream input\n");
@@ -893,10 +1100,7 @@ describe("public-review snapshot trust orchestration", () => {
     const status = (_command: string, args: string[]) => {
       const operation = args.slice(2, 4).join(" ");
       cleanupOperations.push(operation);
-      if (
-        options.cleanupFailure &&
-        operation === "worktree remove"
-      ) {
+      if (options.cleanupFailure && operation === "worktree remove") {
         return { status: 1, stderr: "cleanup failed" };
       }
       return { status: 0, stderr: "" };
@@ -948,7 +1152,11 @@ describe("public-review snapshot trust orchestration", () => {
       baseSha: shaB,
     });
     expect(harness.cleanupOperations).toEqual(
-      expect.arrayContaining(["worktree remove", "worktree prune", "update-ref -d"])
+      expect.arrayContaining([
+        "worktree remove",
+        "worktree prune",
+        "update-ref -d",
+      ])
     );
     expect(
       harness.cleanupOperations.filter(

--- a/lib/public-review/solidityReferenceTypes.ts
+++ b/lib/public-review/solidityReferenceTypes.ts
@@ -661,5 +661,7 @@ export interface SolidityReferenceReviewIdentity {
   readonly availableVersions: readonly string[];
   readonly reviewId: string;
   readonly sourceCommits: Readonly<Record<string, string>>;
+  readonly sourceIndexActiveVersion?: string | undefined;
+  readonly sourceIndexAvailableVersions?: readonly string[] | undefined;
   readonly sourceRepository: string;
 }

--- a/lib/public-review/solidityReferenceValidation.server.ts
+++ b/lib/public-review/solidityReferenceValidation.server.ts
@@ -428,20 +428,24 @@ export function assertSolidityReferenceIndex(
       (entry, index) =>
         isRecord(entry) && entry["version"] === availableVersions[index]
     );
+  const publishedVersionSet = new Set(identity.availableVersions);
+  const publishedProjectionVersions = sourceIndexAvailableVersions.filter(
+    (version) => publishedVersionSet.has(version)
+  );
   const isFullSourceIndex = hasExactIdentityShape(
     sourceIndexActiveVersion,
     sourceIndexAvailableVersions
   );
   const isPublishedProjection = hasExactIdentityShape(
     identity.activeVersion,
-    identity.availableVersions
+    publishedProjectionVersions
   );
   if (!isFullSourceIndex && !isPublishedProjection) {
     throw new Error("Invalid Solidity reference index identity.");
   }
   const expectedVersions = isFullSourceIndex
     ? sourceIndexAvailableVersions
-    : identity.availableVersions;
+    : publishedProjectionVersions;
   const seenVersions = new Set<string>();
   let activeVersionCommit: string | undefined;
   let sourceIndexActiveVersionCommit: string | undefined;

--- a/lib/public-review/solidityReferenceValidation.server.ts
+++ b/lib/public-review/solidityReferenceValidation.server.ts
@@ -407,24 +407,49 @@ export function assertSolidityReferenceIndex(
     identity.sourceIndexActiveVersion ?? identity.activeVersion;
   const sourceIndexAvailableVersions =
     identity.sourceIndexAvailableVersions ?? identity.availableVersions;
+  if (!isRecord(value)) {
+    throw new Error("Invalid Solidity reference index identity.");
+  }
+  const versions = value["versions"];
   if (
-    !isRecord(value) ||
     value["schemaVersion"] !== SOLIDITY_REFERENCE_INDEX_SCHEMA ||
     value["reviewId"] !== identity.reviewId ||
-    value["activeVersion"] !== sourceIndexActiveVersion ||
-    !Array.isArray(value["versions"]) ||
-    value["versions"].length !== sourceIndexAvailableVersions.length
+    !Array.isArray(versions)
   ) {
     throw new Error("Invalid Solidity reference index identity.");
   }
+  const hasExactIdentityShape = (
+    activeVersion: string,
+    availableVersions: readonly string[]
+  ): boolean =>
+    value["activeVersion"] === activeVersion &&
+    versions.length === availableVersions.length &&
+    versions.every(
+      (entry, index) =>
+        isRecord(entry) && entry["version"] === availableVersions[index]
+    );
+  const isFullSourceIndex = hasExactIdentityShape(
+    sourceIndexActiveVersion,
+    sourceIndexAvailableVersions
+  );
+  const isPublishedProjection = hasExactIdentityShape(
+    identity.activeVersion,
+    identity.availableVersions
+  );
+  if (!isFullSourceIndex && !isPublishedProjection) {
+    throw new Error("Invalid Solidity reference index identity.");
+  }
+  const expectedVersions = isFullSourceIndex
+    ? sourceIndexAvailableVersions
+    : identity.availableVersions;
   const seenVersions = new Set<string>();
   let activeVersionCommit: string | undefined;
   let sourceIndexActiveVersionCommit: string | undefined;
-  for (const entry of value["versions"]) {
+  for (const entry of versions) {
     if (
       !isRecord(entry) ||
       typeof entry["version"] !== "string" ||
-      !sourceIndexAvailableVersions.includes(entry["version"]) ||
+      !expectedVersions.includes(entry["version"]) ||
       entry["commit"] !== identity.sourceCommits[entry["version"]] ||
       typeof entry["bundlePath"] !== "string" ||
       !isSha256(entry["bundleSha256"]) ||
@@ -462,8 +487,9 @@ export function assertSolidityReferenceIndex(
     throw new Error("Invalid active Solidity reference source commit.");
   }
   if (
+    isFullSourceIndex &&
     sourceIndexActiveVersionCommit !==
-    identity.sourceCommits[sourceIndexActiveVersion]
+      identity.sourceCommits[sourceIndexActiveVersion]
   ) {
     throw new Error("Invalid source-index Solidity reference source commit.");
   }

--- a/lib/public-review/solidityReferenceValidation.server.ts
+++ b/lib/public-review/solidityReferenceValidation.server.ts
@@ -403,23 +403,28 @@ export function assertSolidityReferenceIndex(
   value: unknown,
   identity: SolidityReferenceReviewIdentity
 ): asserts value is SolidityReferenceIndex {
+  const sourceIndexActiveVersion =
+    identity.sourceIndexActiveVersion ?? identity.activeVersion;
+  const sourceIndexAvailableVersions =
+    identity.sourceIndexAvailableVersions ?? identity.availableVersions;
   if (
     !isRecord(value) ||
     value["schemaVersion"] !== SOLIDITY_REFERENCE_INDEX_SCHEMA ||
     value["reviewId"] !== identity.reviewId ||
-    value["activeVersion"] !== identity.activeVersion ||
+    value["activeVersion"] !== sourceIndexActiveVersion ||
     !Array.isArray(value["versions"]) ||
-    value["versions"].length !== identity.availableVersions.length
+    value["versions"].length !== sourceIndexAvailableVersions.length
   ) {
     throw new Error("Invalid Solidity reference index identity.");
   }
   const seenVersions = new Set<string>();
   let activeVersionCommit: string | undefined;
+  let sourceIndexActiveVersionCommit: string | undefined;
   for (const entry of value["versions"]) {
     if (
       !isRecord(entry) ||
       typeof entry["version"] !== "string" ||
-      !identity.availableVersions.includes(entry["version"]) ||
+      !sourceIndexAvailableVersions.includes(entry["version"]) ||
       entry["commit"] !== identity.sourceCommits[entry["version"]] ||
       typeof entry["bundlePath"] !== "string" ||
       !isSha256(entry["bundleSha256"]) ||
@@ -444,9 +449,23 @@ export function assertSolidityReferenceIndex(
     if (entry["version"] === identity.activeVersion) {
       activeVersionCommit = entry["commit"];
     }
+    if (entry["version"] === sourceIndexActiveVersion) {
+      sourceIndexActiveVersionCommit = entry["commit"];
+    }
+  }
+  if (
+    identity.availableVersions.some((version) => !seenVersions.has(version))
+  ) {
+    throw new Error("Missing public Solidity reference version.");
   }
   if (activeVersionCommit !== identity.activeSourceCommit) {
     throw new Error("Invalid active Solidity reference source commit.");
+  }
+  if (
+    sourceIndexActiveVersionCommit !==
+    identity.sourceCommits[sourceIndexActiveVersion]
+  ) {
+    throw new Error("Invalid source-index Solidity reference source commit.");
   }
 }
 

--- a/lib/public-review/streamSolidityReference.tsx
+++ b/lib/public-review/streamSolidityReference.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/public-review/SolidityReferenceViews";
 import { getAppMetadata } from "@/components/providers/metadata";
 import { publicEnv } from "@/config/env";
+import streamReferenceConfig from "@/config/public-reviews/6529-stream.reference.json";
 import { isPublicReviewEnabled } from "@/config/publicReviews";
 import { DEFAULT_LOCALE } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
@@ -83,6 +84,29 @@ const referenceActiveStreamReviewVersion =
   publiclyAvailableStreamReviewVersions.at(-1) ??
   activeStreamReviewVersion;
 
+const streamReferenceSourceCommits = Object.fromEntries(
+  STREAM_REVIEW_DEFINITION.versions.map((candidate) => [
+    candidate.version,
+    candidate.source.commit,
+  ])
+);
+streamReferenceSourceCommits[streamReferenceConfig.reviewVersion] =
+  streamReferenceConfig.source.commit;
+
+if (
+  streamReferenceConfig.reviewId !== STREAM_REVIEW_SLUG ||
+  streamReferenceConfig.source.repository !==
+    activeStreamReviewVersion.source.repository ||
+  !streamReferenceConfig.output.retainedVersions.includes(
+    streamReferenceConfig.reviewVersion
+  ) ||
+  streamReferenceConfig.output.retainedVersions.some(
+    (version) => !streamReferenceSourceCommits[version]
+  )
+) {
+  throw new Error("The Stream Solidity source-index identity is invalid.");
+}
+
 const STREAM_SOLIDITY_REFERENCE_IDENTITY: SolidityReferenceReviewIdentity = {
   activeSourceCommit: referenceActiveStreamReviewVersion.source.commit,
   activeVersion: referenceActiveStreamReviewVersion.version,
@@ -90,12 +114,9 @@ const STREAM_SOLIDITY_REFERENCE_IDENTITY: SolidityReferenceReviewIdentity = {
     (candidate) => candidate.version
   ),
   reviewId: STREAM_REVIEW_SLUG,
-  sourceCommits: Object.fromEntries(
-    STREAM_REVIEW_DEFINITION.versions.map((candidate) => [
-      candidate.version,
-      candidate.source.commit,
-    ])
-  ),
+  sourceCommits: streamReferenceSourceCommits,
+  sourceIndexActiveVersion: streamReferenceConfig.reviewVersion,
+  sourceIndexAvailableVersions: streamReferenceConfig.output.retainedVersions,
   sourceRepository: activeStreamReviewVersion.source.repository,
 };
 

--- a/scripts/package-public-review-artifacts.cjs
+++ b/scripts/package-public-review-artifacts.cjs
@@ -323,13 +323,6 @@ function getPublicReviewPublicationPlans(repoRoot) {
         `${publication.reviewId} source review index drifted from publication config.`
       );
 
-      const activePublication = publication.versions.find(
-        (version) => version.version === reference.config.reviewVersion
-      );
-      invariant(
-        activePublication?.lifecycleState === publication.lifecycleState,
-        `${publication.reviewId} active publication lifecycle drifted.`
-      );
       const publishedVersions = new Set(
         publication.versions
           .filter((version) =>
@@ -344,6 +337,27 @@ function getPublicReviewPublicationPlans(repoRoot) {
         : [...retainedVersions]
             .reverse()
             .find((version) => publishedVersions.has(version));
+      const sourceActivePublication = publication.versions.find(
+        (version) => version.version === reference.config.reviewVersion
+      );
+      invariant(
+        sourceActivePublication,
+        `${publication.reviewId} has no publication entry for its source-active version.`
+      );
+      if (sourceActivePublication.lifecycleState !== "DRAFT") {
+        invariant(
+          sourceActivePublication.lifecycleState === publication.lifecycleState,
+          `${publication.reviewId} active publication lifecycle drifted.`
+        );
+      } else if (publication.lifecycleState !== "DRAFT") {
+        const fallbackPublication = publication.versions.find(
+          (version) => version.version === indexActiveVersion
+        );
+        invariant(
+          fallbackPublication?.lifecycleState === publication.lifecycleState,
+          `${publication.reviewId} fallback publication lifecycle drifted.`
+        );
+      }
 
       return [
         publication.reviewId,
@@ -363,9 +377,7 @@ function getPublishedReviewIds(repoRoot) {
   return new Set(
     [...getPublicReviewPublicationPlans(repoRoot).entries()]
       .filter(([, plan]) =>
-        PUBLIC_REVIEW_PUBLIC_ROUTE_STATES.has(
-          plan.publication.lifecycleState
-        )
+        PUBLIC_REVIEW_PUBLIC_ROUTE_STATES.has(plan.publication.lifecycleState)
       )
       .map(([reviewId]) => reviewId)
   );
@@ -790,9 +802,7 @@ function assertCanonicalReviewEvidence({
     config.reviewId
   );
   return index.versions
-    .filter((entry) =>
-      publicationPlan.publishedVersions.has(entry.version)
-    )
+    .filter((entry) => publicationPlan.publishedVersions.has(entry.version))
     .map((entry) => {
       invariant(
         SAFE_VERSION_PATTERN.test(entry.version) &&
@@ -801,11 +811,7 @@ function assertCanonicalReviewEvidence({
           SHA256_URN_PATTERN.test(entry.bundleSha256),
         `${config.reviewId}@${entry.version} review index entry is invalid.`
       );
-      const versionRoot = path.join(
-        reviewRoot,
-        "versions",
-        entry.version
-      );
+      const versionRoot = path.join(reviewRoot, "versions", entry.version);
       const bundlePath = path.join(versionRoot, config.output.bundleFile);
       const expectedBundlePath = `/review-data/${config.reviewId}/versions/${entry.version}/${config.output.bundleFile}`;
       invariant(
@@ -959,10 +965,7 @@ function assertStagingEvidence(
     }) ===
       directoryIdentity(bundlePublicReviewRoot, {
         ignore: (relativePath) =>
-          isReviewIndexPath(
-            `review-data/${relativePath}`,
-            publicationPlans
-          ),
+          isReviewIndexPath(`review-data/${relativePath}`, publicationPlans),
       }),
     "Staging public-review data does not exactly match the trusted source tree."
   );
@@ -1087,12 +1090,7 @@ function assertProfileBundle({
 }) {
   invariant(PROFILES.has(profile), `Unsupported artifact profile: ${profile}`);
   invariant(fs.statSync(bundleRoot).isDirectory(), "Bundle root is missing.");
-  assertPublicCopyIdentity(
-    repoRoot,
-    bundleRoot,
-    profile,
-    publicationPlans
-  );
+  assertPublicCopyIdentity(repoRoot, bundleRoot, profile, publicationPlans);
 
   if (profile === "production") {
     assertProductionAbsence(bundleRoot);

--- a/scripts/public-reviews/verify-snapshot-pr.cjs
+++ b/scripts/public-reviews/verify-snapshot-pr.cjs
@@ -18,6 +18,8 @@ const {
 } = require("./solidity-reference-lib.cjs");
 
 const CONFIG_PATH = "config/public-reviews/6529-stream.reference.json";
+const PUBLICATION_CONFIG_PATH =
+  "config/public-reviews/6529-stream.publication.json";
 const REVIEW_ROOT = "public/review-data/6529-stream";
 const FRONTEND_REMOTE =
   "https://github.com/6529-Collections/6529seize-frontend.git";
@@ -259,17 +261,29 @@ function snapshotChangePolicy(entries) {
     invariant(
       entry.paths.every(
         (candidatePath) =>
-          candidatePath === CONFIG_PATH || isReviewDataPath(candidatePath)
+          candidatePath === CONFIG_PATH ||
+          candidatePath === PUBLICATION_CONFIG_PATH ||
+          isReviewDataPath(candidatePath)
       ),
-      "Snapshot PRs may change only the fixed config and review-data tree."
+      "Snapshot PRs may change only the fixed reference config, publication config, and review-data tree."
     );
     if (entry.paths[0] === CONFIG_PATH) {
       invariant(
         ["A", "M"].includes(entry.status),
-        "Snapshot config must be added or modified, never deleted."
+        "Snapshot reference config must be added or modified, never deleted."
       );
     }
   }
+  const publicationChanges = entries.filter((entry) =>
+    entry.paths.includes(PUBLICATION_CONFIG_PATH)
+  );
+  invariant(
+    flattenedPaths.includes(CONFIG_PATH) &&
+      publicationChanges.length === 1 &&
+      publicationChanges[0].status === "M" &&
+      publicationChanges[0].paths.length === 1,
+    "Snapshot PRs must update the fixed reference config and modify exactly one fixed publication config."
+  );
   return { touchesSnapshot: true };
 }
 
@@ -305,6 +319,23 @@ function exactCandidateBlobMaps(repositoryRoot, headSha, run = defaultRun) {
     configBuffer.length <= MAX_CONFIG_BYTES,
     "Candidate snapshot config exceeds the trusted size limit."
   );
+  const publicationEntries = readTreeAtPaths(
+    repositoryRoot,
+    headSha,
+    [PUBLICATION_CONFIG_PATH],
+    run
+  );
+  invariant(
+    publicationEntries.size === 1 &&
+      publicationEntries.has(PUBLICATION_CONFIG_PATH),
+    "Candidate snapshot must contain exactly one fixed publication config blob."
+  );
+  const publicationEntry = publicationEntries.get(PUBLICATION_CONFIG_PATH);
+  const publicationBuffer = readGitBlob(repositoryRoot, publicationEntry, run);
+  invariant(
+    publicationBuffer.length <= MAX_CONFIG_BYTES,
+    "Candidate publication config exceeds the trusted size limit."
+  );
   const reviewEntries = readTreeAtPaths(
     repositoryRoot,
     headSha,
@@ -334,7 +365,13 @@ function exactCandidateBlobMaps(repositoryRoot, headSha, run = defaultRun) {
       buffer,
     });
   }
-  return { configBuffer, configEntry, reviewBlobs };
+  return {
+    configBuffer,
+    configEntry,
+    publicationBuffer,
+    publicationEntry,
+    reviewBlobs,
+  };
 }
 
 function fetchAndBindCandidate(context, dependencies = {}) {
@@ -538,6 +575,49 @@ function validateTrustedConfigPolicy(baseConfig, candidateConfig, versions) {
     stableJson(candidateConfig.output.retainedVersions) ===
       stableJson([...versions, candidateConfig.reviewVersion]),
     "Candidate retainedVersions must append to exact base history."
+  );
+}
+
+function validateTrustedPublicationPolicy(
+  basePublication,
+  candidatePublication,
+  candidateConfig,
+  baseVersions
+) {
+  invariant(
+    baseVersions !== null &&
+      basePublication !== null &&
+      typeof basePublication === "object" &&
+      !Array.isArray(basePublication) &&
+      Array.isArray(basePublication.versions),
+    "Trusted base publication requires an existing review history."
+  );
+  invariant(
+    candidatePublication !== null &&
+      typeof candidatePublication === "object" &&
+      !Array.isArray(candidatePublication) &&
+      Array.isArray(candidatePublication.versions),
+    "Candidate publication config is invalid."
+  );
+  invariant(
+    stableJson(basePublication.versions.map((entry) => entry.version)) ===
+      stableJson(baseVersions),
+    "Trusted base publication versions drifted from trusted review history."
+  );
+  const candidateVersions = candidateConfig.output.retainedVersions;
+  invariant(
+    stableJson(candidatePublication.versions.map((entry) => entry.version)) ===
+      stableJson(candidateVersions),
+    "Candidate publication versions must match retained review history."
+  );
+  const expectedPublication = JSON.parse(JSON.stringify(basePublication));
+  expectedPublication.versions.push({
+    version: candidateConfig.reviewVersion,
+    lifecycleState: "DRAFT",
+  });
+  invariant(
+    stableJson(candidatePublication) === stableJson(expectedPublication),
+    "Candidate publication must preserve trusted state and append exactly one DRAFT version."
   );
 }
 
@@ -920,11 +1000,8 @@ async function verifySnapshotPr(context, dependencies = {}) {
     }
 
     if (binding.touchesSnapshot) {
-      const { configBuffer, reviewBlobs } = exactCandidateBlobMaps(
-        context.repositoryRoot,
-        context.headSha,
-        run
-      );
+      const { configBuffer, publicationBuffer, reviewBlobs } =
+        exactCandidateBlobMaps(context.repositoryRoot, context.headSha, run);
       const baseConfigPath = path.join(
         context.repositoryRoot,
         ...CONFIG_PATH.split("/")
@@ -936,6 +1013,24 @@ async function verifySnapshotPr(context, dependencies = {}) {
       const candidateConfig = parseJson(configBuffer, "candidate config");
       const versions = baseIndexVersions(context.repositoryRoot);
       validateTrustedConfigPolicy(baseConfig, candidateConfig, versions);
+      const basePublicationPath = path.join(
+        context.repositoryRoot,
+        ...PUBLICATION_CONFIG_PATH.split("/")
+      );
+      const basePublication = parseJson(
+        fs.readFileSync(basePublicationPath),
+        "trusted base publication config"
+      );
+      const candidatePublication = parseJson(
+        publicationBuffer,
+        "candidate publication config"
+      );
+      validateTrustedPublicationPolicy(
+        basePublication,
+        candidatePublication,
+        candidateConfig,
+        versions
+      );
 
       tempRoot = fs.mkdtempSync(
         path.join(os.tmpdir(), `public-review-trust-${context.prNumber}-`)
@@ -1068,6 +1163,7 @@ module.exports = {
   CONFIG_PATH,
   FRONTEND_REMOTE,
   GIT_REGULAR_MODE,
+  PUBLICATION_CONFIG_PATH,
   PROTECTED_TRUST_ROOT_PATHS,
   REVIEW_ROOT,
   SOLC_LONG_VERSION,
@@ -1093,6 +1189,7 @@ module.exports = {
   validateIdentifiers,
   validateSolcDigest,
   validateTrustedConfigPolicy,
+  validateTrustedPublicationPolicy,
   verifyOfficialStreamInputs,
   verifySnapshotPr,
 };


### PR DESCRIPTION
## Issue

The trusted Stream snapshot PR cannot include the publication manifest, while the application build now requires publication versions to match retained snapshot versions. This creates a deadlock: the integrity-only snapshot passes trust but fails the app build.

## Fix

Keep snapshot integrity and public activation as separate authorization boundaries. A trusted snapshot may append the new version to the publication manifest only as `DRAFT`; a later ordinary feature PR explicitly publishes it.

## Notable changes

- bind the fixed publication manifest as a size-limited regular blob from the exact candidate SHA
- require snapshot PRs to modify the reference config, publication manifest, and generated review-data tree only
- require the candidate publication object to equal the trusted base object plus exactly one `DRAFT` version
- package the previous public version as active while a newer source snapshot remains hidden in `DRAFT`
- reject publication-history drift, non-DRAFT preload, fallback-state mismatch, and policy-scope bypasses

## Validation

- 41 snapshot-trust tests pass
- 32 public-review artifact packaging tests pass
- changed-file ESLint passes
- changed-file typecheck passes
- scoped Prettier and whitespace checks pass
- full production build passes

`check:changed` reached lint after typecheck but included a pre-existing `useWaveDropsSerialScroll.ts` rule failure outside this PR; the scoped lint and full build are green.

## Risk and review notes

This changes the `pull_request_target` trust root. Candidate code is still never checked out or executed: only exact-head Git blobs are read, mode/size checked, and compared under the base-owned verifier. The trust workflow will intentionally request the repository's explicit maintainer bypass for its own protected verifier-file change; that bypass does not apply to later snapshot PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of Solidity reference indexes, including version lists, commit provenance, active versions, and published projections.
  * Prevented publication snapshots from accepting invalid lifecycle changes, review identity changes, or publication history drift.
  * Preserved the prior public version while a new draft review is preloaded.

* **Validation**
  * Added stronger checks for trusted publication configurations and snapshot changes.
  * Added coverage for invalid indexes, commit mismatches, missing versions, and malformed publication candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->