### PR TITLE
test(public-review): decouple snapshot trust fixtures

### DIFF
--- a/__tests__/scripts/public-review-snapshot-trust.test.ts
+++ b/__tests__/scripts/public-review-snapshot-trust.test.ts
@@ -165,6 +165,7 @@ const {
 const shaA = "a".repeat(40);
 const shaB = "b".repeat(40);
 const shaC = "c".repeat(40);
+const SYNTHETIC_FUTURE_VERSION = "2099-12-31.1";
 
 function loadConfig(): Config {
   return JSON.parse(
@@ -536,40 +537,29 @@ describe("public-review snapshot trust immutable history", () => {
 
   it("requires a future version to append exact immutable history", () => {
     const base = loadConfig();
+    const trustedVersions = [...base.output.retainedVersions];
     const candidate = cloneConfig(base);
-    candidate.reviewVersion = "2026-07-27.2";
+    candidate.reviewVersion = SYNTHETIC_FUTURE_VERSION;
     candidate.source.commit = shaA;
     candidate.source.tree = shaB;
-    candidate.output.directory =
-      "public/review-data/6529-stream/versions/2026-07-27.2";
+    candidate.output.directory = `public/review-data/6529-stream/versions/${SYNTHETIC_FUTURE_VERSION}`;
     candidate.output.retainedVersions = [
-      "2026-07-26.1",
-      "2026-07-27.1",
-      "2026-07-27.2",
+      ...trustedVersions,
+      SYNTHETIC_FUTURE_VERSION,
     ];
 
     expect(() =>
-      validateTrustedConfigPolicy(base, candidate, [
-        "2026-07-26.1",
-        "2026-07-27.1",
-      ])
+      validateTrustedConfigPolicy(base, candidate, trustedVersions)
     ).not.toThrow();
-    candidate.output.retainedVersions = ["2026-07-27.2"];
+    candidate.output.retainedVersions = [SYNTHETIC_FUTURE_VERSION];
     expect(() =>
-      validateTrustedConfigPolicy(base, candidate, [
-        "2026-07-26.1",
-        "2026-07-27.1",
-      ])
+      validateTrustedConfigPolicy(base, candidate, trustedVersions)
     ).toThrow("append to exact base history");
-    candidate.reviewVersion = "2026-07-27.1";
-    candidate.output.directory =
-      "public/review-data/6529-stream/versions/2026-07-27.1";
-    candidate.output.retainedVersions = ["2026-07-26.1", "2026-07-27.1"];
+    candidate.reviewVersion = base.reviewVersion;
+    candidate.output.directory = `public/review-data/6529-stream/versions/${base.reviewVersion}`;
+    candidate.output.retainedVersions = [...trustedVersions];
     expect(() =>
-      validateTrustedConfigPolicy(base, candidate, [
-        "2026-07-26.1",
-        "2026-07-27.1",
-      ])
+      validateTrustedConfigPolicy(base, candidate, trustedVersions)
     ).toThrow("strictly greater");
   });
 });
@@ -577,15 +567,13 @@ describe("public-review snapshot trust immutable history", () => {
 describe("public-review snapshot trust publication preload", () => {
   function futureConfig(): Config {
     const candidate = cloneConfig(loadConfig());
-    candidate.reviewVersion = "2026-07-28.1";
+    candidate.reviewVersion = SYNTHETIC_FUTURE_VERSION;
     candidate.source.commit = shaA;
     candidate.source.tree = shaB;
-    candidate.output.directory =
-      "public/review-data/6529-stream/versions/2026-07-28.1";
+    candidate.output.directory = `public/review-data/6529-stream/versions/${SYNTHETIC_FUTURE_VERSION}`;
     candidate.output.retainedVersions = [
-      "2026-07-26.1",
-      "2026-07-27.1",
-      "2026-07-28.1",
+      ...candidate.output.retainedVersions,
+      SYNTHETIC_FUTURE_VERSION,
     ];
     return candidate;
   }
@@ -595,7 +583,7 @@ describe("public-review snapshot trust publication preload", () => {
       JSON.stringify(loadPublication())
     ) as Publication;
     candidate.versions.push({
-      version: "2026-07-28.1",
+      version: SYNTHETIC_FUTURE_VERSION,
       lifecycleState: "DRAFT",
     });
     return candidate;
@@ -607,7 +595,7 @@ describe("public-review snapshot trust publication preload", () => {
         loadPublication(),
         draftPublication(),
         futureConfig(),
-        ["2026-07-26.1", "2026-07-27.1"]
+        loadConfig().output.retainedVersions
       )
     ).not.toThrow();
   });
@@ -669,29 +657,32 @@ describe("public-review snapshot trust publication preload", () => {
         loadPublication(),
         candidate,
         futureConfig(),
-        ["2026-07-26.1", "2026-07-27.1"]
+        loadConfig().output.retainedVersions
       )
     ).toThrow(message);
   });
 
   it("rejects publication history that does not match either trusted index", () => {
     const base = loadPublication();
+    const trustedVersions = loadConfig().output.retainedVersions;
     expect(() =>
       validateTrustedPublicationPolicy(
         base,
         draftPublication(),
         futureConfig(),
-        ["2026-07-26.1"]
+        trustedVersions.slice(0, -1)
       )
     ).toThrow("Trusted base publication versions drifted");
 
     const candidate = draftPublication();
-    candidate.versions.at(-1)!.version = "2026-07-29.1";
+    candidate.versions.at(-1)!.version = "2099-12-31.2";
     expect(() =>
-      validateTrustedPublicationPolicy(base, candidate, futureConfig(), [
-        "2026-07-26.1",
-        "2026-07-27.1",
-      ])
+      validateTrustedPublicationPolicy(
+        base,
+        candidate,
+        futureConfig(),
+        trustedVersions
+      )
     ).toThrow("must match retained review history");
   });
 
@@ -701,7 +692,7 @@ describe("public-review snapshot trust publication preload", () => {
         loadPublication(),
         null as unknown as Publication,
         futureConfig(),
-        ["2026-07-26.1", "2026-07-27.1"]
+        loadConfig().output.retainedVersions
       )
     ).toThrow("Candidate publication config is invalid");
   });
@@ -934,9 +925,8 @@ describe("public-review snapshot trust orchestration", () => {
     );
 
     const futureConfig = cloneConfig(baseConfig);
-    futureConfig.reviewVersion = "2026-07-28.1";
-    futureConfig.output.directory =
-      "public/review-data/6529-stream/versions/2026-07-28.1";
+    futureConfig.reviewVersion = SYNTHETIC_FUTURE_VERSION;
+    futureConfig.output.directory = `public/review-data/6529-stream/versions/${SYNTHETIC_FUTURE_VERSION}`;
     futureConfig.output.retainedVersions = [
       ...baseConfig.output.retainedVersions,
       futureConfig.reviewVersion,


### PR DESCRIPTION
## Issue
The snapshot trust test fixtures hard-coded `2026-07-28.1` as the next review version. Once that exact version is source-active in a candidate snapshot, the fixtures create duplicate retained/publication versions and fail before exercising the verifier behavior they are meant to test.

## Fix
- derive trusted history from the checked-out reference config
- append a fixed synthetic future review version that cannot collide with current retained history
- keep the existing immutable-history, publication-tamper, exact-base, cleanup, and regeneration assertions unchanged
- change tests only; production verifier and snapshot policy are untouched

## Validation
- snapshot trust suite: 41/41 passing
- changed-file lint: passing
- changed-file typecheck: passing
- Prettier: passing
- whitespace check: passing

## Risk
Low. One test file changes. The purpose is to keep the trust suite valid before and after real snapshot preloads without weakening any production trust invariant.

## Review notes
Please verify the synthetic future version is used only by fixtures and that trusted retained history still comes from the checked-out repository state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test consistency by using a shared synthetic future version across snapshot trust and publication validation scenarios.
  * Updated test setup to derive retained version history from configured values, improving resilience to configuration changes.
  * Preserved existing test behaviors and assertions while reducing hardcoded version data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->