### PR TITLE
fix(public-review): bind snapshot DRAFT to source commit

### DIFF
--- a/__tests__/scripts/public-review-snapshot-trust.test.ts
+++ b/__tests__/scripts/public-review-snapshot-trust.test.ts
@@ -23,7 +23,11 @@ type Publication = {
   schemaVersion: string;
   reviewId: string;
   lifecycleState: string;
-  versions: Array<{ version: string; lifecycleState: string }>;
+  versions: Array<{
+    version: string;
+    lifecycleState: string;
+    sourceCommit: string;
+  }>;
   [key: string]: unknown;
 };
 
@@ -585,19 +589,66 @@ describe("public-review snapshot trust publication preload", () => {
     candidate.versions.push({
       version: SYNTHETIC_FUTURE_VERSION,
       lifecycleState: "DRAFT",
+      sourceCommit: shaA,
     });
     return candidate;
   }
 
-  it("allows exactly one new DRAFT entry while preserving published state", () => {
+  it("accepts exactly one future DRAFT with the explicit configured source commit", () => {
+    const base = loadPublication();
+    const candidate = draftPublication();
+
+    expect(candidate.lifecycleState).toBe(base.lifecycleState);
+    expect(candidate.versions.slice(0, -1)).toEqual(base.versions);
+    expect(candidate.versions.at(-1)).toEqual({
+      version: SYNTHETIC_FUTURE_VERSION,
+      lifecycleState: "DRAFT",
+      sourceCommit: shaA,
+    });
     expect(() =>
       validateTrustedPublicationPolicy(
-        loadPublication(),
-        draftPublication(),
+        base,
+        candidate,
         futureConfig(),
         loadConfig().output.retainedVersions
       )
     ).not.toThrow();
+  });
+
+  it.each([
+    {
+      label: "missing",
+      sourceCommit: undefined,
+    },
+    {
+      label: "malformed",
+      sourceCommit: "not-a-full-lowercase-sha",
+    },
+    {
+      label: "mismatched",
+      sourceCommit: shaB,
+    },
+  ])("fails closed for a $label sourceCommit", ({ sourceCommit }) => {
+    const candidate = draftPublication();
+    const appendedVersion = candidate.versions.at(-1)! as {
+      sourceCommit?: string;
+    };
+    if (sourceCommit === undefined) {
+      delete appendedVersion.sourceCommit;
+    } else {
+      appendedVersion.sourceCommit = sourceCommit;
+    }
+
+    expect(() =>
+      validateTrustedPublicationPolicy(
+        loadPublication(),
+        candidate,
+        futureConfig(),
+        loadConfig().output.retainedVersions
+      )
+    ).toThrow(
+      "Candidate publication must preserve trusted state and append exactly one DRAFT version"
+    );
   });
 
   it.each([
@@ -619,6 +670,13 @@ describe("public-review snapshot trust publication preload", () => {
       label: "a historical lifecycle change",
       mutate: (candidate: Publication) => {
         candidate.versions[0]!.lifecycleState = "ARCHIVED";
+      },
+      message: "append exactly one DRAFT version",
+    },
+    {
+      label: "a historical source commit change",
+      mutate: (candidate: Publication) => {
+        candidate.versions[0]!.sourceCommit = shaB;
       },
       message: "append exactly one DRAFT version",
     },
@@ -660,6 +718,28 @@ describe("public-review snapshot trust publication preload", () => {
         loadConfig().output.retainedVersions
       )
     ).toThrow(message);
+  });
+
+  it("rejects a missing or duplicated appended version", () => {
+    expect(() =>
+      validateTrustedPublicationPolicy(
+        loadPublication(),
+        loadPublication(),
+        futureConfig(),
+        loadConfig().output.retainedVersions
+      )
+    ).toThrow("must match retained review history");
+
+    const candidate = draftPublication();
+    candidate.versions.push({ ...candidate.versions.at(-1)! });
+    expect(() =>
+      validateTrustedPublicationPolicy(
+        loadPublication(),
+        candidate,
+        futureConfig(),
+        loadConfig().output.retainedVersions
+      )
+    ).toThrow("must match retained review history");
   });
 
   it("rejects publication history that does not match either trusted index", () => {
@@ -940,6 +1020,7 @@ describe("public-review snapshot trust orchestration", () => {
     candidatePublicationObject.versions.push({
       version: futureConfig.reviewVersion,
       lifecycleState: "DRAFT",
+      sourceCommit: futureConfig.source.commit,
     });
     const candidatePublication = Buffer.from(
       `${JSON.stringify(candidatePublicationObject, null, 2)}\n`

--- a/pr-reports/3513.md
+++ b/pr-reports/3513.md
@@ -1,0 +1,64 @@
+# PR Report: Bind Stream Snapshot DRAFT to Its Source Commit
+
+PR: https://github.com/6529-Collections/6529seize-frontend/pull/3513
+Branch: `agent-prxt/fix-stream-snapshot-trust-source-commit` -> `main`
+Related PRs: https://github.com/6529-Collections/6529seize-frontend/pull/3510
+
+## Summary
+
+Aligns the protected, base-owned Stream snapshot verifier with publication
+schema v3 by requiring the next retained DRAFT identity to carry the exact
+Stream source commit from the independently validated candidate config.
+
+## What Changed
+
+- Builds the trusted expected DRAFT entry with `version`, `lifecycleState`, and
+  `sourceCommit`.
+- Accepts only the source commit already bound to the candidate snapshot config.
+- Adds fail-closed regression coverage for missing, malformed, and mismatched
+  source commits.
+- Preserves immutable publication history, exact single-version append
+  semantics, and existing public/draft lifecycle behavior.
+- Keeps the verifier protected and leaves the snapshot change policy and
+  trusted regeneration boundary unchanged.
+
+## Frontend Impact
+
+- Routes/views: Not affected.
+- Components: Not affected.
+- Generated API/client: Not affected.
+- User-visible behavior: Not affected; this changes CI trust verification for
+  future Stream Solidity snapshot pull requests.
+
+## Config / Env
+
+No configuration or environment changes.
+
+## Release Notes
+
+Future Stream snapshot pull requests can carry publication schema v3 identities
+without being rejected by the base-owned verifier solely because the trusted
+expected DRAFT omitted its source commit.
+
+## Risks / Follow-Ups
+
+### Protected Verifier Follow-Up
+
+This is the architectural follow-up to PR #3510. Candidate-executed code and
+generated artifacts remain outside the identity-authority boundary.
+
+### Expected Maintainer Bypass
+
+The changed verifier remains in `PROTECTED_TRUST_ROOT_PATHS`. Its own protected
+trust check is expected to require an explicit maintainer-authorized bypass
+when this pull request is merged. That expected result must not be addressed by
+weakening protection or adding an automatic self-bypass.
+
+### Separate GitHub Settings Recommendation
+
+Read-only inspection found that `Installed app checks` is required by the active
+main ruleset, but PR #3507 merged through the ruleset's pull-request-only bypass
+path while that check was still running; it later failed. Consider narrowing or
+removing the broad administrator/maintainer bypass for routine main merges, or
+retaining it only for documented emergency use. This pull request does not
+change GitHub rulesets or branch-protection settings.

--- a/scripts/public-reviews/verify-snapshot-pr.cjs
+++ b/scripts/public-reviews/verify-snapshot-pr.cjs
@@ -614,6 +614,7 @@ function validateTrustedPublicationPolicy(
   expectedPublication.versions.push({
     version: candidateConfig.reviewVersion,
     lifecycleState: "DRAFT",
+    sourceCommit: candidateConfig.source.commit,
   });
   invariant(
     stableJson(candidatePublication) === stableJson(expectedPublication),


### PR DESCRIPTION
## Issue

- Publication schema v3 requires every retained Stream snapshot identity to include its explicit `sourceCommit`.
- The protected base-owned snapshot verifier still modeled the next appended DRAFT with only `version` and `lifecycleState`, so the next legitimate snapshot PR would fail closed despite carrying the required identity.

## Fix

- Build the trusted expected DRAFT identity with `sourceCommit: candidateConfig.source.commit`.
- Keep the candidate config—already independently validated and bound to official Stream Git objects—as the identity authority.

## Changes

- Updates `validateTrustedPublicationPolicy` to require the exact configured source commit on the appended DRAFT.
- Adds regression coverage for correct, missing, malformed, and mismatched source commits.
- Verifies existing publication history remains immutable, the next version is appended exactly once as DRAFT, and existing public/draft lifecycle behavior is unchanged.
- Leaves `PROTECTED_TRUST_ROOT_PATHS`, `snapshotChangePolicy`, trusted regeneration, and candidate-code isolation intact.

## Validation

- `./bin/6529 run test --coverage=false --runInBand --testPathPatterns=__tests__/scripts/public-review-snapshot-trust.test.ts` — 46 tests passed.
- `./bin/6529 run lint:changed` — passed.
- `./bin/6529 run typecheck:changed` — passed; no production TypeScript files changed.
- `git diff --check` — passed.

## Risk

- Level: Medium.
- Why: the implementation is narrowly scoped and heavily covered, but it intentionally changes a protected public-review trust-root verifier.
- Rollback: revert this PR; no publication data, generated artifacts, runtime behavior, API, or environment configuration changes are included.

## Review Notes

### Protected verifier follow-up

- This is the architectural follow-up to #3510. The verifier now models publication schema v3 without weakening its base-owned trust boundary.

### Expected maintainer bypass

- `scripts/public-reviews/verify-snapshot-pr.cjs` intentionally remains protected. `Public Review Snapshot Trust` is therefore expected to fail with the explicit-maintainer-bypass message on this PR.
- Do not weaken or self-bypass the verifier. A maintainer-authorized ruleset bypass is required when this protected verifier update is eventually merged.

### Separate GitHub settings recommendation

- Read-only inspection confirmed `Installed app checks` is a required main-ruleset check. PR #3507 nevertheless merged through the ruleset's pull-request-only bypass path while that check was still running; it later failed.
- Consider narrowing/removing the broad admin/maintainer pull-request bypass for routine main merges, or retaining it only for documented emergency use. No repository ruleset or branch-protection setting is changed by this PR.