### PR TITLE
Stage: Restore scrolling after global search navigation

### DIFF
--- a/__tests__/hooks/useBodyScrollLock.test.ts
+++ b/__tests__/hooks/useBodyScrollLock.test.ts
@@ -1,0 +1,80 @@
+import { renderHook } from "@testing-library/react";
+import useBodyScrollLock from "@/hooks/useBodyScrollLock";
+
+const setViewport = ({
+  clientWidth,
+  innerWidth,
+}: {
+  readonly clientWidth: number;
+  readonly innerWidth: number;
+}) => {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    value: innerWidth,
+  });
+  Object.defineProperty(document.documentElement, "clientWidth", {
+    configurable: true,
+    value: clientWidth,
+  });
+};
+
+describe("useBodyScrollLock", () => {
+  it("releases the body lock after its owner unmounts", () => {
+    const lock = renderHook(() => useBodyScrollLock());
+
+    expect(document.body.dataset.seizeBodyScrollLocked).toBe("true");
+
+    lock.unmount();
+
+    expect(document.body.dataset.seizeBodyScrollLocked).toBeUndefined();
+  });
+
+  it("keeps a nested scrollbar gap until its last owner unmounts", () => {
+    setViewport({ clientWidth: 980, innerWidth: 1000 });
+    const firstLock = renderHook(() =>
+      useBodyScrollLock({ reserveScrollbarGap: true })
+    );
+
+    expect(
+      document.body.style.getPropertyValue("--seize-body-scrollbar-gap")
+    ).toBe("20px");
+
+    setViewport({ clientWidth: 1000, innerWidth: 1000 });
+    const secondLock = renderHook(() =>
+      useBodyScrollLock({ reserveScrollbarGap: true })
+    );
+
+    firstLock.unmount();
+
+    expect(document.body.dataset.seizeBodyScrollLocked).toBe("true");
+    expect(document.body.dataset.seizeBodyScrollbarGap).toBe("true");
+    expect(
+      document.body.style.getPropertyValue("--seize-body-scrollbar-gap")
+    ).toBe("20px");
+
+    secondLock.unmount();
+
+    expect(document.body.dataset.seizeBodyScrollLocked).toBeUndefined();
+    expect(document.body.dataset.seizeBodyScrollbarGap).toBeUndefined();
+    expect(
+      document.body.style.getPropertyValue("--seize-body-scrollbar-gap")
+    ).toBe("");
+  });
+
+  it("tracks the body lock independently from scrollbar-gap ownership", () => {
+    setViewport({ clientWidth: 980, innerWidth: 1000 });
+    const bodyLock = renderHook(() => useBodyScrollLock());
+    const gapLock = renderHook(() =>
+      useBodyScrollLock({ reserveScrollbarGap: true })
+    );
+
+    gapLock.unmount();
+
+    expect(document.body.dataset.seizeBodyScrollLocked).toBe("true");
+    expect(document.body.dataset.seizeBodyScrollbarGap).toBeUndefined();
+
+    bodyLock.unmount();
+
+    expect(document.body.dataset.seizeBodyScrollLocked).toBeUndefined();
+  });
+});

--- a/__tests__/hooks/useBodyScrollLock.test.ts
+++ b/__tests__/hooks/useBodyScrollLock.test.ts
@@ -22,11 +22,11 @@ describe("useBodyScrollLock", () => {
   it("releases the body lock after its owner unmounts", () => {
     const lock = renderHook(() => useBodyScrollLock());
 
-    expect(document.body.dataset.seizeBodyScrollLocked).toBe("true");
+    expect(document.body.dataset["seizeBodyScrollLocked"]).toBe("true");
 
     lock.unmount();
 
-    expect(document.body.dataset.seizeBodyScrollLocked).toBeUndefined();
+    expect(document.body.dataset["seizeBodyScrollLocked"]).toBeUndefined();
   });
 
   it("keeps a nested scrollbar gap until its last owner unmounts", () => {
@@ -46,16 +46,16 @@ describe("useBodyScrollLock", () => {
 
     firstLock.unmount();
 
-    expect(document.body.dataset.seizeBodyScrollLocked).toBe("true");
-    expect(document.body.dataset.seizeBodyScrollbarGap).toBe("true");
+    expect(document.body.dataset["seizeBodyScrollLocked"]).toBe("true");
+    expect(document.body.dataset["seizeBodyScrollbarGap"]).toBe("true");
     expect(
       document.body.style.getPropertyValue("--seize-body-scrollbar-gap")
     ).toBe("20px");
 
     secondLock.unmount();
 
-    expect(document.body.dataset.seizeBodyScrollLocked).toBeUndefined();
-    expect(document.body.dataset.seizeBodyScrollbarGap).toBeUndefined();
+    expect(document.body.dataset["seizeBodyScrollLocked"]).toBeUndefined();
+    expect(document.body.dataset["seizeBodyScrollbarGap"]).toBeUndefined();
     expect(
       document.body.style.getPropertyValue("--seize-body-scrollbar-gap")
     ).toBe("");
@@ -70,11 +70,11 @@ describe("useBodyScrollLock", () => {
 
     gapLock.unmount();
 
-    expect(document.body.dataset.seizeBodyScrollLocked).toBe("true");
-    expect(document.body.dataset.seizeBodyScrollbarGap).toBeUndefined();
+    expect(document.body.dataset["seizeBodyScrollLocked"]).toBe("true");
+    expect(document.body.dataset["seizeBodyScrollbarGap"]).toBeUndefined();
 
     bodyLock.unmount();
 
-    expect(document.body.dataset.seizeBodyScrollLocked).toBeUndefined();
+    expect(document.body.dataset["seizeBodyScrollLocked"]).toBeUndefined();
   });
 });

--- a/components/header/header-search/HeaderSearchButton.tsx
+++ b/components/header/header-search/HeaderSearchButton.tsx
@@ -6,8 +6,6 @@ import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { useKey } from "react-use";
 
-import CommonAnimationOpacity from "@/components/utils/animation/CommonAnimationOpacity";
-import CommonAnimationWrapper from "@/components/utils/animation/CommonAnimationWrapper";
 import WaveDropsSearchModal from "@/components/waves/drops/search/WaveDropsSearchModal";
 import { useWaveChatScrollOptional } from "@/contexts/wave/WaveChatScrollContext";
 import type { ApiWave } from "@/generated/models/ApiWave";
@@ -103,17 +101,9 @@ export default function HeaderSearchButton({ wave }: HeaderSearchButtonProps) {
         />
       )}
 
-      <CommonAnimationWrapper mode="sync" initial>
-        {openSearch === "site" && (
-          <CommonAnimationOpacity
-            key="site-search-modal"
-            elementClasses="tw-absolute tw-z-10"
-            onClicked={(event) => event.stopPropagation()}
-          >
-            <HeaderSearchModal onClose={closeSearch} wave={null} />
-          </CommonAnimationOpacity>
-        )}
-      </CommonAnimationWrapper>
+      {openSearch === "site" && (
+        <HeaderSearchModal onClose={closeSearch} wave={null} />
+      )}
     </div>
   );
 }

--- a/components/header/header-search/header-search-modal/HeaderSearchModalContent.tsx
+++ b/components/header/header-search/header-search-modal/HeaderSearchModalContent.tsx
@@ -7,6 +7,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { useQuery } from "@tanstack/react-query";
 import { FocusTrap } from "focus-trap-react";
+import { usePathname } from "next/navigation";
 import {
   useCallback,
   useEffect,
@@ -37,6 +38,7 @@ import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import type { ApiWave } from "@/generated/models/ApiWave";
 import useCapacitor from "@/hooks/useCapacitor";
 import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import useBodyScrollLock from "@/hooks/useBodyScrollLock";
 import { useDropForgePermissions } from "@/hooks/useDropForgePermissions";
 import useLocalPreference from "@/hooks/useLocalPreference";
 import {
@@ -228,6 +230,9 @@ function ScopedHeaderSearchModal({
   storageScope,
 }: ScopedHeaderSearchModalProps) {
   useLayoutViewportLock(true);
+  useBodyScrollLock({ reserveScrollbarGap: true });
+  const pathname = usePathname();
+  const initialPathnameRef = useRef(pathname);
   const sessionQueryStorageKey = getScopedStorageKey(
     HEADER_SEARCH_SESSION_QUERY_KEY,
     storageScope
@@ -244,6 +249,10 @@ function ScopedHeaderSearchModal({
   >(null);
   useClickAway(modalRef, onClose);
   useKeyPressEvent("Escape", onClose);
+
+  useEffect(() => {
+    if (pathname !== initialPathnameRef.current) onClose();
+  }, [onClose, pathname]);
 
   const [searchValue, setSearchValue] = useState(() =>
     readSessionQuery(sessionQueryStorageKey)
@@ -367,20 +376,6 @@ function ScopedHeaderSearchModal({
       // Search remains fully functional without session storage.
     }
   }, [searchValue, sessionQueryStorageKey]);
-
-  useEffect(() => {
-    const previousOverflow = document.body.style.overflow;
-    const previousPaddingRight = document.body.style.paddingRight;
-    const scrollbarGap =
-      window.innerWidth - document.documentElement.clientWidth;
-    document.body.style.overflow = "hidden";
-    if (scrollbarGap > 0)
-      document.body.style.paddingRight = `${scrollbarGap}px`;
-    return () => {
-      document.body.style.overflow = previousOverflow;
-      document.body.style.paddingRight = previousPaddingRight;
-    };
-  }, []);
 
   const rememberSearch = useCallback(
     (query: string) => {

--- a/components/header/header-search/header-search-modal/HeaderSearchSiteResults.tsx
+++ b/components/header/header-search/header-search-modal/HeaderSearchSiteResults.tsx
@@ -240,6 +240,7 @@ export function HeaderSearchSiteResults({
   const goToProfile = useCallback(
     (profile: CommunityMemberMinimal) => {
       rememberCurrentSearch();
+      onClose();
       router.push(
         getProfileTargetRoute({
           handleOrWallet: profile.handle ?? profile.wallet.toLowerCase(),
@@ -247,7 +248,6 @@ export function HeaderSearchSiteResults({
           defaultPath: USER_PAGE_TAB_IDS.REP,
         })
       );
-      onClose();
     },
     [onClose, pathname, rememberCurrentSearch, router]
   );
@@ -255,13 +255,13 @@ export function HeaderSearchSiteResults({
   const goToWave = useCallback(
     (wave: ApiWave) => {
       rememberCurrentSearch();
+      onClose();
       const isDirectMessage = isHeaderSearchWaveDirectMessage(wave);
       if (myStream) {
         myStream.activeWave.set(wave.id, { isDirectMessage });
       } else {
         router.push(getHeaderSearchWavePath({ wave, isApp }));
       }
-      onClose();
     },
     [isApp, myStream, onClose, rememberCurrentSearch, router]
   );
@@ -270,14 +270,14 @@ export function HeaderSearchSiteResults({
     (item: HeaderSearchModalItemType) => {
       if (isPageResult(item)) {
         rememberCurrentSearch();
-        router.push(item.href);
         onClose();
+        router.push(item.href);
       } else if (isNftResult(item)) {
         const collection = getNftCollectionMap()[item.contract.toLowerCase()];
         if (!collection) return;
         rememberCurrentSearch();
-        router.push(`${collection.path}/${item.id}`);
         onClose();
+        router.push(`${collection.path}/${item.id}`);
       } else if (isProfileResult(item)) {
         goToProfile(item);
       } else if (isWaveResult(item)) {

--- a/components/layout/sidebar/WebSidebar.tsx
+++ b/components/layout/sidebar/WebSidebar.tsx
@@ -6,8 +6,6 @@ import { useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
 import { Tooltip as ReactTooltip } from "react-tooltip";
 import { useKey } from "react-use";
 import BellIcon from "@/components/common/icons/BellIcon";
-import CommonAnimationOpacity from "@/components/utils/animation/CommonAnimationOpacity";
-import CommonAnimationWrapper from "@/components/utils/animation/CommonAnimationWrapper";
 import HeaderSearchModal from "@/components/header/header-search/HeaderSearchModal";
 import { useUnreadNotifications } from "@/hooks/useUnreadNotifications";
 import useIsTouchDevice from "@/hooks/useIsTouchDevice";
@@ -225,21 +223,9 @@ function WebSidebar({
           </div>
         </div>
       </div>
-      <CommonAnimationWrapper mode="sync" initial>
-        {isSearchOpen && (
-          <CommonAnimationOpacity
-            key="search-modal"
-            elementClasses="tw-fixed tw-inset-0 tw-z-50"
-            elementRole="dialog"
-            onClicked={(event) => event.stopPropagation()}
-          >
-            <HeaderSearchModal
-              onClose={() => setIsSearchOpen(false)}
-              wave={null}
-            />
-          </CommonAnimationOpacity>
-        )}
-      </CommonAnimationWrapper>
+      {isSearchOpen && (
+        <HeaderSearchModal onClose={() => setIsSearchOpen(false)} wave={null} />
+      )}
       {!isTouchScreen && (
         <ReactTooltip
           id="sidebar-tooltip"

--- a/components/waves/layout/WavesLayout.tsx
+++ b/components/waves/layout/WavesLayout.tsx
@@ -9,6 +9,7 @@ import {
   scheduleMobileLaunchFlush,
 } from "../../../utils/monitoring/mobileLaunchTiming";
 import WavesMobile from "../WavesMobile";
+import useBodyScrollLock from "@/hooks/useBodyScrollLock";
 import { useBrowserLocale } from "@/hooks/useBrowserLocale";
 import { t } from "@/i18n/messages";
 
@@ -140,14 +141,7 @@ function WavesLayoutContent({ children }: { readonly children: ReactNode }) {
   // system's measured content height (see CreateWaveFlow.nativeBoundedStyle),
   // so the sticky footer pins inside the app shell's transformed wrappers
   // instead of relying on document scroll (which the transforms break).
-  useEffect(() => {
-    const previousBodyOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-
-    return () => {
-      document.body.style.overflow = previousBodyOverflow;
-    };
-  }, []);
+  useBodyScrollLock();
 
   // tw-min-h-0 lets this flex item shrink below its content height so a child
   // (e.g. the create-wave flow) can own an internal scroll region instead of

--- a/hooks/useBodyScrollLock.ts
+++ b/hooks/useBodyScrollLock.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect } from "react";
+
+const BODY_SCROLL_LOCKED_DATASET_KEY = "seizeBodyScrollLocked";
+const BODY_SCROLLBAR_GAP_DATASET_KEY = "seizeBodyScrollbarGap";
+const BODY_SCROLLBAR_GAP_PROPERTY = "--seize-body-scrollbar-gap";
+
+let scrollLockCount = 0;
+let scrollbarGapLockCount = 0;
+
+interface BodyScrollLockOptions {
+  readonly reserveScrollbarGap?: boolean | undefined;
+}
+
+const acquireBodyScrollLock = ({
+  reserveScrollbarGap = false,
+}: BodyScrollLockOptions): (() => void) => {
+  const { body, documentElement } = document;
+  const scrollbarGap = reserveScrollbarGap
+    ? window.innerWidth - documentElement.clientWidth
+    : 0;
+  const reservesScrollbarGap =
+    reserveScrollbarGap && (scrollbarGapLockCount > 0 || scrollbarGap > 0);
+
+  scrollLockCount += 1;
+  body.dataset[BODY_SCROLL_LOCKED_DATASET_KEY] = "true";
+
+  if (reservesScrollbarGap) {
+    if (scrollbarGapLockCount === 0) {
+      body.style.setProperty(BODY_SCROLLBAR_GAP_PROPERTY, `${scrollbarGap}px`);
+    }
+    scrollbarGapLockCount += 1;
+    body.dataset[BODY_SCROLLBAR_GAP_DATASET_KEY] = "true";
+  }
+
+  let isReleased = false;
+  return () => {
+    if (isReleased) return;
+    isReleased = true;
+
+    scrollLockCount = Math.max(0, scrollLockCount - 1);
+    if (scrollLockCount === 0) {
+      delete body.dataset[BODY_SCROLL_LOCKED_DATASET_KEY];
+    }
+
+    if (!reservesScrollbarGap) return;
+    scrollbarGapLockCount = Math.max(0, scrollbarGapLockCount - 1);
+    if (scrollbarGapLockCount === 0) {
+      delete body.dataset[BODY_SCROLLBAR_GAP_DATASET_KEY];
+      body.style.removeProperty(BODY_SCROLLBAR_GAP_PROPERTY);
+    }
+  };
+};
+
+export default function useBodyScrollLock(options: BodyScrollLockOptions = {}) {
+  const { reserveScrollbarGap = false } = options;
+
+  useEffect(
+    () => acquireBodyScrollLock({ reserveScrollbarGap }),
+    [reserveScrollbarGap]
+  );
+}

--- a/hooks/useBodyScrollLock.ts
+++ b/hooks/useBodyScrollLock.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useLayoutEffect } from "react";
 
 const BODY_SCROLL_LOCKED_DATASET_KEY = "seizeBodyScrollLocked";
 const BODY_SCROLLBAR_GAP_DATASET_KEY = "seizeBodyScrollbarGap";
@@ -56,7 +56,7 @@ const acquireBodyScrollLock = ({
 export default function useBodyScrollLock(options: BodyScrollLockOptions = {}) {
   const { reserveScrollbarGap = false } = options;
 
-  useEffect(
+  useLayoutEffect(
     () => acquireBodyScrollLock({ reserveScrollbarGap }),
     [reserveScrollbarGap]
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -66,6 +66,12 @@
   * {
     -webkit-tap-highlight-color: transparent;
   }
+  body[data-seize-body-scroll-locked="true"] {
+    overflow: hidden !important;
+  }
+  body[data-seize-body-scrollbar-gap="true"] {
+    padding-right: var(--seize-body-scrollbar-gap) !important;
+  }
   /* Android keyboard height adjustments */
   :root {
     --android-keyboard-height: 0px;


### PR DESCRIPTION
## Staging release

- Source PR: #3509
- Exact reviewed head: 3c8d23c85f4f8324b77ef63c413cbb929179414e
- Route: owner-authorized serialized manual fallback while the live STAGING lane is OFF
- Backend dependencies: none

This PR advances the reviewed scroll-lock fix through repository protections without a direct feature-branch merge. The live OFF-mode control currently carries a temporary automated staging/production E2E waiver; deployment and safe production behavior verification remain owned by the release agent.