### PR TITLE
fix: ignore Release Bus runtime bundles in lint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -461,6 +461,7 @@ export const baseRules = deepFreezeRuleConfig({
 export const baseGlobalIgnores = Object.freeze([
   "**/node_modules",
   "**/.next",
+  "**/.release-bus/**",
   "**/dist",
   "**/out",
   "**/public",


### PR DESCRIPTION
Ignore immutable Release Bus runtime bundles during repository-wide ESLint runs. This prevents manual staging builds from linting deployed release archives outside the active TypeScript project. Focused validation confirmed a TypeScript fixture under .release-bus/releases is ignored. Owner authorized immediate merge without waiting for CI.