### PR TITLE
Accept detached Release Bus staging ownership

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -563,6 +563,11 @@ export const createEslintConfig = ({
     {
       files: ["**/*.{js,cjs,mjs}"],
       extends: [tseslint.configs.disableTypeChecked],
+      rules: {
+        // This rule requests parser services when eslint-config-next owns the
+        // JavaScript parser, so keep it scoped to the typed-file config.
+        "@typescript-eslint/consistent-type-imports": "off",
+      },
     },
 
     // TypeScript-specific rules with type-checking

--- a/ops/scripts/release-bus-status.mjs
+++ b/ops/scripts/release-bus-status.mjs
@@ -14,6 +14,7 @@ const VALID_STAGING_STATES = new Set([
   "LIVE",
   "CLEAN_MAIN",
   "ROLLBACK_FAILED",
+  "DETACHED_MANUAL_OWNERSHIP",
 ]);
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "[::1]", "localhost"]);
 

--- a/ops/scripts/release-bus-status.test.ts
+++ b/ops/scripts/release-bus-status.test.ts
@@ -58,7 +58,8 @@ type SanitizedStatus = {
       | "UNINITIALIZED"
       | "LIVE"
       | "CLEAN_MAIN"
-      | "ROLLBACK_FAILED";
+      | "ROLLBACK_FAILED"
+      | "DETACHED_MANUAL_OWNERSHIP";
     readonly current_manifest_id: string | null;
     readonly last_validated_manifest_id: string | null;
     readonly frontend_sha: string | null;
@@ -214,7 +215,6 @@ async function runWithResponse(
   }
 }
 
-// eslint-disable-next-line max-lines-per-function -- This integration-style suite shares one isolated helper/server fixture.
 describe("release-bus-status helper", () => {
   test.each(["OFF", "STAGING", "PRODUCTION"] as const)(
     "prints sanitized status for %s mode",
@@ -279,6 +279,47 @@ describe("release-bus-status helper", () => {
       clean_main: false,
       last_transition_train_id: null,
       row_version: 7,
+    });
+  });
+
+  it("reports detached manual ownership without claiming physical staging absence", async () => {
+    const pausedLaneControls = VALID_CONTROLS.map((control) => ({
+      ...control,
+      paused: control.scope !== "ALL",
+    }));
+    const result = await runWithResponse({
+      mode: "PRODUCTION",
+      controls: pausedLaneControls,
+      lanes: laneStates("PRODUCTION", pausedLaneControls),
+      staging_state: {
+        status: "DETACHED_MANUAL_OWNERSHIP",
+        current_manifest_id: null,
+        last_validated_manifest_id: "historical-manifest",
+        frontend_sha: null,
+        backend_sha: null,
+        frontend_staging_ref_sha: null,
+        backend_staging_ref_sha: null,
+        clean_main: false,
+        last_transition_train_id: null,
+        row_version: 8,
+      },
+    });
+
+    expect(result.code).toBe(0);
+    expect(parseSanitizedStatus(result.stdout)).toMatchObject({
+      lanes: {
+        STAGING: { status: "OFF", changeable: true },
+        PRODUCTION: { status: "OFF", changeable: true },
+      },
+      staging: {
+        status: "DETACHED_MANUAL_OWNERSHIP",
+        current_manifest_id: null,
+        last_validated_manifest_id: "historical-manifest",
+        frontend_sha: null,
+        backend_sha: null,
+        clean_main: false,
+        row_version: 8,
+      },
     });
   });
 

--- a/ops/scripts/release-bus-status.test.ts
+++ b/ops/scripts/release-bus-status.test.ts
@@ -306,10 +306,20 @@ describe("release-bus-status helper", () => {
     });
 
     expect(result.code).toBe(0);
-    expect(parseSanitizedStatus(result.stdout)).toMatchObject({
+    expect(result.stderr).toBe("");
+    expect(result.authorization).toBe(`Bearer ${TOKEN}`);
+    expect(parseSanitizedStatus(result.stdout)).toEqual({
       lanes: {
-        STAGING: { status: "OFF", changeable: true },
-        PRODUCTION: { status: "OFF", changeable: true },
+        STAGING: {
+          status: "OFF",
+          changeable: true,
+          reason: "Staging enabled",
+        },
+        PRODUCTION: {
+          status: "OFF",
+          changeable: true,
+          reason: "Production enabled",
+        },
       },
       staging: {
         status: "DETACHED_MANUAL_OWNERSHIP",
@@ -317,7 +327,10 @@ describe("release-bus-status helper", () => {
         last_validated_manifest_id: "historical-manifest",
         frontend_sha: null,
         backend_sha: null,
+        frontend_staging_ref_sha: null,
+        backend_staging_ref_sha: null,
         clean_main: false,
+        last_transition_train_id: null,
         row_version: 8,
       },
     });
@@ -630,6 +643,7 @@ describe("release-bus-status helper", () => {
   });
 
   test.each([
+    ["status", "DETACHED", INVALID_STAGING_STATE],
     ["row_version", true, INVALID_STAGING_STATE],
     ["row_version", "7", INVALID_STAGING_STATE],
     ["clean_main", null, INVALID_STAGING_STATE],


### PR DESCRIPTION
## Issue

- Logical candidate deregistration intentionally changes authoritative staging state to `DETACHED_MANUAL_OWNERSHIP`.
- The frontend status helper rejected that backend-supported state and failed closed, preventing operators from proving OFF-mode manual fallback remained available.
- Exact-head CI also exposed that diff lint re-enabled a TypeScript parser-service rule for `.mjs` files.

## Fix

- Accept the explicit detached ownership state without inferring physical staging absence.
- Keep `@typescript-eslint/consistent-type-imports` scoped away from non-TypeScript files in the tight diff config.
- Add contract coverage proving both lanes remain independently OFF/changeable, nullable detached identity is preserved, and unknown states still fail closed.

## Changes

- Extend the helper staging-state allowlist and sanitized test type.
- Add exact detached-state output assertions, including lane reasons and all nullable identity fields.
- Add an unknown detached-state rejection case.
- Correct the JavaScript diff-lint rule scope found by exact-head CI.

## Validation

- `./bin/6529 run lint:changed` — passed.
- `./bin/6529 run typecheck:changed` — passed.
- Focused helper and PR-CI policy suites — 56 tests passed.
- Node syntax, Prettier, and `git diff --check` — passed.
- Prior exact-head workflow-contract lane — 218 tests passed before the lint-config failure.
- Live helper invocation against the detached production response — passed.
- Latest exact-head CI is running.

## Risk

- Level: Low.
- Why: one explicit backend-defined enum value, a non-TypeScript lint scoping correction, and focused operational-helper tests.
- Rollback: revert the commits; the helper will fail closed on detached ownership again.

## Review Notes

- Confirm the helper rejects every unknown staging state and never claims detached ownership means physical staging is absent.
- Confirm JavaScript diff lint stays parser-service-free while TypeScript files retain tight type-aware rules.