### PR TITLE
Bind frontend Release Bus PR evidence to composed SHA

### DIFF
--- a/.github/workflows/release-bus-v2-preflight.yml
+++ b/.github/workflows/release-bus-v2-preflight.yml
@@ -142,6 +142,7 @@ jobs:
         continue-on-error: true
         env:
           CANDIDATE_EVIDENCE_MODE: ${{ inputs.candidate_evidence_mode }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
           GH_TOKEN: ${{ github.token }}
           REUSE_ARTIFACT_DIGEST: ${{ inputs.reuse_artifact_digest }}
           REUSE_ARTIFACT_NAME: ${{ inputs.reuse_artifact_name }}
@@ -188,6 +189,7 @@ jobs:
 
           validate_reuse_artifact_identity
           merge_sha="${REUSE_ARTIFACT_NAME#release-bus-v2-pr-}"
+          test "$merge_sha" = "$EXPECTED_SHA"
           set +e
           run="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$REUSE_ARTIFACT_RUN_ID" 2>&1)"
           run_status=$?
@@ -230,7 +232,7 @@ jobs:
           )"
           test "$(cat "$evidence_root/SHA256SUMS")" = "$expected_checksums"
           (cd "$evidence_root" && sha256sum -c SHA256SUMS)
-          jq -e --arg merge_sha "$merge_sha" '
+          jq -e --arg merge_sha "$EXPECTED_SHA" '
             .schema_version == 1 and
             .evidence_contract == "exact-merge-tree-pr-ci-v1" and
             .repository == "frontend" and

--- a/__tests__/scripts/release-bus-artifact-compatibility.test.ts
+++ b/__tests__/scripts/release-bus-artifact-compatibility.test.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { execFileSync, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import YAML from "yaml";
 
 const ROOT = process.cwd();
@@ -10,6 +10,7 @@ const EXPECTED_SHA = "a".repeat(40);
 const TRAIN_ID = "compatibility-train";
 
 type WorkflowStep = {
+  env?: Record<string, string>;
   name?: string;
   run?: string;
   uses?: string;
@@ -888,10 +889,7 @@ describe("Release Bus artifact rollout compatibility", () => {
         ARTIFACT_ENVIRONMENT: "staging",
         CANDIDATE_EVIDENCE_MODE: "strict-single",
         DEPLOY_UNITS: "[]",
-        EXPECTED_SHA: execFileSync("git", ["rev-parse", "HEAD"], {
-          cwd: ROOT,
-          encoding: "utf8",
-        }).trim(),
+        EXPECTED_SHA: mergeSha,
         GITHUB_REPOSITORY: "6529-Collections/6529seize-frontend",
         GITHUB_OUTPUT: evidenceOutput,
         MOCK_ARTIFACT_DIGEST: artifactDigest,
@@ -918,6 +916,12 @@ describe("Release Bus artifact rollout compatibility", () => {
       );
       expect(workflow.jobs.evidence.needs).toBe("authorize");
       expect(workflow.jobs.build.needs).toBe("evidence");
+      expect(validateEvidence.env).toMatchObject({
+        EXPECTED_SHA: "${{ inputs.expected_sha }}",
+      });
+      expect(validateEvidence.run).toContain(
+        'test "$merge_sha" = "$EXPECTED_SHA"'
+      );
       expect(runShell(validateLocal.run!, { env: baseEnv }).status).toBe(0);
       expect(fs.existsSync(ghInvocations)).toBe(false);
       expect(
@@ -936,9 +940,15 @@ describe("Release Bus artifact rollout compatibility", () => {
       ).toBe(0);
       expect(fs.existsSync(curlPayload)).toBe(true);
       expect(runShell(validateEvidence.run!, { env: baseEnv }).status).toBe(0);
+      expect(baseEnv.EXPECTED_SHA).not.toBe(baseEnv.MOCK_HEAD_SHA);
       expect(fs.readFileSync(ghInvocations, "utf8")).toContain(
         "actions/runs/1234/artifacts"
       );
+      expect(
+        runShell(validateEvidence.run!, {
+          env: { ...baseEnv, EXPECTED_SHA: baseEnv.MOCK_HEAD_SHA },
+        }).status
+      ).not.toBe(0);
       expect(
         runShell(validateEvidence.run!, {
           env: { ...baseEnv, MOCK_HEAD_SHA: "a".repeat(40) },


### PR DESCRIPTION
## Issue

- Strict single-candidate Release Bus preflight must distinguish the pull-request head SHA reported by GitHub Actions from the merge-tree/composed SHA dispatched as expected_sha.
- Treating those identities as interchangeable rejects valid immutable PR CI evidence or can leave the composed SHA insufficiently bound.

## Fix

- Bind the reusable artifact name and evidence manifest merge_sha to the exact preflight expected_sha.
- Continue binding the Actions run head_sha to the evidence manifest head_sha, allowing the PR head and merge-tree SHA to differ as GitHub defines them.

## Changes

- Pass expected_sha into the authorized evidence-validation job and fail closed if the reusable artifact merge-tree identity differs.
- Validate the immutable manifest merge identity against expected_sha.
- Extend executable workflow-contract coverage for the valid distinct head/merge case, the invalid head-as-expected case, and the workflow input mapping.

## Validation

- Focused Release Bus evidence and performance contracts: 2 suites, 18 tests.
- Broader Release Bus workflow contracts: 7 suites, 40 tests.
- check:changed, lint:changed, typecheck:changed, typecheck:tests, and git diff --check.

## Risk

- Level: Medium
- Why: the change is narrow but sits on the fail-closed Release Bus evidence path.
- Rollback: revert this commit; no artifact schema, runtime code, lane state, or deployment state is mutated by this PR.

## Review Notes

- Verify that GitHub Actions run metadata remains bound only to manifest head_sha, while the artifact and manifest merge identities are both bound to the train exact expected_sha.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release preflight validation to ensure CI evidence matches the expected merge revision.
  - Prevented release artifacts from being accepted when evidence references an incorrect or inconsistent revision.
  - Strengthened validation of evidence manifests and artifact sources for more reliable release checks.

- **Tests**
  - Expanded automated coverage for valid evidence, revision mismatches, and failure scenarios across supported evidence modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->