### PR TITLE
Defer automatic staging E2E for baseline adoption

### DIFF
--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -71,19 +71,58 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  baseline-adoption-decision:
+    name: Resolve pending baseline adoption
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.head_branch == '1a-staging'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      decision: ${{ steps.decision.outputs.decision }}
+      manifest_ready: ${{ steps.decision.outputs.manifest_ready }}
+    steps:
+      - name: Check out trusted decision client
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          sparse-checkout: scripts/release-bus-baseline-adoption-decision.cjs
+          sparse-checkout-cone-mode: false
+
+      - name: Resolve exact automatic E2E decision
+        id: decision
+        env:
+          DEPLOYED_REF: ${{ github.event.workflow_run.head_branch }}
+          DEPLOYED_SHA: ${{ github.event.workflow_run.head_sha }}
+          DEPLOY_WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          RELEASE_BUS_API_URL: ${{ vars.RELEASE_BUS_API_URL }}
+          RELEASE_BUS_WORKFLOW_AUTH_TOKEN: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
+        run: node scripts/release-bus-baseline-adoption-decision.cjs
+
   staging-packs:
     name: Staging E2E packs
+    needs: baseline-adoption-decision
     # Trust gate: this job holds a secret and executes checked-out code, so
     # workflow_run triggers must come from this repository's own 1a-staging
     # branch (staging deploys are push-triggered; forks cannot push there).
     # The explicit head_repository/head_branch conditions keep that invariant
     # enforced even if the upstream deploy workflow's triggers ever change.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
+      always() &&
       (
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.head_repository.full_name == github.repository &&
-        github.event.workflow_run.head_branch == '1a-staging'
+        github.event_name == 'workflow_dispatch' ||
+        (
+          needs.baseline-adoption-decision.result == 'success' &&
+          needs.baseline-adoption-decision.outputs.decision == 'LEGACY' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_repository.full_name == github.repository &&
+          github.event.workflow_run.head_branch == '1a-staging'
+        )
       )
     runs-on: ubuntu-latest
     timeout-minutes: 90

--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -91,8 +91,21 @@ jobs:
         with:
           ref: ${{ github.workflow_sha }}
           persist-credentials: false
-          sparse-checkout: scripts/release-bus-baseline-adoption-decision.cjs
+          sparse-checkout: |
+            bin/6529
+            package.json
+            scripts/release-bus-baseline-adoption-decision.cjs
           sparse-checkout-cone-mode: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22.17.1"
+
+      - name: Activate pinned pnpm
+        run: |
+          corepack enable pnpm
+          corepack prepare "$(node -p 'require("./package.json").packageManager')" --activate
 
       - name: Resolve exact automatic E2E decision
         id: decision
@@ -102,7 +115,24 @@ jobs:
           DEPLOY_WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
           RELEASE_BUS_API_URL: ${{ vars.RELEASE_BUS_API_URL }}
           RELEASE_BUS_WORKFLOW_AUTH_TOKEN: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
-        run: node scripts/release-bus-baseline-adoption-decision.cjs
+        run: |
+          set -euo pipefail
+          result="$(./bin/6529 exec node scripts/release-bus-baseline-adoption-decision.cjs)"
+          case "$result" in
+            LEGACY:false)
+              printf 'decision=LEGACY\nmanifest_ready=false\n'
+              ;;
+            DEFERRED:false)
+              printf 'decision=DEFERRED\nmanifest_ready=false\n'
+              ;;
+            DEFERRED:true)
+              printf 'decision=DEFERRED\nmanifest_ready=true\n'
+              ;;
+            *)
+              echo "Baseline-adoption decision returned an invalid exact token" >&2
+              exit 1
+              ;;
+          esac >> "$GITHUB_OUTPUT"
 
   staging-packs:
     name: Staging E2E packs

--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -117,7 +117,10 @@ jobs:
           RELEASE_BUS_WORKFLOW_AUTH_TOKEN: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
         run: |
           set -euo pipefail
-          result="$(./bin/6529 exec node scripts/release-bus-baseline-adoption-decision.cjs)"
+          if ! result="$(./bin/6529 exec node scripts/release-bus-baseline-adoption-decision.cjs)"; then
+            echo "Baseline-adoption decision client failed closed" >&2
+            exit 1
+          fi
           case "$result" in
             LEGACY:false)
               printf 'decision=LEGACY\nmanifest_ready=false\n'

--- a/__tests__/scripts/release-bus-baseline-adoption-decision.test.ts
+++ b/__tests__/scripts/release-bus-baseline-adoption-decision.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 const {
   decide,
   exactDecision,
+  formatDecisionToken,
 } = require("../../scripts/release-bus-baseline-adoption-decision.cjs");
 const YAML = require("yaml");
 
@@ -161,6 +162,14 @@ describe("baseline-adoption automatic E2E decision client", () => {
     ).toThrow("malformed");
   });
 
+  it.each([
+    [{ decision: "LEGACY", manifestReady: false }, "LEGACY:false\n"],
+    [{ decision: "DEFERRED", manifestReady: false }, "DEFERRED:false\n"],
+    [{ decision: "DEFERRED", manifestReady: true }, "DEFERRED:true\n"],
+  ])("formats the exact workflow token for %j", (decision, expected) => {
+    expect(formatDecisionToken(decision)).toBe(expected);
+  });
+
   it("gates the expensive staging suite on LEGACY while bound dispatch remains unchanged", () => {
     const workflow = fs.readFileSync(
       path.join(process.cwd(), ".github/workflows/staging-e2e.yml"),
@@ -172,7 +181,11 @@ describe("baseline-adoption automatic E2E decision client", () => {
     );
     expect(workflow).toContain("bin/6529");
     expect(workflow).toContain("LEGACY:false)");
+    expect(workflow).toContain("DEFERRED:false)");
     expect(workflow).toContain("DEFERRED:true)");
+    expect(workflow).toContain(
+      'if ! result="$(./bin/6529 exec node scripts/release-bus-baseline-adoption-decision.cjs)"; then'
+    );
     expect(workflow).toContain("needs: baseline-adoption-decision");
     expect(workflow).toContain(
       "needs.baseline-adoption-decision.outputs.decision == 'LEGACY'"

--- a/__tests__/scripts/release-bus-baseline-adoption-decision.test.ts
+++ b/__tests__/scripts/release-bus-baseline-adoption-decision.test.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 const {
@@ -12,7 +11,7 @@ const SHA = "a".repeat(40);
 const INTENT_ID = "8af60034-9741-4b9d-bb1c-80b483f75455";
 const NOW = 1_900_000_000_000;
 
-function environment(outputPath: string) {
+function environment() {
   return {
     RELEASE_BUS_API_URL: "http://127.0.0.1:9876",
     RELEASE_BUS_WORKFLOW_AUTH_TOKEN: "workflow-secret",
@@ -20,7 +19,6 @@ function environment(outputPath: string) {
     DEPLOY_WORKFLOW_RUN_ID: "67890",
     DEPLOYED_REF: "1a-staging",
     DEPLOYED_SHA: SHA,
-    GITHUB_OUTPUT: outputPath,
   };
 }
 
@@ -33,18 +31,6 @@ function response(body: unknown, status = 200) {
 }
 
 describe("baseline-adoption automatic E2E decision client", () => {
-  let directory: string;
-  let outputPath: string;
-
-  beforeEach(() => {
-    directory = fs.mkdtempSync(path.join(os.tmpdir(), "rb2-decision-"));
-    outputPath = path.join(directory, "github-output");
-  });
-
-  afterEach(() => {
-    fs.rmSync(directory, { recursive: true, force: true });
-  });
-
   it("preserves ordinary legacy E2E on the exact no-intent response", async () => {
     const fetchImpl = jest.fn(async (_url, request) => {
       expect(request).toMatchObject({
@@ -68,18 +54,13 @@ describe("baseline-adoption automatic E2E decision client", () => {
       });
     });
 
-    await expect(
-      decide(environment(outputPath), fetchImpl, NOW)
-    ).resolves.toEqual({
+    await expect(decide(environment(), fetchImpl, NOW)).resolves.toEqual({
       decision: "LEGACY",
       manifestReady: false,
     });
-    expect(fs.readFileSync(outputPath, "utf8")).toBe(
-      "decision=LEGACY\nmanifest_ready=false\n"
-    );
   });
 
-  it("writes an exact DEFERRED decision without manufacturing evidence", async () => {
+  it("returns an exact DEFERRED decision without manufacturing evidence", async () => {
     const fetchImpl = jest.fn(async () =>
       response({
         decision: "DEFERRED",
@@ -90,13 +71,10 @@ describe("baseline-adoption automatic E2E decision client", () => {
       })
     );
 
-    await expect(
-      decide(environment(outputPath), fetchImpl, NOW)
-    ).resolves.toEqual({
+    await expect(decide(environment(), fetchImpl, NOW)).resolves.toEqual({
       decision: "DEFERRED",
       manifestReady: false,
     });
-    expect(fs.readFileSync(outputPath, "utf8")).toContain("decision=DEFERRED");
   });
 
   it("keeps a manifest-ready automatic callback DEFERRED so only the bound dispatch can run tests", async () => {
@@ -110,15 +88,10 @@ describe("baseline-adoption automatic E2E decision client", () => {
       })
     );
 
-    await expect(
-      decide(environment(outputPath), fetchImpl, NOW)
-    ).resolves.toEqual({
+    await expect(decide(environment(), fetchImpl, NOW)).resolves.toEqual({
       decision: "DEFERRED",
       manifestReady: true,
     });
-    expect(fs.readFileSync(outputPath, "utf8")).toBe(
-      "decision=DEFERRED\nmanifest_ready=true\n"
-    );
   });
 
   it.each([
@@ -162,19 +135,14 @@ describe("baseline-adoption automatic E2E decision client", () => {
     ],
   ])("fails closed on %s", async (_label, fetchImpl) => {
     await expect(
-      decide(environment(outputPath), jest.fn(fetchImpl), NOW)
+      decide(environment(), jest.fn(fetchImpl), NOW)
     ).rejects.toThrow();
-    expect(fs.existsSync(outputPath)).toBe(false);
   });
 
   it("rejects malformed deployment identity before network access", async () => {
     const fetchImpl = jest.fn();
     await expect(
-      decide(
-        { ...environment(outputPath), DEPLOYED_REF: "main" },
-        fetchImpl,
-        NOW
-      )
+      decide({ ...environment(), DEPLOYED_REF: "main" }, fetchImpl, NOW)
     ).rejects.toThrow("identity is malformed");
     expect(fetchImpl).not.toHaveBeenCalled();
   });
@@ -200,8 +168,11 @@ describe("baseline-adoption automatic E2E decision client", () => {
     );
     expect(workflow).toContain("baseline-adoption-decision:");
     expect(workflow).toContain(
-      "run: node scripts/release-bus-baseline-adoption-decision.cjs"
+      "./bin/6529 exec node scripts/release-bus-baseline-adoption-decision.cjs"
     );
+    expect(workflow).toContain("bin/6529");
+    expect(workflow).toContain("LEGACY:false)");
+    expect(workflow).toContain("DEFERRED:true)");
     expect(workflow).toContain("needs: baseline-adoption-decision");
     expect(workflow).toContain(
       "needs.baseline-adoption-decision.outputs.decision == 'LEGACY'"
@@ -227,15 +198,22 @@ describe("baseline-adoption automatic E2E decision client", () => {
       "needs.baseline-adoption-decision.outputs.decision == 'LEGACY'"
     );
     expect(parsed.jobs["staging-packs"].if).not.toContain("DEFERRED");
-    expect(parsed.jobs["baseline-adoption-decision"].steps).toHaveLength(2);
+    expect(parsed.jobs["baseline-adoption-decision"].steps).toHaveLength(4);
     expect(
       parsed.jobs["baseline-adoption-decision"].steps[0].with
     ).toMatchObject({
       ref: "${{ github.workflow_sha }}",
       "persist-credentials": false,
     });
+    expect(parsed.jobs["baseline-adoption-decision"].steps[1]).toMatchObject({
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020",
+      with: { "node-version": "22.17.1" },
+    });
+    expect(parsed.jobs["baseline-adoption-decision"].steps[2].run).toContain(
+      "corepack prepare"
+    );
     expect(
-      parsed.jobs["baseline-adoption-decision"].steps[1].env
+      parsed.jobs["baseline-adoption-decision"].steps[3].env
     ).toMatchObject({
       DEPLOYED_REF: "${{ github.event.workflow_run.head_branch }}",
       DEPLOYED_SHA: "${{ github.event.workflow_run.head_sha }}",

--- a/__tests__/scripts/release-bus-baseline-adoption-decision.test.ts
+++ b/__tests__/scripts/release-bus-baseline-adoption-decision.test.ts
@@ -84,7 +84,7 @@ describe("baseline-adoption automatic E2E decision client", () => {
       response({
         decision: "DEFERRED",
         adoption_id: INTENT_ID,
-        operation_key: `rb2:${INTENT_ID}:e2e:staging`,
+        operation_key: `rb2:${INTENT_ID}:baseline-adoption-e2e:staging:a1`,
         expires_at: NOW + 60_000,
         manifest_ready: false,
       })
@@ -104,7 +104,7 @@ describe("baseline-adoption automatic E2E decision client", () => {
       response({
         decision: "DEFERRED",
         adoption_id: INTENT_ID,
-        operation_key: `rb2:${INTENT_ID}:e2e:staging`,
+        operation_key: `rb2:${INTENT_ID}:baseline-adoption-e2e:staging:a1`,
         expires_at: NOW + 60_000,
         manifest_ready: true,
       })
@@ -132,7 +132,7 @@ describe("baseline-adoption automatic E2E decision client", () => {
         response({
           decision: "DEFERRED",
           adoption_id: INTENT_ID,
-          operation_key: `rb2:${INTENT_ID}:e2e:staging`,
+          operation_key: `rb2:${INTENT_ID}:baseline-adoption-e2e:staging:a1`,
           expires_at: NOW,
           manifest_ready: false,
         }),
@@ -143,7 +143,7 @@ describe("baseline-adoption automatic E2E decision client", () => {
         response({
           decision: "DEFERRED",
           adoption_id: INTENT_ID,
-          operation_key: "rb2:different:e2e:staging",
+          operation_key: "rb2:different:baseline-adoption-e2e:staging:a1",
           expires_at: NOW + 60_000,
           manifest_ready: false,
         }),
@@ -154,7 +154,8 @@ describe("baseline-adoption automatic E2E decision client", () => {
         response({
           decision: "DEFERRED",
           adoption_id: "8af60034-9741-3b9d-bb1c-80b483f75455",
-          operation_key: "rb2:8af60034-9741-3b9d-bb1c-80b483f75455:e2e:staging",
+          operation_key:
+            "rb2:8af60034-9741-3b9d-bb1c-80b483f75455:baseline-adoption-e2e:staging:a1",
           expires_at: NOW + 60_000,
           manifest_ready: false,
         }),

--- a/__tests__/scripts/release-bus-baseline-adoption-decision.test.ts
+++ b/__tests__/scripts/release-bus-baseline-adoption-decision.test.ts
@@ -1,0 +1,245 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const {
+  decide,
+  exactDecision,
+} = require("../../scripts/release-bus-baseline-adoption-decision.cjs");
+const YAML = require("yaml");
+
+const SHA = "a".repeat(40);
+const INTENT_ID = "8af60034-9741-4b9d-bb1c-80b483f75455";
+const NOW = 1_900_000_000_000;
+
+function environment(outputPath: string) {
+  return {
+    RELEASE_BUS_API_URL: "http://127.0.0.1:9876",
+    RELEASE_BUS_WORKFLOW_AUTH_TOKEN: "workflow-secret",
+    GITHUB_RUN_ID: "12345",
+    DEPLOY_WORKFLOW_RUN_ID: "67890",
+    DEPLOYED_REF: "1a-staging",
+    DEPLOYED_SHA: SHA,
+    GITHUB_OUTPUT: outputPath,
+  };
+}
+
+function response(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  };
+}
+
+describe("baseline-adoption automatic E2E decision client", () => {
+  let directory: string;
+  let outputPath: string;
+
+  beforeEach(() => {
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), "rb2-decision-"));
+    outputPath = path.join(directory, "github-output");
+  });
+
+  afterEach(() => {
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("preserves ordinary legacy E2E on the exact no-intent response", async () => {
+    const fetchImpl = jest.fn(async (_url, request) => {
+      expect(request).toMatchObject({
+        method: "POST",
+        headers: {
+          authorization: "Bearer workflow-secret",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          e2e_workflow_run_id: "12345",
+          deploy_workflow_run_id: "67890",
+          deployed_ref: "1a-staging",
+          deployed_sha: SHA,
+        }),
+      });
+      return response({
+        decision: "LEGACY",
+        adoption_id: null,
+        operation_key: null,
+        expires_at: null,
+      });
+    });
+
+    await expect(
+      decide(environment(outputPath), fetchImpl, NOW)
+    ).resolves.toEqual({
+      decision: "LEGACY",
+      manifestReady: false,
+    });
+    expect(fs.readFileSync(outputPath, "utf8")).toBe(
+      "decision=LEGACY\nmanifest_ready=false\n"
+    );
+  });
+
+  it("writes an exact DEFERRED decision without manufacturing evidence", async () => {
+    const fetchImpl = jest.fn(async () =>
+      response({
+        decision: "DEFERRED",
+        adoption_id: INTENT_ID,
+        operation_key: `rb2:${INTENT_ID}:e2e:staging`,
+        expires_at: NOW + 60_000,
+        manifest_ready: false,
+      })
+    );
+
+    await expect(
+      decide(environment(outputPath), fetchImpl, NOW)
+    ).resolves.toEqual({
+      decision: "DEFERRED",
+      manifestReady: false,
+    });
+    expect(fs.readFileSync(outputPath, "utf8")).toContain("decision=DEFERRED");
+  });
+
+  it("keeps a manifest-ready automatic callback DEFERRED so only the bound dispatch can run tests", async () => {
+    const fetchImpl = jest.fn(async () =>
+      response({
+        decision: "DEFERRED",
+        adoption_id: INTENT_ID,
+        operation_key: `rb2:${INTENT_ID}:e2e:staging`,
+        expires_at: NOW + 60_000,
+        manifest_ready: true,
+      })
+    );
+
+    await expect(
+      decide(environment(outputPath), fetchImpl, NOW)
+    ).resolves.toEqual({
+      decision: "DEFERRED",
+      manifestReady: true,
+    });
+    expect(fs.readFileSync(outputPath, "utf8")).toBe(
+      "decision=DEFERRED\nmanifest_ready=true\n"
+    );
+  });
+
+  it.each([
+    [
+      "ambiguous or stale server rejection",
+      async () => response({ error: "ambiguous" }, 409),
+    ],
+    [
+      "expired response",
+      async () =>
+        response({
+          decision: "DEFERRED",
+          adoption_id: INTENT_ID,
+          operation_key: `rb2:${INTENT_ID}:e2e:staging`,
+          expires_at: NOW,
+          manifest_ready: false,
+        }),
+    ],
+    [
+      "identity mismatch",
+      async () =>
+        response({
+          decision: "DEFERRED",
+          adoption_id: INTENT_ID,
+          operation_key: "rb2:different:e2e:staging",
+          expires_at: NOW + 60_000,
+          manifest_ready: false,
+        }),
+    ],
+    [
+      "non-v4 operation identity",
+      async () =>
+        response({
+          decision: "DEFERRED",
+          adoption_id: "8af60034-9741-3b9d-bb1c-80b483f75455",
+          operation_key: "rb2:8af60034-9741-3b9d-bb1c-80b483f75455:e2e:staging",
+          expires_at: NOW + 60_000,
+          manifest_ready: false,
+        }),
+    ],
+  ])("fails closed on %s", async (_label, fetchImpl) => {
+    await expect(
+      decide(environment(outputPath), jest.fn(fetchImpl), NOW)
+    ).rejects.toThrow();
+    expect(fs.existsSync(outputPath)).toBe(false);
+  });
+
+  it("rejects malformed deployment identity before network access", async () => {
+    const fetchImpl = jest.fn();
+    await expect(
+      decide(
+        { ...environment(outputPath), DEPLOYED_REF: "main" },
+        fetchImpl,
+        NOW
+      )
+    ).rejects.toThrow("identity is malformed");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("requires exact nulls for the ordinary legacy response", () => {
+    expect(() =>
+      exactDecision(
+        {
+          decision: "LEGACY",
+          adoption_id: INTENT_ID,
+          operation_key: null,
+          expires_at: null,
+        },
+        NOW
+      )
+    ).toThrow("malformed");
+  });
+
+  it("gates the expensive staging suite on LEGACY while bound dispatch remains unchanged", () => {
+    const workflow = fs.readFileSync(
+      path.join(process.cwd(), ".github/workflows/staging-e2e.yml"),
+      "utf8"
+    );
+    expect(workflow).toContain("baseline-adoption-decision:");
+    expect(workflow).toContain(
+      "run: node scripts/release-bus-baseline-adoption-decision.cjs"
+    );
+    expect(workflow).toContain("needs: baseline-adoption-decision");
+    expect(workflow).toContain(
+      "needs.baseline-adoption-decision.outputs.decision == 'LEGACY'"
+    );
+    expect(workflow).toContain("github.event_name == 'workflow_dispatch'");
+    expect(workflow).toContain("cancel-in-progress: false");
+    expect(
+      workflow.match(/name: Run staging packs against staging\.6529\.io/g)
+    ).toHaveLength(1);
+    expect(workflow).not.toContain(
+      "continue-on-error: true\n        env:\n          DEPLOYED_REF"
+    );
+
+    const parsed = YAML.parse(workflow);
+    expect(Object.keys(parsed.jobs)).toEqual([
+      "baseline-adoption-decision",
+      "staging-packs",
+    ]);
+    expect(parsed.jobs["staging-packs"].needs).toBe(
+      "baseline-adoption-decision"
+    );
+    expect(parsed.jobs["staging-packs"].if).toContain(
+      "needs.baseline-adoption-decision.outputs.decision == 'LEGACY'"
+    );
+    expect(parsed.jobs["staging-packs"].if).not.toContain("DEFERRED");
+    expect(parsed.jobs["baseline-adoption-decision"].steps).toHaveLength(2);
+    expect(
+      parsed.jobs["baseline-adoption-decision"].steps[0].with
+    ).toMatchObject({
+      ref: "${{ github.workflow_sha }}",
+      "persist-credentials": false,
+    });
+    expect(
+      parsed.jobs["baseline-adoption-decision"].steps[1].env
+    ).toMatchObject({
+      DEPLOYED_REF: "${{ github.event.workflow_run.head_branch }}",
+      DEPLOYED_SHA: "${{ github.event.workflow_run.head_sha }}",
+      DEPLOY_WORKFLOW_RUN_ID: "${{ github.event.workflow_run.id }}",
+    });
+    expect(workflow).not.toMatch(/\b(?:sleep|setInterval|setTimeout)\b/);
+  });
+});

--- a/ops/docs/developer/simple-release-bus-v2.md
+++ b/ops/docs/developer/simple-release-bus-v2.md
@@ -150,6 +150,58 @@ The departing candidate's declared units are redeployed from the new
 candidate-free composition so prior runtime bytes cannot survive. Production
 selection never changes shared staging membership.
 
+## Exact deployed-baseline adoption
+
+The backend provides an operator-only one-shot capability for a separately
+authorized brief manual freeze. Deploying the capability is not permission to
+invoke it. Keep both effective lanes `OFF` and changeable, keep `ALL` unpaused,
+and do not start until the staging lock, staging mutation/E2E workflows and
+already-dispatched exact operations are fully drained.
+
+Before moving either `1a-staging` ref or dispatching a manual staging
+deployment, prepare one authenticated immutable intent through
+`POST /deploy/release-bus-v2/maintenance/adopt-exact-staging-baseline`. Bind
+the UUID v4 identity and expiry to the unchanged authoritative staging-state
+row version, exact target frontend/backend refs and SHAs, required runtime SHAs,
+every required backend deployment unit/SHA, and the exact zero-or-known
+candidate inventory/row versions. Preparation writes only an audited intent:
+it creates no train, manifest, operation or lock, and performs no deployment or
+ref/state mutation. The target refs and runtimes are revalidated after the
+later deployments.
+
+The existing manual backend workflow emits one authenticated terminal event
+for each staging unit while leaving ordinary no-intent deployments unchanged.
+The normal frontend `Web Deploy - STAGING` success still triggers
+`staging-e2e.yml`. For that `workflow_run`, the trusted decision client makes
+one authenticated lookup:
+
+- `LEGACY` means there is no active intent, and the existing expensive
+  automatic E2E runs unchanged;
+- `DEFERRED` means one unique unexpired intent exactly matches the upstream
+  deploy/ref/SHA; frontend deployment/runtime evidence and the defer are
+  recorded idempotently, and the expensive packs are skipped;
+- unavailable, stale, moved, expired, malformed, ambiguous or
+  identity-mismatched evidence fails closed and cannot validate or adopt.
+
+The last exact required frontend/backend deployment event revalidates the state
+version, refs, runtimes, candidate membership, OFF controls, drain and staging
+lock. Only then does one transaction create the real
+`ADOPT_EXACT_DEPLOYED_BASELINE_V1` train, acquire the existing staging lock,
+freeze the immutable manifest, and create one manifest-bound `E2E_STAGING`
+operation. It dispatches one `staging-e2e.yml` `workflow_dispatch`; if the
+frontend event was last, workflow concurrency queues it behind the short
+automatic decision run with `cancel-in-progress: false`.
+
+Only the exact authenticated terminal success of that sole bound E2E may
+CAS-adopt the exact pair as authoritative `LIVE` staging state. Final ref,
+runtime, control, state-version, candidate, lock, workflow, manifest and
+operation identities are all revalidated first. Failure leaves authoritative
+state and developer/production intent unchanged and releases only the owned
+staging lock. Retries reuse the same immutable intent/operation and cannot
+dispatch a second expensive E2E. There is no polling runner, synthetic proof
+train, cancellation, bypass, new shared lease/watchdog, automatic handoff or
+manual-workflow guard.
+
 ## Production lifecycle
 
 Staging validation never creates production readiness. A developer explicitly

--- a/ops/docs/developer/simple-release-bus-v2.md
+++ b/ops/docs/developer/simple-release-bus-v2.md
@@ -152,6 +152,11 @@ selection never changes shared staging membership.
 
 ## Exact deployed-baseline adoption
 
+Before preparing an intent or performing any manual deployment, run
+`./bin/6529 exec node ops/scripts/release-bus-status.mjs` and follow the
+`deploy-6529` instructions. Continue only when both effective lanes are
+authoritatively `OFF` and changeable and the required drain gate passes.
+
 The backend provides an operator-only one-shot capability for a separately
 authorized brief manual freeze. Deploying the capability is not permission to
 invoke it. Keep both effective lanes `OFF` and changeable, keep `ALL` unpaused,

--- a/ops/docs/developer/simple-release-bus-v2.md
+++ b/ops/docs/developer/simple-release-bus-v2.md
@@ -163,14 +163,19 @@ deployment, prepare one authenticated immutable intent through
 `POST /deploy/release-bus-v2/maintenance/adopt-exact-staging-baseline`. Bind
 the UUID v4 identity and expiry to the unchanged authoritative staging-state
 row version, exact target frontend/backend refs and SHAs, required runtime SHAs,
-every required backend deployment unit/SHA, and the exact zero-or-known
-candidate inventory/row versions. Preparation writes only an audited intent:
-it creates no train, manifest, operation or lock, and performs no deployment or
-ref/state mutation. The target refs and runtimes are revalidated after the
+the single runtime-verifiable `api` deployment unit/SHA, and the exact
+zero-or-known candidate inventory/row versions. A non-API unit cannot be
+accepted on workflow success alone. Preparation writes only an audited intent:
+it creates no train, manifest, operation or lock, and performs no deployment
+or ref/state mutation. The target refs and runtimes are revalidated after the
 later deployments.
 
 The existing manual backend workflow emits one authenticated terminal event
-for each staging unit while leaving ordinary no-intent deployments unchanged.
+for each staging service while leaving ordinary no-intent deployments
+unchanged. Only the exact API event can advance an intent; a different service
+during the held freeze fails that intent closed. Its additive callback step is
+non-blocking for the ordinary deploy job: unavailable evidence prevents
+adoption freeze without failing an unrelated manual deploy.
 The normal frontend `Web Deploy - STAGING` success still triggers
 `staging-e2e.yml`. For that `workflow_run`, the trusted decision client makes
 one authenticated lookup:
@@ -191,6 +196,9 @@ freeze the immutable manifest, and create one manifest-bound `E2E_STAGING`
 operation. It dispatches one `staging-e2e.yml` `workflow_dispatch`; if the
 frontend event was last, workflow concurrency queues it behind the short
 automatic decision run with `cancel-in-progress: false`.
+The sole operation identity is
+`rb2:<adoption-id>:baseline-adoption-e2e:staging:a1`, so ordinary E2E callbacks
+cannot enter its adoption handler.
 
 Only the exact authenticated terminal success of that sole bound E2E may
 CAS-adopt the exact pair as authoritative `LIVE` staging state. Final ref,

--- a/scripts/release-bus-baseline-adoption-decision.cjs
+++ b/scripts/release-bus-baseline-adoption-decision.cjs
@@ -100,10 +100,14 @@ async function decide(environment, fetchImpl = fetch, now = Date.now()) {
   return decision;
 }
 
+function formatDecisionToken({ decision, manifestReady }) {
+  return `${decision}:${manifestReady}\n`;
+}
+
 if (require.main === module) {
   decide(process.env)
     .then(({ decision, manifestReady }) => {
-      process.stdout.write(`${decision}:${manifestReady}\n`);
+      process.stdout.write(formatDecisionToken({ decision, manifestReady }));
     })
     .catch((error) => {
       process.stderr.write(
@@ -113,4 +117,9 @@ if (require.main === module) {
     });
 }
 
-module.exports = { decide, exactDecision, exactEnvironment };
+module.exports = {
+  decide,
+  exactDecision,
+  exactEnvironment,
+  formatDecisionToken,
+};

--- a/scripts/release-bus-baseline-adoption-decision.cjs
+++ b/scripts/release-bus-baseline-adoption-decision.cjs
@@ -1,7 +1,5 @@
 "use strict";
 
-const fs = require("node:fs");
-
 const SHA_PATTERN = /^[a-f0-9]{40}$/;
 const RUN_ID_PATTERN = /^[1-9]\d{0,19}$/;
 const UUID_PATTERN =
@@ -38,7 +36,6 @@ function exactEnvironment(environment) {
   return {
     apiUrl,
     token: required(environment, "RELEASE_BUS_WORKFLOW_AUTH_TOKEN"),
-    outputPath: required(environment, "GITHUB_OUTPUT"),
     body: {
       e2e_workflow_run_id: e2eWorkflowRunId,
       deploy_workflow_run_id: deployWorkflowRunId,
@@ -100,20 +97,13 @@ async function decide(environment, fetchImpl = fetch, now = Date.now()) {
     );
   }
   const decision = exactDecision(await response.json(), now);
-  fs.appendFileSync(
-    identity.outputPath,
-    `decision=${decision.decision}\nmanifest_ready=${decision.manifestReady}\n`,
-    "utf8"
-  );
   return decision;
 }
 
 if (require.main === module) {
   decide(process.env)
     .then(({ decision, manifestReady }) => {
-      process.stdout.write(
-        `Automatic staging E2E decision: ${decision} (manifest_ready=${manifestReady})\n`
-      );
+      process.stdout.write(`${decision}:${manifestReady}\n`);
     })
     .catch((error) => {
       process.stderr.write(

--- a/scripts/release-bus-baseline-adoption-decision.cjs
+++ b/scripts/release-bus-baseline-adoption-decision.cjs
@@ -120,6 +120,5 @@ if (require.main === module) {
 module.exports = {
   decide,
   exactDecision,
-  exactEnvironment,
   formatDecisionToken,
 };

--- a/scripts/release-bus-baseline-adoption-decision.cjs
+++ b/scripts/release-bus-baseline-adoption-decision.cjs
@@ -64,7 +64,8 @@ function exactDecision(value, now = Date.now()) {
     value.decision === "DEFERRED" &&
     typeof value.adoption_id === "string" &&
     UUID_PATTERN.test(value.adoption_id) &&
-    value.operation_key === `rb2:${value.adoption_id}:e2e:staging` &&
+    value.operation_key ===
+      `rb2:${value.adoption_id}:baseline-adoption-e2e:staging:a1` &&
     Number.isSafeInteger(value.expires_at) &&
     value.expires_at > now &&
     typeof value.manifest_ready === "boolean"

--- a/scripts/release-bus-baseline-adoption-decision.cjs
+++ b/scripts/release-bus-baseline-adoption-decision.cjs
@@ -1,0 +1,125 @@
+"use strict";
+
+const fs = require("node:fs");
+
+const SHA_PATTERN = /^[a-f0-9]{40}$/;
+const RUN_ID_PATTERN = /^[1-9]\d{0,19}$/;
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+function required(environment, key) {
+  const value = environment[key];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Missing ${key}`);
+  }
+  return value;
+}
+
+function exactEnvironment(environment) {
+  const apiUrl = new URL(required(environment, "RELEASE_BUS_API_URL"));
+  if (
+    apiUrl.protocol !== "https:" &&
+    !["127.0.0.1", "localhost"].includes(apiUrl.hostname)
+  ) {
+    throw new Error("Release Bus API URL must use HTTPS");
+  }
+  const e2eWorkflowRunId = required(environment, "GITHUB_RUN_ID");
+  const deployWorkflowRunId = required(environment, "DEPLOY_WORKFLOW_RUN_ID");
+  const deployedRef = required(environment, "DEPLOYED_REF");
+  const deployedSha = required(environment, "DEPLOYED_SHA").toLowerCase();
+  if (
+    !RUN_ID_PATTERN.test(e2eWorkflowRunId) ||
+    !RUN_ID_PATTERN.test(deployWorkflowRunId) ||
+    deployedRef !== "1a-staging" ||
+    !SHA_PATTERN.test(deployedSha)
+  ) {
+    throw new Error("Automatic staging deployment identity is malformed");
+  }
+  return {
+    apiUrl,
+    token: required(environment, "RELEASE_BUS_WORKFLOW_AUTH_TOKEN"),
+    outputPath: required(environment, "GITHUB_OUTPUT"),
+    body: {
+      e2e_workflow_run_id: e2eWorkflowRunId,
+      deploy_workflow_run_id: deployWorkflowRunId,
+      deployed_ref: deployedRef,
+      deployed_sha: deployedSha,
+    },
+  };
+}
+
+function exactDecision(value, now = Date.now()) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Baseline-adoption decision response is not an object");
+  }
+  if (
+    value.decision === "LEGACY" &&
+    value.adoption_id === null &&
+    value.operation_key === null &&
+    value.expires_at === null
+  ) {
+    return { decision: "LEGACY", manifestReady: false };
+  }
+  if (
+    value.decision === "DEFERRED" &&
+    typeof value.adoption_id === "string" &&
+    UUID_PATTERN.test(value.adoption_id) &&
+    value.operation_key === `rb2:${value.adoption_id}:e2e:staging` &&
+    Number.isSafeInteger(value.expires_at) &&
+    value.expires_at > now &&
+    typeof value.manifest_ready === "boolean"
+  ) {
+    return {
+      decision: "DEFERRED",
+      manifestReady: value.manifest_ready,
+    };
+  }
+  throw new Error("Baseline-adoption decision response is malformed");
+}
+
+async function decide(environment, fetchImpl = fetch, now = Date.now()) {
+  const identity = exactEnvironment(environment);
+  const endpoint = new URL(
+    "/deploy/release-bus-v2/maintenance/adopt-exact-staging-baseline/automatic-e2e-decision",
+    identity.apiUrl
+  );
+  const response = await fetchImpl(endpoint, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${identity.token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(identity.body),
+    redirect: "error",
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Baseline-adoption decision failed closed with HTTP ${response.status}`
+    );
+  }
+  const decision = exactDecision(await response.json(), now);
+  fs.appendFileSync(
+    identity.outputPath,
+    `decision=${decision.decision}\nmanifest_ready=${decision.manifestReady}\n`,
+    "utf8"
+  );
+  return decision;
+}
+
+if (require.main === module) {
+  decide(process.env)
+    .then(({ decision, manifestReady }) => {
+      process.stdout.write(
+        `Automatic staging E2E decision: ${decision} (manifest_ready=${manifestReady})\n`
+      );
+    })
+    .catch((error) => {
+      process.stderr.write(
+        `${error instanceof Error ? error.message : "Decision failed closed"}\n`
+      );
+      process.exitCode = 1;
+    });
+}
+
+module.exports = { decide, exactDecision, exactEnvironment };


### PR DESCRIPTION
## Summary

- preserve ordinary automatic staging E2E when no active baseline-adoption intent exists
- perform one authenticated exact intent lookup from the trusted workflow revision
- record exact pending adoption as idempotent `DEFERRED` without running the expensive suite
- fail closed on stale, ambiguous, expired, moved, malformed, or identity-mismatched evidence
- allow the backend to dispatch the sole manifest-bound E2E after the full exact manifest is frozen
- bind the cross-repo handshake to the exact `baseline-adoption-e2e:staging:a1` operation subtype

## Safety and conformance

- no adoption has been prepared or invoked
- no staging ref, deployment, E2E, baseline, developer work, or lane state was mutated
- both Release Bus lanes remain OFF
- ordinary manual deployments retain their normal automatic legacy E2E
- no polling, cancellation, bypass, or second expensive adoption E2E

## Validation

- 102 focused frontend routing/workflow/policy tests passed
- 28 focused Release Bus/workflow tests passed
- 10 executable baseline-adoption decision tests passed
- 74 focused cross-repo/workflow contract tests passed after review hardening
- targeted lint and formatting checks passed
- Knip dead-code check passed after removing the unused internal export
- the automatic decision job now runs through the pinned repository wrapper and emits only locally validated fixed output tokens
- backend first full regression: 3184/3185 tests passed; the sole rollout-trust digest fixture mismatch was corrected and its affected test passed
- second full local backend regression: **310/310 suites and 3185/3185 tests passed** in 423.045 seconds
- corrected pre-rebase backend head `6ac861f96bb1b897fd1d99e5243939faf7ee9297`: **310/310 suites and 3188/3188 tests passed** in 551.001 seconds
- rebased exact backend head `bb1d07c4289af229193311e1791010b948c2cb0b`: **311/311 suites and 3217/3217 tests passed** in 464.225 seconds

Backend counterpart: https://github.com/6529-Collections/6529seize-backend/pull/1885

Signed commit with DCO sign-off.
