### PR TITLE
Allow identity-only public review drafts

### DIFF
--- a/__tests__/lib/public-review/streamReviewPublication.test.ts
+++ b/__tests__/lib/public-review/streamReviewPublication.test.ts
@@ -1,5 +1,6 @@
 import {
   getStreamReviewVersionPublication,
+  parseStreamReviewPublicationMetadata,
   parseStreamReviewVersionIdentities,
   STREAM_REVIEW_VERSION_IDENTITIES,
 } from "@/lib/public-review/streamReviewPublication";
@@ -36,6 +37,27 @@ describe("Stream public-review version identities", () => {
     expect(
       Object.isFrozen(getStreamReviewVersionPublication("2026-07-27.1"))
     ).toBe(true);
+  });
+
+  it("accepts a draft identity before publication metadata is assigned", () => {
+    expect(parseStreamReviewPublicationMetadata({}, "DRAFT")).toBeUndefined();
+  });
+
+  it.each([
+    {
+      label: "published version without metadata",
+      lifecycleState: "PUBLIC_REVIEW" as const,
+      metadata: {},
+    },
+    {
+      label: "draft with partial metadata",
+      lifecycleState: "DRAFT" as const,
+      metadata: { deploymentStatus: "NOT_DEPLOYED" },
+    },
+  ])("rejects a $label", ({ lifecycleState, metadata }) => {
+    expect(() =>
+      parseStreamReviewPublicationMetadata(metadata, lifecycleState)
+    ).toThrow("The Stream public-review version config is invalid.");
   });
 
   it.each([

--- a/__tests__/scripts/package-public-review-artifacts.test.ts
+++ b/__tests__/scripts/package-public-review-artifacts.test.ts
@@ -15,6 +15,7 @@ const {
   assertZipListingSafety,
   expectedBundleEntries,
   getPublishedReviewIds,
+  hasValidPublicationMetadata,
   parseCli,
   parseZipListing,
   prepareProfileBundle,
@@ -31,6 +32,7 @@ const {
   ): readonly ReviewEvidence[];
   expectedBundleEntries(bundleRoot: string): readonly string[];
   getPublishedReviewIds(repoRoot: string): ReadonlySet<string>;
+  hasValidPublicationMetadata(version: Record<string, unknown>): boolean;
   parseCli(argv: readonly string[]): {
     readonly command: "prepare" | "assert-listing" | "assert-zip";
     readonly profile: ArtifactProfile;
@@ -89,6 +91,32 @@ const SOURCE_REPOSITORY = "6529-Collections/6529Stream";
 const SOURCE_PATH = "smart-contracts/StreamCore.sol";
 const DEFINITION_ID = `${SOURCE_PATH}:StreamCore`;
 const DEFINITION_KEY = Buffer.from(DEFINITION_ID).toString("base64url");
+
+describe("public-review publication metadata", () => {
+  it("accepts a minimal hidden draft", () => {
+    expect(
+      hasValidPublicationMetadata({
+        lifecycleState: "DRAFT",
+      })
+    ).toBe(true);
+  });
+
+  it.each([
+    {
+      label: "published version without metadata",
+      version: { lifecycleState: "PUBLIC_REVIEW" },
+    },
+    {
+      label: "draft with partial metadata",
+      version: {
+        lifecycleState: "DRAFT",
+        deploymentStatus: "NOT_DEPLOYED",
+      },
+    },
+  ])("rejects a $label", ({ version }) => {
+    expect(hasValidPublicationMetadata(version)).toBe(false);
+  });
+});
 
 function sha256Urn(value: string | Buffer): string {
   return `sha256:${crypto.createHash("sha256").update(value).digest("hex")}`;

--- a/lib/public-review/streamReviewPublication.ts
+++ b/lib/public-review/streamReviewPublication.ts
@@ -27,7 +27,7 @@ export interface StreamReviewVersionIdentity {
   readonly version: string;
 }
 
-export interface StreamReviewPublicationMetadata {
+interface StreamReviewPublicationMetadata {
   readonly deploymentStatus: StreamReviewDeploymentStatus;
   readonly auditStatus: StreamReviewAuditStatus;
 }

--- a/lib/public-review/streamReviewPublication.ts
+++ b/lib/public-review/streamReviewPublication.ts
@@ -15,6 +15,8 @@ const STREAM_REVIEW_AUDIT_STATUSES = [
 ] as const;
 const STREAM_REVIEW_SOURCE_COMMIT_PATTERN = /^[0-9a-f]{40}$/;
 const STREAM_REVIEW_VERSION_PATTERN = /^\d{4}-\d{2}-\d{2}\.\d+$/;
+const STREAM_REVIEW_VERSION_CONFIG_ERROR =
+  "The Stream public-review version config is invalid.";
 
 type StreamReviewDeploymentStatus =
   (typeof STREAM_REVIEW_DEPLOYMENT_STATUSES)[number];
@@ -25,10 +27,13 @@ export interface StreamReviewVersionIdentity {
   readonly version: string;
 }
 
-interface StreamReviewVersionPublication extends StreamReviewVersionIdentity {
+export interface StreamReviewPublicationMetadata {
   readonly deploymentStatus: StreamReviewDeploymentStatus;
   readonly auditStatus: StreamReviewAuditStatus;
 }
+
+interface StreamReviewVersionPublication
+  extends StreamReviewVersionIdentity, StreamReviewPublicationMetadata {}
 
 function isStreamReviewDeploymentStatus(
   value: unknown
@@ -52,11 +57,36 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+export function parseStreamReviewPublicationMetadata(
+  value: unknown,
+  lifecycleState: PublicReviewLifecycleState
+): StreamReviewPublicationMetadata | undefined {
+  if (!isRecord(value)) {
+    throw new Error(STREAM_REVIEW_VERSION_CONFIG_ERROR);
+  }
+  const deploymentStatus = value["deploymentStatus"];
+  const auditStatus = value["auditStatus"];
+  if (
+    lifecycleState === "DRAFT" &&
+    deploymentStatus === undefined &&
+    auditStatus === undefined
+  ) {
+    return undefined;
+  }
+  if (
+    !isStreamReviewDeploymentStatus(deploymentStatus) ||
+    !isStreamReviewAuditStatus(auditStatus)
+  ) {
+    throw new Error(STREAM_REVIEW_VERSION_CONFIG_ERROR);
+  }
+  return Object.freeze({ deploymentStatus, auditStatus });
+}
+
 export function parseStreamReviewVersionIdentities(
   value: unknown
 ): readonly StreamReviewVersionIdentity[] {
   if (!Array.isArray(value) || value.length === 0) {
-    throw new Error("The Stream public-review version config is invalid.");
+    throw new Error(STREAM_REVIEW_VERSION_CONFIG_ERROR);
   }
 
   const seenVersions = new Set<string>();
@@ -70,7 +100,7 @@ export function parseStreamReviewVersionIdentities(
       !STREAM_REVIEW_SOURCE_COMMIT_PATTERN.test(candidate["sourceCommit"]) ||
       seenVersions.has(candidate["version"])
     ) {
-      throw new Error("The Stream public-review version config is invalid.");
+      throw new Error(STREAM_REVIEW_VERSION_CONFIG_ERROR);
     }
     seenVersions.add(candidate["version"]);
     return Object.freeze({
@@ -108,21 +138,9 @@ const STREAM_REVIEW_VERSION_LIFECYCLE_STATES = new Map<
 const STREAM_REVIEW_VERSION_SOURCE_COMMITS = new Map<string, string>();
 for (const [index, identity] of STREAM_REVIEW_VERSION_IDENTITIES.entries()) {
   const version = publication.versions[index];
-  if (
-    !version ||
-    !isStreamReviewDeploymentStatus(version.deploymentStatus) ||
-    !isStreamReviewAuditStatus(version.auditStatus)
-  ) {
-    throw new Error("The Stream public-review version config is invalid.");
+  if (!version) {
+    throw new Error(STREAM_REVIEW_VERSION_CONFIG_ERROR);
   }
-  STREAM_REVIEW_VERSION_PUBLICATIONS.set(
-    identity.version,
-    Object.freeze({
-      ...identity,
-      deploymentStatus: version.deploymentStatus,
-      auditStatus: version.auditStatus,
-    })
-  );
   STREAM_REVIEW_VERSION_LIFECYCLE_STATES.set(
     identity.version,
     identity.lifecycleState
@@ -131,6 +149,19 @@ for (const [index, identity] of STREAM_REVIEW_VERSION_IDENTITIES.entries()) {
     identity.version,
     identity.sourceCommit
   );
+  const metadata = parseStreamReviewPublicationMetadata(
+    version,
+    identity.lifecycleState
+  );
+  if (metadata) {
+    STREAM_REVIEW_VERSION_PUBLICATIONS.set(
+      identity.version,
+      Object.freeze({
+        ...identity,
+        ...metadata,
+      })
+    );
+  }
 }
 
 export function getStreamReviewVersionPublication(

--- a/scripts/package-public-review-artifacts.cjs
+++ b/scripts/package-public-review-artifacts.cjs
@@ -56,6 +56,17 @@ function invariant(condition, message) {
   }
 }
 
+function hasValidPublicationMetadata(version) {
+  const hasNoPublicationMetadata =
+    version.lifecycleState === "DRAFT" &&
+    version.deploymentStatus === undefined &&
+    version.auditStatus === undefined;
+  const hasCompletePublicationMetadata =
+    PUBLIC_REVIEW_DEPLOYMENT_STATUSES.has(version.deploymentStatus) &&
+    PUBLIC_REVIEW_AUDIT_STATUSES.has(version.auditStatus);
+  return hasNoPublicationMetadata || hasCompletePublicationMetadata;
+}
+
 function normalizeRelativePath(value) {
   return value.split(path.sep).join("/");
 }
@@ -264,8 +275,7 @@ function getPublicReviewPublicationConfigs(repoRoot) {
               SAFE_VERSION_PATTERN.test(version.version) &&
               PUBLIC_REVIEW_LIFECYCLE_STATES.has(version.lifecycleState) &&
               SOURCE_PIN_PATTERN.test(version.sourceCommit) &&
-              PUBLIC_REVIEW_DEPLOYMENT_STATUSES.has(version.deploymentStatus) &&
-              PUBLIC_REVIEW_AUDIT_STATUSES.has(version.auditStatus)
+              hasValidPublicationMetadata(version)
           ) &&
           new Set(config.versions.map((version) => version.version)).size ===
             config.versions.length,
@@ -1445,6 +1455,7 @@ module.exports = {
   directoryIdentity,
   expectedBundleEntries,
   getPublishedReviewIds,
+  hasValidPublicationMetadata,
   main,
   parseCli,
   parseZipListing,


### PR DESCRIPTION
## Issue
Snapshot Trust requires a newly retained public-review version to enter as an identity-only DRAFT. The artifact packager and Stream runtime parser still required deployment and audit metadata on every version, so a trusted snapshot could not pass the app build.

## Fix
Accept an identity-only DRAFT while preserving strict publication metadata validation for every published version. A draft with only one status field remains invalid.

## Notable changes
- let artifact packaging validate a DRAFT with no deployment or audit metadata
- retain lifecycle and source identity for such drafts without manufacturing publication claims
- keep complete metadata supported for existing drafts
- cover valid minimal drafts and invalid published/partial shapes in both validator suites

## Validation
- focused Jest: 2 suites, 52 tests passed
- lint:changed
- typecheck:changed
- Prettier check on all four changed files
- codex-diff-check
- exact snapshot config from PR #3529 accepted by the repaired packager

## Risk
Low and bounded to draft public-review metadata parsing. Public routes still require valid deployment and audit statuses, and draft evidence remains excluded from packaged routes.

## Review notes
This is the prerequisite for #3529. It intentionally does not alter Snapshot Trust policy or publication state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for draft versions without publication status metadata.
  - Improved validation of deployment and audit status information across publication versions.
  - Invalid or incomplete publication configurations now receive a consistent error.

- **Bug Fixes**
  - Prevented incomplete draft metadata from being treated as valid.
  - Improved handling of invalid version identities and publication configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->