### PR TITLE
fix(release-bus): accept base adoption operation key

### DIFF
--- a/__tests__/scripts/release-bus-baseline-adoption-decision.test.ts
+++ b/__tests__/scripts/release-bus-baseline-adoption-decision.test.ts
@@ -66,7 +66,7 @@ describe("baseline-adoption automatic E2E decision client", () => {
       response({
         decision: "DEFERRED",
         adoption_id: INTENT_ID,
-        operation_key: `rb2:${INTENT_ID}:baseline-adoption-e2e:staging:a1`,
+        operation_key: `rb2:${INTENT_ID}:baseline-adoption-e2e:staging`,
         expires_at: NOW + 60_000,
         manifest_ready: false,
       })
@@ -83,7 +83,7 @@ describe("baseline-adoption automatic E2E decision client", () => {
       response({
         decision: "DEFERRED",
         adoption_id: INTENT_ID,
-        operation_key: `rb2:${INTENT_ID}:baseline-adoption-e2e:staging:a1`,
+        operation_key: `rb2:${INTENT_ID}:baseline-adoption-e2e:staging`,
         expires_at: NOW + 60_000,
         manifest_ready: true,
       })
@@ -106,8 +106,30 @@ describe("baseline-adoption automatic E2E decision client", () => {
         response({
           decision: "DEFERRED",
           adoption_id: INTENT_ID,
-          operation_key: `rb2:${INTENT_ID}:baseline-adoption-e2e:staging:a1`,
+          operation_key: `rb2:${INTENT_ID}:baseline-adoption-e2e:staging`,
           expires_at: NOW,
+          manifest_ready: false,
+        }),
+    ],
+    [
+      "dispatcher-owned attempt suffix in the durable operation key",
+      async () =>
+        response({
+          decision: "DEFERRED",
+          adoption_id: INTENT_ID,
+          operation_key: `rb2:${INTENT_ID}:baseline-adoption-e2e:staging:a1`,
+          expires_at: NOW + 60_000,
+          manifest_ready: false,
+        }),
+    ],
+    [
+      "double attempt suffix in the durable operation key",
+      async () =>
+        response({
+          decision: "DEFERRED",
+          adoption_id: INTENT_ID,
+          operation_key: `rb2:${INTENT_ID}:baseline-adoption-e2e:staging:a1:a1`,
+          expires_at: NOW + 60_000,
           manifest_ready: false,
         }),
     ],
@@ -129,7 +151,7 @@ describe("baseline-adoption automatic E2E decision client", () => {
           decision: "DEFERRED",
           adoption_id: "8af60034-9741-3b9d-bb1c-80b483f75455",
           operation_key:
-            "rb2:8af60034-9741-3b9d-bb1c-80b483f75455:baseline-adoption-e2e:staging:a1",
+            "rb2:8af60034-9741-3b9d-bb1c-80b483f75455:baseline-adoption-e2e:staging",
           expires_at: NOW + 60_000,
           manifest_ready: false,
         }),

--- a/scripts/release-bus-baseline-adoption-decision.cjs
+++ b/scripts/release-bus-baseline-adoption-decision.cjs
@@ -62,7 +62,7 @@ function exactDecision(value, now = Date.now()) {
     typeof value.adoption_id === "string" &&
     UUID_PATTERN.test(value.adoption_id) &&
     value.operation_key ===
-      `rb2:${value.adoption_id}:baseline-adoption-e2e:staging:a1` &&
+      `rb2:${value.adoption_id}:baseline-adoption-e2e:staging` &&
     Number.isSafeInteger(value.expires_at) &&
     value.expires_at > now &&
     typeof value.manifest_ready === "boolean"


### PR DESCRIPTION
## Summary
- accept the immutable suffix-free baseline-adoption operation identity returned by the backend decision endpoint
- keep attempt suffix ownership in the generic manifest-bound dispatcher
- reject both once-suffixed and double-suffixed durable operation keys in the automatic-decision client

## Verification
- `git diff --check`
- `node --check scripts/release-bus-baseline-adoption-decision.cjs`
- exact focused Jest/Prettier validation delegated to GitHub CI because this fresh isolated worktree has no installed dependencies, per CI-first recovery authorization

## Operational context
The production API correctly returned HTTP 200 and the suffix-free key, while the existing frontend client rejected it before any expensive E2E pack ran. This narrow compatibility fix does not mutate lanes, refs, runtimes, intents, manifests, or staging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated deferred baseline-adoption decisions to use the correct durable operation identifier.
  * Improved validation to reject operation identifiers with unsupported attempt suffixes.
  * Preserved correct behavior for automatic callbacks, expired responses, and mismatched operation identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->