### PR TITLE
fix(deploy): preserve empty CLI values

### DIFF
--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -8,6 +8,7 @@ const {
   createReleaseReport,
   evaluateReleaseReadiness,
   heartbeatManifest,
+  parseArgs,
   productionPreflight,
   recordPostDeployWatch,
   recordValidationCheck,
@@ -828,6 +829,30 @@ describe("deployment bus manifest", () => {
   afterEach(() => {
     jest.restoreAllMocks();
     Reflect.deleteProperty(globalThis, "fetch");
+  });
+
+  it("preserves an explicit empty production candidate from manual workflow dispatch", () => {
+    const args = parseArgs([
+      "--environment",
+      "staging",
+      "--staging-deploy-sha",
+      STAGING_SHA,
+      "--production-candidate-sha",
+      "",
+      "--production-eligible",
+      "false",
+    ]);
+
+    expect(args["production-candidate-sha"]).toBe("");
+    const manifest = buildManifest({
+      environment: args.environment,
+      stagingDeploySha: args["staging-deploy-sha"],
+      productionCandidateSha: args["production-candidate-sha"],
+      productionEligible: args["production-eligible"],
+      now: "2026-06-18T12:00:00.000Z",
+    });
+    expect(manifest.shas.production_candidate_sha).toBeNull();
+    expect(manifest.production_eligible).toBe(false);
   });
 
   it("builds a valid standard staging manifest", () => {

--- a/ops/scripts/cli-args.cjs
+++ b/ops/scripts/cli-args.cjs
@@ -21,7 +21,7 @@ function parseArgs(argv) {
     }
 
     const nextToken = argv[index + 1];
-    if (!nextToken || nextToken.startsWith("--")) {
+    if (nextToken === undefined || nextToken.startsWith("--")) {
       args[rawKey] = true;
       index += 1;
       continue;


### PR DESCRIPTION
## Summary
- distinguish an omitted CLI flag value from an explicitly supplied empty string
- keep manual staging workflow dispatches with no production candidate from passing boolean `true` into SHA formatting
- add a focused regression matching the failing deployment manifest command

## Verification
- focused direct parser/manifest regression passed
- `git diff --check`
- Node syntax checks for the parser and deployment-bus CLI
- exact Jest/Prettier validation delegated to GitHub CI because this fresh worktree has no installed dependencies, per CI-first recovery authorization

## Failure evidence
Frontend staging run 30562345627 failed before deployment with `sha.slice is not a function` when `--production-candidate-sha ""` was parsed as a boolean flag. No ref or runtime changed.
