### PR TITLE
chore(release): enroll Stream review in Release Bus v2

### DIFF
--- a/__tests__/lib/public-review/streamReviewDefinition.test.ts
+++ b/__tests__/lib/public-review/streamReviewDefinition.test.ts
@@ -160,4 +160,38 @@ describe("6529 Stream public review definition", () => {
 
     expect(understatedPages).toEqual([]);
   });
+
+  it("uses direct prose throughout the active editorial", () => {
+    const editorialRoot = path.join(
+      process.cwd(),
+      "content",
+      "public-reviews",
+      "6529-stream",
+      "versions",
+      STREAM_REVIEW_VERSION,
+      "editorial"
+    );
+    const contrastPatterns = [
+      /\bnot\s+(?:just|merely|only)\b/i,
+      /\bnot\b[^.!?]{0,160}\bbut\b/i,
+      /\brather\s+than\b/i,
+      /\binstead\s+of\b/i,
+      /\bisn['’]t\b/i,
+      /\baren['’]t\b/i,
+    ];
+
+    const findings = STREAM_REVIEW_PAGES.flatMap((page) => {
+      const markdown = fs
+        .readFileSync(path.join(editorialRoot, page.editorialFile), "utf8")
+        .replace(/\s+/g, " ");
+
+      return contrastPatterns.flatMap((pattern) =>
+        pattern.test(markdown)
+          ? [{ page: page.id, pattern: pattern.toString() }]
+          : []
+      );
+    });
+
+    expect(findings).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Issue

The Stream copy fix merged just before staging was switched back to Simple Release Bus v2. The bus requires an open PR with immutable exact-head CI evidence.

## Fix

This release-enrollment PR adds one regression test over the active 14-page editorial. It normalizes whitespace and fails on the contrast constructions removed in the copy pass, including not-X-but-Y, not just/only/merely, rather than, instead of, isn't, and aren't.

## Validation

- Focused Jest: 7/7 passed
- lint:changed
- typecheck:changed
- codex-diff-check

## Risk

Test-only change. No runtime or public artifact behavior changes.

## Review notes

Leave this PR open for Release Bus v2 staging qualification and exact production selection.