### PR TITLE
fix(release): report non-retryable staging ref success

### DIFF
--- a/.github/workflows/release-bus-v2-advance-staging-ref.yml
+++ b/.github/workflows/release-bus-v2-advance-staging-ref.yml
@@ -207,7 +207,15 @@ jobs:
           status="$(jq -er .status "$result")"
           failure_class="$(jq -r '.failure_class // ""' "$result")"
           failure_phase="$(jq -r '.failure_phase // ""' "$result")"
-          retryable="$(jq -er .retryable "$result")"
+          retryable="$(
+            jq -er '
+              if (.retryable | type) == "boolean" then
+                (.retryable | tostring)
+              else
+                error("retryable must be a boolean")
+              end
+            ' "$result"
+          )"
           summary="$(jq -c .summary "$result")"
           payload="$(jq -n \
             --arg train_id "$TRAIN_ID" \

--- a/__tests__/scripts/release-bus-v2-advance-staging-ref-workflow.test.ts
+++ b/__tests__/scripts/release-bus-v2-advance-staging-ref-workflow.test.ts
@@ -83,6 +83,11 @@ describe("Release Bus v2 staging ref advancement workflow", () => {
     );
     expect(workflow).toContain('elif [ "$CHECKOUT_OUTCOME" != success ]; then');
     expect(workflow).toContain("failure_phase=checkout");
+    expect(workflow).toContain(
+      'if (.retryable | type) == "boolean" then'
+    );
+    expect(workflow).toContain("(.retryable | tostring)");
+    expect(workflow).not.toContain('jq -er .retryable "$result"');
     expect(workflow.match(/--connect-timeout 10/g)).toHaveLength(2);
     expect(workflow.match(/--max-time 60/g)).toHaveLength(2);
   });


### PR DESCRIPTION
## Issue

Release Bus v2 staging train `d575e9f4-201a-48b6-a373-95b4425c12ec` successfully advanced the frontend `1a-staging` ref, then failed before reporting its structured terminal result.

## Fix

Preserve strict boolean validation while converting `.retryable` to text before shell assignment. `jq -e` treats the valid boolean `false` as a non-zero result; converting the validated boolean to `"false"` avoids that shell failure and still feeds a real JSON boolean to the callback payload.

## Notable changes

- Fix the staging-ref result reporter for both successful and non-retryable failure outcomes.
- Add regression assertions to the existing workflow test.

## Validation

- `seize run test --testPathPatterns=__tests__/scripts/release-bus-v2-advance-staging-ref-workflow.test.ts --runInBand` (3/3)
- `seize run lint:changed`
- `seize run typecheck:changed`
- `codex-diff-check`

## Risk

Low and isolated to parsing the already-generated structured result before the existing callback. The ref mutation and callback contract are unchanged.

## Review notes

This is the minimal recovery fix for a live immutable staging train whose ref advance already converged to the exact target SHA.