### PR TITLE
Enable Stream public review in production

### DIFF
--- a/__tests__/app/stream/page.test.ts
+++ b/__tests__/app/stream/page.test.ts
@@ -1,7 +1,9 @@
 const mockNotFound = jest.fn(() => {
   throw new Error("NEXT_NOT_FOUND");
 });
-const mockRedirect = jest.fn();
+const mockRedirect = jest.fn(() => {
+  throw new Error("NEXT_REDIRECT");
+});
 
 jest.mock("next/navigation", () => ({
   notFound: mockNotFound,
@@ -17,9 +19,9 @@ jest.mock("@/config/env", () => ({
 import StreamReviewRedirectPage from "@/app/stream/page";
 
 describe("/stream production gate", () => {
-  it("terminates with not found before attempting a redirect", () => {
-    expect(() => StreamReviewRedirectPage()).toThrow("NEXT_NOT_FOUND");
-    expect(mockNotFound).toHaveBeenCalledTimes(1);
-    expect(mockRedirect).not.toHaveBeenCalled();
+  it("redirects production traffic to the published Stream review", () => {
+    expect(() => StreamReviewRedirectPage()).toThrow("NEXT_REDIRECT");
+    expect(mockNotFound).not.toHaveBeenCalled();
+    expect(mockRedirect).toHaveBeenCalledWith("/reviews/6529-stream");
   });
 });

--- a/__tests__/config/publicReviews.test.ts
+++ b/__tests__/config/publicReviews.test.ts
@@ -8,16 +8,17 @@ describe("public review environment gate", () => {
     ["http://localhost:3101", "local"],
     ["http://127.0.0.1:3001", "local"],
     ["https://staging.6529.io", "staging"],
+    ["https://6529.io", "production"],
+    ["https://www.6529.io", "production"],
   ] as const)("enables %s as %s", (endpoint, environment) => {
     expect(getPublicReviewEnvironment(endpoint)).toBe(environment);
     expect(isPublicReviewEnabled(endpoint)).toBe(true);
   });
 
   it.each([
-    "https://6529.io",
-    "https://www.6529.io",
     "https://test.6529.io",
     "https://staging.6529.io.evil.example",
+    "https://6529.io.evil.example",
     "not-a-url",
   ])("fails closed for %s", (endpoint) => {
     expect(getPublicReviewEnvironment(endpoint)).toBe("disabled");

--- a/__tests__/lib/public-review/streamReviewPublication.test.ts
+++ b/__tests__/lib/public-review/streamReviewPublication.test.ts
@@ -2,12 +2,17 @@ import {
   getStreamReviewVersionPublication,
   parseStreamReviewPublicationMetadata,
   parseStreamReviewVersionIdentities,
+  STREAM_REVIEW_PRODUCTION_ENABLED,
   STREAM_REVIEW_VERSION_IDENTITIES,
 } from "@/lib/public-review/streamReviewPublication";
 
 const SOURCE_COMMIT = "513bd7e079eafe109df6ae1ae21bfbca6fec6786";
 
 describe("Stream public-review version identities", () => {
+  it("publishes the review on the production host", () => {
+    expect(STREAM_REVIEW_PRODUCTION_ENABLED).toBe(true);
+  });
+
   it("pins every retained public and draft version to an explicit source commit", () => {
     expect(STREAM_REVIEW_VERSION_IDENTITIES).toEqual([
       {

--- a/__tests__/lib/public-review/streamReviewRoutes.test.ts
+++ b/__tests__/lib/public-review/streamReviewRoutes.test.ts
@@ -57,13 +57,13 @@ describe("6529 Stream public review routes", () => {
     ).toBeUndefined();
   });
 
-  it("returns no route model or source identifiers in production", () => {
+  it("resolves the production route without exposing source or discussion identifiers", () => {
     const model = resolveStreamReviewRoute({
       baseEndpoint: "https://6529.io",
       params: ACTIVE_REVIEW,
     });
 
-    expect(model).toBeUndefined();
+    expect(model?.canonicalPath).toBe("/reviews/6529-stream");
     const serialized = JSON.stringify(model) ?? "";
     expect(serialized).not.toContain(STREAM_REVIEW_SOURCE_COMMIT);
     expect(serialized).not.toMatch(/wave|subwave|discussion/i);

--- a/__tests__/scripts/package-public-review-artifacts.test.ts
+++ b/__tests__/scripts/package-public-review-artifacts.test.ts
@@ -343,6 +343,22 @@ function createFixture(lifecycleState = "PUBLIC_REVIEW"): {
   };
 }
 
+function setProductionReviewEnabled(
+  fixture: ReturnType<typeof createFixture>,
+  productionEnabled: unknown
+): void {
+  const publicationPath = path.join(
+    fixture.repoRoot,
+    `config/public-reviews/${REVIEW_ID}.publication.json`
+  );
+  const publication = JSON.parse(fs.readFileSync(publicationPath, "utf8"));
+  publication.productionEnabled = productionEnabled;
+  fs.writeFileSync(
+    publicationPath,
+    `${JSON.stringify(publication, null, 2)}\n`
+  );
+}
+
 function addHistoricalVersion({
   fixture,
   activeLifecycleState,
@@ -754,6 +770,65 @@ describe("profile-aware public-review artifact packaging", () => {
     ).toBe(false);
     expect(fs.readFileSync(fixture.sourceFile, "utf8")).toBe(
       "contract StreamCore {}\n"
+    );
+  });
+
+  it("packages exact published review evidence when production publication is enabled", () => {
+    const fixture = createFixture();
+    fixtureRoots.push(fixture.repoRoot);
+    setProductionReviewEnabled(fixture, true);
+
+    expect(
+      prepareProfileBundle({
+        repoRoot: fixture.repoRoot,
+        bundleRoot: fixture.bundleRoot,
+        profile: "production",
+      })
+    ).toEqual([
+      expect.objectContaining({
+        reviewId: REVIEW_ID,
+        reviewVersion: REVIEW_VERSION,
+      }),
+    ]);
+    expect(
+      fs.existsSync(
+        path.join(
+          fixture.bundleRoot,
+          `public/review-data/${REVIEW_ID}/versions/${REVIEW_VERSION}/reference-manifest.json`
+        )
+      )
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(
+          fixture.bundleRoot,
+          `public/review-data/${REVIEW_ID}/versions/${REVIEW_VERSION}/knowledge/manifest.json`
+        )
+      )
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(
+          fixture.bundleRoot,
+          `content/public-reviews/${REVIEW_ID}/versions/${REVIEW_VERSION}/editorial/overview.md`
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("rejects an invalid production publication flag", () => {
+    const fixture = createFixture();
+    fixtureRoots.push(fixture.repoRoot);
+    setProductionReviewEnabled(fixture, "yes");
+
+    expect(() =>
+      prepareProfileBundle({
+        repoRoot: fixture.repoRoot,
+        bundleRoot: fixture.bundleRoot,
+        profile: "production",
+      })
+    ).toThrow(
+      `${REVIEW_ID}.publication.json is not a valid public-review publication config.`
     );
   });
 

--- a/__tests__/scripts/sync-agent-files.test.ts
+++ b/__tests__/scripts/sync-agent-files.test.ts
@@ -217,9 +217,11 @@ describe("sync-agent-files", () => {
           .map(
             ({
               environments: _environments,
+              public_review_id: _publicReviewId,
               ...record
             }: {
               environments?: string[];
+              public_review_id?: string;
               [key: string]: unknown;
             }) => record
           ),
@@ -229,7 +231,7 @@ describe("sync-agent-files", () => {
         source.records.find(
           (record: { id: string }) => record.id === "public-reviews.stream"
         )?.environments
-      ).toEqual(["local", "staging"]);
+      ).toEqual(["local", "staging", "production"]);
       expect(published).toEqual(expectedProduction);
     });
   });

--- a/__tests__/scripts/sync-help-index.test.ts
+++ b/__tests__/scripts/sync-help-index.test.ts
@@ -21,7 +21,7 @@ function getPublishedRecordIds(baseEndpoint: string): Set<string> {
 
 describe("sync-help-index publication policy", () => {
   const publicReviewRecord = {
-    environments: ["local", "staging"],
+    environments: ["local", "staging", "production"],
     public_review_id: "6529-stream",
   };
 
@@ -42,7 +42,7 @@ describe("sync-help-index publication policy", () => {
         "production",
         new Set(["6529-stream"])
       )
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("leaves unrelated records governed only by their environment", () => {
@@ -68,11 +68,11 @@ describe("sync-help-index publication policy", () => {
     }
   });
 
-  it("generates a production-filtered help corpus without Stream summaries", () => {
+  it("generates the production help corpus with the published Stream summaries", () => {
     const publishedRecordIds = getPublishedRecordIds("https://6529.io");
 
     for (const recordId of STREAM_SUMMARY_RECORD_IDS) {
-      expect(publishedRecordIds.has(recordId)).toBe(false);
+      expect(publishedRecordIds.has(recordId)).toBe(true);
     }
   });
 });

--- a/config/public-reviews/6529-stream.publication.json
+++ b/config/public-reviews/6529-stream.publication.json
@@ -2,6 +2,7 @@
   "schemaVersion": "public-review.publication.v3",
   "reviewId": "6529-stream",
   "lifecycleState": "PUBLIC_REVIEW",
+  "productionEnabled": true,
   "versions": [
     {
       "version": "2026-07-26.1",

--- a/config/publicReviews.ts
+++ b/config/publicReviews.ts
@@ -1,7 +1,10 @@
+import { STREAM_REVIEW_PRODUCTION_ENABLED } from "@/lib/public-review/streamReviewPublication";
+
 const LOCAL_REVIEW_HOSTNAMES = new Set(["localhost", "127.0.0.1"]);
 const STAGING_REVIEW_HOSTNAMES = new Set(["staging.6529.io"]);
+const PRODUCTION_REVIEW_HOSTNAMES = new Set(["6529.io", "www.6529.io"]);
 
-type PublicReviewEnvironment = "local" | "staging" | "disabled";
+type PublicReviewEnvironment = "local" | "staging" | "production" | "disabled";
 
 export function getPublicReviewEnvironment(
   baseEndpoint: string
@@ -20,6 +23,10 @@ export function getPublicReviewEnvironment(
 
   if (STAGING_REVIEW_HOSTNAMES.has(hostname)) {
     return "staging";
+  }
+
+  if (PRODUCTION_REVIEW_HOSTNAMES.has(hostname)) {
+    return STREAM_REVIEW_PRODUCTION_ENABLED ? "production" : "disabled";
   }
 
   return "disabled";

--- a/lib/public-review/streamReviewPublication.ts
+++ b/lib/public-review/streamReviewPublication.ts
@@ -116,13 +116,16 @@ export function parseStreamReviewVersionIdentities(
 if (
   publication.schemaVersion !== STREAM_REVIEW_PUBLICATION_SCHEMA ||
   publication.reviewId !== STREAM_REVIEW_PUBLICATION_ID ||
-  !isPublicReviewLifecycleState(publication.lifecycleState)
+  !isPublicReviewLifecycleState(publication.lifecycleState) ||
+  typeof publication.productionEnabled !== "boolean"
 ) {
   throw new Error("The Stream public-review publication config is invalid.");
 }
 
 export const STREAM_REVIEW_LIFECYCLE_STATE: PublicReviewLifecycleState =
   publication.lifecycleState;
+export const STREAM_REVIEW_PRODUCTION_ENABLED: boolean =
+  publication.productionEnabled;
 
 export const STREAM_REVIEW_VERSION_IDENTITIES =
   parseStreamReviewVersionIdentities(publication.versions);

--- a/ops/help/README.md
+++ b/ops/help/README.md
@@ -25,9 +25,9 @@ Each record should be short, factual, and linkable:
 - `related_paths` should include only useful fallback or adjacent destinations.
 - `source_refs` should point to the frontend docs, components, or route files
   that justify the record.
-- `environments` may be `["local", "staging"]` for records whose routes or
-  controls are deliberately absent on production. Omit it for records that are
-  valid everywhere.
+- `environments` may contain `local`, `staging`, and `production` for records
+  whose routes or controls are available only in selected environments. Omit
+  it for records that are valid everywhere.
 - Do not index migrated legacy WordPress pages. The sync script rejects records
   whose canonical or related paths resolve to WordPress-migrated `page.tsx`
   files, or whose `source_refs` point at those files.

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -113,7 +113,7 @@
         "not deployed"
       ],
       "facts": [
-        "The 6529 Stream public review lives at /reviews/6529-stream only when both its lifecycle and the current environment permit publication; the initial environment allow-list is local development and shared staging, not production.",
+        "The 6529 Stream public review is published at /reviews/6529-stream in local development, shared staging, and production while its lifecycle permits public routes.",
         "The review presents Stream as an attempt to build the most complete, artist-centered contract system for serious one-of-one digital art, while retaining support for editions where an artist chooses them.",
         "The overview explains which artistic and protocol guarantees each major mechanism protects and which responsibilities a superficially simpler design would abandon or move into websites, databases, custodians, marketplaces, or unwritten recovery processes.",
         "Stream is not deployed and is pre-audit; Current Implementation and Readiness is the authoritative page for connected paths, source-only foundations, accepted targets, proposals, evidence, known limitations, and release blockers.",

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -89,7 +89,7 @@
     },
     {
       "id": "public-reviews.stream",
-      "environments": ["local", "staging"],
+      "environments": ["local", "staging", "production"],
       "public_review_id": "6529-stream",
       "kind": "route",
       "title": "6529 Stream contract review",
@@ -157,7 +157,7 @@
     },
     {
       "id": "public-reviews.stream.feedback-status",
-      "environments": ["local", "staging"],
+      "environments": ["local", "staging", "production"],
       "public_review_id": "6529-stream",
       "kind": "ui_affordance",
       "title": "Stream review feedback and public ledger",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -88,6 +88,131 @@
       ]
     },
     {
+      "id": "public-reviews.stream",
+      "kind": "route",
+      "title": "6529 Stream contract review",
+      "aliases": [
+        "stream",
+        "stream review",
+        "stream contract",
+        "6529 stream",
+        "contract review",
+        "public contract review"
+      ],
+      "keywords": [
+        "stream",
+        "contract",
+        "review",
+        "solidity",
+        "artist",
+        "audit",
+        "security",
+        "pre-audit",
+        "not deployed"
+      ],
+      "facts": [
+        "The 6529 Stream public review is published at /reviews/6529-stream in local development, shared staging, and production while its lifecycle permits public routes.",
+        "The review presents Stream as an attempt to build the most complete, artist-centered contract system for serious one-of-one digital art, while retaining support for editions where an artist chooses them.",
+        "The overview explains which artistic and protocol guarantees each major mechanism protects and which responsibilities a superficially simpler design would abandon or move into websites, databases, custodians, marketplaces, or unwritten recovery processes.",
+        "Stream is not deployed and is pre-audit; Current Implementation and Readiness is the authoritative page for connected paths, source-only foundations, accepted targets, proposals, evidence, known limitations, and release blockers.",
+        "Fourteen editorial pages explain artwork lifecycle, artist controls, roles, curation and TDH authorization, minting, sales, revenue, randomness, metadata, freezing, governance, current implementation and readiness, and community review.",
+        "Every page shows the review version, exact source link, page navigation, on-page contents, and a collapsible feedback rail; detailed evidence and release status are centralized on Current Implementation and Readiness.",
+        "Review, Technical reference, and Public feedback are the three consistent top-level review areas shown below the status banner; page comments and sending feedback remain separate page actions.",
+        "Active and historical routes read immutable versioned editorial content and validate its manifest before rendering.",
+        "Each immutable version has its own lifecycle, deployment status, and audit status: superseded versions can remain readable as REVIEW_CLOSED, stop accepting submissions, link back to the current review, and avoid inheriting newer deployment or audit claims.",
+        "The generated technical reference exposes the exact versioned Solidity source, definitions, functions, events, errors, and other declarations.",
+        "The all-declarations explorer applies its text, kind, scope, and location filters on the server and returns at most 100 matches per page instead of sending the complete declaration inventory to the browser.",
+        "Every editorial page combines its version-scoped comments and structured feedback composer in a collapsible rail that docks beside wide documents and opens as a dismissible right-side overlay on narrower layouts.",
+        "The reusable lifecycle map supports draft, scheduled, public review, review closed, remediation, audit, final candidate, deployed, and archived states; only public review accepts new feedback.",
+        "While the lifecycle is DRAFT, navigation and all editorial, technical-reference, source, declaration-search, and feedback-ledger routes are unavailable, and raw generated evidence plus editorial content are omitted from staging packages.",
+        "When enabled, NFTs > 6529 Stream — Review appears after ReMemes and before NFT Activity."
+      ],
+      "canonical_path": "/reviews/6529-stream",
+      "related_paths": [
+        "/stream",
+        "/reviews/6529-stream/artwork-lifecycle",
+        "/reviews/6529-stream/for-artists",
+        "/reviews/6529-stream/roles-and-trust",
+        "/reviews/6529-stream/curation-and-tdh-authorization",
+        "/reviews/6529-stream/tokens-collections-and-minting",
+        "/reviews/6529-stream/fixed-price-sales-and-auctions",
+        "/reviews/6529-stream/revenue-splits-and-royalties",
+        "/reviews/6529-stream/randomness",
+        "/reviews/6529-stream/metadata-scripts-and-dependencies",
+        "/reviews/6529-stream/freezing-preservation-and-artwork-finality",
+        "/reviews/6529-stream/governance-pausing-and-successors",
+        "/reviews/6529-stream/security-testing-and-known-limitations",
+        "/reviews/6529-stream/community-review",
+        "/reviews/6529-stream/reference",
+        "/reviews/6529-stream/feedback"
+      ],
+      "tags": ["stream", "contract", "review", "security"],
+      "source_refs": [
+        "app/reviews/[review]/page.tsx",
+        "components/public-review/PublicReviewShell.tsx",
+        "ops/docs/public-reviews/README.md"
+      ]
+    },
+    {
+      "id": "public-reviews.stream.feedback-status",
+      "kind": "ui_affordance",
+      "title": "Stream review feedback and public ledger",
+      "aliases": [
+        "stream feedback",
+        "comment on stream",
+        "report stream issue",
+        "stream review wave"
+      ],
+      "keywords": [
+        "stream",
+        "feedback",
+        "comment",
+        "security",
+        "vulnerability",
+        "source"
+      ],
+      "facts": [
+        "Every Stream editorial and technical reference page has one structured feedback composer connected to the server-resolved Stream review Wave destination.",
+        "Editorial pages place the current page's loaded comments and composer in one collapsible rail; closing and reopening it preserves the current draft, and the browser remembers the open or closed preference.",
+        "The page-comments rail reads the most recent 50 Wave messages for the exact review version, shows entries attached to the current page, and can load older 50-message pages on request.",
+        "Editorial feedback can reference a stable page section; technical feedback can reference an exact Solidity file and line range.",
+        "A code-reference submission remains unavailable until the browser computes the exact selected snippet checksum; changing the selection invalidates any earlier preview but preserves the written draft.",
+        "If a reviewer edits the draft or changes its attached page, section, or source range while a post is in flight, a successful response preserves the newer work and the next post uses a fresh submission ID.",
+        "A successful feedback post uses the standard app toast; Open discussion in the Wave remains the single route from the review back to the posted discussion.",
+        "Every submission carries the immutable review version, page or section, category, suspected severity, and exact source provenance when code is selected.",
+        "Possible exploitable security vulnerabilities are intentionally submitted to the same public review during Stream's predeployment lifecycle.",
+        "The review records a source-confirmed limitation in which finalizing an unfrozen collection before any token is minted writes zero, which setCollectionData can later treat as uninitialized and replace with a nonzero cap; the candidate needs a monotonic finalization guard or equivalent before this promise is irreversible.",
+        "Public vulnerability submission is available only during the PUBLIC_REVIEW lifecycle state; deployed reviews use their configured post-deployment disclosure policy.",
+        "The public feedback ledger supports category, page, contract, severity, disposition, and text filters plus CSV and Markdown auditor exports.",
+        "Ledger entries are identified and deduplicated by immutable Wave drop ID rather than the client-supplied submission UUID.",
+        "Ledger metadata for a 50-drop page is hydrated in batches of no more than eight concurrent requests.",
+        "A feedback section is accepted only when that exact section is explicitly allowed for the selected page; pages without a section allow-list accept no section IDs.",
+        "Immutable review-version routes have their own version-filtered feedback ledger and exact source-commit banner; review versions 2026-07-26.1 and 2026-07-27.1 are retained with feedback closed while 2026-07-30.1 is the active writing revision.",
+        "Every Stream editorial page includes a visible authorship note explaining that bots wrote the review under punk6529's mission and standards.",
+        "Ledger code links open the immutable in-site versioned source and also provide the pinned GitHub source."
+      ],
+      "canonical_path": "/reviews/6529-stream/feedback",
+      "related_paths": [
+        "/reviews/6529-stream",
+        "/reviews/6529-stream/community-review",
+        "/reviews/6529-stream/security-testing-and-known-limitations",
+        "/reviews/6529-stream/reference",
+        "/reviews/6529-stream/versions/2026-07-30.1/feedback",
+        "/reviews/6529-stream/versions/2026-07-27.1/feedback",
+        "/reviews/6529-stream/versions/2026-07-26.1/feedback"
+      ],
+      "tags": ["stream", "review", "feedback", "security"],
+      "source_refs": [
+        "app/reviews/[review]/feedback/page.tsx",
+        "app/reviews/[review]/versions/[version]/feedback/page.tsx",
+        "components/public-review/PublicReviewFeedbackComposer.tsx",
+        "components/public-review/PublicReviewLedger.tsx",
+        "components/public-review/PublicReviewShell.tsx",
+        "lib/public-review/streamReviewFeedback.server.ts",
+        "ops/docs/public-reviews/README.md"
+      ]
+    },
+    {
       "id": "join.6529",
       "kind": "route",
       "title": "Join 6529",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -7,7 +7,7 @@ Site data such as TDH, REP, and Wave activity changes continuously. Fetch the fi
 ## Machine-readable files
 
 - [llms.txt](https://6529.io/llms.txt): this file — the stable entry point.
-- [help-index.json](https://6529.io/help-index.json): 197 curated records covering routes, workflows, UI affordances, business rules, and glossary terms. Each record has an id, title, aliases, facts, and a canonical_path that is validated against the app's real routes at build time. This is the primary reference for answering questions about 6529.io.
+- [help-index.json](https://6529.io/help-index.json): 199 curated records covering routes, workflows, UI affordances, business rules, and glossary terms. Each record has an id, title, aliases, facts, and a canonical_path that is validated against the app's real routes at build time. This is the primary reference for answering questions about 6529.io.
 - [glossary.json](https://6529.io/glossary.json): 27 term definitions (TDH, xTDH, REP, NIC, Waves, Drops, Groups, Subscriptions, and more) projected from the same help corpus. Each term carries its help-index record id, definition facts, and canonical page path.
 - [sitemap.xml](https://6529.io/sitemap.xml): the crawlable page list, regenerated on every deploy.
 - [robots.txt](https://6529.io/robots.txt): standard crawler directives; it also references the files above.

--- a/scripts/package-public-review-artifacts.cjs
+++ b/scripts/package-public-review-artifacts.cjs
@@ -266,6 +266,8 @@ function getPublicReviewPublicationConfigs(repoRoot) {
         config.schemaVersion === PUBLIC_REVIEW_PUBLICATION_SCHEMA &&
           SAFE_ID_PATTERN.test(config.reviewId) &&
           PUBLIC_REVIEW_LIFECYCLE_STATES.has(config.lifecycleState) &&
+          (config.productionEnabled === undefined ||
+            typeof config.productionEnabled === "boolean") &&
           Array.isArray(config.versions) &&
           config.versions.length > 0 &&
           config.versions.every(
@@ -408,11 +410,23 @@ function getPublicReviewPublicationPlans(repoRoot) {
           configPath: reference.configPath,
           indexActiveVersion,
           publication,
+          productionEnabled: publication.productionEnabled === true,
           publishedVersions,
           sourceIndex,
         },
       ];
     })
+  );
+}
+
+function getProfilePublicationPlans(publicationPlans, profile) {
+  if (profile !== "production") {
+    return publicationPlans;
+  }
+  return new Map(
+    [...publicationPlans.entries()].filter(
+      ([, plan]) => plan.productionEnabled === true
+    )
   );
 }
 
@@ -1011,11 +1025,13 @@ function assertEditorialEvidence({ bundleRoot, review }) {
   return directoryIdentity(editorialRoot);
 }
 
-function assertStagingEvidence(
+function assertPublishedEvidence(
   repoRoot,
   bundleRoot,
+  profile,
   publicationPlans = getPublicReviewPublicationPlans(repoRoot)
 ) {
+  const profileLabel = profile === "production" ? "Production" : "Staging";
   const sourcePublicReviewRoot = path.join(
     repoRoot,
     PUBLIC_REVIEW_DATA_DIRECTORY
@@ -1044,7 +1060,7 @@ function assertStagingEvidence(
           );
         },
       }),
-    "Staging public-review data does not exactly match the trusted source tree."
+    `${profileLabel} public-review data does not exactly match the trusted source tree.`
   );
   assertPublishedReviewIndexes(bundleRoot, publicationPlans);
 
@@ -1061,7 +1077,7 @@ function assertStagingEvidence(
       ignore: (relativePath) =>
         isUnpublishedEditorialPath(relativePath, publicationPlans),
     }) === directoryIdentity(bundleEditorialRoot),
-    "Staging editorial content does not exactly match the trusted source tree."
+    `${profileLabel} editorial content does not exactly match the trusted source tree.`
   );
 
   const reviews = [...publicationPlans.values()].flatMap((plan) =>
@@ -1081,18 +1097,18 @@ function assertStagingEvidence(
     invariant(
       !fs.existsSync(bundlePublicReviewRoot) &&
         !fs.existsSync(bundleEditorialRoot),
-      "Draft public-review evidence must be absent from staging."
+      `Draft public-review evidence must be absent from ${profile}.`
     );
   } else {
     assertExactChildDirectories(
       bundlePublicReviewRoot,
       reviewIds,
-      "Staging public-review data"
+      `${profileLabel} public-review data`
     );
     assertExactChildDirectories(
       bundleEditorialRoot,
       reviewIds,
-      "Staging editorial content"
+      `${profileLabel} editorial content`
     );
   }
 
@@ -1115,7 +1131,10 @@ function assertPublicCopyIdentity(
   const bundlePublic = path.join(bundleRoot, "public");
   const options = {
     ignore: (relativePath) => {
-      if (profile === "production") {
+      if (
+        profile === "production" &&
+        !hasPublishedReviewVersions(publicationPlans)
+      ) {
         return isReviewDataPath(relativePath);
       }
       return (
@@ -1173,14 +1192,30 @@ function assertProfileBundle({
 }) {
   invariant(PROFILES.has(profile), `Unsupported artifact profile: ${profile}`);
   invariant(fs.statSync(bundleRoot).isDirectory(), "Bundle root is missing.");
-  assertPublicCopyIdentity(repoRoot, bundleRoot, profile, publicationPlans);
+  const profilePublicationPlans = getProfilePublicationPlans(
+    publicationPlans,
+    profile
+  );
+  assertPublicCopyIdentity(
+    repoRoot,
+    bundleRoot,
+    profile,
+    profilePublicationPlans
+  );
 
   if (profile === "production") {
-    assertProductionAbsence(bundleRoot);
     assertProductionRuntimeConfig(bundleRoot);
-    return [];
+    if (!hasPublishedReviewVersions(profilePublicationPlans)) {
+      assertProductionAbsence(bundleRoot);
+      return [];
+    }
   }
-  return assertStagingEvidence(repoRoot, bundleRoot, publicationPlans);
+  return assertPublishedEvidence(
+    repoRoot,
+    bundleRoot,
+    profile,
+    profilePublicationPlans
+  );
 }
 
 function removeDirectoryIfPresent(directory) {
@@ -1228,35 +1263,37 @@ function prepareProfileBundle({ repoRoot, bundleRoot, profile }) {
   const sourceIdentity = captureSourceIdentity(repoRoot);
   const sourcePublic = path.join(repoRoot, "public");
   const bundlePublic = path.join(bundleRoot, "public");
-  const publicationPlans = getPublicReviewPublicationPlans(repoRoot);
+  const publicationPlans = getProfilePublicationPlans(
+    getPublicReviewPublicationPlans(repoRoot),
+    profile
+  );
   replaceDirectory(sourcePublic, bundlePublic, {
     ignore: (relativePath) =>
-      profile === "production"
+      profile === "production" &&
+      !hasPublishedReviewVersions(publicationPlans)
         ? isReviewDataPath(relativePath)
         : isUnpublishedReviewDataPath(relativePath, publicationPlans),
   });
-  if (profile === "staging") {
+  if (hasPublishedReviewVersions(publicationPlans)) {
     writePublishedReviewIndexes(bundleRoot, publicationPlans);
     copyPublishedKnowledgePacks(repoRoot, bundleRoot, publicationPlans);
   }
 
-  if (profile === "staging") {
-    const sourceEditorial = path.join(
-      repoRoot,
-      PUBLIC_REVIEW_EDITORIAL_DIRECTORY
-    );
-    const bundleEditorial = path.join(
-      bundleRoot,
-      PUBLIC_REVIEW_EDITORIAL_DIRECTORY
-    );
-    if (hasPublishedReviewVersions(publicationPlans)) {
-      replaceDirectory(sourceEditorial, bundleEditorial, {
-        ignore: (relativePath) =>
-          isUnpublishedEditorialPath(relativePath, publicationPlans),
-      });
-    } else {
-      removeDirectoryIfPresent(bundleEditorial);
-    }
+  const sourceEditorial = path.join(
+    repoRoot,
+    PUBLIC_REVIEW_EDITORIAL_DIRECTORY
+  );
+  const bundleEditorial = path.join(
+    bundleRoot,
+    PUBLIC_REVIEW_EDITORIAL_DIRECTORY
+  );
+  if (hasPublishedReviewVersions(publicationPlans)) {
+    replaceDirectory(sourceEditorial, bundleEditorial, {
+      ignore: (relativePath) =>
+        isUnpublishedEditorialPath(relativePath, publicationPlans),
+    });
+  } else if (profile === "staging") {
+    removeDirectoryIfPresent(bundleEditorial);
   }
 
   const reviews = assertProfileBundle({

--- a/scripts/sync-help-index.cjs
+++ b/scripts/sync-help-index.cjs
@@ -34,7 +34,11 @@ const LEGACY_WORDPRESS_MARKERS = [
   "wp-json/wp/v2/",
   "wp-content/",
 ];
-const ALLOWED_PUBLICATION_ENVIRONMENTS = new Set(["local", "staging"]);
+const ALLOWED_PUBLICATION_ENVIRONMENTS = new Set([
+  "local",
+  "staging",
+  "production",
+]);
 const PUBLIC_REVIEW_ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 
 function fail(message) {


### PR DESCRIPTION
## Issue

The production deployment was healthy and on the expected SHA, but `/reviews/6529-stream` still returned the masked 404. Production was excluded by both the host gate and the artifact packager.

## Fix

- add an explicit `productionEnabled` publication switch for the Stream review
- enable the exact production hosts (`6529.io` and `www.6529.io`) only while that switch is active
- package and validate only lifecycle-published review versions, editorial content, reference data, and knowledge corpus in production
- preserve the existing production-absence policy when the switch is absent or false
- update the Help Bot source to describe production availability

## Validation

- 68 focused Jest tests
- `public-review:check`
- `lint:changed`
- `typecheck:changed`
- `deadcode:knip`
- `codex-diff-check`
- Next webpack production compile completed; the later framework type phase encountered the pre-existing `app/api/pepe/resolve/route.ts` extra-export error. GitHub CI remains authoritative for the clean-install/Turbopack build.

## Risk

The change intentionally publishes previously masked review material. The artifact allow-list is publication-driven, so draft versions remain excluded and the previous production-empty behavior remains covered for reviews without explicit activation.

## Review notes

This is a fix-forward for the verified production 404 found immediately after release run 30594351203. The deployed Stream copy itself is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The 6529 Stream public review is now available in production at `/reviews/6529-stream`.
  * Public review content can now be included in production publications when explicitly enabled.
  * Production packages preserve published review evidence when available.

* **Bug Fixes**
  * Improved production endpoint recognition and validation to prevent incorrectly treating similar or deceptive domains as approved environments.
  * Production review routes now use the correct canonical route information while excluding sensitive source details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->