### PR TITLE
Fix production Stream feedback configuration

### DIFF
--- a/.github/workflows/build-upload-deploy-prod.yml
+++ b/.github/workflows/build-upload-deploy-prod.yml
@@ -399,17 +399,39 @@ jobs:
           SSR_CLIENT_SECRET: ${{ secrets.SSR_CLIENT_SECRET }}
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
           GITHUB_LINK_STATUS_PREVIEW_TOKEN: ${{ secrets.LINK_STATUS_PREVIEW_GITHUB_TOKEN }}
+          PUBLIC_REVIEW_DISCUSSION_DESTINATIONS: ${{ secrets.PUBLIC_REVIEW_PRODUCTION_DISCUSSION_DESTINATIONS }}
         run: |
+          set -euo pipefail
+
+          jq -e '
+            type == "object" and
+            keys == ["production"] and
+            (.production | type == "object") and
+            (.production["stream-review"] | type == "string" and test("^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"))
+          ' <<<"$PUBLIC_REVIEW_DISCUSSION_DESTINATIONS" >/dev/null
+
+          option_settings="$(
+            jq -cn \
+              --arg ssr_client_id "$SSR_CLIENT_ID" \
+              --arg ssr_client_secret "$SSR_CLIENT_SECRET" \
+              --arg alchemy_api_key "$ALCHEMY_API_KEY" \
+              --arg github_link_status_preview_token "$GITHUB_LINK_STATUS_PREVIEW_TOKEN" \
+              --arg public_review_discussion_destinations "$PUBLIC_REVIEW_DISCUSSION_DESTINATIONS" \
+              '[
+                {Namespace:"aws:elasticbeanstalk:application:environment",OptionName:"SSR_CLIENT_ID",Value:$ssr_client_id},
+                {Namespace:"aws:elasticbeanstalk:application:environment",OptionName:"SSR_CLIENT_SECRET",Value:$ssr_client_secret},
+                {Namespace:"aws:elasticbeanstalk:application:environment",OptionName:"ALCHEMY_API_KEY",Value:$alchemy_api_key},
+                {Namespace:"aws:elasticbeanstalk:application:environment",OptionName:"GITHUB_LINK_STATUS_PREVIEW_TOKEN",Value:$github_link_status_preview_token},
+                {Namespace:"aws:elasticbeanstalk:application:environment",OptionName:"PUBLIC_REVIEW_DISCUSSION_DESTINATIONS",Value:$public_review_discussion_destinations},
+                {Namespace:"aws:elasticbeanstalk:application:environment",OptionName:"SENTRY_SERVER_INSTRUMENTATION",Value:"false"}
+              ]'
+          )"
+
           aws elasticbeanstalk update-environment \
             --application-name "${{ env.BEANSTALK_APP_NAME }}" \
             --environment-name "${{ env.BEANSTALK_ENV_NAME }}" \
             --version-label "${{ env.COMMIT_SHA }}" \
-            --option-settings \
-              "Namespace=aws:elasticbeanstalk:application:environment,OptionName=SSR_CLIENT_ID,Value=${SSR_CLIENT_ID}" \
-              "Namespace=aws:elasticbeanstalk:application:environment,OptionName=SSR_CLIENT_SECRET,Value=${SSR_CLIENT_SECRET}" \
-              "Namespace=aws:elasticbeanstalk:application:environment,OptionName=ALCHEMY_API_KEY,Value=${ALCHEMY_API_KEY}" \
-              "Namespace=aws:elasticbeanstalk:application:environment,OptionName=GITHUB_LINK_STATUS_PREVIEW_TOKEN,Value=${GITHUB_LINK_STATUS_PREVIEW_TOKEN}" \
-              "Namespace=aws:elasticbeanstalk:application:environment,OptionName=SENTRY_SERVER_INSTRUMENTATION,Value=false"
+            --option-settings "$option_settings"
 
       - name: Check Elastic Beanstalk health and readiness (120s warmup then 20 retries with 60s delay)
         env:

--- a/.github/workflows/release-bus-deploy-production.yml
+++ b/.github/workflows/release-bus-deploy-production.yml
@@ -261,18 +261,40 @@ jobs:
           SSR_CLIENT_SECRET: ${{ secrets.SSR_CLIENT_SECRET }}
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
           GITHUB_LINK_STATUS_PREVIEW_TOKEN: ${{ secrets.LINK_STATUS_PREVIEW_GITHUB_TOKEN }}
+          PUBLIC_REVIEW_DISCUSSION_DESTINATIONS: ${{ secrets.PUBLIC_REVIEW_PRODUCTION_DISCUSSION_DESTINATIONS }}
         run: |
+          set -euo pipefail
           [[ "$EXPECTED_SHA" =~ ^[a-f0-9]{40}$ ]]
+
+          jq -e '
+            type == "object" and
+            keys == ["production"] and
+            (.production | type == "object") and
+            (.production["stream-review"] | type == "string" and test("^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"))
+          ' <<<"$PUBLIC_REVIEW_DISCUSSION_DESTINATIONS" >/dev/null
+
+          option_settings="$(
+            jq -cn \
+              --arg ssr_client_id "$SSR_CLIENT_ID" \
+              --arg ssr_client_secret "$SSR_CLIENT_SECRET" \
+              --arg alchemy_api_key "$ALCHEMY_API_KEY" \
+              --arg github_link_status_preview_token "$GITHUB_LINK_STATUS_PREVIEW_TOKEN" \
+              --arg public_review_discussion_destinations "$PUBLIC_REVIEW_DISCUSSION_DESTINATIONS" \
+              '[
+                {Namespace:"aws:elasticbeanstalk:application:environment",OptionName:"SSR_CLIENT_ID",Value:$ssr_client_id},
+                {Namespace:"aws:elasticbeanstalk:application:environment",OptionName:"SSR_CLIENT_SECRET",Value:$ssr_client_secret},
+                {Namespace:"aws:elasticbeanstalk:application:environment",OptionName:"ALCHEMY_API_KEY",Value:$alchemy_api_key},
+                {Namespace:"aws:elasticbeanstalk:application:environment",OptionName:"GITHUB_LINK_STATUS_PREVIEW_TOKEN",Value:$github_link_status_preview_token},
+                {Namespace:"aws:elasticbeanstalk:application:environment",OptionName:"PUBLIC_REVIEW_DISCUSSION_DESTINATIONS",Value:$public_review_discussion_destinations},
+                {Namespace:"aws:elasticbeanstalk:application:environment",OptionName:"SENTRY_SERVER_INSTRUMENTATION",Value:"false"}
+              ]'
+          )"
+
           aws elasticbeanstalk update-environment \
             --application-name "$BEANSTALK_APP_NAME" \
             --environment-name "$BEANSTALK_ENV_NAME" \
             --version-label "$EXPECTED_SHA" \
-            --option-settings \
-              "Namespace=aws:elasticbeanstalk:application:environment,OptionName=SSR_CLIENT_ID,Value=${SSR_CLIENT_ID}" \
-              "Namespace=aws:elasticbeanstalk:application:environment,OptionName=SSR_CLIENT_SECRET,Value=${SSR_CLIENT_SECRET}" \
-              "Namespace=aws:elasticbeanstalk:application:environment,OptionName=ALCHEMY_API_KEY,Value=${ALCHEMY_API_KEY}" \
-              "Namespace=aws:elasticbeanstalk:application:environment,OptionName=GITHUB_LINK_STATUS_PREVIEW_TOKEN,Value=${GITHUB_LINK_STATUS_PREVIEW_TOKEN}" \
-              'Namespace=aws:elasticbeanstalk:application:environment,OptionName=SENTRY_SERVER_INSTRUMENTATION,Value=false'
+            --option-settings "$option_settings"
       - name: Wait for healthy exact version
         run: |
           set -euo pipefail

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -157,8 +157,14 @@ describe("release bus staging artifact transfer", () => {
       deployStep.run.indexOf('ln -sfn "$release_dir/app" "$current_link"')
     );
     expect(deployStep.run).toContain('(has("production") | not)');
-    expect(productionDeployWorkflowSource).not.toContain(
-      "PUBLIC_REVIEW_DISCUSSION_DESTINATIONS"
+    expect(productionDeployWorkflowSource).toContain(
+      "PUBLIC_REVIEW_DISCUSSION_DESTINATIONS: ${{ secrets.PUBLIC_REVIEW_PRODUCTION_DISCUSSION_DESTINATIONS }}"
+    );
+    expect(productionDeployWorkflowSource).toContain(
+      'keys == ["production"]'
+    );
+    expect(productionDeployWorkflowSource).toContain(
+      'OptionName:"PUBLIC_REVIEW_DISCUSSION_DESTINATIONS"'
     );
   });
 

--- a/__tests__/scripts/public-review-artifact-workflows.test.ts
+++ b/__tests__/scripts/public-review-artifact-workflows.test.ts
@@ -91,6 +91,19 @@ describe("public-review artifact workflow contract", () => {
     expect(legacyProduction).not.toMatch(/\bcp -r public\b/);
   });
 
+  it("injects a validated production-only public-review destination", () => {
+    expect(legacyProduction).toContain(
+      "PUBLIC_REVIEW_DISCUSSION_DESTINATIONS: ${{ secrets.PUBLIC_REVIEW_PRODUCTION_DISCUSSION_DESTINATIONS }}"
+    );
+    expect(legacyProduction).toContain('keys == ["production"]');
+    expect(legacyProduction).toContain(
+      'OptionName:"PUBLIC_REVIEW_DISCUSSION_DESTINATIONS"'
+    );
+    expect(legacyProduction).toContain(
+      '--option-settings "$option_settings"'
+    );
+  });
+
   it("keeps legacy staging aligned with the public-review bundle contract", () => {
     expect(legacyStaging).toContain(
       "PUBLIC_REVIEW_DISCUSSION_DESTINATIONS: ${{ secrets.PUBLIC_REVIEW_DISCUSSION_DESTINATIONS }}"


### PR DESCRIPTION
## Issue

- Production now publishes the Stream review, but the production EB runtime does not receive `PUBLIC_REVIEW_DISCUSSION_DESTINATIONS`.
- Every review page reaches the server error boundary while resolving its feedback Wave, and production feedback cannot reach the configured production Wave.

## Fix

- Add a dedicated production-only GitHub environment secret contract to both manual and Release Bus v2 frontend production deploy workflows.
- Validate the secret as an exact production destination map before deployment mutation.
- Build EB option settings as JSON so destination JSON is passed without shell or AWS shorthand parsing ambiguity.

## Changes

- Wire `PUBLIC_REVIEW_PRODUCTION_DISCUSSION_DESTINATIONS` into the runtime as `PUBLIC_REVIEW_DISCUSSION_DESTINATIONS`.
- Preserve all existing production runtime settings in the same EB update.
- Cover both production deployment paths with workflow contract tests.

## Validation

- 92/92 focused workflow, deployment-bus, and manual-routing tests passed.
- CI planning, changed-secret scan, and workflow-security validation passed with zero findings.
- Changed-file lint, source/test typechecks, and diff checks passed.
- `pr-ci-policy-bundle.test.ts` is intentionally Linux-only for its `O_NOFOLLOW` invariant; local Windows execution fails closed, and exact-head Linux CI remains authoritative.

## Risk

- Level: Medium
- Why: production deployment configuration changes, but the value is validated before mutation and scoped to one runtime setting.
- Rollback: revert the workflow commit and redeploy the prior exact main SHA; the existing EB runtime setting can also be removed through the same reviewed deploy path.

## Review Notes

- Focus on secret scoping, fail-closed JSON validation, and the JSON-form EB option settings construction.
- The secret value is production-only; staging keeps its existing separate secret and path unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deployment**
  - Production deployments now configure public review discussion destinations securely from deployment secrets.
  - Configuration is validated to accept only the production review destination format before deployment.
  - Environment settings are passed consistently during Elastic Beanstalk updates.

- **Tests**
  - Added coverage confirming production-only configuration and correct deployment wiring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->