### PR TITLE
Fix Release Bus help artifact merge churn

### DIFF
--- a/__tests__/scripts/sync-agent-files.test.ts
+++ b/__tests__/scripts/sync-agent-files.test.ts
@@ -176,7 +176,8 @@ describe("sync-agent-files", () => {
       for (const requiredPath of REQUIRED_LLMS_PATHS) {
         expect(llms).toContain(requiredPath);
       }
-      expect(llms).toContain(`${glossary.term_count} term`);
+      expect(llms).toContain("Term definitions");
+      expect(llms).not.toContain(`${glossary.term_count} term`);
     });
 
     it("matches the committed public artifacts (run `6529 run agent-files:sync` after editing the corpus)", () => {

--- a/__tests__/scripts/sync-agent-files.test.ts
+++ b/__tests__/scripts/sync-agent-files.test.ts
@@ -113,19 +113,19 @@ describe("sync-agent-files", () => {
   describe("renderLlmsTemplate", () => {
     const validTemplate = [
       "# Site",
-      "Revision {{GENERATED_AT}} with {{HELP_RECORD_COUNT}} records and {{GLOSSARY_TERM_COUNT}} terms.",
+      "Revision {{GENERATED_AT}} at {{BASE_URL}}.",
       ...REQUIRED_LLMS_PATHS.map((requiredPath: string) => `- ${requiredPath}`),
     ].join("\n");
     const replacements = {
       BASE_URL: "https://6529.io",
       GENERATED_AT: "2026-06-29T09:23:18.000Z",
-      HELP_RECORD_COUNT: 188,
-      GLOSSARY_TERM_COUNT: 30,
     };
 
     it("replaces tokens and terminates with a newline", () => {
       const rendered = renderLlmsTemplate(validTemplate, replacements);
-      expect(rendered).toContain("188 records and 30 terms");
+      expect(rendered).toContain(
+        "Revision 2026-06-29T09:23:18.000Z at https://6529.io."
+      );
       expect(rendered).not.toContain("{{");
       expect(rendered.endsWith("\n")).toBe(true);
     });

--- a/ops/help/llms.txt.template
+++ b/ops/help/llms.txt.template
@@ -7,8 +7,8 @@ Site data such as TDH, REP, and Wave activity changes continuously. Fetch the fi
 ## Machine-readable files
 
 - [llms.txt]({{BASE_URL}}/llms.txt): this file — the stable entry point.
-- [help-index.json]({{BASE_URL}}/help-index.json): {{HELP_RECORD_COUNT}} curated records covering routes, workflows, UI affordances, business rules, and glossary terms. Each record has an id, title, aliases, facts, and a canonical_path that is validated against the app's real routes at build time. This is the primary reference for answering questions about 6529.io.
-- [glossary.json]({{BASE_URL}}/glossary.json): {{GLOSSARY_TERM_COUNT}} term definitions (TDH, xTDH, REP, NIC, Waves, Drops, Groups, Subscriptions, and more) projected from the same help corpus. Each term carries its help-index record id, definition facts, and canonical page path.
+- [help-index.json]({{BASE_URL}}/help-index.json): Curated records covering routes, workflows, UI affordances, business rules, and glossary terms. Each record has an id, title, aliases, facts, and a canonical_path that is validated against the app's real routes at build time. This is the primary reference for answering questions about 6529.io.
+- [glossary.json]({{BASE_URL}}/glossary.json): Term definitions (TDH, xTDH, REP, NIC, Waves, Drops, Groups, Subscriptions, and more) projected from the same help corpus. Each term carries its help-index record id, definition facts, and canonical page path.
 - [sitemap.xml]({{BASE_URL}}/sitemap.xml): the crawlable page list, regenerated on every deploy.
 - [robots.txt]({{BASE_URL}}/robots.txt): standard crawler directives; it also references the files above.
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -7,8 +7,8 @@ Site data such as TDH, REP, and Wave activity changes continuously. Fetch the fi
 ## Machine-readable files
 
 - [llms.txt](https://6529.io/llms.txt): this file — the stable entry point.
-- [help-index.json](https://6529.io/help-index.json): 199 curated records covering routes, workflows, UI affordances, business rules, and glossary terms. Each record has an id, title, aliases, facts, and a canonical_path that is validated against the app's real routes at build time. This is the primary reference for answering questions about 6529.io.
-- [glossary.json](https://6529.io/glossary.json): 27 term definitions (TDH, xTDH, REP, NIC, Waves, Drops, Groups, Subscriptions, and more) projected from the same help corpus. Each term carries its help-index record id, definition facts, and canonical page path.
+- [help-index.json](https://6529.io/help-index.json): Curated records covering routes, workflows, UI affordances, business rules, and glossary terms. Each record has an id, title, aliases, facts, and a canonical_path that is validated against the app's real routes at build time. This is the primary reference for answering questions about 6529.io.
+- [glossary.json](https://6529.io/glossary.json): Term definitions (TDH, xTDH, REP, NIC, Waves, Drops, Groups, Subscriptions, and more) projected from the same help corpus. Each term carries its help-index record id, definition facts, and canonical page path.
 - [sitemap.xml](https://6529.io/sitemap.xml): the crawlable page list, regenerated on every deploy.
 - [robots.txt](https://6529.io/robots.txt): standard crawler directives; it also references the files above.
 


### PR DESCRIPTION
## Issue

- Cumulative staging composition failed when both current `main` and the preserved staging parent changed generated `public/llms.txt` record-count lines.

## Fix

- Remove volatile help-record and glossary counts from the stable `llms.txt` entry point so independent help-corpus additions no longer edit the same generated lines.

## Changes

- Make the help-index and glossary descriptions count-independent in the source template.
- Update the committed generated `public/llms.txt` artifact to match.

## Validation

- `git diff --check` passed.
- Broad local suites were intentionally skipped to publish the minimal fix directly to exact-head PR CI; generated-artifact sync is enforced there.

## Risk

- Level: Low
- Why: copy-only generated artifact stabilization; no runtime route, API, dependency, or workflow change.
- Rollback: revert the two text lines if dynamic counts are desired again.

## Review Notes

- Please focus on generated-source/output parity and whether any consumer requires the numeric counts (none are used as a contract).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated machine-readable file descriptions to remove hardcoded record and term counts.
  * Clarified that the help index and glossary contain curated content derived from the help corpus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->