### PR TITLE
Fix Release Bus deployment verifier checkout

### DIFF
--- a/.github/workflows/release-bus-deploy-production.yml
+++ b/.github/workflows/release-bus-deploy-production.yml
@@ -312,11 +312,19 @@ jobs:
           done
           echo 'Elastic Beanstalk did not reach the expected healthy version.' >&2
           exit 1
+      - name: Check out deployment verifier
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          path: .release-bus-verifier
+          sparse-checkout: ops/scripts/verify-deployment-version.cjs
+          sparse-checkout-cone-mode: false
       - name: Verify exact production version
         id: version
         run: |
           [[ "$EXPECTED_SHA" =~ ^[a-f0-9]{40}$ ]]
-          node ops/scripts/verify-deployment-version.cjs \
+          node .release-bus-verifier/ops/scripts/verify-deployment-version.cjs \
             --base-url https://6529.io \
             --expected-version "$EXPECTED_SHA" \
             --attempts 12 \

--- a/.github/workflows/release-bus-deploy-production.yml
+++ b/.github/workflows/release-bus-deploy-production.yml
@@ -318,7 +318,9 @@ jobs:
           ref: ${{ github.workflow_sha }}
           persist-credentials: false
           path: .release-bus-verifier
-          sparse-checkout: ops/scripts/verify-deployment-version.cjs
+          sparse-checkout: |
+            ops/scripts/verify-deployment-version.cjs
+            ops/scripts/cli-args.cjs
           sparse-checkout-cone-mode: false
       - name: Verify exact production version
         id: version

--- a/.github/workflows/release-bus-deploy-staging.yml
+++ b/.github/workflows/release-bus-deploy-staging.yml
@@ -586,7 +586,9 @@ jobs:
           ref: ${{ github.workflow_sha }}
           persist-credentials: false
           path: .release-bus-verifier
-          sparse-checkout: ops/scripts/verify-deployment-version.cjs
+          sparse-checkout: |
+            ops/scripts/verify-deployment-version.cjs
+            ops/scripts/cli-args.cjs
           sparse-checkout-cone-mode: false
       - name: Verify exact staging version
         id: version

--- a/.github/workflows/release-bus-deploy-staging.yml
+++ b/.github/workflows/release-bus-deploy-staging.yml
@@ -580,13 +580,21 @@ jobs:
           aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" --query StandardOutputContent --output text || true
           aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" --query StandardErrorContent --output text || true
           test "$terminal" = Success
+      - name: Check out deployment verifier
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          path: .release-bus-verifier
+          sparse-checkout: ops/scripts/verify-deployment-version.cjs
+          sparse-checkout-cone-mode: false
       - name: Verify exact staging version
         id: version
         env:
           STAGING_AUTH: ${{ secrets.STAGING_AUTH }}
         run: |
           [[ "$EXPECTED_SHA" =~ ^[a-f0-9]{40}$ ]]
-          node ops/scripts/verify-deployment-version.cjs \
+          node .release-bus-verifier/ops/scripts/verify-deployment-version.cjs \
             --base-url https://staging.6529.io \
             --expected-version "$EXPECTED_SHA" \
             --attempts 18 \

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -93,6 +93,44 @@ describe("release bus staging artifact transfer", () => {
     ).toEqual([]);
   });
 
+  it("checks out each immutable deployment verifier before invoking it", () => {
+    for (const { workflow, verifyStepName } of [
+      {
+        workflow: deployWorkflow,
+        verifyStepName: "Verify exact staging version",
+      },
+      {
+        workflow: YAML.parse(productionDeployWorkflowSource),
+        verifyStepName: "Verify exact production version",
+      },
+    ]) {
+      const steps = workflow.jobs.deploy.steps;
+      const checkoutIndex = steps.findIndex(
+        (step: { name?: string }) =>
+          step.name === "Check out deployment verifier"
+      );
+      const verifyIndex = steps.findIndex(
+        (step: { name?: string }) => step.name === verifyStepName
+      );
+      const checkout = steps[checkoutIndex];
+      const verify = steps[verifyIndex];
+
+      expect(checkoutIndex).toBeGreaterThanOrEqual(0);
+      expect(checkoutIndex).toBeLessThan(verifyIndex);
+      expect(checkout.uses).toMatch(/^actions\/checkout@/);
+      expect(checkout.with).toMatchObject({
+        ref: "${{ github.workflow_sha }}",
+        "persist-credentials": false,
+        path: ".release-bus-verifier",
+        "sparse-checkout": "ops/scripts/verify-deployment-version.cjs",
+        "sparse-checkout-cone-mode": false,
+      });
+      expect(verify.run).toContain(
+        "node .release-bus-verifier/ops/scripts/verify-deployment-version.cjs"
+      );
+    }
+  });
+
   it("uses the bucket region and rejects redirect bodies before activation", () => {
     const stageStep = deployWorkflow.jobs.deploy.steps.find(
       (step: { name?: string }) =>

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -112,21 +112,30 @@ describe("release bus staging artifact transfer", () => {
       const verifyIndex = steps.findIndex(
         (step: { name?: string }) => step.name === verifyStepName
       );
-      const checkout = steps[checkoutIndex];
-      const verify = steps[verifyIndex];
 
       expect(checkoutIndex).toBeGreaterThanOrEqual(0);
+      expect(verifyIndex).toBeGreaterThanOrEqual(0);
       expect(checkoutIndex).toBeLessThan(verifyIndex);
+      const checkout = steps[checkoutIndex];
+      const verify = steps[verifyIndex];
       expect(checkout.uses).toMatch(/^actions\/checkout@/);
       expect(checkout.with).toMatchObject({
         ref: "${{ github.workflow_sha }}",
         "persist-credentials": false,
         path: ".release-bus-verifier",
-        "sparse-checkout": "ops/scripts/verify-deployment-version.cjs",
         "sparse-checkout-cone-mode": false,
       });
+      expect(checkout.with["sparse-checkout"]).toContain(
+        "ops/scripts/verify-deployment-version.cjs"
+      );
+      expect(checkout.with["sparse-checkout"]).toContain(
+        "ops/scripts/cli-args.cjs"
+      );
       expect(verify.run).toContain(
         "node .release-bus-verifier/ops/scripts/verify-deployment-version.cjs"
+      );
+      expect(verify.run).not.toContain(
+        "node ops/scripts/verify-deployment-version.cjs"
       );
     }
   });


### PR DESCRIPTION
## What changed

- check out the immutable deployment verifier before the v2 staging deployment version check
- apply the same fix to the v2 production deployment path
- add workflow regression coverage for both environments

## Root cause

The immutable frontend bundle deployed successfully, but the v2 staging workflow invoked `ops/scripts/verify-deployment-version.cjs` without a repository checkout. The runner therefore failed with `MODULE_NOT_FOUND` after deployment.

## Validation

Published CI-first. `git diff --check` passes; authoritative PR CI will run the focused workflow regression and full required gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment verification for staging and production by using the verifier from the workflow’s pinned revision.
  * Restricted checkout scope and credentials during deployment verification for enhanced security and consistency.

* **Tests**
  * Added coverage confirming staging and production workflows use the expected verified scripts and checkout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->