### PR TITLE
FIX: accept video media in mint E2E

### DIFF
--- a/tests/media/media-mint-detail-readonly.spec.ts
+++ b/tests/media/media-mint-detail-readonly.spec.ts
@@ -125,7 +125,9 @@ test.describe("Media, mint, and detail read-only coverage @surface @medium @larg
       page.locator("main a[href^='/the-memes/']").first()
     ).toBeVisible({ timeout: 15000 });
     await expect(
-      page.locator("main img[id^='image-'][alt], main iframe").first()
+      page
+        .locator("main img[id^='image-'][alt], main video, main iframe")
+        .first()
     ).toBeVisible();
     await expect(
       page.getByRole("link", { name: "Distribution Plan" })


### PR DESCRIPTION
## Issue

The staging post-deploy media pack rejected the current The Memes mint page on desktop and mobile because the featured artwork is a native video. The page rendered successfully, but the read-only assertion only accepted an image or iframe.

## Fix

Allow the existing mint-media assertion to accept a visible native `video` alongside the existing image and iframe renderers.

## Notable changes

- keeps the same main-content scope and visibility assertion
- does not change application behavior or deployment code
- preserves image and iframe coverage

## Validation

- staging focused Playwright: The Memes mint page, desktop Chromium and Pixel 7 mobile Chromium — 2/2 passed
- `seize run lint:changed`
- `codex-diff-check`

The failing manifest-bound run was https://github.com/6529-Collections/6529seize-frontend/actions/runs/30723015468; its other media tests rendered the deployed site normally.

## Risk

Very low. Test-only selector broadening for a media type already supported by the mint page.

## Review notes

Please verify that accepting native video is the intended renderer contract for the mint surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated mint page media visibility checks to support matching images, videos, or embedded frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->