### PR TITLE
Fix Museum envelope record mapping

### DIFF
--- a/__tests__/lib/museum/normalize.test.ts
+++ b/__tests__/lib/museum/normalize.test.ts
@@ -87,13 +87,22 @@ describe("Museum domain mapping", () => {
           jsonDocument(
             "records/accessions/6529NM.2026.001/objects/object-001.json",
             {
-              record_type: "OBJECT_RECORD",
-              object_id: "6529NM.2026.001.001",
-              accession_lot_id: "6529NM.2026.001",
-              status: "accessioned",
-              artist: "Casey REAS",
-              title: "Object record",
-              record_scope: "A declared accession object.",
+              envelope: {
+                event_type: "MUSEUM_RECORD_COMMITTED",
+              },
+              payload: {
+                record_type: "WORK_DESCRIPTION",
+                object_id: "6529NM.2026.001.001",
+                accession_lot_id: "6529NM.2026.001",
+                current_state: "accessioned",
+                artist: { preferred_name: "Casey REAS" },
+                title: "Object record",
+                medium: "On-chain generative software.",
+                claims: {
+                  artist_statement: "An artist statement.",
+                  museum_interpretation: "A declared accession object.",
+                },
+              },
             }
           ),
       },
@@ -112,6 +121,17 @@ describe("Museum domain mapping", () => {
         expect.objectContaining({
           objectId: "6529NM.2026.001.001",
           accessionLotId: "6529NM.2026.001",
+          title: "Object record",
+          artist: "Casey REAS",
+          artistStatement: "An artist statement.",
+          classification: "On-chain generative software.",
+          status: "accessioned",
+          scope: "A declared accession object.",
+          record: expect.objectContaining({
+            payload: expect.objectContaining({
+              record_type: "WORK_DESCRIPTION",
+            }),
+          }),
         }),
       ])
     );

--- a/__tests__/lib/museum/normalize.test.ts
+++ b/__tests__/lib/museum/normalize.test.ts
@@ -80,6 +80,7 @@ describe("Museum domain mapping", () => {
             status: "selected_unminted",
             artist: { handle: "Artist" },
             title: "Selected work",
+            artist_statement: { text: "A legacy artist statement." },
             record_scope: "Not an accession statement.",
           }
         ),
@@ -95,7 +96,7 @@ describe("Museum domain mapping", () => {
                 object_id: "6529NM.2026.001.001",
                 accession_lot_id: "6529NM.2026.001",
                 current_state: "accessioned",
-                artist: { preferred_name: "Casey REAS" },
+                artist: { preferred_name: "", handle: "Casey REAS" },
                 title: "Object record",
                 medium: "On-chain generative software.",
                 claims: {
@@ -140,6 +141,7 @@ describe("Museum domain mapping", () => {
         expect.objectContaining({
           objectId: "6529NM-AP-01-OUT-001",
           accessionLotId: null,
+          artistStatement: "A legacy artist statement.",
         }),
       ])
     );

--- a/app/museum/network/objects/[objectId]/page.tsx
+++ b/app/museum/network/objects/[objectId]/page.tsx
@@ -49,17 +49,6 @@ export default async function MuseumObjectDetailPage({
     museumSlugMatches(item.objectId, objectId)
   );
   if (!object) notFound();
-  const record = object.record as {
-    readonly artist_statement?: unknown;
-  };
-  const artistStatement =
-    typeof record.artist_statement === "object" &&
-    record.artist_statement !== null &&
-    !Array.isArray(record.artist_statement)
-      ? (record.artist_statement as { readonly text?: unknown })
-      : null;
-  const statementText =
-    typeof artistStatement?.text === "string" ? artistStatement.text : "";
 
   return (
     <article>
@@ -110,7 +99,7 @@ export default async function MuseumObjectDetailPage({
           {object.scope}
         </p>
       )}
-      {statementText && (
+      {object.artistStatement && (
         <section
           className="tw-mt-8 tw-max-w-3xl tw-rounded-2xl tw-border tw-border-white/10 tw-bg-iron-900/60 tw-p-5"
           aria-labelledby="object-statement-title"
@@ -122,7 +111,7 @@ export default async function MuseumObjectDetailPage({
             {t(DEFAULT_LOCALE, "museum.network.objects.statement")}
           </h2>
           <div className="tw-mt-5">
-            <MuseumMarkdown>{statementText}</MuseumMarkdown>
+            <MuseumMarkdown>{object.artistStatement}</MuseumMarkdown>
           </div>
         </section>
       )}

--- a/lib/museum/normalize.ts
+++ b/lib/museum/normalize.ts
@@ -367,10 +367,9 @@ function objectRecords(
 
       const artistValue = root.artist;
       const artist = isObject(artistValue)
-        ? stringValue(
-            artistValue.preferred_name,
-            stringValue(artistValue.handle)
-          )
+        ? (nullableString(artistValue.preferred_name) ??
+          nullableString(artistValue.handle) ??
+          "")
         : stringValue(artistValue);
       const claims = isObject(root.claims) ? root.claims : {};
       const objectId = stringValue(root.object_id, stringValue(root.record_id));

--- a/lib/museum/normalize.ts
+++ b/lib/museum/normalize.ts
@@ -68,6 +68,14 @@ interface JsonObject {
   readonly record_type?: unknown;
   readonly object_id?: unknown;
   readonly handle?: unknown;
+  readonly payload?: unknown;
+  readonly current_state?: unknown;
+  readonly record_status?: unknown;
+  readonly claims?: unknown;
+  readonly artist_statement?: unknown;
+  readonly museum_interpretation?: unknown;
+  readonly medium?: unknown;
+  readonly text?: unknown;
   readonly classification?: unknown;
   readonly record_scope?: unknown;
 }
@@ -83,6 +91,14 @@ function stringValue(value: unknown, fallback = ""): string {
 function nullableString(value: unknown): string | null {
   const result = stringValue(value).trim();
   return result.length > 0 ? result : null;
+}
+
+function textValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  return isObject(value) ? stringValue(value.text) : "";
 }
 
 function numberValue(value: unknown): number | null {
@@ -332,10 +348,12 @@ function objectRecords(
         path.endsWith(".json") && document.contentType === "json"
     )
     .flatMap(([path, document]) => {
-      const root = jsonObject(document);
-      if (root === null) {
+      const record = jsonObject(document);
+      if (record === null) {
         return [];
       }
+
+      const root = isObject(record.payload) ? record.payload : record;
 
       const recordType = stringValue(root.record_type).toLocaleLowerCase();
       const isObjectRecord =
@@ -349,8 +367,12 @@ function objectRecords(
 
       const artistValue = root.artist;
       const artist = isObject(artistValue)
-        ? stringValue(artistValue.handle)
+        ? stringValue(
+            artistValue.preferred_name,
+            stringValue(artistValue.handle)
+          )
         : stringValue(artistValue);
+      const claims = isObject(root.claims) ? root.claims : {};
       const objectId = stringValue(root.object_id, stringValue(root.record_id));
       if (objectId.length === 0) {
         return [];
@@ -362,11 +384,26 @@ function objectRecords(
           accessionLotId: nullableString(root.accession_lot_id),
           title: stringValue(root.title, objectId),
           artist: artist || "Unknown artist",
-          classification: stringValue(root.classification),
-          status: stringValue(root.status, "unknown"),
-          scope: stringValue(root.record_scope),
+          artistStatement:
+            nullableString(textValue(root.artist_statement)) ??
+            nullableString(textValue(claims.artist_statement)),
+          classification: stringValue(
+            root.classification,
+            stringValue(root.medium)
+          ),
+          status: stringValue(
+            root.status,
+            stringValue(
+              root.current_state,
+              stringValue(root.record_status, "unknown")
+            )
+          ),
+          scope: stringValue(
+            root.record_scope,
+            stringValue(claims.museum_interpretation)
+          ),
           sourcePath: path,
-          record: root,
+          record,
         },
       ];
     });

--- a/lib/museum/types.ts
+++ b/lib/museum/types.ts
@@ -122,6 +122,7 @@ export interface MuseumObjectRecord {
   readonly accessionLotId: string | null;
   readonly title: string;
   readonly artist: string;
+  readonly artistStatement: string | null;
   readonly classification: string;
   readonly status: string;
   readonly scope: string;


### PR DESCRIPTION
## Issue

- The production Museum accession page reports that object-level records are not declared even though the canonical release manifest includes seven Casey REAS object records.
- The records use the governed `{ envelope, payload }` structure, while the website normalizer only read top-level object fields.

## Fix

- Read presentation fields from a validated object payload when present, while retaining the full raw envelope for technical disclosure.
- Normalize the current Museum vocabulary for artist name, accession state, medium, artist statement, and museum interpretation.

## Changes

- Add envelope-aware object normalization with backward compatibility for plain program outcome records.
- Pass normalized artist statements to object pages instead of probing an assumed raw shape in the route.
- Add regression coverage using the canonical wrapped object-record shape.

## Validation

- Focused Museum normalization Jest test: pass.
- `lint:changed`: pass.
- `typecheck:changed`: pass after frozen dependency refresh.
- `react-doctor:diff`: 100/100, no issues.
- Live-corpus integration read: fresh 194-entry release mapped to seven Casey accessioned objects and sixteen Keys and Gates selected outcomes, with the expected statuses and statements.

## Risk

- Level: Low.
- Why: the change is isolated to Museum object-domain normalization and presentation; source allowlisting, hash verification, sanitization, caching, and fetch boundaries are unchanged.
- Rollback: revert this commit and redeploy the prior frontend main.

## Review Notes

- Please focus on fallback behavior for plain records and preservation of the complete envelope in technical disclosure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Museum object pages now display artist statements from normalized object data.
  * Improved extraction of artist names, classifications, statuses, scopes, and artist statements across supported record formats.
  * Original record details are preserved for more complete object information.

* **Bug Fixes**
  * Improved handling of nested event payloads and text values.
  * Artist statements now render consistently when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->