### PR TITLE
Document Museum sweep-two production release

### DIFF
--- a/ops/workstreams/museum-publication-sweep-two/active-context.md
+++ b/ops/workstreams/museum-publication-sweep-two/active-context.md
@@ -2,19 +2,24 @@
 
 ## Current state
 
-- Rescue PR #3550 is merged as
-  `bd0983475802c8a742a1f52416fe480285ab1960` and is live in production.
-- Production `/api/version` returned that exact commit with `stale=false`; the
-  deployment workflow's three-match HTTP-version check passed.
-- Production validation passed core smoke 14/14, WCAG/i18n 6/6, and the
-  Museum-specific desktop/mobile sweep 10/10 plus live and return-to-still.
-- The general surface matrix reproduced two pre-existing harness false
-  positives. The release owner accepted an explicit exception with raw evidence:
-  an init script wrote session storage in a sandboxed Arweave child frame, and
-  two `eth_getBlockByNumber` reads used safe JSON-RPC methods on hosts missing
-  from the test guard's public-RPC host set.
-- Sweep two is isolated on a clean branch from the exact released main commit.
-  It does not mutate the qualified production candidate.
+- Sweep-two PR #3551 is merged as
+  `5acf2f5f85531a0970cd6ba1fd8988f762923865` and is live in production.
+- Production `/api/version` and the announced-version endpoint returned that
+  exact commit with `stale=false`; the deployment workflow's three-match
+  HTTP-version check passed.
+- The release was staged as composition
+  `156e2d0c3134d96d78a14b110f5006b57873268d`, which contains exact production
+  main `5acf2f5f85531a0970cd6ba1fd8988f762923865`.
+- Production validation passed all 11 declared read-only packs (73 tests), core
+  smoke 14/14, surface matrix 26 passed with 22 intentional project skips,
+  WCAG/i18n 6/6, and the Museum-specific desktop/mobile sweep 14/14 plus live
+  recovery.
+- The required 30-minute post-deploy watch completed with 33 exact-version
+  samples and no mismatch. The final deployment manifest validates without
+  holds or warnings.
+- Canonical Museum source remains
+  `04856bc3d137cc2a74a8cf15f068e02d3d026038`; the live source route links to
+  that immutable commit.
 
 ## Canonical documents
 
@@ -55,10 +60,11 @@ The strict publication must add these exact manifest-declared files under
 
 ## Immediate work
 
-1. Push the signed review follow-up to ready PR #3551.
-2. Iterate exact-head bots and CI, and obtain owning task review before merge.
-3. Qualify the exact merged release through staging and production under the
-   repository deployment controls.
+1. No release action remains for sweep two.
+2. Keep future Museum publication changes atomic and source-manifest bound.
+3. Repair and re-enable Release Bus automation separately; both effective lanes
+   remain deliberately OFF/changeable under the recorded manual-fallback
+   control.
 
 ## Review disposition
 
@@ -99,6 +105,16 @@ The strict publication must add these exact manifest-declared files under
 - Debt Ratchet: passed.
 - React Doctor: 100/100, no issues.
 - `codex-diff-check`: passed.
+- Exact-head App PR CI and Debt Ratchet: passed on
+  `b42e30880aee2792f2b133635d42ed368a3cd997`.
+- Staging deploy run `30779714023`: passed; automatic staging E2E run
+  `30780357100`: passed all 12 packs.
+- Production deploy run `30780811939`: passed, including Elastic Beanstalk
+  health, deployed-version validation, three consecutive HTTP version matches,
+  announced version, and durable version evidence.
+- Production post-deploy: 11/11 declared packs and 73/73 tests passed; core
+  smoke 14/14; surface matrix 26 passed and 22 skipped; WCAG/i18n 6/6; Museum
+  desktop/mobile routes 14/14 plus live recovery.
 
 ## Internationalization fallback debt
 

--- a/ops/workstreams/museum-publication-sweep-two/active-context.md
+++ b/ops/workstreams/museum-publication-sweep-two/active-context.md
@@ -109,12 +109,18 @@ The strict publication must add these exact manifest-declared files under
   `b42e30880aee2792f2b133635d42ed368a3cd997`.
 - Staging deploy run `30779714023`: passed; automatic staging E2E run
   `30780357100`: passed all 12 packs.
+- The staging and production environments intentionally resolve different
+  manifest-declared post-deploy sets: staging resolved 12 packs, while
+  production resolved its complete 11-pack inventory (73 tests).
 - Production deploy run `30780811939`: passed, including Elastic Beanstalk
   health, deployed-version validation, three consecutive HTTP version matches,
   announced version, and durable version evidence.
 - Production post-deploy: 11/11 declared packs and 73/73 tests passed; core
   smoke 14/14; surface matrix 26 passed and 22 skipped; WCAG/i18n 6/6; Museum
   desktop/mobile routes 14/14 plus live recovery.
+- The surface matrix increased from the prior release's 24 passing cases to 26
+  because the two previously excepted harness cases now pass after the
+  top-frame session-storage and read-only RPC guard hardening.
 
 ## Internationalization fallback debt
 

--- a/ops/workstreams/museum-publication-sweep-two/run-log.md
+++ b/ops/workstreams/museum-publication-sweep-two/run-log.md
@@ -88,6 +88,9 @@
   passed all 12 read-only packs. The retained Museum sweep passed 14/14
   desktop/mobile route checks, exact source binding, dossier coverage, artwork
   loading, 390px no-overflow, and forced-stall live recovery.
+- Staging and production intentionally resolve different manifest-declared
+  post-deploy sets: staging resolved 12 packs, while production resolved its
+  complete 11-pack inventory (73 tests).
 - Production deployment run
   `https://github.com/6529-Collections/6529seize-frontend/actions/runs/30780811939`
   passed on exact main. Elastic Beanstalk health/readiness, deployed-version
@@ -98,6 +101,9 @@
   WCAG/i18n 6/6, and the retained Museum sweep 14/14 plus live recovery. A
   fresh 390px browser check confirmed the native shell, exact source heading,
   no horizontal overflow, and no console errors.
+- The surface matrix moved from the prior release's 24 passing cases to 26
+  because the two previously excepted harness cases now pass after the
+  top-frame session-storage and read-only RPC guard hardening.
 - The required 30-minute post-deploy watch ran from
   `2026-08-03T03:26:15.408Z` through
   `2026-08-03T03:56:18.3927356Z`, recording 33 exact-version samples and no

--- a/ops/workstreams/museum-publication-sweep-two/run-log.md
+++ b/ops/workstreams/museum-publication-sweep-two/run-log.md
@@ -66,3 +66,52 @@
   route generation, and sitemap postbuild. The final prompt-state-only viewer
   cleanup then passed changed-code lint, changed-code typecheck, 65 focused
   tests, React Doctor 100/100, and the whitespace gate.
+
+## 2026-08-03 - sweep-two review, release, and closeout
+
+- PR #3551 completed exact-head review on
+  `b42e30880aee2792f2b133635d42ed368a3cd997`. App PR CI, Debt Ratchet,
+  CodeQL, Sonar, security checks, both Playwright packs, and the configured
+  review bots passed; all review threads were resolved. The owning
+  product/curatorial review approved that exact head.
+- The controlled admin disposition documented the sole self-approval
+  constraint without changing the ruleset. PR #3551 squash-merged as
+  `5acf2f5f85531a0970cd6ba1fd8988f762923865`.
+- The staging branch was advanced without force by merging exact main into the
+  existing staging head. Staging composition
+  `156e2d0c3134d96d78a14b110f5006b57873268d` contains exact production main
+  `5acf2f5f85531a0970cd6ba1fd8988f762923865`.
+- Staging deployment run
+  `https://github.com/6529-Collections/6529seize-frontend/actions/runs/30779714023`
+  passed. Automatic staging E2E run
+  `https://github.com/6529-Collections/6529seize-frontend/actions/runs/30780357100`
+  passed all 12 read-only packs. The retained Museum sweep passed 14/14
+  desktop/mobile route checks, exact source binding, dossier coverage, artwork
+  loading, 390px no-overflow, and forced-stall live recovery.
+- Production deployment run
+  `https://github.com/6529-Collections/6529seize-frontend/actions/runs/30780811939`
+  passed on exact main. Elastic Beanstalk health/readiness, deployed-version
+  validation, three consecutive HTTP version matches, announced version, and
+  durable version evidence all passed.
+- Production validation passed all 11 declared read-only packs (73 tests), core
+  smoke 14/14, surface matrix 26 passed with 22 intentional project skips,
+  WCAG/i18n 6/6, and the retained Museum sweep 14/14 plus live recovery. A
+  fresh 390px browser check confirmed the native shell, exact source heading,
+  no horizontal overflow, and no console errors.
+- The required 30-minute post-deploy watch ran from
+  `2026-08-03T03:26:15.408Z` through
+  `2026-08-03T03:56:18.3927356Z`, recording 33 exact-version samples and no
+  mismatch. Final readback confirmed all representative Museum routes at HTTP
+  200, frontend main and live production at
+  `5acf2f5f85531a0970cd6ba1fd8988f762923865`, and canonical Museum main at
+  `04856bc3d137cc2a74a8cf15f068e02d3d026038`.
+- Redacted validation evidence is retained below
+  `s3://6529reviewbot-prod-artifacts/frontend-deployment/fe-production-20260803T030417Z-5acf2f5f8553/`.
+  The completed release manifest is
+  `release-closeout/20260803T035843Z/deployment-bus-manifest.json` with
+  SHA-256
+  `bd7136f2548c49b9c0a9ccacf5c8e9ebe68daed7609060f2028ed23307cefb6f`;
+  it validates without holds or warnings.
+- Final control readback found no active release actor. STAGING and PRODUCTION
+  remain deliberately OFF/changeable under their recorded manual-fallback
+  controls; no lane or protection rule was weakened for this release.


### PR DESCRIPTION
## What changed

- updates the Museum sweep-two active context from pre-release work to the exact merged and deployed state
- records staging composition, staging/production run IDs, exact source and frontend SHAs, validation results, and the completed 30-minute production watch
- records the approved durable release-evidence prefix and final manifest digest

## Why

The runtime release is complete; this keeps the indexed workstream ledger accurate for future operators without changing application code or the deployed candidate.

## Validation

- targeted Prettier check
- `seize run lint:changed`
- `seize run typecheck:changed`
- `codex-diff-check -- ops/workstreams/museum-publication-sweep-two`
- public local-path/credential scrub

Runtime qualification referenced by the ledger: 11/11 production packs (73 tests), core smoke 14/14, surface matrix 26 passed / 22 intentional skips, WCAG/i18n 6/6, Museum desktop/mobile 14/14 plus live recovery, and a 30-minute exact-version watch with zero mismatches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated release records to reflect completed deployment and validation activities.
  - Added final review, deployment, monitoring, and evidence-retention results.
  - Documented maintenance guidance and confirmed existing fallback procedures remain available.

- **Chores**
  - Recorded successful production verification and post-release monitoring.
  - Confirmed no version inconsistencies were observed after deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->