### PR TITLE
Align Museum navigation across web and app layouts

### DIFF
--- a/__tests__/components/header/AppSidebar.test.tsx
+++ b/__tests__/components/header/AppSidebar.test.tsx
@@ -119,6 +119,7 @@ jest.mock("@/components/cookies/CookieConsentContext", () => ({
       render(<AppSidebar open={true} onClose={onClose} />);
       expect(getMenu().map((item) => item.label)).toEqual([
         "NFTs",
+        "Museum",
         "Waves",
         "DMs",
         "Join 6529",
@@ -128,11 +129,16 @@ jest.mock("@/components/cookies/CookieConsentContext", () => ({
         expect.arrayContaining([
           expect.objectContaining({ label: "DMs", path: "/messages" }),
           expect.objectContaining({
+            label: "Museum",
+            path: "/museum/network",
+          }),
+          expect.objectContaining({
             label: "Join 6529",
             path: "/join-6529",
           }),
         ])
       );
+      expect(getMenuItem("Museum").children).toBeUndefined();
       expect(getMenuChildren("NFTs")).toEqual([
         { label: "The Memes", path: "/the-memes" },
         { label: "6529 Gradient", path: "/6529-gradient" },
@@ -238,6 +244,7 @@ jest.mock("@/components/cookies/CookieConsentContext", () => ({
 
       expect(getMenu().map((item) => item.label)).toEqual([
         "NFTs",
+        "Museum",
         "Waves",
         "DMs",
         "Join 6529",

--- a/__tests__/components/layout/sidebar/WebSidebarNav.test.tsx
+++ b/__tests__/components/layout/sidebar/WebSidebarNav.test.tsx
@@ -42,6 +42,21 @@ jest.mock("@/hooks/useUnreadIndicator", () => ({
 
 const mockUsePathname = usePathname as jest.Mock;
 
+function expectDocumentOrder(elements: HTMLElement[]) {
+  for (let index = 0; index < elements.length - 1; index += 1) {
+    const current = elements[index];
+    const next = elements[index + 1];
+
+    if (current === undefined || next === undefined) {
+      throw new Error("Missing sidebar navigation item");
+    }
+
+    expect(
+      current.compareDocumentPosition(next) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  }
+}
+
 describe("WebSidebarNav", () => {
   beforeEach(() => {
     mockUsePathname.mockReturnValue("/waves");
@@ -57,6 +72,22 @@ describe("WebSidebarNav", () => {
     );
     expect(screen.queryByRole("button", { name: "Waves" })).toBeNull();
     expect(screen.queryByRole("link", { name: "Discover Waves" })).toBeNull();
+  });
+
+  it("keeps art destinations together and Waves adjacent to DMs", () => {
+    mockCanAccessDropForge = true;
+
+    render(<WebSidebarNav isCollapsed={false} />);
+
+    expectDocumentOrder([
+      screen.getByRole("button", { name: "NFTs" }),
+      screen.getByRole("link", { name: "Museum" }),
+      screen.getByRole("link", { name: "Waves" }),
+      screen.getByRole("link", { name: "DMs" }),
+      screen.getByRole("link", { name: "Join 6529" }),
+      screen.getByRole("button", { name: "About" }),
+      screen.getByRole("link", { name: "Drop Forge" }),
+    ]);
   });
 
   it("keeps Waves active for nested wave routes", () => {

--- a/__tests__/components/layout/sidebar/WebSidebarNav.test.tsx
+++ b/__tests__/components/layout/sidebar/WebSidebarNav.test.tsx
@@ -51,9 +51,12 @@ function expectDocumentOrder(elements: HTMLElement[]) {
       throw new Error("Missing sidebar navigation item");
     }
 
-    expect(
-      current.compareDocumentPosition(next) & Node.DOCUMENT_POSITION_FOLLOWING
-    ).toBeTruthy();
+    const currentRow = current.closest("li");
+    const nextRow = next.closest("li");
+
+    expect(currentRow).not.toBeNull();
+    expect(nextRow).not.toBeNull();
+    expect(currentRow?.nextElementSibling).toBe(nextRow);
   }
 }
 

--- a/__tests__/hooks/useSidebarSections.test.ts
+++ b/__tests__/hooks/useSidebarSections.test.ts
@@ -7,8 +7,8 @@ describe("useSidebarSections", () => {
 
     expect(result.current.map((section) => section.key)).toEqual([
       "nfts",
-      "waves",
       "museum",
+      "waves",
       "about",
     ]);
 

--- a/components/header/AppSidebar.tsx
+++ b/components/header/AppSidebar.tsx
@@ -56,6 +56,26 @@ function mapSectionToMenuItem(section: SidebarSection): SidebarMenu[number] {
   };
 }
 
+function mapSectionToDirectMenuItem(
+  section: SidebarSection | undefined
+): SidebarMenu[number] | undefined {
+  if (section === undefined) {
+    return undefined;
+  }
+
+  const primaryItem = section.items[0];
+
+  if (primaryItem === undefined) {
+    return undefined;
+  }
+
+  return {
+    label: section.name,
+    path: primaryItem.href,
+    icon: section.icon,
+  };
+}
+
 export default function AppSidebar({
   open,
   onClose,
@@ -86,6 +106,7 @@ export default function AppSidebar({
 
     return [
       sectionMap.get("nfts"),
+      mapSectionToDirectMenuItem(sectionMap.get("museum")),
       sectionMap.get("waves"),
       {
         label: t(DEFAULT_LOCALE, "navigation.primary.dms"),

--- a/components/header/AppSidebar.tsx
+++ b/components/header/AppSidebar.tsx
@@ -6,6 +6,7 @@ import {
   TransitionChild,
 } from "@headlessui/react";
 import { Fragment, useCallback, useEffect, useMemo } from "react";
+import { BuildingLibraryIcon } from "@heroicons/react/24/outline";
 import { useOptionalCookieConsent } from "@/components/cookies/CookieConsentContext";
 import {
   DROP_FORGE_PATH,
@@ -56,26 +57,6 @@ function mapSectionToMenuItem(section: SidebarSection): SidebarMenu[number] {
   };
 }
 
-function mapSectionToDirectMenuItem(
-  section: SidebarSection | undefined
-): SidebarMenu[number] | undefined {
-  if (section === undefined) {
-    return undefined;
-  }
-
-  const primaryItem = section.items[0];
-
-  if (primaryItem === undefined) {
-    return undefined;
-  }
-
-  return {
-    label: section.name,
-    path: primaryItem.href,
-    icon: section.icon,
-  };
-}
-
 export default function AppSidebar({
   open,
   onClose,
@@ -106,7 +87,11 @@ export default function AppSidebar({
 
     return [
       sectionMap.get("nfts"),
-      mapSectionToDirectMenuItem(sectionMap.get("museum")),
+      {
+        label: t(DEFAULT_LOCALE, "navigation.primary.museum"),
+        path: "/museum/network",
+        icon: BuildingLibraryIcon,
+      },
       sectionMap.get("waves"),
       {
         label: t(DEFAULT_LOCALE, "navigation.primary.dms"),

--- a/components/layout/sidebar/WebSidebarNav.tsx
+++ b/components/layout/sidebar/WebSidebarNav.tsx
@@ -420,9 +420,9 @@ const WebSidebarNav = React.forwardRef<
       <ul className="tw-m-0 tw-list-none tw-p-0">
         {nftsSection && renderExpandableSection(nftsSection)}
 
-        {wavesSection && renderDirectSectionLink(wavesSection)}
-
         {museumSection && renderDirectSectionLink(museumSection)}
+
+        {wavesSection && renderDirectSectionLink(wavesSection)}
 
         <li>
           <WebSidebarNavItem

--- a/hooks/useSidebarSections.ts
+++ b/hooks/useSidebarSections.ts
@@ -166,8 +166,8 @@ function buildSidebarSections(
 ): SidebarSection[] {
   return [
     getNftsSection(publicReviewsEnabled),
-    getWavesSection(),
     getMuseumSection(),
+    getWavesSection(),
     getAboutSection(appWalletsSupported, hideSubscriptions),
   ];
 }

--- a/ops/docs/navigation/README.md
+++ b/ops/docs/navigation/README.md
@@ -15,10 +15,11 @@ and mobile app layouts.
 
 ## Route Coverage
 
-- Web/sidebar primary section switching: `NFTs` (`/the-memes`), `Waves`
-  (`/waves`), `DMs` (`/messages`), `Join 6529` (`/join-6529`), and `About`
-  (`/about`), plus gated `Drop Forge` (`/drop-forge`) when the connected wallet
-  can access it. Home remains available through the 6529 logo link to `/`.
+- Web/sidebar primary section switching: `NFTs` (`/the-memes`), `Museum`
+  (`/museum/network`), `Waves` (`/waves`), `DMs` (`/messages`), `Join 6529`
+  (`/join-6529`), and `About` (`/about`), plus gated `Drop Forge`
+  (`/drop-forge`) when the connected wallet can access it. Home remains
+  available through the 6529 logo link to `/`.
 - App bottom section switching: `/discover`, `/waves`, `/messages`, `/`,
   `/network`, `/the-memes`, and `/notifications`.
 - Secondary jumps: `Discover Waves` (`/discover`), `/network/*`,
@@ -39,8 +40,8 @@ and mobile app layouts.
   `Collections`, and `Notifications`.
 - [App Sidebar Menu](feature-app-sidebar-menu.md): app drawer with sidebar
   primary concepts, a connected profile-avatar shortcut, gated `Drop Forge`
-  access when available, grouped secondary links under `NFTs`, `Waves`, and
-  `About`, and footer account actions.
+  access when available, a direct `Museum` row below `NFTs`, grouped secondary
+  links under `NFTs`, `Waves`, and `About`, and footer account actions.
 
 ### Shared Shell Controls
 

--- a/ops/docs/navigation/feature-app-sidebar-menu.md
+++ b/ops/docs/navigation/feature-app-sidebar-menu.md
@@ -6,6 +6,8 @@ In app layout, the top-left menu/avatar button opens a left drawer for
 primary navigation concepts, grouped secondary routes, and account actions.
 Connected account surfaces in this drawer can show unread notification
 indicators (dot/count badges) to help account switching.
+The standalone `Museum` row appears immediately after `NFTs`, keeping the
+art destinations together while leaving `Waves` adjacent to `DMs`.
 When the connected wallet can access Drop Forge, the drawer lists it as a
 standalone row after `About`.
 
@@ -13,7 +15,8 @@ standalone row after `About`.
 
 - App routes rendered with `AppLayout`, when header left control is menu/avatar
   (not `Back`).
-- Primary rows/groups: `NFTs`, `Waves`, `DMs`, `Join 6529`, and `About`.
+- Primary rows/groups: `NFTs`, `Museum`, `Waves`, `DMs`, `Join 6529`, and
+  `About`.
 - Gated primary row: `Drop Forge`, after `About`, only when the connected
   wallet can access it.
 - Drawer header: connected profile avatar shortcut to
@@ -41,15 +44,17 @@ standalone row after `About`.
    - disconnected: `6529` logo linking to `/`
 4. Drawer body shows direct rows plus grouped sections:
    - `NFTs`
+   - `Museum`
    - `Waves`
    - `DMs`
    - `Join 6529`
    - `About`
 5. Tap the connected profile avatar to open your own profile route
-   (`/{normalized-handle}` with `/{walletAddress}` fallback), tap `DMs` for
-   `/messages`, tap `Join 6529` for `/join-6529`, use the standalone `Drop
-   Forge` row when present, or expand grouped sections for nested routes. About
-   opens to group headings first, then each group expands to its links.
+   (`/{normalized-handle}` with `/{walletAddress}` fallback), tap `Museum` for
+   `/museum/network`, tap `DMs` for `/messages`, tap `Join 6529` for
+   `/join-6529`, use the standalone `Drop Forge` row when present, or expand
+   grouped sections for nested routes. About opens to group headings first,
+   then each group expands to its links.
 6. Drawer closes and route navigation runs.
 7. Use footer actions for QR scan, connect/session actions, push settings, and
    optional chain switching.
@@ -64,6 +69,8 @@ standalone row after `About`.
   `/reviews/6529-stream` and is absent on production.
 - Open `Waves`:
   `/waves` and `Discover Waves` at `/discover`.
+- Open `Museum`:
+  `/museum/network`.
 - Open `Join 6529`:
   `/join-6529`.
 - Open `About > Network & Reputation`:
@@ -111,8 +118,8 @@ standalone row after `About`.
   connected wallet can access the landing route.
 - Profile avatar shortcut is unavailable when disconnected because the header
   shows the `6529` home link instead.
-- `NFTs`, `Waves`, and `About` are collapsible; About group headers are nested
-  disclosure controls, not links.
+- `NFTs`, `Waves`, and `About` are collapsible; `Museum` is a direct row. About
+  group headers are nested disclosure controls, not links.
 - `App Wallets` appears inside `About > Delegation & Wallets` only when
   app-wallet support is available.
 - `Scan QR Code` appears only when running in Capacitor with scanner support.
@@ -146,8 +153,8 @@ standalone row after `About`.
 - App-sidebar behavior is app-layout only.
 - The Stream review entry uses the same environment gate as its routes and is
   never enabled by wallet state alone.
-- Bottom navigation and this drawer expose the same primary product concepts;
-  profile/account actions stay in account surfaces.
+- `Museum` is available from the app drawer rather than as a bottom-navigation
+  tab; profile/account actions stay in account surfaces.
 - Search stays in the header search control, not in this drawer.
 - Session/proxy details are owned by
   [Wallet and Account Controls](feature-wallet-account-controls.md).

--- a/ops/docs/navigation/feature-header-search-modal.md
+++ b/ops/docs/navigation/feature-header-search-modal.md
@@ -42,8 +42,8 @@ The search control opens one of two clearly scoped experiences:
   - `View all <Category>` opens the full list for that category.
 - Pages catalog:
   - Page results can include top-level navigation destinations such as
-    `NFTs`, `Waves`, `DMs`, `Join 6529`, and `About`, secondary destinations
-    such as `Discover Waves` (`/discover`) and `6529 Apps`
+    `NFTs`, `Museum`, `Waves`, `DMs`, `Join 6529`, and `About`, secondary
+    destinations such as `Discover Waves` (`/discover`) and `6529 Apps`
     (`/about/6529-apps`), plus
     permission-gated operational routes such as `Drop Forge`, `Craft Claims`,
     or `Launch Claims`, subject to the current route catalog.

--- a/ops/docs/navigation/feature-sidebar-navigation.md
+++ b/ops/docs/navigation/feature-sidebar-navigation.md
@@ -16,9 +16,12 @@ On web layouts, route switching is sidebar-first.
 - Collapsed flyouts enter with a short opacity and horizontal-position reveal;
   reduced-motion preferences show them immediately without animation.
 - The 6529 logo links to `/`; there is no labeled `Home` product row.
-- Primary menu concepts are `NFTs`, `Waves`, `DMs`, `Join 6529`, and `About`.
-- `NFTs` and `About` are expandable groups; `Waves`, `DMs`, and `Join 6529`
-  are direct rows.
+- Primary menu concepts are ordered `NFTs`, `Museum`, `Waves`, `DMs`,
+  `Join 6529`, and `About` so art destinations stay together while Waves and
+  DMs remain adjacent.
+- `NFTs` and `About` are expandable groups; `Museum`, `Waves`, `DMs`, and
+  `Join 6529` are direct rows.
+- The `Museum` row opens `/museum/network` in one click.
 - The `Waves` sidebar row opens `/waves` in one click. `Discover Waves`
   remains a secondary Waves experience link and searchable destination.
 - When the connected wallet can access Drop Forge, the sidebar adds a
@@ -34,7 +37,8 @@ On web layouts, route switching is sidebar-first.
 
 - Web routes rendered with `WebLayout` or `SmallScreenLayout` (non-app).
 - Home entry: 6529 logo link to `/`.
-- Primary rows/groups: `NFTs`, `Waves`, `DMs`, `Join 6529`, `About`.
+- Primary rows/groups: `NFTs`, `Museum`, `Waves`, `DMs`, `Join 6529`,
+  `About`.
 - Gated primary row: `Drop Forge`, after `About`, only when the connected
   wallet can access it.
 - Utility rows: desktop `Search`, connected-only `Notifications`,
@@ -47,6 +51,7 @@ On web layouts, route switching is sidebar-first.
 - Desktop and narrow desktop web: use sidebar chevron toggle.
 - Touch small-screen web: use header menu button.
 - Select direct rows or expand groups for nested routes.
+- Open `Museum` directly from the primary sidebar row.
 - Open `Waves` directly from the primary sidebar row.
 - Open `Join 6529` directly from the primary sidebar row.
 - Open `Discover Waves` from the expanded Waves panel header or search.
@@ -64,8 +69,8 @@ On web layouts, route switching is sidebar-first.
 2. Switch primary sections with direct rows.
 3. Use lower utility rows for connected `Notifications`, connected `Profile`,
    or disconnected `Share`.
-4. Open `NFTs` or `About` for nested routes; use the `Waves` row for direct
-   `/waves` navigation and the `Join 6529` row for `/join-6529`.
+4. Open `NFTs` or `About` for nested routes; use the `Museum`, `Waves`, and
+   `Join 6529` rows for direct navigation.
 5. In collapsed mode, hover a group row with a mouse or activate it by tap,
    click, or keyboard to open an anchored flyout submenu. The flyout preserves
    subsection labels such as `Network & Reputation`, `Delegation & Wallets`, or
@@ -85,6 +90,8 @@ On web layouts, route switching is sidebar-first.
 - Open `Waves` routes:
   use the primary `Waves` row for `/waves`; use `Discover Waves` in the Waves
   panel header or search for `/discover`.
+- Open `Museum`:
+  use the primary `Museum` row for `/museum/network`.
 - Open `Join 6529`:
   use the primary `Join 6529` row for the shareable onboarding guide at
   `/join-6529`.
@@ -111,7 +118,7 @@ On web layouts, route switching is sidebar-first.
   `NFTs` keeps collection and NFT activity links, and `About` keeps subsection
   labels such as `Network & Reputation`, `Delegation & Wallets`, and
   `Data & Developer Tools` instead of flattening every route into one list.
-  `Waves` and `Join 6529` remain direct rows in collapsed mode.
+  `Museum`, `Waves`, and `Join 6529` remain direct rows in collapsed mode.
 - Open `About` and `6529 Capital` routes from grouped links.
 - Open connected `Notifications` from the lower row above `Profile`.
 - Open `Share` to generate QR/deep links for the current route:

--- a/ops/docs/navigation/flow-navigation-entry-and-switching.md
+++ b/ops/docs/navigation/flow-navigation-entry-and-switching.md
@@ -17,9 +17,9 @@ context-aware `Back`).
 
 ## Entry Points
 
-- Web sidebar primary concepts (`NFTs`, `Waves`, `DMs`, `Join 6529`, `About`)
-  plus gated `Drop Forge` when available and connected utility rows such as
-  `Notifications`.
+- Web sidebar primary concepts (`NFTs`, `Museum`, `Waves`, `DMs`, `Join 6529`,
+  `About`) plus gated `Drop Forge` when available and connected utility rows
+  such as `Notifications`.
 - Small-screen header menu button (opens the sidebar in overlay mode).
 - App bottom navigation tabs (`Discovery`, `Waves`, `Messages`, `Home`,
   `Network`, `Collections`, `Notifications`).
@@ -64,6 +64,8 @@ context-aware `Back`).
 - Small-screen web: open overlay menu, pick a route, and continue after
   auto-close on navigation.
 - Join 6529 jump: use the primary `Join 6529` row to open `/join-6529`.
+- Museum jump: use the direct `Museum` row after `NFTs` to open
+  `/museum/network` in web and app sidebars.
 - Desktop web share: while disconnected use the standalone lower `Share` row;
   while connected open the user menu and choose `Share`.
 - App secondary route jump: open app drawer and choose grouped `About` routes
@@ -82,6 +84,8 @@ context-aware `Back`).
 - `Waves` is one-click from the web sidebar. `Discover Waves` is secondary in
   the Waves experience and searchable, while the app bottom bar keeps a
   dedicated `Discovery` tab for `/discover`.
+- `Museum` is one-click from both sidebar variants and has no dedicated app
+  bottom-navigation tab.
 - The app-drawer profile avatar is connected-only and resolves handle-first
   profile routing with wallet fallback.
 - In the app drawer header, only the connected profile avatar is a profile

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -123,8 +123,8 @@
         "expand"
       ],
       "facts": [
-        "The primary navigation concepts are NFTs, Waves, Museum, DMs, Join 6529, and About.",
-        "Museum is a standalone sidebar row linking to /museum/network; historical /museum gallery routes remain available from the Museum entry point.",
+        "The sidebar orders primary navigation as NFTs, Museum, Waves, DMs, Join 6529, and About, with gated Drop Forge after About.",
+        "Museum is a standalone web and app sidebar row linking to /museum/network; historical /museum gallery routes remain available from the Museum entry point.",
         "Home remains available through the 6529 logo link to /.",
         "The web sidebar Waves row opens /waves directly; Discover Waves remains secondary inside the Waves experience and searchable, while Network, Delegation, Tools, Open Data, and reference material live under About.",
         "Drop Forge appears as a standalone sidebar row after About only when the connected wallet can access /drop-forge.",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -123,8 +123,8 @@
         "expand"
       ],
       "facts": [
-        "The primary navigation concepts are NFTs, Waves, Museum, DMs, Join 6529, and About.",
-        "Museum is a standalone sidebar row linking to /museum/network; historical /museum gallery routes remain available from the Museum entry point.",
+        "The sidebar orders primary navigation as NFTs, Museum, Waves, DMs, Join 6529, and About, with gated Drop Forge after About.",
+        "Museum is a standalone web and app sidebar row linking to /museum/network; historical /museum gallery routes remain available from the Museum entry point.",
         "Home remains available through the 6529 logo link to /.",
         "The web sidebar Waves row opens /waves directly; Discover Waves remains secondary inside the Waves experience and searchable, while Network, Delegation, Tools, Open Data, and reference material live under About.",
         "Drop Forge appears as a standalone sidebar row after About only when the connected wallet can access /drop-forge.",


### PR DESCRIPTION
## Issue

- The web sidebar placed Museum between Waves and DMs, separating two related communication destinations.
- The native mobile app drawer did not expose Museum at all.

## Fix

- Order the web navigation as NFTs, Museum, Waves, DMs, Join 6529, About, and gated Drop Forge.
- Add Museum to the native app drawer as a direct one-tap row immediately below NFTs.

## Changes

- Reorder the shared sidebar sections so page search and visible navigation use the same information architecture.
- Apply the web order through the shared sidebar used by desktop and small-screen mobile browser layouts.
- Add exact ordering coverage for web and app sidebars, including the direct Museum route.
- Update navigation docs and the published Help Bot corpus.

## Validation

- Focused sidebar and shared-section Jest suites pass.
- Changed-file lint and TypeScript checks pass.
- Help-index and public agent artifacts are synchronized.
- React Doctor scored 99/100; its only warning is the existing inline submenu render helper outside this ordering change.
- No local browser server or deployment was started; this change only reorders existing rendered navigation primitives and is covered by DOM-order assertions.

## Risk

- Level: Low
- Why: The change only reorders existing navigation entries and exposes the already-live Museum route in the app drawer.
- Rollback: Revert this commit to restore the previous ordering and app menu contents.

## Review Notes

- Please confirm the intended grouping: NFTs beside Museum, and Waves beside DMs, consistently across desktop web, mobile browser, and the mobile app drawer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added **Museum** as a standalone sidebar navigation item.
  - Museum links directly to `/museum/network` and appears between **NFTs** and **Waves**.
  - Updated web and app navigation ordering, including collapsed sidebar behavior.

- **Documentation**
  - Updated navigation guides and help content to describe the Museum destination and its standalone sidebar placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->