### PR TITLE
Handle unavailable Network Nerd pathname

### DIFF
--- a/__tests__/app/network/nerd/index.active.test.tsx
+++ b/__tests__/app/network/nerd/index.active.test.tsx
@@ -68,6 +68,12 @@ describe("ClientCommunityNerdPage", () => {
     expect(capturedProps.focus).toBe(LeaderboardFocus.TDH);
   });
 
+  it("keeps the initial focus while the pathname is unavailable", () => {
+    usePathnameMock.mockReturnValue(null);
+    renderPage(LeaderboardFocus.INTERACTIONS);
+    expect(capturedProps.focus).toBe(LeaderboardFocus.INTERACTIONS);
+  });
+
   it("updates path when focus changes", () => {
     renderPage(LeaderboardFocus.TDH);
     act(() => capturedProps.setFocus(LeaderboardFocus.INTERACTIONS));

--- a/app/network/nerd/[[...focus]]/page.client.tsx
+++ b/app/network/nerd/[[...focus]]/page.client.tsx
@@ -28,14 +28,14 @@ function getFocusPath(focus: LeaderboardFocus): string {
 }
 
 function getFocusFromPathname(
-  pathname: string,
+  pathname: string | null,
   fallback: LeaderboardFocus
 ): LeaderboardFocus {
-  if (pathname.includes("/interactions")) {
+  if (pathname?.includes("/interactions")) {
     return LeaderboardFocus.INTERACTIONS;
   }
 
-  if (pathname.startsWith("/network/nerd")) {
+  if (pathname?.startsWith("/network/nerd")) {
     return LeaderboardFocus.TDH;
   }
 


### PR DESCRIPTION
## Issue

The current frontend `main` compiles, then fails the full Next production build because `usePathname()` is nullable in the production type surface while Network Nerd's focus helper accepts only `string`. This blocks unrelated release branches from completing the repository-wide build gate.

## Fix

Make the pure focus parser accept `string | null`. A missing pathname retains the server-provided initial focus; known Network Nerd paths keep their existing behavior.

## Changes

- widen `getFocusFromPathname` to accept the production hook's nullable result
- use optional pathname checks without changing known-path routing
- add a regression test for the unavailable-pathname fallback

## Validation

- Network Nerd Jest suites: 2 suites, 8 tests passed
- `seize run typecheck:changed`: passed (1,257-file ratchet)
- `seize run lint:changed`: passed
- `codex-diff-check`: passed
- `seize run build`: passed, including optimized compilation, TypeScript, route generation, sitemap, and postbuild

## Risk

Low. The only new branch handles a transient absent pathname by preserving the existing initial focus. Existing interactions and cards-collected paths are unchanged and covered by the existing suites.