### PR TITLE
Harden Museum navigation after release

### DIFF
--- a/__tests__/app/museum/network/institutionalPracticeRoutes.test.tsx
+++ b/__tests__/app/museum/network/institutionalPracticeRoutes.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { notFound } from "next/navigation";
+import type { AnchorHTMLAttributes, ReactNode } from "react";
 import MuseumInstitutionProfilePage, {
   generateMetadata,
 } from "@/app/museum/network/stories/a-field-of-practice/[slug]/page";
@@ -22,6 +23,22 @@ jest.mock("next/navigation", () => ({
   }),
 }));
 
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    prefetch,
+    ...props
+  }: AnchorHTMLAttributes<HTMLAnchorElement> & {
+    readonly children: ReactNode;
+    readonly prefetch?: boolean;
+  }) => (
+    <a {...props} data-prefetch={String(prefetch)}>
+      {children}
+    </a>
+  ),
+}));
+
 jest.mock("@/lib/museum/publication/runtime", () => ({
   getMuseumPublicationState: jest.fn(),
 }));
@@ -36,6 +53,17 @@ jest.mock("@/components/museum/MuseumArtworkFigure", () => ({
 
 const mockedPublicationState = jest.mocked(getMuseumPublicationState);
 const mockedNotFound = jest.mocked(notFound);
+
+function expectNextLinkWithoutPrefetch(href: string) {
+  const link = screen
+    .getAllByRole("link")
+    .find(
+      (candidate) =>
+        candidate.getAttribute("href") === href &&
+        candidate.getAttribute("data-prefetch") === "false"
+    );
+  expect(link).toBeDefined();
+}
 
 function studyMarkdown(): string {
   return `# A field of practice
@@ -219,6 +247,13 @@ describe("Museum institutional-practice reading room", () => {
     expect(profileLinks).toHaveLength(14);
     expect(profileLinks[0]).toHaveTextContent("01");
     expect(profileLinks[13]).toHaveTextContent("14");
+    for (const link of screen
+      .getAllByRole("link")
+      .filter((candidate) =>
+        candidate.getAttribute("href")?.startsWith("/museum/network")
+      )) {
+      expect(link).toHaveAttribute("data-prefetch", "false");
+    }
   });
 
   it("renders the comparative study as one governed document hierarchy", async () => {
@@ -246,6 +281,10 @@ describe("Museum institutional-practice reading room", () => {
     ).toHaveAttribute(
       "href",
       `https://github.com/6529-Collections/6529networkmuseum/blob/${"a".repeat(40)}/docs/curatorial-publication-standard.md`
+    );
+    expectNextLinkWithoutPrefetch("/museum/network/stories");
+    expectNextLinkWithoutPrefetch(
+      "/museum/network/stories/a-field-of-practice/sources"
     );
   });
 
@@ -290,6 +329,15 @@ describe("Museum institutional-practice reading room", () => {
       "href",
       "/museum/network/stories/a-field-of-practice/getty"
     );
+    expectNextLinkWithoutPrefetch(
+      "/museum/network/stories/a-field-of-practice"
+    );
+    expectNextLinkWithoutPrefetch(
+      "/museum/network/stories/a-field-of-practice/sources"
+    );
+    expectNextLinkWithoutPrefetch(
+      "/museum/network/stories/a-field-of-practice/getty"
+    );
   });
 
   it("uses the governed profile title in page metadata", async () => {
@@ -316,6 +364,9 @@ describe("Museum institutional-practice reading room", () => {
     expect(screen.getByRole("link", { name: "Open Access" })).toHaveAttribute(
       "target",
       "_blank"
+    );
+    expectNextLinkWithoutPrefetch(
+      "/museum/network/stories/a-field-of-practice"
     );
   });
 

--- a/__tests__/components/museum/MuseumShell.test.tsx
+++ b/__tests__/components/museum/MuseumShell.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import type { AnchorHTMLAttributes, ReactNode } from "react";
+import { MuseumShell } from "@/components/museum/MuseumShell";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    prefetch,
+    ...props
+  }: AnchorHTMLAttributes<HTMLAnchorElement> & {
+    readonly children: ReactNode;
+    readonly prefetch?: boolean;
+  }) => (
+    <a {...props} data-prefetch={String(prefetch)}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("@/components/museum/MuseumSourceContribution", () => ({
+  MuseumSourceContribution: () => null,
+}));
+
+describe("MuseumShell", () => {
+  it("does not speculatively prefetch Museum section routes", () => {
+    render(
+      <MuseumShell
+        view={{
+          sourceState: "fresh",
+          publicationIdentity: null,
+          pageSources: [],
+        }}
+      >
+        <p>Collection record</p>
+      </MuseumShell>
+    );
+
+    for (const name of [
+      "6529 Network Museum",
+      "Collection",
+      "Artists",
+      "Programs",
+      "Stories & Research",
+      "About",
+    ]) {
+      expect(screen.getByRole("link", { name })).toHaveAttribute(
+        "data-prefetch",
+        "false"
+      );
+    }
+  });
+});

--- a/__tests__/playwright/pageAssertions.test.ts
+++ b/__tests__/playwright/pageAssertions.test.ts
@@ -1,5 +1,6 @@
 import {
   assertNoConsoleErrors,
+  assertNoFailedResponses,
   type PageDiagnostics,
 } from "../../tests/support/consoleDiagnostics";
 
@@ -58,6 +59,18 @@ describe("Playwright page assertions", () => {
 
     expect(() => assertNoConsoleErrors(result)).toThrow(
       "502 GET https://telemetry.example/metrics"
+    );
+  });
+
+  it("fails on a silent 5xx response", () => {
+    const result: PageDiagnostics = {
+      consoleErrors: [],
+      failedResponses: ["502 GET https://6529.io/museum/network/collection"],
+      pageErrors: [],
+    };
+
+    expect(() => assertNoFailedResponses(result)).toThrow(
+      "502 GET https://6529.io/museum/network/collection"
     );
   });
 

--- a/__tests__/playwright/pageAssertions.test.ts
+++ b/__tests__/playwright/pageAssertions.test.ts
@@ -21,10 +21,44 @@ describe("Playwright page assertions", () => {
     ).not.toThrow();
   });
 
+  it("ignores blocked Coinbase analytics transport diagnostics", () => {
+    expect(() =>
+      assertNoConsoleErrors(
+        diagnostics([
+          "Analytics SDK: TypeError: Failed to fetch (cca-lite.coinbase.com)\n    at fetch",
+        ])
+      )
+    ).not.toThrow();
+  });
+
+  it("does not suppress analytics failures without the known host", () => {
+    expect(() =>
+      assertNoConsoleErrors(
+        diagnostics([
+          "Analytics SDK: TypeError: Failed to fetch (museum.example)\n    at fetch",
+        ])
+      )
+    ).toThrow("museum.example");
+  });
+
   it("still fails on actionable console errors", () => {
     expect(() =>
       assertNoConsoleErrors(diagnostics(["Uncaught TypeError: boom"]))
     ).toThrow("Unexpected browser console error");
+  });
+
+  it("includes failed-response evidence with an actionable console error", () => {
+    const result: PageDiagnostics = {
+      consoleErrors: [
+        "Failed to load resource: the server responded with a status of 502 ()",
+      ],
+      failedResponses: ["502 GET https://telemetry.example/metrics"],
+      pageErrors: [],
+    };
+
+    expect(() => assertNoConsoleErrors(result)).toThrow(
+      "502 GET https://telemetry.example/metrics"
+    );
   });
 
   it("keeps explicit allowances scoped to matching messages", () => {

--- a/app/museum/network/stories/a-field-of-practice/[slug]/page.tsx
+++ b/app/museum/network/stories/a-field-of-practice/[slug]/page.tsx
@@ -74,6 +74,7 @@ export default async function MuseumInstitutionProfilePage({
     <article className="tw-min-w-0">
       <Link
         href="/museum/network/stories/a-field-of-practice"
+        prefetch={false}
         className="tw-inline-flex tw-min-h-11 tw-items-center tw-text-sm tw-font-medium tw-text-iron-400 tw-underline tw-underline-offset-4 hover:tw-text-white focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
       >
         {t(DEFAULT_LOCALE, "museum.network.institutionalPractice.backToStudy")}
@@ -108,6 +109,7 @@ export default async function MuseumInstitutionProfilePage({
       >
         <Link
           href="/museum/network/stories/a-field-of-practice/sources"
+          prefetch={false}
           className="hover:tw-text-primary-200 tw-inline-flex tw-min-h-11 tw-items-center tw-text-sm tw-font-semibold tw-text-primary-300 tw-underline tw-underline-offset-4 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
         >
           {t(
@@ -129,6 +131,7 @@ export default async function MuseumInstitutionProfilePage({
         ) : (
           <Link
             href={`/museum/network/stories/a-field-of-practice/${previousProfile.slug}`}
+            prefetch={false}
             className="tw-group tw-min-w-0 tw-py-2 tw-text-left tw-no-underline focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
           >
             <span className="tw-block tw-text-xs tw-font-semibold tw-uppercase tw-tracking-[0.12em] tw-text-iron-500">
@@ -145,6 +148,7 @@ export default async function MuseumInstitutionProfilePage({
         {nextProfile === undefined ? null : (
           <Link
             href={`/museum/network/stories/a-field-of-practice/${nextProfile.slug}`}
+            prefetch={false}
             className="tw-group tw-min-w-0 tw-py-2 tw-text-left tw-no-underline focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 sm:tw-text-right"
           >
             <span className="tw-block tw-text-xs tw-font-semibold tw-uppercase tw-tracking-[0.12em] tw-text-iron-500">

--- a/app/museum/network/stories/a-field-of-practice/page.tsx
+++ b/app/museum/network/stories/a-field-of-practice/page.tsx
@@ -37,6 +37,7 @@ export default async function MuseumInstitutionalPracticePage() {
     <article className="tw-min-w-0">
       <Link
         href="/museum/network/stories"
+        prefetch={false}
         className="tw-inline-flex tw-min-h-11 tw-items-center tw-text-sm tw-font-medium tw-text-iron-400 tw-underline tw-underline-offset-4 hover:tw-text-white focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
       >
         {t(
@@ -76,6 +77,7 @@ export default async function MuseumInstitutionalPracticePage() {
       >
         <Link
           href="/museum/network/stories/a-field-of-practice/sources"
+          prefetch={false}
           className="hover:tw-text-primary-200 tw-inline-flex tw-min-h-11 tw-items-center tw-text-sm tw-font-semibold tw-text-primary-300 tw-underline tw-underline-offset-4 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
         >
           {t(

--- a/app/museum/network/stories/a-field-of-practice/sources/page.tsx
+++ b/app/museum/network/stories/a-field-of-practice/sources/page.tsx
@@ -40,6 +40,7 @@ export default async function MuseumInstitutionalPracticeSourcesPage() {
     <article className="tw-min-w-0">
       <Link
         href="/museum/network/stories/a-field-of-practice"
+        prefetch={false}
         className="tw-inline-flex tw-min-h-11 tw-items-center tw-text-sm tw-font-medium tw-text-iron-400 tw-underline tw-underline-offset-4 hover:tw-text-white focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
       >
         {t(DEFAULT_LOCALE, "museum.network.institutionalPractice.backToStudy")}

--- a/app/museum/network/stories/page.tsx
+++ b/app/museum/network/stories/page.tsx
@@ -122,6 +122,7 @@ export default async function MuseumStoriesPage() {
           </p>
           <Link
             href="/museum/network/stories/a-field-of-practice"
+            prefetch={false}
             className="hover:tw-text-primary-200 tw-mt-5 tw-inline-flex tw-min-h-11 tw-items-center tw-text-sm tw-font-semibold tw-text-primary-300 tw-underline tw-underline-offset-4 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
           >
             {t(

--- a/app/museum/network/stories/page.tsx
+++ b/app/museum/network/stories/page.tsx
@@ -94,6 +94,7 @@ export default async function MuseumStoriesPage() {
           </p>
           <Link
             href={`/museum/network/gifts/${CASEY_ACCESSION_ID}#casey-reas-collection-essay`}
+            prefetch={false}
             className="hover:tw-text-primary-200 tw-mt-5 tw-inline-flex tw-min-h-11 tw-items-center tw-text-sm tw-font-semibold tw-text-primary-300 tw-underline tw-underline-offset-4 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
           >
             {t(DEFAULT_LOCALE, "museum.network.stories.readEssay")}
@@ -147,6 +148,7 @@ export default async function MuseumStoriesPage() {
         </p>
         <Link
           href="/museum/network/stories/source-and-chronology"
+          prefetch={false}
           className="hover:tw-text-primary-200 tw-mt-4 tw-inline-flex tw-min-h-11 tw-items-center tw-text-sm tw-font-semibold tw-text-primary-300 tw-underline tw-underline-offset-4 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
         >
           {t(DEFAULT_LOCALE, "museum.network.research.readSourceMatrix")}
@@ -164,6 +166,7 @@ export default async function MuseumStoriesPage() {
         </p>
         <Link
           href={`/museum/network/artists/${artist.slug}#artist-profile-title`}
+          prefetch={false}
           className="hover:tw-text-primary-200 tw-mt-4 tw-inline-flex tw-min-h-11 tw-items-center tw-text-sm tw-font-semibold tw-text-primary-300 tw-underline tw-underline-offset-4 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
         >
           {t(DEFAULT_LOCALE, "museum.network.stories.readResearch")}

--- a/components/museum/InstitutionalPracticeReadingRoom.tsx
+++ b/components/museum/InstitutionalPracticeReadingRoom.tsx
@@ -324,6 +324,7 @@ export function InstitutionalPracticeDirectory({
         >
           <Link
             href={`${STUDY_ROUTE}/${profile.slug}`}
+            prefetch={false}
             className="hover:tw-text-primary-200 tw-grid tw-min-h-20 tw-grid-cols-[2.25rem_minmax(0,1fr)] tw-gap-x-4 tw-gap-y-1 tw-py-5 tw-text-iron-100 tw-no-underline focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 sm:tw-grid-cols-[3rem_minmax(16rem,0.8fr)_minmax(18rem,1.2fr)] sm:tw-items-baseline sm:tw-gap-x-6"
           >
             <span className="tw-font-mono tw-text-xs tw-text-iron-500">

--- a/components/museum/MuseumShell.tsx
+++ b/components/museum/MuseumShell.tsx
@@ -62,6 +62,7 @@ export function MuseumShell({
         <div className="tw-mx-auto tw-flex tw-w-full tw-max-w-[1324px] tw-flex-col tw-gap-4 tw-px-4 tw-py-5 sm:tw-px-6 lg:tw-flex-row lg:tw-items-center lg:tw-justify-between lg:tw-px-8">
           <Link
             href="/museum/network"
+            prefetch={false}
             className="tw-flex tw-min-h-11 tw-items-center tw-text-base tw-font-semibold tw-text-iron-50 tw-no-underline focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
           >
             6529 Network Museum
@@ -78,6 +79,7 @@ export function MuseumShell({
                 <li key={href}>
                   <Link
                     href={href}
+                    prefetch={false}
                     className="tw-inline-flex tw-min-h-11 tw-items-center tw-text-sm tw-font-medium tw-text-iron-300 tw-no-underline tw-transition-colors tw-duration-150 hover:tw-text-white focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
                   >
                     {t(DEFAULT_LOCALE, labelKey)}

--- a/ops/workstreams/museum-institutional-practice/active-context.md
+++ b/ops/workstreams/museum-institutional-practice/active-context.md
@@ -37,7 +37,8 @@
   Final desktop and mobile captures cover the study, long-name profile, source
   register, and the mobile Stories & Research directory at their layout
   extremes.
-- Staging qualification: composition `6d3ceba25b2d`, deploy run `30883469768`,
+- Staging qualification: composition
+  `6d3ceba25b2dccf258f62adcff511516e0b37fea`, deploy run `30883469768`,
   automatic E2E run `30884413504`, and independent Museum 32/32 all passed.
 - Production deployment: run `30885146909`; runtime and announced version both
   read exact `655b5408b68b` with `stale:false`; rendered desktop/mobile review

--- a/ops/workstreams/museum-institutional-practice/active-context.md
+++ b/ops/workstreams/museum-institutional-practice/active-context.md
@@ -2,8 +2,9 @@
 
 - Goal: publish the Museum's institutional-practice study on 6529.io and carry
   it through source and frontend review, staging, production, and retained E2E.
-- Frontend branch: `codex/museum-institutional-practice`.
-- Frontend base: `33f057f5003ed62269f2c6cca03dd1fdd40278e1`.
+- Frontend release PR: `6529-Collections/6529seize-frontend#3569`, merged.
+- Released frontend main: `655b5408b68bbdac79249f4531c196349eff7d52`.
+- Follow-up branch: `codex/museum-institutional-practice-closeout`.
 - Museum source PR: `6529-Collections/6529networkmuseum#22`, merged.
 - Canonical Museum source commit:
   `f5080e1873a3b86280c5a92e1fbe6cbd7fea38a4`.
@@ -36,6 +37,15 @@
   Final desktop and mobile captures cover the study, long-name profile, source
   register, and the mobile Stories & Research directory at their layout
   extremes.
-- Immediate next actions: commit the exact candidate; open and iterate the
-  frontend PR; then qualify staging and production with retained browser
-  evidence and exact runtime-version readback.
+- Staging qualification: composition `6d3ceba25b2d`, deploy run `30883469768`,
+  automatic E2E run `30884413504`, and independent Museum 32/32 all passed.
+- Production deployment: run `30885146909`; runtime and announced version both
+  read exact `655b5408b68b` with `stale:false`; rendered desktop/mobile review
+  passed.
+- Production hardening finding: speculative Museum link prefetches can produce
+  unrelated first-party RSC 502 console failures. The follow-up disables those
+  prefetches, records exact failed-response URLs, and narrowly classifies only
+  the known blocked Coinbase analytics transport as benign.
+- Immediate next actions: publish the tested follow-up PR, iterate exact-head
+  bots and CI, merge, redeploy staging and production, and require a strict
+  green 32-route production pass with first-party 5xx handling unchanged.

--- a/ops/workstreams/museum-institutional-practice/run-log.md
+++ b/ops/workstreams/museum-institutional-practice/run-log.md
@@ -168,3 +168,8 @@
   tests; changed lint and typecheck (1,264 files); the portable diff check; and
   an exact optimized production build in 425.2 seconds. No manuscript, source
   identity, visible copy, layout, or styling changed.
+- Follow-up review correctly observed that collected 5xx responses were only
+  appended to a console-error failure. The Museum acceptance pack now fails on
+  every captured 5xx even when the browser emits no console message. All four
+  internal routes on Stories & Research also opt out of speculative prefetch,
+  and route-level tests preserve the boundary beyond the shared-shell test.

--- a/ops/workstreams/museum-institutional-practice/run-log.md
+++ b/ops/workstreams/museum-institutional-practice/run-log.md
@@ -131,3 +131,40 @@
   manuscript syntax.
 - Parser follow-up validation passed 33/33 route and publication tests,
   changed lint and typecheck (1,264 files), and the portable diff check.
+
+## 2026-08-04 frontend release and production hardening
+
+- Frontend PR #3569 reached exact head
+  `d14c248df11a6873940c188dac2ffffbd99587ff` with every configured quality,
+  security, DCO, review-bot, build, and 32-route browser check green. It
+  squash-merged as `655b5408b68bbdac79249f4531c196349eff7d52`.
+- Staging composition `6d3ceba25b2dccf258f62adcff511516e0b37fea`
+  preserved the existing shared staging head and added exact production main
+  as its second parent. Staging deploy run `30883469768` passed, automatic
+  staging E2E run `30884413504` passed, and the independent institutional-
+  practice pack passed all 32 desktop/mobile routes in 255.3 seconds.
+- Owning staging pixel review covered the study, Serpentine Arts Technologies,
+  the source register, and Stories & Research at 1,440 by 1,000 and exact 390
+  by 844 viewports. Source commit, headings, native shell, and page widths were
+  correct; no visual or editorial hold remained.
+- Production deploy run `30885146909` passed on exact main. Three independent
+  `/api/version` readbacks returned the same runtime and announced SHA with
+  `stale:false`. The public study and profile repeated the staging pixel,
+  source, heading, and width checks.
+- The first production pack exposed two distinct background-network failures.
+  The browser blocked Coinbase's nonessential analytics transport at
+  `cca-lite.coinbase.com`; its exact SDK diagnostic is now classified as
+  benign while every other host remains actionable. Subsequent failures were
+  first-party 502 responses from speculative Next.js RSC prefetches for Museum
+  shell routes such as Collection, Artists, and Programs. Shared assets also
+  returned isolated 502 responses during the early post-deploy interval.
+- The gate was not weakened for first-party failures. Diagnostics now retain
+  exact 5xx method and URL evidence. A 20-repeat mobile profile stress run
+  passed 20/20 and a five-endpoint watch passed 50/50, but a later full sweep
+  still caught a background Collection RSC 502. The product follow-up disables
+  speculative prefetch on the Museum shell and institutional-study links,
+  reducing needless server work while preserving ordinary navigation.
+- Follow-up local validation passed 19 focused shell, route, and diagnostic
+  tests; changed lint and typecheck (1,264 files); the portable diff check; and
+  an exact optimized production build in 425.2 seconds. No manuscript, source
+  identity, visible copy, layout, or styling changed.

--- a/tests/museum/institutional-practice-readonly.spec.ts
+++ b/tests/museum/institutional-practice-readonly.spec.ts
@@ -9,6 +9,7 @@ import {
 } from "../testHelpers";
 import {
   assertNoConsoleErrors,
+  assertNoFailedResponses,
   attachPageDiagnostics,
 } from "../support/pageAssertions";
 import { gotoDocumentWithTransientRetry } from "../support/routeReadiness";
@@ -199,6 +200,7 @@ async function expectStudyRoute(
     assertNoConsoleErrors(diagnostics, {
       allowedConsoleErrorPatterns: LOCAL_SHELL_ALLOWED_CONSOLE_ERROR_PATTERNS,
     });
+    assertNoFailedResponses(diagnostics);
   }
 }
 

--- a/tests/support/consoleDiagnostics.ts
+++ b/tests/support/consoleDiagnostics.ts
@@ -1,5 +1,6 @@
 export type PageDiagnostics = {
   consoleErrors: string[];
+  failedResponses?: string[];
   pageErrors: string[];
 };
 
@@ -11,16 +12,14 @@ const BENIGN_CONSOLE_ERROR_PATTERNS = [
   /Failed to load resource: the server responded with a status of (403|404)/i,
   /net::ERR_ABORTED/i,
   /^Failed to load resource: net::ERR_BLOCKED_BY_CLIENT(?:\.[a-z]+)?$/i,
+  /^Analytics SDK: TypeError: Failed to fetch \(cca-lite\.coinbase\.com\)(?:\n|$)/,
 ];
 
 function isBenignConsoleError(message: string) {
   return BENIGN_CONSOLE_ERROR_PATTERNS.some((pattern) => pattern.test(message));
 }
 
-function isAllowedConsoleError(
-  message: string,
-  options: ConsoleErrorOptions
-) {
+function isAllowedConsoleError(message: string, options: ConsoleErrorOptions) {
   return (options.allowedConsoleErrorPatterns ?? []).some((pattern) =>
     pattern.test(message)
   );
@@ -56,7 +55,13 @@ export function assertNoConsoleErrors(
     return;
   }
 
+  const failedResponses = diagnostics.failedResponses ?? [];
+  const responseEvidence =
+    failedResponses.length === 0
+      ? ""
+      : `\nFailed 5xx response(s):\n${failedResponses.join("\n")}`;
+
   throw new Error(
-    `Unexpected browser console error(s):\n${actionable.join("\n")}`
+    `Unexpected browser console error(s):\n${actionable.join("\n")}${responseEvidence}`
   );
 }

--- a/tests/support/consoleDiagnostics.ts
+++ b/tests/support/consoleDiagnostics.ts
@@ -45,6 +45,17 @@ export function assertNoPageErrors(diagnostics: PageDiagnostics) {
   );
 }
 
+export function assertNoFailedResponses(diagnostics: PageDiagnostics) {
+  const failedResponses = diagnostics.failedResponses ?? [];
+  if (failedResponses.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    `Unexpected browser 5xx response(s):\n${failedResponses.join("\n")}`
+  );
+}
+
 export function assertNoConsoleErrors(
   diagnostics: PageDiagnostics,
   options: ConsoleErrorOptions = {}

--- a/tests/support/pageAssertions.ts
+++ b/tests/support/pageAssertions.ts
@@ -6,6 +6,7 @@ import {
 } from "./artifactRedaction";
 export {
   assertNoConsoleErrors,
+  assertNoFailedResponses,
   assertNoPageErrors,
   type PageDiagnostics,
 } from "./consoleDiagnostics";

--- a/tests/support/pageAssertions.ts
+++ b/tests/support/pageAssertions.ts
@@ -14,6 +14,7 @@ import type { PageDiagnostics } from "./consoleDiagnostics";
 export function attachPageDiagnostics(page: Page): PageDiagnostics {
   const diagnostics: PageDiagnostics = {
     consoleErrors: [],
+    failedResponses: [],
     pageErrors: [],
   };
 
@@ -28,6 +29,15 @@ export function attachPageDiagnostics(page: Page): PageDiagnostics {
     diagnostics.pageErrors.push(error.stack || error.message);
   });
 
+  page.on("response", (response) => {
+    if (response.status() < 500) {
+      return;
+    }
+    diagnostics.failedResponses?.push(
+      `${response.status()} ${response.request().method()} ${response.url()}`
+    );
+  });
+
   return diagnostics;
 }
 
@@ -37,6 +47,7 @@ export async function attachPageDiagnosticsArtifact(
 ) {
   if (
     diagnostics.consoleErrors.length === 0 &&
+    (diagnostics.failedResponses?.length ?? 0) === 0 &&
     diagnostics.pageErrors.length === 0
   ) {
     return;
@@ -51,6 +62,9 @@ export async function attachPageDiagnosticsArtifact(
       "",
       "Console errors:",
       ...diagnostics.consoleErrors,
+      "",
+      "Failed responses:",
+      ...(diagnostics.failedResponses ?? []),
     ].join("\n")
   );
 }


### PR DESCRIPTION
## Outcome

Hardens the newly released Museum institutional-practice pages after production qualification exposed intermittent first-party RSC 502s from speculative navigation prefetches.

## Product change

- disables automatic prefetch on the shared Museum shell and institutional-study navigation links;
- preserves ordinary visitor navigation, copy, layout, source identity, and manuscript rendering;
- narrowly classifies only the exact blocked Coinbase analytics transport diagnostic as non-actionable;
- records exact URL/method evidence for every 5xx response and keeps all first-party 5xx responses release-blocking.

## Evidence

- production release: exact runtime `655b5408b68bbdac79249f4531c196349eff7d52`, deploy run `30885146909`, `stale:false`;
- failure evidence included 502 RSC prefetches for Museum Collection, Artists, Programs, and study routes;
- 20-repeat mobile stress run passed 20/20; five-endpoint HTTP watch passed 50/50;
- focused shell/route/diagnostic tests: 19/19;
- changed lint and typecheck: pass;
- optimized production build: pass in 425.2 seconds;
- portable diff check: pass.

## Release plan

Merge only after exact-head bots and CI are green, then redeploy through staging and production and require the strict 32-route production pack to pass with first-party 5xx handling unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Museum navigation reliability by disabling unnecessary link prefetching across study, profile, source, and directory pages.
  * Refined browser diagnostics to distinguish known Coinbase Analytics failures from actionable errors.
  * Added clearer reporting for failed server responses during page checks.

* **Tests**
  * Added coverage for Museum navigation behavior and browser error-handling diagnostics.

* **Documentation**
  * Updated release, deployment, and production-validation records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->