### PR TITLE
Add Deploy Hub frontend shadow workflow

### DIFF
--- a/.github/workflows/deploy-hub-shadow.yml
+++ b/.github/workflows/deploy-hub-shadow.yml
@@ -1,0 +1,78 @@
+name: Deploy Hub - FE Shadow
+
+run-name: Deploy Hub shadow ${{ inputs.operation_id }} (${{ inputs.scenario }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation_id:
+        description: Unique Deploy Hub operation identifier
+        required: true
+        type: string
+      manifest:
+        description: Ordered JSON array of exact frontend PR requests
+        required: true
+        type: string
+      scenario:
+        description: Deterministic shadow outcome
+        required: true
+        default: success
+        type: choice
+        options:
+          - success
+          - product-failure
+          - infrastructure-failure
+          - cancelled
+          - stale
+      phase_delay_seconds:
+        description: Delay between fake phases for UI observation
+        required: true
+        default: "0"
+        type: choice
+        options:
+          - "0"
+          - "5"
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  shadow:
+    name: Simulate exact frontend request
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+
+    steps:
+      - name: Require default-branch dispatch
+        env:
+          EXPECTED_REF: refs/heads/${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = "$EXPECTED_REF"
+
+      - name: Check out immutable shadow runner
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          sparse-checkout: ops/scripts/deploy-hub-shadow.cjs
+          sparse-checkout-cone-mode: false
+
+      - name: Run permission-limited shadow operation
+        env:
+          DEPLOY_HUB_ACTOR: ${{ github.actor }}
+          DEPLOY_HUB_API_URL: ${{ github.api_url }}
+          DEPLOY_HUB_MANIFEST: ${{ inputs.manifest }}
+          DEPLOY_HUB_OPERATION_ID: ${{ inputs.operation_id }}
+          DEPLOY_HUB_PHASE_DELAY_SECONDS: ${{ inputs.phase_delay_seconds }}
+          DEPLOY_HUB_REPOSITORY: ${{ github.repository }}
+          DEPLOY_HUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          DEPLOY_HUB_SCENARIO: ${{ inputs.scenario }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node ops/scripts/deploy-hub-shadow.cjs >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-hub-shadow.yml
+++ b/.github/workflows/deploy-hub-shadow.yml
@@ -68,6 +68,7 @@ jobs:
         env:
           DEPLOY_HUB_ACTOR: ${{ github.actor }}
           DEPLOY_HUB_API_URL: ${{ github.api_url }}
+          DEPLOY_HUB_BASE_REF: ${{ github.event.repository.default_branch }}
           DEPLOY_HUB_MANIFEST: ${{ inputs.manifest }}
           DEPLOY_HUB_OPERATION_ID: ${{ inputs.operation_id }}
           DEPLOY_HUB_PHASE_DELAY_SECONDS: ${{ inputs.phase_delay_seconds }}

--- a/__tests__/scripts/deploy-hub-shadow.test.ts
+++ b/__tests__/scripts/deploy-hub-shadow.test.ts
@@ -85,6 +85,9 @@ describe("Deploy Hub FE shadow workflow", () => {
       statuses: "write",
     });
     expect(workflow.jobs.shadow.permissions).toEqual(workflow.permissions);
+    expect(workflow.jobs.shadow.steps[2].env.DEPLOY_HUB_BASE_REF).toBe(
+      "${{ github.event.repository.default_branch }}"
+    );
     expect(source).not.toContain("secrets.");
     expect(source).not.toContain("contents: write");
     expect(source).not.toContain("actions: write");
@@ -146,6 +149,10 @@ describe("Deploy Hub FE shadow manifest", () => {
       "an unknown target",
       { ...request(1, SHA_A, "staging"), target: "preview" },
     ],
+    [
+      "an invalid request time",
+      { ...request(1, SHA_A, "staging"), requested_at: "not-a-date" },
+    ],
   ])("rejects %s", (_name, invalidRequest) => {
     expect(() =>
       normalizeManifest(
@@ -187,6 +194,7 @@ describe("Deploy Hub FE shadow execution", () => {
       scenario: "success",
       delaySeconds: 0,
       repository: EXPECTED_REPOSITORY,
+      baseRef: "main",
       actor: ACTOR,
       runUrl: RUN_URL,
       github,
@@ -219,6 +227,7 @@ describe("Deploy Hub FE shadow execution", () => {
       scenario: "success",
       delaySeconds: 0,
       repository: EXPECTED_REPOSITORY,
+      baseRef: "main",
       actor: ACTOR,
       runUrl: RUN_URL,
       github,
@@ -270,6 +279,7 @@ describe("Deploy Hub FE shadow execution", () => {
       scenario: "success",
       delaySeconds: 0,
       repository: EXPECTED_REPOSITORY,
+      baseRef: "main",
       actor: ACTOR,
       runUrl: RUN_URL,
       github,
@@ -301,6 +311,7 @@ describe("Deploy Hub FE shadow execution", () => {
         scenario: "success",
         delaySeconds: 0,
         repository: EXPECTED_REPOSITORY,
+        baseRef: "main",
         actor: ACTOR,
         runUrl: RUN_URL,
         github,
@@ -317,6 +328,38 @@ describe("Deploy Hub FE shadow execution", () => {
         status: expect.objectContaining({ state: "error" }),
       }),
     ]);
+  });
+
+  it("uses the repository default branch instead of assuming main", async () => {
+    const statuses: Array<{ sha: string; status: Record<string, string> }> = [];
+    const github = {
+      async getPullRequest() {
+        return {
+          state: "open",
+          base: { ref: "develop" },
+          head: { sha: SHA_A },
+        };
+      },
+      async createCommitStatus(sha: string, status: Record<string, string>) {
+        statuses.push({ sha, status });
+        return {};
+      },
+    };
+
+    const result = await executeShadow({
+      operationId: "operation-default-branch",
+      manifestJson: JSON.stringify([request(1, SHA_A, "staging")]),
+      scenario: "success",
+      delaySeconds: 0,
+      repository: EXPECTED_REPOSITORY,
+      baseRef: "develop",
+      actor: ACTOR,
+      runUrl: RUN_URL,
+      github,
+    });
+
+    expect(result.conclusion).toBe("success");
+    expect(statuses.at(-1)?.status).toMatchObject({ state: "success" });
   });
 
   it.each([

--- a/__tests__/scripts/deploy-hub-shadow.test.ts
+++ b/__tests__/scripts/deploy-hub-shadow.test.ts
@@ -4,11 +4,15 @@ const YAML = require("yaml");
 
 const {
   EXPECTED_REPOSITORY,
+  createFailureSummary,
+  createGithubClient,
+  createSummary,
   executeShadow,
   normalizeManifest,
   partitionCohorts,
   statusContext,
   statusPlan,
+  validateOperation,
 } = require("../../ops/scripts/deploy-hub-shadow.cjs");
 
 const SHA_A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -151,6 +155,22 @@ describe("Deploy Hub FE shadow manifest", () => {
       )
     ).toThrow();
   });
+
+  it.each([
+    ["operation ID", { operationId: "bad operation" }],
+    ["delay", { delaySeconds: 1 }],
+    ["run URL", { runUrl: "https://example.com/actions/runs/12345" }],
+  ])("rejects an invalid %s", (_name, override) => {
+    expect(() =>
+      validateOperation({
+        operationId: "operation-1",
+        scenario: "success",
+        delaySeconds: 0,
+        runUrl: RUN_URL,
+        ...override,
+      })
+    ).toThrow();
+  });
 });
 
 describe("Deploy Hub FE shadow execution", () => {
@@ -225,6 +245,81 @@ describe("Deploy Hub FE shadow execution", () => {
   });
 
   it.each([
+    [
+      "closed",
+      { state: "closed", base: { ref: "main" }, head: { sha: SHA_A } },
+    ],
+    [
+      "wrong base",
+      { state: "open", base: { ref: "develop" }, head: { sha: SHA_A } },
+    ],
+  ])("fails closed when the PR is %s", async (_name, pull) => {
+    const statuses: Array<{ sha: string; status: Record<string, string> }> = [];
+    const github = {
+      async getPullRequest() {
+        return pull;
+      },
+      async createCommitStatus(sha: string, status: Record<string, string>) {
+        statuses.push({ sha, status });
+        return {};
+      },
+    };
+    const result = await executeShadow({
+      operationId: "operation-stale-pr",
+      manifestJson: JSON.stringify([request(1, SHA_A, "staging")]),
+      scenario: "success",
+      delaySeconds: 0,
+      repository: EXPECTED_REPOSITORY,
+      actor: ACTOR,
+      runUrl: RUN_URL,
+      github,
+    });
+
+    expect(result).toMatchObject({ scenario: "stale", conclusion: "failure" });
+    expect(statuses.at(-1)?.status).toMatchObject({ state: "error" });
+  });
+
+  it("best-effort terminates pending projections after an API interruption", async () => {
+    const github = githubForHeads({ 1: SHA_A, 2: SHA_B });
+    const originalCreateStatus = github.createCommitStatus.bind(github);
+    let calls = 0;
+    github.createCommitStatus = async (sha, status) => {
+      calls += 1;
+      if (calls === 3) {
+        throw new Error("simulated API interruption");
+      }
+      return originalCreateStatus(sha, status);
+    };
+
+    await expect(
+      executeShadow({
+        operationId: "operation-interrupted",
+        manifestJson: JSON.stringify([
+          request(1, SHA_A, "staging"),
+          request(2, SHA_B, "staging"),
+        ]),
+        scenario: "success",
+        delaySeconds: 0,
+        repository: EXPECTED_REPOSITORY,
+        actor: ACTOR,
+        runUrl: RUN_URL,
+        github,
+      })
+    ).rejects.toThrow("simulated API interruption");
+
+    expect(github.statuses.slice(-2)).toEqual([
+      expect.objectContaining({
+        sha: SHA_A,
+        status: expect.objectContaining({ state: "error" }),
+      }),
+      expect.objectContaining({
+        sha: SHA_B,
+        status: expect.objectContaining({ state: "error" }),
+      }),
+    ]);
+  });
+
+  it.each([
     ["product-failure", "failure", "product-failure"],
     ["infrastructure-failure", "error", "infrastructure-failure"],
     ["cancelled", "error", "cancelled"],
@@ -248,6 +343,65 @@ describe("Deploy Hub FE shadow execution", () => {
     );
     expect(statusContext("production")).toBe(
       "Deploy Hub Shadow — Target: Production"
+    );
+  });
+
+  it("creates unambiguous success and pre-execution failure summaries", () => {
+    const summary = createSummary(
+      {
+        operationId: "operation-summary",
+        scenario: "success",
+        conclusion: "success",
+        requests: [request(1, SHA_A, "staging")],
+        cohorts: [
+          { target: "staging", requests: [request(1, SHA_A, "staging")] },
+        ],
+      },
+      RUN_URL
+    );
+    expect(summary).toContain("SHADOW ONLY");
+    expect(summary).toContain(RUN_URL);
+    expect(createFailureSummary("Manifest must be valid JSON.")).toContain(
+      "Manifest must be valid JSON."
+    );
+  });
+});
+
+describe("Deploy Hub FE shadow GitHub client", () => {
+  it("uses the exact repository API and never exposes an error response body", async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ state: "open" }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({ secret: "must-not-escape" }),
+      });
+    const client = createGithubClient({
+      apiUrl: "https://api.github.com",
+      repository: EXPECTED_REPOSITORY,
+      token: "token-canary",
+      fetchImpl,
+    });
+
+    await expect(client.getPullRequest(1)).resolves.toEqual({ state: "open" });
+    await expect(
+      client.createCommitStatus(SHA_A, {
+        state: "pending",
+        target_url: RUN_URL,
+        description: "SHADOW: queued",
+        context: "Deploy Hub Shadow",
+      })
+    ).rejects.toThrow("GitHub request failed with HTTP 503.");
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      `https://api.github.com/repos/${EXPECTED_REPOSITORY}/pulls/1`
+    );
+    expect(JSON.stringify(fetchImpl.mock.calls)).not.toContain(
+      "must-not-escape"
     );
   });
 });

--- a/__tests__/scripts/deploy-hub-shadow.test.ts
+++ b/__tests__/scripts/deploy-hub-shadow.test.ts
@@ -1,0 +1,253 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const YAML = require("yaml");
+
+const {
+  EXPECTED_REPOSITORY,
+  executeShadow,
+  normalizeManifest,
+  partitionCohorts,
+  statusContext,
+  statusPlan,
+} = require("../../ops/scripts/deploy-hub-shadow.cjs");
+
+const SHA_A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const SHA_B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const SHA_C = "cccccccccccccccccccccccccccccccccccccccc";
+const ACTOR = "prxt6529";
+const RUN_URL =
+  "https://github.com/6529-Collections/6529seize-frontend/actions/runs/12345";
+
+function request(pr: number, sha: string, target: "staging" | "production") {
+  return {
+    repository: EXPECTED_REPOSITORY,
+    pr,
+    sha,
+    target,
+    requester: ACTOR,
+    requested_at: "2026-08-04T12:00:00.000Z",
+  };
+}
+
+function githubForHeads(heads: Record<number, string>) {
+  const statuses: Array<{
+    sha: string;
+    status: Record<string, string>;
+  }> = [];
+  return {
+    statuses,
+    async getPullRequest(pr: number) {
+      return {
+        state: "open",
+        base: { ref: "main" },
+        head: { sha: heads[pr] },
+      };
+    },
+    async createCommitStatus(sha: string, status: Record<string, string>) {
+      statuses.push({ sha, status });
+      return {};
+    },
+  };
+}
+
+describe("Deploy Hub FE shadow workflow", () => {
+  const source = fs.readFileSync(
+    path.join(process.cwd(), ".github/workflows/deploy-hub-shadow.yml"),
+    "utf8"
+  );
+  const workflow = YAML.parse(source);
+
+  it("is manually dispatched with only read and shadow-status authority", () => {
+    expect(workflow.on).toEqual({
+      workflow_dispatch: {
+        inputs: expect.objectContaining({
+          operation_id: expect.objectContaining({ required: true }),
+          manifest: expect.objectContaining({ required: true }),
+          scenario: expect.objectContaining({
+            options: [
+              "success",
+              "product-failure",
+              "infrastructure-failure",
+              "cancelled",
+              "stale",
+            ],
+          }),
+        }),
+      },
+    });
+    expect(workflow.permissions).toEqual({
+      contents: "read",
+      "pull-requests": "read",
+      statuses: "write",
+    });
+    expect(workflow.jobs.shadow.permissions).toEqual(workflow.permissions);
+    expect(source).not.toContain("secrets.");
+    expect(source).not.toContain("contents: write");
+    expect(source).not.toContain("actions: write");
+    expect(source).not.toContain("deployments:");
+    expect(source).not.toContain("id-token:");
+    expect(source).not.toContain("environment:");
+    expect(source).not.toContain("aws-actions/");
+    expect(source).not.toContain("deploy-staging.yml");
+    expect(source).not.toContain("build-upload-deploy-prod.yml");
+  });
+
+  it("runs immutable workflow code from the default branch without checkout credentials", () => {
+    const steps = workflow.jobs.shadow.steps;
+    expect(steps[0].name).toBe("Require default-branch dispatch");
+    expect(steps[0].run).toContain('test "$GITHUB_REF" = "$EXPECTED_REF"');
+    expect(steps[1].with).toMatchObject({
+      ref: "${{ github.workflow_sha }}",
+      "persist-credentials": false,
+      "sparse-checkout": "ops/scripts/deploy-hub-shadow.cjs",
+      "sparse-checkout-cone-mode": false,
+    });
+  });
+});
+
+describe("Deploy Hub FE shadow manifest", () => {
+  it("freezes exact requests and partitions only adjacent equal targets", () => {
+    const manifest = [
+      request(1, SHA_A, "production"),
+      request(2, SHA_B, "production"),
+      request(3, SHA_C, "staging"),
+      request(4, SHA_A, "production"),
+    ];
+    const normalized = normalizeManifest(
+      JSON.stringify(manifest),
+      ACTOR,
+      EXPECTED_REPOSITORY
+    );
+
+    expect(normalized).toEqual(manifest);
+    expect(partitionCohorts(normalized)).toEqual([
+      { target: "production", requests: normalized.slice(0, 2) },
+      { target: "staging", requests: normalized.slice(2, 3) },
+      { target: "production", requests: normalized.slice(3, 4) },
+    ]);
+    expect(Object.isFrozen(normalized[0])).toBe(true);
+  });
+
+  it.each([
+    [
+      "another repository",
+      { ...request(1, SHA_A, "staging"), repository: "owner/other" },
+    ],
+    [
+      "a moved requester",
+      { ...request(1, SHA_A, "staging"), requester: "someone-else" },
+    ],
+    ["a non-exact SHA", { ...request(1, SHA_A, "staging"), sha: "main" }],
+    [
+      "an unknown target",
+      { ...request(1, SHA_A, "staging"), target: "preview" },
+    ],
+  ])("rejects %s", (_name, invalidRequest) => {
+    expect(() =>
+      normalizeManifest(
+        JSON.stringify([invalidRequest]),
+        ACTOR,
+        EXPECTED_REPOSITORY
+      )
+    ).toThrow();
+  });
+});
+
+describe("Deploy Hub FE shadow execution", () => {
+  it("posts exact-run-linked phases and an unambiguous success", async () => {
+    const github = githubForHeads({ 1: SHA_A, 2: SHA_B });
+    const manifest = [
+      request(1, SHA_A, "production"),
+      request(2, SHA_B, "production"),
+    ];
+
+    const result = await executeShadow({
+      operationId: "operation-1",
+      manifestJson: JSON.stringify(manifest),
+      scenario: "success",
+      delaySeconds: 0,
+      repository: EXPECTED_REPOSITORY,
+      actor: ACTOR,
+      runUrl: RUN_URL,
+      github,
+    });
+
+    expect(result.conclusion).toBe("success");
+    expect(github.statuses).toHaveLength(8);
+    expect(github.statuses.at(-1)).toEqual({
+      sha: SHA_B,
+      status: {
+        state: "success",
+        target_url: RUN_URL,
+        description: "SHADOW: Production simulation complete; not deployed",
+        context: "Deploy Hub Shadow — Target: Production",
+      },
+    });
+    expect(
+      github.statuses.every(({ status }) => status["target_url"] === RUN_URL)
+    ).toBe(true);
+  });
+
+  it("fails closed and marks every request when one exact PR head moved", async () => {
+    const github = githubForHeads({ 1: SHA_A, 2: SHA_C });
+    const result = await executeShadow({
+      operationId: "operation-stale",
+      manifestJson: JSON.stringify([
+        request(1, SHA_A, "staging"),
+        request(2, SHA_B, "staging"),
+      ]),
+      scenario: "success",
+      delaySeconds: 0,
+      repository: EXPECTED_REPOSITORY,
+      actor: ACTOR,
+      runUrl: RUN_URL,
+      github,
+    });
+
+    expect(result.conclusion).toBe("failure");
+    expect(result.scenario).toBe("stale");
+    expect(github.statuses).toEqual([
+      expect.objectContaining({
+        sha: SHA_A,
+        status: expect.objectContaining({
+          state: "error",
+          description: "SHADOW: blocked by stale cohort input; no deployment",
+        }),
+      }),
+      expect.objectContaining({
+        sha: SHA_B,
+        status: expect.objectContaining({
+          state: "error",
+          description: "SHADOW: stale exact PR head; no deployment",
+        }),
+      }),
+    ]);
+  });
+
+  it.each([
+    ["product-failure", "failure", "product-failure"],
+    ["infrastructure-failure", "error", "infrastructure-failure"],
+    ["cancelled", "error", "cancelled"],
+    ["stale", "error", "stale"],
+  ])(
+    "projects the %s terminal outcome without deployment evidence",
+    (scenario, terminalState, terminalPhase) => {
+      const plan = statusPlan("staging", scenario);
+      expect(plan.at(-1)).toMatchObject({
+        phase: terminalPhase,
+        state: terminalState,
+      });
+      expect(plan.at(-1).description).toMatch(/SHADOW:/);
+      expect(plan.at(-1).description).toMatch(/deployment|deployed/);
+    }
+  );
+
+  it("uses target-specific shadow contexts", () => {
+    expect(statusContext("staging")).toBe(
+      "Deploy Hub Shadow — Target: Staging"
+    );
+    expect(statusContext("production")).toBe(
+      "Deploy Hub Shadow — Target: Production"
+    );
+  });
+});

--- a/ops/scripts/README.md
+++ b/ops/scripts/README.md
@@ -14,6 +14,9 @@ wrapper expects that location.
   `ops/docs`.
 - `deployment-bus.cjs`: deployment bus manifest, validation, heartbeat,
   production-preflight, and GitHub Deployment status helper.
+- `deploy-hub-shadow.cjs`: validates exact frontend PR manifests, partitions
+  adjacent target cohorts, and publishes clearly labelled, non-deploying shadow
+  status phases for the Deploy Hub pilot.
 - `native-surface-evidence.cjs`: executable native-surface evidence
   classifier. It reports whether current Capacitor/Electron coverage is only
   browser simulation or whether package prerequisites are present.

--- a/ops/scripts/deploy-hub-shadow.cjs
+++ b/ops/scripts/deploy-hub-shadow.cjs
@@ -1,0 +1,429 @@
+#!/usr/bin/env node
+
+const EXPECTED_REPOSITORY = "6529-Collections/6529seize-frontend";
+const MAX_REQUESTS = 20;
+const OPERATION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/;
+const SHA_PATTERN = /^[a-f0-9]{40}$/;
+const REQUESTER_PATTERN = /^[A-Za-z0-9-]{1,39}$/;
+const TARGETS = new Set(["staging", "production"]);
+const SCENARIOS = new Set([
+  "success",
+  "product-failure",
+  "infrastructure-failure",
+  "cancelled",
+  "stale",
+]);
+const DELAYS = new Set([0, 5]);
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function normalizeManifest(manifestJson, actor, repository) {
+  let parsed;
+  try {
+    parsed = JSON.parse(manifestJson);
+  } catch {
+    throw new Error("Manifest must be valid JSON.");
+  }
+
+  assert(Array.isArray(parsed), "Manifest must be a JSON array.");
+  assert(parsed.length > 0, "Manifest must contain at least one request.");
+  assert(
+    parsed.length <= MAX_REQUESTS,
+    `Manifest cannot contain more than ${MAX_REQUESTS} requests.`
+  );
+
+  const seenPrs = new Set();
+  return parsed.map((request, index) => {
+    const label = `Manifest request ${index + 1}`;
+    assert(
+      request && typeof request === "object" && !Array.isArray(request),
+      `${label} must be an object.`
+    );
+    assert(
+      request.repository === repository && repository === EXPECTED_REPOSITORY,
+      `${label} has an invalid repository.`
+    );
+    assert(
+      Number.isInteger(request.pr) && request.pr > 0,
+      `${label} has an invalid PR number.`
+    );
+    assert(!seenPrs.has(request.pr), `${label} repeats PR ${request.pr}.`);
+    seenPrs.add(request.pr);
+    assert(
+      typeof request.sha === "string" && SHA_PATTERN.test(request.sha),
+      `${label} has an invalid exact SHA.`
+    );
+    assert(TARGETS.has(request.target), `${label} has an invalid target.`);
+    assert(
+      typeof request.requester === "string" &&
+        REQUESTER_PATTERN.test(request.requester) &&
+        !request.requester.startsWith("-") &&
+        !request.requester.endsWith("-") &&
+        request.requester.toLowerCase() === actor.toLowerCase(),
+      `${label} requester must match the dispatching GitHub actor.`
+    );
+    assert(
+      typeof request.requested_at === "string" &&
+        new Date(request.requested_at).toISOString() === request.requested_at,
+      `${label} has an invalid request time.`
+    );
+
+    return Object.freeze({
+      repository: request.repository,
+      pr: request.pr,
+      sha: request.sha,
+      target: request.target,
+      requester: request.requester,
+      requested_at: request.requested_at,
+    });
+  });
+}
+
+function partitionCohorts(requests) {
+  return requests.reduce((cohorts, request) => {
+    const current = cohorts.at(-1);
+    if (!current || current.target !== request.target) {
+      cohorts.push({ target: request.target, requests: [request] });
+    } else {
+      current.requests.push(request);
+    }
+    return cohorts;
+  }, []);
+}
+
+function targetLabel(target) {
+  return target === "production" ? "Production" : "Staging";
+}
+
+function statusContext(target) {
+  return `Deploy Hub Shadow — Target: ${targetLabel(target)}`;
+}
+
+function statusPlan(target, scenario) {
+  const label = targetLabel(target);
+  const queued = {
+    phase: "queued",
+    state: "pending",
+    description: `SHADOW: ${label} request queued; no deployment`,
+  };
+  const staging = {
+    phase: "running",
+    state: "pending",
+    description: "SHADOW: simulating staging; no deployment",
+  };
+
+  if (scenario === "stale") {
+    return [
+      {
+        phase: "stale",
+        state: "error",
+        description: "SHADOW: stale exact PR head; no deployment",
+      },
+    ];
+  }
+  if (scenario === "cancelled") {
+    return [
+      queued,
+      {
+        phase: "cancelled",
+        state: "error",
+        description: "SHADOW: simulated cancellation; no deployment",
+      },
+    ];
+  }
+  if (scenario === "infrastructure-failure") {
+    return [
+      queued,
+      staging,
+      {
+        phase: "infrastructure-failure",
+        state: "error",
+        description: "SHADOW: simulated infrastructure failure; no deployment",
+      },
+    ];
+  }
+  if (scenario === "product-failure") {
+    return [
+      queued,
+      staging,
+      {
+        phase: "reconciling",
+        state: "pending",
+        description: "SHADOW: simulating bounded reconciliation",
+      },
+      {
+        phase: "product-failure",
+        state: "failure",
+        description: "SHADOW: simulated product failure; not deployed",
+      },
+    ];
+  }
+
+  const plan = [queued, staging];
+  if (target === "production") {
+    plan.push({
+      phase: "staging-succeeded",
+      state: "pending",
+      description: "SHADOW: staging passed; simulating production",
+    });
+  }
+  plan.push({
+    phase: "succeeded",
+    state: "success",
+    description: `SHADOW: ${label} simulation complete; not deployed`,
+  });
+  return plan;
+}
+
+function createGithubClient({ apiUrl, repository, token, fetchImpl = fetch }) {
+  async function request(path, options = {}) {
+    const response = await fetchImpl(`${apiUrl}/repos/${repository}${path}`, {
+      method: options.method ?? "GET",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: options.body ? JSON.stringify(options.body) : undefined,
+    });
+    if (!response.ok) {
+      throw new Error(`GitHub request failed with HTTP ${response.status}.`);
+    }
+    if (response.status === 204) {
+      return null;
+    }
+    return response.json();
+  }
+
+  return {
+    getPullRequest(pr) {
+      return request(`/pulls/${pr}`);
+    },
+    createCommitStatus(sha, status) {
+      return request(`/statuses/${sha}`, {
+        method: "POST",
+        body: status,
+      });
+    },
+  };
+}
+
+async function writeStatus(github, request, runUrl, phase) {
+  await github.createCommitStatus(request.sha, {
+    state: phase.state,
+    target_url: runUrl,
+    description: phase.description,
+    context: statusContext(request.target),
+  });
+}
+
+async function resolveStaleRequests(github, requests) {
+  const stale = new Set();
+  for (const request of requests) {
+    const pull = await github.getPullRequest(request.pr);
+    if (
+      pull.state !== "open" ||
+      pull.base?.ref !== "main" ||
+      pull.head?.sha !== request.sha
+    ) {
+      stale.add(request.pr);
+    }
+  }
+  return stale;
+}
+
+async function publishStaleResult({
+  github,
+  requests,
+  runUrl,
+  forceStale,
+  staleRequests,
+}) {
+  const stalePhase = statusPlan("staging", "stale")[0];
+  for (const request of requests) {
+    const description =
+      forceStale || staleRequests.has(request.pr)
+        ? stalePhase.description
+        : "SHADOW: blocked by stale cohort input; no deployment";
+    await writeStatus(github, request, runUrl, {
+      ...stalePhase,
+      description,
+    });
+  }
+}
+
+async function publishCohorts({
+  github,
+  cohorts,
+  runUrl,
+  scenario,
+  delaySeconds,
+  sleep,
+}) {
+  for (const cohort of cohorts) {
+    const plan = statusPlan(cohort.target, scenario);
+    for (const phase of plan) {
+      for (const request of cohort.requests) {
+        await writeStatus(github, request, runUrl, phase);
+      }
+      if (delaySeconds > 0 && phase !== plan.at(-1)) {
+        await sleep(delaySeconds * 1000);
+      }
+    }
+  }
+}
+
+function validateOperation({ operationId, scenario, delaySeconds, runUrl }) {
+  assert(
+    OPERATION_ID_PATTERN.test(operationId),
+    "Operation ID has an invalid format."
+  );
+  assert(SCENARIOS.has(scenario), "Scenario is not supported.");
+  assert(DELAYS.has(delaySeconds), "Phase delay is not supported.");
+  assert(
+    /^https:\/\/github\.com\/6529-Collections\/6529seize-frontend\/actions\/runs\/[1-9][0-9]*$/.test(
+      runUrl
+    ),
+    "Run URL has an invalid format."
+  );
+}
+
+async function executeShadow({
+  operationId,
+  manifestJson,
+  scenario,
+  delaySeconds,
+  repository,
+  actor,
+  runUrl,
+  github,
+  sleep = (milliseconds) =>
+    new Promise((resolve) => setTimeout(resolve, milliseconds)),
+}) {
+  validateOperation({ operationId, scenario, delaySeconds, runUrl });
+  const requests = normalizeManifest(manifestJson, actor, repository);
+  const cohorts = partitionCohorts(requests);
+  const staleRequests = await resolveStaleRequests(github, requests);
+  const forceStale = scenario === "stale";
+
+  if (forceStale || staleRequests.size > 0) {
+    await publishStaleResult({
+      github,
+      requests,
+      runUrl,
+      forceStale,
+      staleRequests,
+    });
+    return {
+      operationId,
+      scenario: "stale",
+      conclusion: "failure",
+      requests,
+      cohorts,
+    };
+  }
+
+  await publishCohorts({
+    github,
+    cohorts,
+    runUrl,
+    scenario,
+    delaySeconds,
+    sleep,
+  });
+
+  return {
+    operationId,
+    scenario,
+    conclusion: scenario === "success" ? "success" : "failure",
+    requests,
+    cohorts,
+  };
+}
+
+function createSummary(result, runUrl) {
+  const lines = [
+    "# Deploy Hub FE Shadow",
+    "",
+    "> SHADOW ONLY — no branch or environment was changed.",
+    "",
+    `- Operation: \`${result.operationId}\``,
+    `- Scenario: \`${result.scenario}\``,
+    `- Conclusion: \`${result.conclusion}\``,
+    `- Authoritative run: ${runUrl}`,
+    "",
+    "## Frozen requests",
+    "",
+    "| PR | Exact SHA | Target | Requester | Requested at |",
+    "| ---: | --- | --- | --- | --- |",
+    ...result.requests.map(
+      (request) =>
+        `| #${request.pr} | \`${request.sha}\` | ${targetLabel(request.target)} | @${request.requester} | ${request.requested_at} |`
+    ),
+    "",
+    "## Adjacent target cohorts",
+    "",
+    ...result.cohorts.map(
+      (cohort, index) =>
+        `${index + 1}. ${targetLabel(cohort.target)}: ${cohort.requests
+          .map((request) => `#${request.pr}`)
+          .join(", ")}`
+    ),
+    "",
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+async function main() {
+  const repository = process.env.DEPLOY_HUB_REPOSITORY ?? "";
+  const token = process.env.GITHUB_TOKEN ?? "";
+  assert(token.length > 0, "GitHub token is unavailable.");
+
+  const result = await executeShadow({
+    operationId: process.env.DEPLOY_HUB_OPERATION_ID ?? "",
+    manifestJson: process.env.DEPLOY_HUB_MANIFEST ?? "",
+    scenario: process.env.DEPLOY_HUB_SCENARIO ?? "",
+    delaySeconds: Number(process.env.DEPLOY_HUB_PHASE_DELAY_SECONDS),
+    repository,
+    actor: process.env.DEPLOY_HUB_ACTOR ?? "",
+    runUrl: process.env.DEPLOY_HUB_RUN_URL ?? "",
+    github: createGithubClient({
+      apiUrl: process.env.DEPLOY_HUB_API_URL ?? "https://api.github.com",
+      repository,
+      token,
+    }),
+  });
+
+  process.stdout.write(createSummary(result, process.env.DEPLOY_HUB_RUN_URL));
+  if (result.conclusion !== "success") {
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  void (async () => {
+    try {
+      await main();
+    } catch (error) {
+      console.error(`Deploy Hub shadow failed: ${error.message}`);
+      process.exitCode = 1;
+    }
+  })();
+}
+
+module.exports = {
+  EXPECTED_REPOSITORY,
+  createSummary,
+  createGithubClient,
+  executeShadow,
+  normalizeManifest,
+  partitionCohorts,
+  statusContext,
+  statusPlan,
+  validateOperation,
+};

--- a/ops/scripts/deploy-hub-shadow.cjs
+++ b/ops/scripts/deploy-hub-shadow.cjs
@@ -22,6 +22,14 @@ function assert(condition, message) {
 }
 
 function normalizeManifest(manifestJson, actor, repository) {
+  assert(repository === EXPECTED_REPOSITORY, "Repository is not supported.");
+  assert(
+    REQUESTER_PATTERN.test(actor) &&
+      !actor.startsWith("-") &&
+      !actor.endsWith("-"),
+    "Dispatching GitHub actor has an invalid format."
+  );
+
   let parsed;
   try {
     parsed = JSON.parse(manifestJson);
@@ -44,7 +52,7 @@ function normalizeManifest(manifestJson, actor, repository) {
       `${label} must be an object.`
     );
     assert(
-      request.repository === repository && repository === EXPECTED_REPOSITORY,
+      request.repository === repository,
       `${label} has an invalid repository.`
     );
     assert(
@@ -267,13 +275,28 @@ async function publishCohorts({
 }) {
   for (const cohort of cohorts) {
     const plan = statusPlan(cohort.target, scenario);
-    for (const phase of plan) {
+    for (const [phaseIndex, phase] of plan.entries()) {
       for (const request of cohort.requests) {
         await writeStatus(github, request, runUrl, phase);
       }
-      if (delaySeconds > 0 && phase !== plan.at(-1)) {
+      if (delaySeconds > 0 && phaseIndex < plan.length - 1) {
         await sleep(delaySeconds * 1000);
       }
+    }
+  }
+}
+
+async function publishTerminalProjectionError(github, requests, runUrl) {
+  for (const request of requests) {
+    try {
+      await writeStatus(github, request, runUrl, {
+        state: "error",
+        description: "SHADOW: status projection interrupted; no deployment",
+      });
+    } catch {
+      // The original GitHub API failure remains authoritative when even the
+      // best-effort terminal status cannot be published.
+      console.error("Deploy Hub shadow could not publish a terminal status.");
     }
   }
 }
@@ -286,7 +309,7 @@ function validateOperation({ operationId, scenario, delaySeconds, runUrl }) {
   assert(SCENARIOS.has(scenario), "Scenario is not supported.");
   assert(DELAYS.has(delaySeconds), "Phase delay is not supported.");
   assert(
-    /^https:\/\/github\.com\/6529-Collections\/6529seize-frontend\/actions\/runs\/[1-9][0-9]*$/.test(
+    /^https:\/\/github\.com\/6529-Collections\/6529seize-frontend\/actions\/runs\/[1-9]\d*$/.test(
       runUrl
     ),
     "Run URL has an invalid format."
@@ -312,13 +335,18 @@ async function executeShadow({
   const forceStale = scenario === "stale";
 
   if (forceStale || staleRequests.size > 0) {
-    await publishStaleResult({
-      github,
-      requests,
-      runUrl,
-      forceStale,
-      staleRequests,
-    });
+    try {
+      await publishStaleResult({
+        github,
+        requests,
+        runUrl,
+        forceStale,
+        staleRequests,
+      });
+    } catch (error) {
+      await publishTerminalProjectionError(github, requests, runUrl);
+      throw error;
+    }
     return {
       operationId,
       scenario: "stale",
@@ -328,14 +356,19 @@ async function executeShadow({
     };
   }
 
-  await publishCohorts({
-    github,
-    cohorts,
-    runUrl,
-    scenario,
-    delaySeconds,
-    sleep,
-  });
+  try {
+    await publishCohorts({
+      github,
+      cohorts,
+      runUrl,
+      scenario,
+      delaySeconds,
+      sleep,
+    });
+  } catch (error) {
+    await publishTerminalProjectionError(github, requests, runUrl);
+    throw error;
+  }
 
   return {
     operationId,
@@ -379,6 +412,18 @@ function createSummary(result, runUrl) {
   return `${lines.join("\n")}\n`;
 }
 
+function createFailureSummary(reason) {
+  return [
+    "# Deploy Hub FE Shadow",
+    "",
+    "> SHADOW ONLY — no branch or environment was changed.",
+    "",
+    "- Conclusion: `failure`",
+    `- Reason: ${reason}`,
+    "",
+  ].join("\n");
+}
+
 async function main() {
   const repository = process.env.DEPLOY_HUB_REPOSITORY ?? "";
   const token = process.env.GITHUB_TOKEN ?? "";
@@ -410,7 +455,10 @@ if (require.main === module) {
     try {
       await main();
     } catch (error) {
-      console.error(`Deploy Hub shadow failed: ${error.message}`);
+      const reason =
+        error instanceof Error ? error.message : "Unexpected shadow failure.";
+      process.stdout.write(createFailureSummary(reason));
+      console.error(`Deploy Hub shadow failed: ${reason}`);
       process.exitCode = 1;
     }
   })();
@@ -418,6 +466,7 @@ if (require.main === module) {
 
 module.exports = {
   EXPECTED_REPOSITORY,
+  createFailureSummary,
   createSummary,
   createGithubClient,
   executeShadow,

--- a/ops/scripts/deploy-hub-shadow.cjs
+++ b/ops/scripts/deploy-hub-shadow.cjs
@@ -76,6 +76,7 @@ function normalizeManifest(manifestJson, actor, repository) {
     );
     assert(
       typeof request.requested_at === "string" &&
+        Number.isFinite(Date.parse(request.requested_at)) &&
         new Date(request.requested_at).toISOString() === request.requested_at,
       `${label} has an invalid request time.`
     );
@@ -230,13 +231,13 @@ async function writeStatus(github, request, runUrl, phase) {
   });
 }
 
-async function resolveStaleRequests(github, requests) {
+async function resolveStaleRequests(github, requests, baseRef) {
   const stale = new Set();
   for (const request of requests) {
     const pull = await github.getPullRequest(request.pr);
     if (
       pull.state !== "open" ||
-      pull.base?.ref !== "main" ||
+      pull.base?.ref !== baseRef ||
       pull.head?.sha !== request.sha
     ) {
       stale.add(request.pr);
@@ -322,6 +323,7 @@ async function executeShadow({
   scenario,
   delaySeconds,
   repository,
+  baseRef,
   actor,
   runUrl,
   github,
@@ -329,9 +331,13 @@ async function executeShadow({
     new Promise((resolve) => setTimeout(resolve, milliseconds)),
 }) {
   validateOperation({ operationId, scenario, delaySeconds, runUrl });
+  assert(
+    typeof baseRef === "string" && baseRef.length > 0 && baseRef.length <= 255,
+    "Base ref has an invalid format."
+  );
   const requests = normalizeManifest(manifestJson, actor, repository);
   const cohorts = partitionCohorts(requests);
-  const staleRequests = await resolveStaleRequests(github, requests);
+  const staleRequests = await resolveStaleRequests(github, requests, baseRef);
   const forceStale = scenario === "stale";
 
   if (forceStale || staleRequests.size > 0) {
@@ -435,6 +441,7 @@ async function main() {
     scenario: process.env.DEPLOY_HUB_SCENARIO ?? "",
     delaySeconds: Number(process.env.DEPLOY_HUB_PHASE_DELAY_SECONDS),
     repository,
+    baseRef: process.env.DEPLOY_HUB_BASE_REF ?? "",
     actor: process.env.DEPLOY_HUB_ACTOR ?? "",
     runUrl: process.env.DEPLOY_HUB_RUN_URL ?? "",
     github: createGithubClient({


### PR DESCRIPTION
## Issue

- Deploy Hub needs a safe frontend-owned workflow to validate exact PR requests and exercise visible lifecycle states before receiving any deployment authority.

## Fix

- Add a manually dispatched FE shadow workflow backed by a small tested runner. It validates immutable request manifests, checks exact live PR heads, partitions adjacent target cohorts, and posts an explicitly labelled shadow-only commit status.

## Changes

- Add `Deploy Hub - FE Shadow` with repository/PR read access and only `statuses: write`.
- Reject non-default-branch dispatches, moved or closed PR heads, invalid targets, spoofed requesters, and malformed exact SHAs.
- Simulate success, product failure/reconciliation, infrastructure failure, cancellation, and stale outcomes without invoking deployment workflows or environments.
- Add workflow-contract and runner tests plus the operational script index entry.

## Validation

- Focused Deploy Hub shadow Jest tests pass.
- Changed-file formatting, lint, typecheck, and quality checks pass.
- Jest typecheck ratchet passes without changing its baseline.
- Workflow-security validation reports no findings.
- Changed-file secret scan reports no findings.

## Risk

- Level: Low
- Why: the workflow is dormant unless manually dispatched, uses no stored secret, cannot write refs or dispatch Actions, and publishes only a dedicated `Deploy Hub Shadow` commit status.
- Rollback: revert this PR to remove the dormant workflow and runner.

## Review Notes

- Confirm the workflow permission boundary, exact-head fail-closed behavior, and unambiguous shadow-only status wording. Real staging authority is intentionally out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shadow deployment workflow to simulate frontend deployment requests.
  * Supports manifest validation, target grouping, stale-request checks, configurable scenarios, and simulated status updates.
  * Generates Markdown summaries for each shadow deployment run.
* **Documentation**
  * Added usage details for the shadow deployment tooling.
* **Tests**
  * Added coverage for validation, execution outcomes, status reporting, permissions, and workflow safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->