### PR TITLE
Fix manual deploy prerequisite failure notifications

### DIFF
--- a/.github/workflows/build-upload-deploy-prod.yml
+++ b/.github/workflows/build-upload-deploy-prod.yml
@@ -721,7 +721,7 @@ jobs:
 
   notify-prerequisite-failure:
     name: Notify about production prerequisite failure
-    needs: [manual-deployment-guard, assert-main-ref, build-upload-deploy]
+    needs: [manual-deployment-guard, assert-main-ref]
     if: >-
       always() &&
       (needs.manual-deployment-guard.result == 'failure' ||

--- a/.github/workflows/build-upload-deploy-prod.yml
+++ b/.github/workflows/build-upload-deploy-prod.yml
@@ -718,3 +718,58 @@ jobs:
           CI_PIPELINES_SERVICE: web
           CI_RELEASE_NOTES_PROMPT_PATH: ops/release-notes/release-notes.prompt.md
         run: node scripts/notify-ci-wave.mjs
+
+  notify-prerequisite-failure:
+    name: Notify about production prerequisite failure
+    needs: [manual-deployment-guard, assert-main-ref, build-upload-deploy]
+    if: >-
+      always() &&
+      (needs.manual-deployment-guard.result == 'failure' ||
+      needs.assert-main-ref.result == 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Notify about failure
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        with:
+          title: "Seize PROD WEB DEPLOY: CI pipeline is broken!!!"
+          description: ${{ github.sha }} - Manual production deployment prerequisite failed
+          content: "<@&1162355330798325861>"
+          color: 0xff0000
+
+      - name: Check out CI wave notifier
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          path: .ci-wave-notifier
+          sparse-checkout: scripts/notify-ci-wave.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Verify CI wave notifier checkout
+        run: |
+          test -f .ci-wave-notifier/scripts/notify-ci-wave.mjs || {
+            echo 'CI wave notifier checkout is unavailable.' >&2
+            exit 1
+          }
+
+      - name: Notify CI wave about failure
+        if: hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''
+        continue-on-error: true
+        env:
+          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
+          CI_PIPELINES_TARGET_ENV: production
+          CI_PIPELINES_STATUS: failure
+          CI_PIPELINES_TITLE: "Seize PROD WEB DEPLOY: CI pipeline is broken!!!"
+          CI_PIPELINES_ENVIRONMENT: production
+          CI_PIPELINES_SERVICE: web
+          CI_PIPELINES_SHA: ${{ github.sha }}
+        run: node .ci-wave-notifier/scripts/notify-ci-wave.mjs

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -723,3 +723,44 @@ jobs:
           CI_PIPELINES_ENVIRONMENT: staging
           CI_PIPELINES_SERVICE: web
         run: node scripts/notify-ci-wave.mjs
+
+  notify-prerequisite-failure:
+    name: Notify about staging prerequisite failure
+    needs: [manual-deployment-guard, deploy-staging]
+    if: always() && needs.manual-deployment-guard.result == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out CI wave notifier
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          path: .ci-wave-notifier
+          sparse-checkout: scripts/notify-ci-wave.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Verify CI wave notifier checkout
+        run: |
+          test -f .ci-wave-notifier/scripts/notify-ci-wave.mjs || {
+            echo 'CI wave notifier checkout is unavailable.' >&2
+            exit 1
+          }
+
+      - name: Notify CI wave about failure
+        if: hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''
+        continue-on-error: true
+        env:
+          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
+          CI_PIPELINES_TARGET_ENV: staging
+          CI_PIPELINES_STATUS: failure
+          CI_PIPELINES_TITLE: "Seize STAGING WEB DEPLOY: CI pipeline is broken!!!"
+          CI_PIPELINES_ENVIRONMENT: staging
+          CI_PIPELINES_SERVICE: web
+          CI_PIPELINES_SHA: ${{ github.sha }}
+        run: node .ci-wave-notifier/scripts/notify-ci-wave.mjs

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -726,7 +726,7 @@ jobs:
 
   notify-prerequisite-failure:
     name: Notify about staging prerequisite failure
-    needs: [manual-deployment-guard, deploy-staging]
+    needs: [manual-deployment-guard]
     if: always() && needs.manual-deployment-guard.result == 'failure'
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/__tests__/scripts/manual-deploy-routing-guard.test.ts
+++ b/__tests__/scripts/manual-deploy-routing-guard.test.ts
@@ -325,14 +325,14 @@ describe("frontend manual deployment routing guards", () => {
     const checkout = notification.steps.find(
       ({ name }) => name === "Check out CI wave notifier"
     );
+    const verification = notification.steps.find(
+      ({ name }) => name === "Verify CI wave notifier checkout"
+    );
     const failureNotifications = notification.steps.filter(
       ({ name }) => name === "Notify CI wave about failure"
     );
 
-    expect(notification.needs).toEqual([
-      "manual-deployment-guard",
-      "deploy-staging",
-    ]);
+    expect(notification.needs).toEqual(["manual-deployment-guard"]);
     expect(notification.if).toBe(
       "always() && needs.manual-deployment-guard.result == 'failure'"
     );
@@ -344,6 +344,12 @@ describe("frontend manual deployment routing guards", () => {
       "sparse-checkout": "scripts/notify-ci-wave.mjs",
       "sparse-checkout-cone-mode": false,
     });
+    expect(verification).toMatchObject({
+      run: expect.stringContaining(
+        "test -f .ci-wave-notifier/scripts/notify-ci-wave.mjs"
+      ),
+    });
+    expect(verification?.["continue-on-error"]).toBeUndefined();
     expect(failureNotifications).toHaveLength(1);
     expect(failureNotifications[0]).toMatchObject({
       if: "hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''",
@@ -380,6 +386,9 @@ describe("frontend manual deployment routing guards", () => {
     const checkout = notification.steps.find(
       ({ name }) => name === "Check out CI wave notifier"
     );
+    const verification = notification.steps.find(
+      ({ name }) => name === "Verify CI wave notifier checkout"
+    );
     const discordNotifications = notification.steps.filter(
       ({ name }) => name === "Notify about failure"
     );
@@ -390,7 +399,6 @@ describe("frontend manual deployment routing guards", () => {
     expect(notification.needs).toEqual([
       "manual-deployment-guard",
       "assert-main-ref",
-      "build-upload-deploy",
     ]);
     expect(notification.if).toBe(
       "always() && (needs.manual-deployment-guard.result == 'failure' || needs.assert-main-ref.result == 'failure')"
@@ -403,6 +411,12 @@ describe("frontend manual deployment routing guards", () => {
       "sparse-checkout": "scripts/notify-ci-wave.mjs",
       "sparse-checkout-cone-mode": false,
     });
+    expect(verification).toMatchObject({
+      run: expect.stringContaining(
+        "test -f .ci-wave-notifier/scripts/notify-ci-wave.mjs"
+      ),
+    });
+    expect(verification?.["continue-on-error"]).toBeUndefined();
     expect(discordNotifications).toHaveLength(1);
     expect(discordNotifications[0]).toMatchObject({
       uses: "sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708",

--- a/__tests__/scripts/manual-deploy-routing-guard.test.ts
+++ b/__tests__/scripts/manual-deploy-routing-guard.test.ts
@@ -6,14 +6,17 @@ import YAML from "yaml";
 
 type WorkflowStep = {
   readonly name?: string;
+  readonly if?: string;
   readonly uses?: string;
   readonly run?: string;
   readonly env?: Readonly<Record<string, string>>;
   readonly with?: Readonly<Record<string, unknown>>;
+  readonly "continue-on-error"?: boolean;
 };
 
 type WorkflowJob = {
   readonly needs?: string | readonly string[];
+  readonly if?: string;
   readonly permissions?: Readonly<Record<string, unknown>>;
   readonly steps: readonly WorkflowStep[];
 };
@@ -313,6 +316,140 @@ describe("frontend manual deployment routing guards", () => {
 
     expect(checkout?.with?.["ref"]).toBe("${{ github.sha }}");
     expect(checkout?.with?.["ref"]).not.toBe("${{ env.STAGING_BRANCH }}");
+  });
+
+  it("notifies once when the staging guard fails without duplicating deployment-job alerts", () => {
+    const parsed = workflow("deploy-staging.yml");
+    const notification = workflowJob(parsed, "notify-prerequisite-failure");
+    const deploy = workflowJob(parsed, "deploy-staging");
+    const checkout = notification.steps.find(
+      ({ name }) => name === "Check out CI wave notifier"
+    );
+    const failureNotifications = notification.steps.filter(
+      ({ name }) => name === "Notify CI wave about failure"
+    );
+
+    expect(notification.needs).toEqual([
+      "manual-deployment-guard",
+      "deploy-staging",
+    ]);
+    expect(notification.if).toBe(
+      "always() && needs.manual-deployment-guard.result == 'failure'"
+    );
+    expect(notification.if).not.toContain("needs.deploy-staging.result");
+    expect(checkout?.with).toMatchObject({
+      ref: "${{ github.workflow_sha }}",
+      path: ".ci-wave-notifier",
+      "persist-credentials": false,
+      "sparse-checkout": "scripts/notify-ci-wave.mjs",
+      "sparse-checkout-cone-mode": false,
+    });
+    expect(failureNotifications).toHaveLength(1);
+    expect(failureNotifications[0]).toMatchObject({
+      if: "hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''",
+      "continue-on-error": true,
+      run: "node .ci-wave-notifier/scripts/notify-ci-wave.mjs",
+      env: {
+        CI_PIPELINES_TARGET_ENV: "staging",
+        CI_PIPELINES_STATUS: "failure",
+        CI_PIPELINES_TITLE:
+          "Seize STAGING WEB DEPLOY: CI pipeline is broken!!!",
+        CI_PIPELINES_ENVIRONMENT: "staging",
+        CI_PIPELINES_SERVICE: "web",
+        CI_PIPELINES_SHA: "${{ github.sha }}",
+      },
+    });
+    expect(
+      deploy.steps.filter(
+        ({ name, if: condition }) =>
+          name === "Notify CI wave about failure" && condition === "failure()"
+      )
+    ).toHaveLength(1);
+    expect(
+      deploy.steps.filter(
+        ({ name, if: condition }) =>
+          name === "Notify CI wave about success" && condition === "success()"
+      )
+    ).toHaveLength(1);
+  });
+
+  it("notifies once for either production prerequisite failure without duplicating deployment-job alerts", () => {
+    const parsed = workflow("build-upload-deploy-prod.yml");
+    const notification = workflowJob(parsed, "notify-prerequisite-failure");
+    const deploy = workflowJob(parsed, "build-upload-deploy");
+    const checkout = notification.steps.find(
+      ({ name }) => name === "Check out CI wave notifier"
+    );
+    const discordNotifications = notification.steps.filter(
+      ({ name }) => name === "Notify about failure"
+    );
+    const failureNotifications = notification.steps.filter(
+      ({ name }) => name === "Notify CI wave about failure"
+    );
+
+    expect(notification.needs).toEqual([
+      "manual-deployment-guard",
+      "assert-main-ref",
+      "build-upload-deploy",
+    ]);
+    expect(notification.if).toBe(
+      "always() && (needs.manual-deployment-guard.result == 'failure' || needs.assert-main-ref.result == 'failure')"
+    );
+    expect(notification.if).not.toContain("needs.build-upload-deploy.result");
+    expect(checkout?.with).toMatchObject({
+      ref: "${{ github.workflow_sha }}",
+      path: ".ci-wave-notifier",
+      "persist-credentials": false,
+      "sparse-checkout": "scripts/notify-ci-wave.mjs",
+      "sparse-checkout-cone-mode": false,
+    });
+    expect(discordNotifications).toHaveLength(1);
+    expect(discordNotifications[0]).toMatchObject({
+      uses: "sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708",
+      "continue-on-error": true,
+      env: {
+        DISCORD_WEBHOOK: "${{ secrets.DISCORD_WEBHOOK }}",
+      },
+      with: {
+        title: "Seize PROD WEB DEPLOY: CI pipeline is broken!!!",
+        description:
+          "${{ github.sha }} - Manual production deployment prerequisite failed",
+        content: "<@&1162355330798325861>",
+        color: 0xff0000,
+      },
+    });
+    expect(failureNotifications).toHaveLength(1);
+    expect(failureNotifications[0]).toMatchObject({
+      if: "hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''",
+      "continue-on-error": true,
+      run: "node .ci-wave-notifier/scripts/notify-ci-wave.mjs",
+      env: {
+        CI_PIPELINES_TARGET_ENV: "production",
+        CI_PIPELINES_STATUS: "failure",
+        CI_PIPELINES_TITLE: "Seize PROD WEB DEPLOY: CI pipeline is broken!!!",
+        CI_PIPELINES_ENVIRONMENT: "production",
+        CI_PIPELINES_SERVICE: "web",
+        CI_PIPELINES_SHA: "${{ github.sha }}",
+      },
+    });
+    expect(
+      deploy.steps.filter(
+        ({ name, if: condition }) =>
+          name === "Notify CI wave about failure" && condition === "failure()"
+      )
+    ).toHaveLength(1);
+    expect(
+      deploy.steps.filter(
+        ({ name, if: condition }) =>
+          name === "Notify CI wave about success" && condition === "success()"
+      )
+    ).toHaveLength(1);
+    expect(
+      deploy.steps.filter(
+        ({ name, if: condition }) =>
+          name === "Notify about failure" && condition === "failure()"
+      )
+    ).toHaveLength(1);
   });
 
   it.each([

--- a/pr-reports/3583.md
+++ b/pr-reports/3583.md
@@ -1,0 +1,43 @@
+# PR Report: Manual deploy prerequisite notifications
+
+PR: https://github.com/6529-Collections/6529seize-frontend/pull/3583
+Branch: agent-prxt/fix-manual-deploy-ci-wave-notifications-019fcc6b -> main
+Related PRs: None
+
+## Summary
+
+Manual staging and production workflows now report prerequisite failures even
+when GitHub skips the deployment job that contains the ordinary deployment
+notifications.
+
+## What Changed
+
+- Added a terminal staging notification job for manual deployment guard
+  failures.
+- Added a terminal production notification job for manual deployment guard or
+  main-ref assertion failures, including the existing Discord alert behavior.
+- Restricted the new jobs to explicit prerequisite failures so ordinary
+  deployment failures and successes continue through the existing notification
+  steps without duplicates.
+- Checked out the CI-wave notifier from the exact workflow SHA and kept alert
+  delivery non-blocking.
+- Added workflow-contract coverage for prerequisite failure, deployment failure,
+  and success paths.
+
+## Frontend Impact
+
+- Routes/views: Not affected.
+- Components: Not affected.
+- Generated API/client: Not affected.
+- User-visible behavior: CI-wave and production Discord operators receive early
+  manual-deployment failure alerts that were previously skipped.
+
+## Config / Env
+
+No new or changed configuration. The workflows continue using the existing
+CI-wave variables/secrets and production Discord webhook secret.
+
+## Release Notes
+
+Manual staging and production deployment prerequisite failures now emit the
+same operational failure alerts as failures that occur after deployment starts.


### PR DESCRIPTION
## Issue
- Manual staging guard failures skip `deploy-staging`, so the CI-wave failure step inside that job never runs.
- Manual production guard or main-ref failures similarly skip `build-upload-deploy` and its CI-wave and Discord failure alerts.

## Fix
- Add one terminal prerequisite-failure notification job to each manual deploy workflow.
- Gate each job with `always()` plus explicit prerequisite result checks so skipped deployment jobs cannot suppress early-failure alerts.
- Keep ordinary deployment failure and success notifications in their existing deployment jobs.

## Changes
- Check out `scripts/notify-ci-wave.mjs` from the exact workflow SHA using the Release Bus production workflow's sparse-checkout pattern.
- Keep CI-wave and production Discord delivery non-blocking.
- Preserve environment/service metadata, titles, run context, actor context, and the exact workflow target SHA.
- Add focused workflow-contract assertions for guard failure, main-ref failure, ordinary deployment failure, and success paths.

## Validation
- `6529 run test:no-coverage --runInBand --runTestsByPath __tests__/scripts/pr-ci-policy-bundle.test.ts __tests__/scripts/deployment-bus.test.ts __tests__/scripts/manual-deploy-routing-guard.test.ts` (96 tests passed)
- `6529 run check:changed`
- Focused ESLint and Prettier checks
- `git diff --check`

## Risk
- Level: Medium
- Why: GitHub Actions control flow changes for manual staging and production deployment workflows; deploy execution steps are unchanged.
- Rollback: revert the terminal notifier jobs and focused test additions.

## Review Notes
- Verify each prerequisite-failure path sends exactly one CI-wave failure alert.
- Verify ordinary deployment failures still use only the existing in-job CI-wave/Discord alerts.
- Verify success produces no prerequisite-failure alert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic failure notifications when staging or production deployment prerequisites are not met.
  - Sends alerts through Discord and CI Wave, including relevant deployment failure details.
  - Notifications do not block or further disrupt deployment workflows.

- **Documentation**
  - Added a report documenting deployment prerequisite alerts, duplicate-alert prevention, and failure-handling behavior.

- **Tests**
  - Added coverage confirming alerts trigger only for applicable prerequisite failures and are not duplicated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->