### PR TITLE
Fix Winners video cards and timeline alignment

### DIFF
--- a/components/waves/winners/WaveWinnersTimeline.tsx
+++ b/components/waves/winners/WaveWinnersTimeline.tsx
@@ -61,17 +61,19 @@ export const WaveWinnersTimeline: React.FC<WaveWinnersTimelineProps> = ({
                 key={`decision-${point.decision_time}`}
                 className="group tw-relative"
               >
-                <div className="tw-absolute tw-left-0 tw-top-[0.3125rem] tw-z-10 lg:tw-left-3">
-                  <div className="tw-flex tw-size-4 tw-items-center tw-justify-center tw-rounded-full tw-border tw-border-iron-700/50 tw-bg-iron-800 tw-transition-all group-hover:tw-border-iron-500">
-                    <div className="tw-size-2 tw-rounded-full tw-bg-iron-500 tw-transition-all group-hover:tw-size-2.5 group-hover:tw-bg-iron-400"></div>
-                  </div>
-                </div>
-
                 <div className="tw-mb-2 tw-ml-6 lg:tw-mb-3 lg:tw-ml-10">
                   <div className="tw-flex tw-flex-wrap tw-items-baseline tw-gap-x-3 tw-gap-y-1">
-                    <h3 className="tw-text-sm tw-font-medium tw-tracking-wide tw-text-iron-300">
-                      {formattedDate}
-                    </h3>
+                    <div className="tw-relative">
+                      <div className="tw-absolute -tw-left-6 tw-top-1/2 tw-z-10 -tw-translate-y-1/2 lg:-tw-left-7">
+                        <div className="tw-flex tw-size-4 tw-items-center tw-justify-center tw-rounded-full tw-border tw-border-iron-700/50 tw-bg-iron-800 tw-transition-all group-hover:tw-border-iron-500">
+                          <div className="tw-size-2 tw-rounded-full tw-bg-iron-500 tw-transition-all group-hover:tw-size-2.5 group-hover:tw-bg-iron-400"></div>
+                        </div>
+                      </div>
+
+                      <h3 className="tw-m-0 tw-text-sm tw-font-medium tw-tracking-wide tw-text-iron-300">
+                        {formattedDate}
+                      </h3>
+                    </div>
 
                     <span className="tw-text-xs tw-font-light tw-tracking-wide tw-text-iron-400">
                       {formattedTime}

--- a/components/waves/winners/drops/MemesWaveWinnerDrop.tsx
+++ b/components/waves/winners/drops/MemesWaveWinnerDrop.tsx
@@ -273,6 +273,8 @@ export const MemesWaveWinnersDrop: React.FC<MemesWaveWinnersDropProps> = ({
                 media_mime_type={artworkMedia.mime_type}
                 media_url={artworkMedia.url}
                 isCompetitionDrop={true}
+                fillVideoContainer={true}
+                videoAlign="center"
               />
             </div>
           )}


### PR DESCRIPTION
## Issue

The Winners tab has two visual defects:

- Videos can grow taller than the fixed media area and paint over voting and action controls.
- Timeline dots are positioned with a fixed top offset, so they do not stay vertically centered on date headings.

## Fix

Keep winner videos contained within the existing media frame and position each timeline dot relative to the actual center of its date heading.

## Notable changes

- Opted the Memes winner card into the existing fill-container video behavior with centered media.
- Moved the timeline marker into a wrapper around the date heading and centered it with a 50% translation.
- Kept the existing timeline line and horizontal geometry unchanged.
- Avoided changes to the shared video player, routes, copy, data loading, and voting behavior.

## Validation

- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff` — 99/100; only the existing component-size advisory remains
- `git diff --check`
- Staging-backed browser QA at 1440, 1280, 1024, 1023, 768, 430, 390, and 360 px
- Verified all tested videos remain at the 384 px media height with zero overflow and a 16 px gap before footer actions
- Verified timeline dots remain vertically centered at every tested breakpoint, including both sides of the 1024 px breakpoint
- Exercised pause/play, mute/unmute, fullscreen return, scrolling over video, voter dialog, a long winner list, signed-out and signed-in states
- Checked video, image, animated GIF, interactive media, and unresolved/loading video entries

The available staging data did not include a deliberately broken/no-media winner or a second signed-in identity without vote power. The changed layout path is video-only and the footer remains auth-independent.

## Risk

Low. The change is local to the custom Winners card and timeline heading layout, and it reuses existing shared media behavior.

## Rollback

Revert commit `87e88646441ed63c06ff1a02c9e354f47a592faa`.

## Review notes

Please focus on the fixed-height video containment and on date-dot alignment across the responsive breakpoint. No user-facing workflow, route, terminology, or Help Bot corpus change is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alignment of timeline decision markers with their corresponding dates.
  * Centered video artwork within winner drop media containers for more consistent presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->