### PR TITLE
Fix manual deploy failure notifications

### DIFF
--- a/.github/workflows/build-upload-deploy-prod.yml
+++ b/.github/workflows/build-upload-deploy-prod.yml
@@ -674,15 +674,6 @@ jobs:
           sparse-checkout: scripts/notify-ci-wave.mjs
           sparse-checkout-cone-mode: false
 
-      - name: Verify CI wave notifier checkout
-        if: always()
-        continue-on-error: true
-        run: |
-          test -f .ci-wave-notifier/scripts/notify-ci-wave.mjs || {
-            echo 'CI wave notifier checkout is unavailable.' >&2
-            exit 1
-          }
-
       - name: Notify about failure
         uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1
         if: failure()
@@ -774,14 +765,6 @@ jobs:
           path: .ci-wave-notifier
           sparse-checkout: scripts/notify-ci-wave.mjs
           sparse-checkout-cone-mode: false
-
-      - name: Verify CI wave notifier checkout
-        continue-on-error: true
-        run: |
-          test -f .ci-wave-notifier/scripts/notify-ci-wave.mjs || {
-            echo 'CI wave notifier checkout is unavailable.' >&2
-            exit 1
-          }
 
       - name: Notify CI wave about prerequisite failure
         if: always() && hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''

--- a/.github/workflows/build-upload-deploy-prod.yml
+++ b/.github/workflows/build-upload-deploy-prod.yml
@@ -663,15 +663,30 @@ jobs:
           if-no-files-found: ignore
           retention-days: 90
 
-      - name: Checkout notification script
+      - name: Check out CI wave notifier
         if: always()
+        continue-on-error: true
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ github.workflow_sha }}
           persist-credentials: false
+          path: .ci-wave-notifier
+          sparse-checkout: scripts/notify-ci-wave.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Verify CI wave notifier checkout
+        if: always()
+        continue-on-error: true
+        run: |
+          test -f .ci-wave-notifier/scripts/notify-ci-wave.mjs || {
+            echo 'CI wave notifier checkout is unavailable.' >&2
+            exit 1
+          }
 
       - name: Notify about failure
         uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1
         if: failure()
+        continue-on-error: true
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
@@ -681,7 +696,7 @@ jobs:
           color: 0xff0000
 
       - name: Notify CI wave about failure
-        if: failure()
+        if: failure() && hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''
         continue-on-error: true
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
@@ -692,11 +707,13 @@ jobs:
           CI_PIPELINES_TITLE: "Seize PROD WEB DEPLOY: CI pipeline is broken!!!"
           CI_PIPELINES_ENVIRONMENT: production
           CI_PIPELINES_SERVICE: web
-        run: node scripts/notify-ci-wave.mjs
+          CI_PIPELINES_SHA: ${{ github.sha }}
+        run: node .ci-wave-notifier/scripts/notify-ci-wave.mjs
 
       - name: Notify about success
         uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1
         if: success()
+        continue-on-error: true
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
@@ -705,7 +722,7 @@ jobs:
           color: 0x00ff00
 
       - name: Notify CI wave about success
-        if: success()
+        if: success() && hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''
         continue-on-error: true
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
@@ -716,5 +733,67 @@ jobs:
           CI_PIPELINES_TITLE: "Seize PROD WEB DEPLOY: CI pipeline complete"
           CI_PIPELINES_ENVIRONMENT: production
           CI_PIPELINES_SERVICE: web
+          CI_PIPELINES_SHA: ${{ github.sha }}
           CI_RELEASE_NOTES_PROMPT_PATH: ops/release-notes/release-notes.prompt.md
-        run: node scripts/notify-ci-wave.mjs
+        run: node .ci-wave-notifier/scripts/notify-ci-wave.mjs
+
+  notify-production-prerequisite-failure:
+    name: Notify about production prerequisite failure
+    needs: [manual-deployment-guard, assert-main-ref, build-upload-deploy]
+    if: >-
+      ${{
+        always() &&
+        needs.build-upload-deploy.result == 'skipped' &&
+        (
+          needs.manual-deployment-guard.result == 'failure' ||
+          needs.assert-main-ref.result == 'failure'
+        )
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Notify about prerequisite failure
+        continue-on-error: true
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        with:
+          title: "Seize PROD WEB DEPLOY: CI pipeline is broken!!!"
+          description: ${{ github.sha }} - A production deployment prerequisite failed before build/upload/deploy.
+          content: "<@&1162355330798325861>"
+          color: 0xff0000
+
+      - name: Check out CI wave notifier
+        continue-on-error: true
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          path: .ci-wave-notifier
+          sparse-checkout: scripts/notify-ci-wave.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Verify CI wave notifier checkout
+        continue-on-error: true
+        run: |
+          test -f .ci-wave-notifier/scripts/notify-ci-wave.mjs || {
+            echo 'CI wave notifier checkout is unavailable.' >&2
+            exit 1
+          }
+
+      - name: Notify CI wave about prerequisite failure
+        if: always() && hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''
+        continue-on-error: true
+        env:
+          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
+          CI_PIPELINES_TARGET_ENV: production
+          CI_PIPELINES_STATUS: failure
+          CI_PIPELINES_TITLE: "Seize PROD WEB DEPLOY: CI pipeline is broken!!!"
+          CI_PIPELINES_ENVIRONMENT: production
+          CI_PIPELINES_SERVICE: web
+          CI_PIPELINES_SHA: ${{ github.sha }}
+        run: node .ci-wave-notifier/scripts/notify-ci-wave.mjs

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -700,15 +700,6 @@ jobs:
           sparse-checkout: scripts/notify-ci-wave.mjs
           sparse-checkout-cone-mode: false
 
-      - name: Verify CI wave notifier checkout
-        if: always()
-        continue-on-error: true
-        run: |
-          test -f .ci-wave-notifier/scripts/notify-ci-wave.mjs || {
-            echo 'CI wave notifier checkout is unavailable.' >&2
-            exit 1
-          }
-
       - name: Notify CI wave about failure
         if: failure() && hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''
         continue-on-error: true
@@ -762,14 +753,6 @@ jobs:
           path: .ci-wave-notifier
           sparse-checkout: scripts/notify-ci-wave.mjs
           sparse-checkout-cone-mode: false
-
-      - name: Verify CI wave notifier checkout
-        continue-on-error: true
-        run: |
-          test -f .ci-wave-notifier/scripts/notify-ci-wave.mjs || {
-            echo 'CI wave notifier checkout is unavailable.' >&2
-            exit 1
-          }
 
       - name: Notify CI wave about prerequisite failure
         if: always() && hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -689,15 +689,28 @@ jobs:
           if-no-files-found: ignore
           retention-days: 30
 
-      - name: Checkout notification script
+      - name: Check out CI wave notifier
         if: always()
+        continue-on-error: true
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ env.COMMIT_SHA }}
+          ref: ${{ github.workflow_sha }}
           persist-credentials: false
+          path: .ci-wave-notifier
+          sparse-checkout: scripts/notify-ci-wave.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Verify CI wave notifier checkout
+        if: always()
+        continue-on-error: true
+        run: |
+          test -f .ci-wave-notifier/scripts/notify-ci-wave.mjs || {
+            echo 'CI wave notifier checkout is unavailable.' >&2
+            exit 1
+          }
 
       - name: Notify CI wave about failure
-        if: failure()
+        if: failure() && hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''
         continue-on-error: true
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
@@ -708,10 +721,11 @@ jobs:
           CI_PIPELINES_TITLE: "Seize STAGING WEB DEPLOY: CI pipeline is broken!!!"
           CI_PIPELINES_ENVIRONMENT: staging
           CI_PIPELINES_SERVICE: web
-        run: node scripts/notify-ci-wave.mjs
+          CI_PIPELINES_SHA: ${{ github.sha }}
+        run: node .ci-wave-notifier/scripts/notify-ci-wave.mjs
 
       - name: Notify CI wave about success
-        if: success()
+        if: success() && hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''
         continue-on-error: true
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
@@ -722,4 +736,52 @@ jobs:
           CI_PIPELINES_TITLE: "Seize STAGING WEB DEPLOY: CI pipeline complete"
           CI_PIPELINES_ENVIRONMENT: staging
           CI_PIPELINES_SERVICE: web
-        run: node scripts/notify-ci-wave.mjs
+          CI_PIPELINES_SHA: ${{ github.sha }}
+        run: node .ci-wave-notifier/scripts/notify-ci-wave.mjs
+
+  notify-staging-prerequisite-failure:
+    name: Notify about staging prerequisite failure
+    needs: [manual-deployment-guard, deploy-staging]
+    if: >-
+      ${{
+        always() &&
+        needs.manual-deployment-guard.result == 'failure' &&
+        needs.deploy-staging.result == 'skipped'
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out CI wave notifier
+        continue-on-error: true
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          path: .ci-wave-notifier
+          sparse-checkout: scripts/notify-ci-wave.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Verify CI wave notifier checkout
+        continue-on-error: true
+        run: |
+          test -f .ci-wave-notifier/scripts/notify-ci-wave.mjs || {
+            echo 'CI wave notifier checkout is unavailable.' >&2
+            exit 1
+          }
+
+      - name: Notify CI wave about prerequisite failure
+        if: always() && hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''
+        continue-on-error: true
+        env:
+          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
+          CI_PIPELINES_TARGET_ENV: staging
+          CI_PIPELINES_STATUS: failure
+          CI_PIPELINES_TITLE: "Seize STAGING WEB DEPLOY: CI pipeline is broken!!!"
+          CI_PIPELINES_ENVIRONMENT: staging
+          CI_PIPELINES_SERVICE: web
+          CI_PIPELINES_SHA: ${{ github.sha }}
+        run: node .ci-wave-notifier/scripts/notify-ci-wave.mjs

--- a/__tests__/scripts/manual-deploy-routing-guard.test.ts
+++ b/__tests__/scripts/manual-deploy-routing-guard.test.ts
@@ -392,9 +392,11 @@ describe("frontend manual deployment routing guards", () => {
         "continue-on-error": true,
         env: {
           CI_PIPELINES_ENVIRONMENT: environment,
+          CI_PIPELINES_SERVICE: "web",
           CI_PIPELINES_SHA: "${{ github.sha }}",
           CI_PIPELINES_STATUS: "failure",
           CI_PIPELINES_TARGET_ENV: environment,
+          CI_PIPELINES_TITLE: `Seize ${environment === "staging" ? "STAGING" : "PROD"} WEB DEPLOY: CI pipeline is broken!!!`,
         },
       });
       for (const job of [deployJob, terminalJob]) {
@@ -405,7 +407,9 @@ describe("frontend manual deployment routing guards", () => {
           with: {
             ref: "${{ github.workflow_sha }}",
             path: ".ci-wave-notifier",
+            "persist-credentials": false,
             "sparse-checkout": "scripts/notify-ci-wave.mjs",
+            "sparse-checkout-cone-mode": false,
           },
         });
       }

--- a/__tests__/scripts/manual-deploy-routing-guard.test.ts
+++ b/__tests__/scripts/manual-deploy-routing-guard.test.ts
@@ -184,6 +184,10 @@ function terminalNotificationRuns(
   );
 }
 
+function deploymentFailureNotificationRuns(result: JobResult): boolean {
+  return result === "failure";
+}
+
 describe("frontend manual deployment routing guards", () => {
   it.each(MANUAL_WORKFLOWS)(
     "allows $environment fallback only with exact authoritative OFF readiness evidence",
@@ -464,6 +468,10 @@ describe("frontend manual deployment routing guards", () => {
       ).toBe(expected);
     }
   );
+
+  it("suppresses the deployment-job notifier when the job is skipped", () => {
+    expect(deploymentFailureNotificationRuns("skipped")).toBe(false);
+  });
 
   it("keeps the production prerequisite Discord alert singular and non-blocking", () => {
     const terminal = workflowJob(

--- a/__tests__/scripts/manual-deploy-routing-guard.test.ts
+++ b/__tests__/scripts/manual-deploy-routing-guard.test.ts
@@ -10,13 +10,18 @@ type WorkflowStep = {
   readonly run?: string;
   readonly env?: Readonly<Record<string, string>>;
   readonly with?: Readonly<Record<string, unknown>>;
+  readonly if?: string;
+  readonly "continue-on-error"?: boolean;
 };
 
 type WorkflowJob = {
   readonly needs?: string | readonly string[];
+  readonly if?: string;
   readonly permissions?: Readonly<Record<string, unknown>>;
   readonly steps: readonly WorkflowStep[];
 };
+
+type JobResult = "success" | "failure" | "skipped";
 
 type Workflow = {
   readonly on: {
@@ -150,6 +155,70 @@ printf '%s' "$FAKE_HTTP_STATUS"
 
 function commandOutput(result: childProcess.SpawnSyncReturns<string>): string {
   return `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+}
+
+function normalizeExpression(expression: string | undefined): string {
+  return expression?.replace(/\s+/gu, " ").trim() ?? "";
+}
+
+function notificationSteps(
+  job: WorkflowJob,
+  status: "failure" | "success"
+): readonly WorkflowStep[] {
+  return job.steps.filter(
+    (step) =>
+      step.run?.endsWith("scripts/notify-ci-wave.mjs") &&
+      step.env?.["CI_PIPELINES_STATUS"] === status
+  );
+}
+
+function prerequisiteNotificationRuns(
+  file: string,
+  results: Readonly<Record<string, JobResult>>
+): boolean {
+  if (file === "deploy-staging.yml") {
+    return (
+      results["manual-deployment-guard"] === "failure" &&
+      results["deploy-staging"] === "skipped"
+    );
+  }
+  return (
+    results["build-upload-deploy"] === "skipped" &&
+    (results["manual-deployment-guard"] === "failure" ||
+      results["assert-main-ref"] === "failure")
+  );
+}
+
+function notificationCounts(
+  file: string,
+  results: Readonly<Record<string, JobResult>>
+): Readonly<{ failure: number; success: number }> {
+  const parsed = workflow(file);
+  const config = MANUAL_WORKFLOWS.find((item) => item.file === file);
+  if (!config) {
+    throw new Error(`Unknown manual workflow: ${file}`);
+  }
+  const deploy = workflowJob(parsed, config.deployJob);
+  const terminalJobName =
+    file === "deploy-staging.yml"
+      ? "notify-staging-prerequisite-failure"
+      : "notify-production-prerequisite-failure";
+  const terminal = workflowJob(parsed, terminalJobName);
+  const deployResult = results[config.deployJob];
+
+  return {
+    failure:
+      (deployResult === "failure"
+        ? notificationSteps(deploy, "failure").length
+        : 0) +
+      (prerequisiteNotificationRuns(file, results)
+        ? notificationSteps(terminal, "failure").length
+        : 0),
+    success:
+      deployResult === "success"
+        ? notificationSteps(deploy, "success").length
+        : 0,
+  };
 }
 
 describe("frontend manual deployment routing guards", () => {
@@ -314,6 +383,199 @@ describe("frontend manual deployment routing guards", () => {
     expect(checkout?.with?.["ref"]).toBe("${{ github.sha }}");
     expect(checkout?.with?.["ref"]).not.toBe("${{ env.STAGING_BRANCH }}");
   });
+
+  it.each([
+    {
+      file: "deploy-staging.yml",
+      job: "notify-staging-prerequisite-failure",
+      needs: ["manual-deployment-guard", "deploy-staging"],
+      condition:
+        "${{ always() && needs.manual-deployment-guard.result == 'failure' && needs.deploy-staging.result == 'skipped' }}",
+      environment: "staging",
+      title: "Seize STAGING WEB DEPLOY: CI pipeline is broken!!!",
+    },
+    {
+      file: "build-upload-deploy-prod.yml",
+      job: "notify-production-prerequisite-failure",
+      needs: [
+        "manual-deployment-guard",
+        "assert-main-ref",
+        "build-upload-deploy",
+      ],
+      condition:
+        "${{ always() && needs.build-upload-deploy.result == 'skipped' && ( needs.manual-deployment-guard.result == 'failure' || needs.assert-main-ref.result == 'failure' ) }}",
+      environment: "production",
+      title: "Seize PROD WEB DEPLOY: CI pipeline is broken!!!",
+    },
+  ])(
+    "routes $file prerequisite failures through one terminal notification job",
+    ({ condition, environment, file, job, needs, title }) => {
+      const terminal = workflowJob(workflow(file), job);
+      const ciWaveFailure = notificationSteps(terminal, "failure");
+
+      expect(terminal.needs).toEqual(needs);
+      expect(normalizeExpression(terminal.if)).toBe(condition);
+      expect(ciWaveFailure).toHaveLength(1);
+      expect(ciWaveFailure[0]).toMatchObject({
+        if: "always() && hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''",
+        "continue-on-error": true,
+        env: {
+          CI_PIPELINES_ENVIRONMENT: environment,
+          CI_PIPELINES_SERVICE: "web",
+          CI_PIPELINES_SHA: "${{ github.sha }}",
+          CI_PIPELINES_STATUS: "failure",
+          CI_PIPELINES_TARGET_ENV: environment,
+          CI_PIPELINES_TITLE: title,
+        },
+        run: "node .ci-wave-notifier/scripts/notify-ci-wave.mjs",
+      });
+    }
+  );
+
+  it.each(MANUAL_WORKFLOWS)(
+    "checks out every $environment notifier from the exact workflow SHA",
+    ({ deployJob, file }) => {
+      const parsed = workflow(file);
+      const terminalJobName =
+        file === "deploy-staging.yml"
+          ? "notify-staging-prerequisite-failure"
+          : "notify-production-prerequisite-failure";
+
+      for (const jobName of [deployJob, terminalJobName]) {
+        const job = workflowJob(parsed, jobName);
+        const checkout = job.steps.find(
+          ({ name }) => name === "Check out CI wave notifier"
+        );
+        const verify = job.steps.find(
+          ({ name }) => name === "Verify CI wave notifier checkout"
+        );
+
+        expect(checkout).toMatchObject({
+          "continue-on-error": true,
+          with: {
+            ref: "${{ github.workflow_sha }}",
+            "persist-credentials": false,
+            path: ".ci-wave-notifier",
+            "sparse-checkout": "scripts/notify-ci-wave.mjs",
+            "sparse-checkout-cone-mode": false,
+          },
+        });
+        expect(verify).toMatchObject({
+          "continue-on-error": true,
+          run: expect.stringContaining(
+            "test -f .ci-wave-notifier/scripts/notify-ci-wave.mjs"
+          ),
+        });
+      }
+    }
+  );
+
+  it("keeps production Discord prerequisite alerts non-blocking and singular", () => {
+    const production = workflow("build-upload-deploy-prod.yml");
+    const deploy = workflowJob(production, "build-upload-deploy");
+    const terminal = workflowJob(
+      production,
+      "notify-production-prerequisite-failure"
+    );
+    const discordSteps = [...deploy.steps, ...terminal.steps].filter(
+      ({ uses }) => uses?.startsWith("sarisia/actions-status-discord@")
+    );
+
+    expect(discordSteps).toHaveLength(3);
+    for (const step of discordSteps) {
+      expect(step["continue-on-error"]).toBe(true);
+    }
+    expect(
+      terminal.steps.filter(({ uses }) =>
+        uses?.startsWith("sarisia/actions-status-discord@")
+      )
+    ).toHaveLength(1);
+  });
+
+  it.each([
+    {
+      path: "staging guard failure",
+      file: "deploy-staging.yml",
+      results: {
+        "manual-deployment-guard": "failure",
+        "deploy-staging": "skipped",
+      },
+      expected: { failure: 1, success: 0 },
+    },
+    {
+      path: "production guard failure",
+      file: "build-upload-deploy-prod.yml",
+      results: {
+        "manual-deployment-guard": "failure",
+        "assert-main-ref": "success",
+        "build-upload-deploy": "skipped",
+      },
+      expected: { failure: 1, success: 0 },
+    },
+    {
+      path: "production main-ref failure",
+      file: "build-upload-deploy-prod.yml",
+      results: {
+        "manual-deployment-guard": "success",
+        "assert-main-ref": "failure",
+        "build-upload-deploy": "skipped",
+      },
+      expected: { failure: 1, success: 0 },
+    },
+    {
+      path: "both production prerequisites failing",
+      file: "build-upload-deploy-prod.yml",
+      results: {
+        "manual-deployment-guard": "failure",
+        "assert-main-ref": "failure",
+        "build-upload-deploy": "skipped",
+      },
+      expected: { failure: 1, success: 0 },
+    },
+    {
+      path: "ordinary staging deployment failure",
+      file: "deploy-staging.yml",
+      results: {
+        "manual-deployment-guard": "success",
+        "deploy-staging": "failure",
+      },
+      expected: { failure: 1, success: 0 },
+    },
+    {
+      path: "ordinary production deployment failure",
+      file: "build-upload-deploy-prod.yml",
+      results: {
+        "manual-deployment-guard": "success",
+        "assert-main-ref": "success",
+        "build-upload-deploy": "failure",
+      },
+      expected: { failure: 1, success: 0 },
+    },
+    {
+      path: "staging success",
+      file: "deploy-staging.yml",
+      results: {
+        "manual-deployment-guard": "success",
+        "deploy-staging": "success",
+      },
+      expected: { failure: 0, success: 1 },
+    },
+    {
+      path: "production success",
+      file: "build-upload-deploy-prod.yml",
+      results: {
+        "manual-deployment-guard": "success",
+        "assert-main-ref": "success",
+        "build-upload-deploy": "success",
+      },
+      expected: { failure: 0, success: 1 },
+    },
+  ] as const)(
+    "emits the expected CI-wave notifications for $path",
+    ({ expected, file, results }) => {
+      expect(notificationCounts(file, results)).toEqual(expected);
+    }
+  );
 
   it.each([
     ["staging", "release-bus-deploy-staging.yml"],

--- a/__tests__/scripts/manual-deploy-routing-guard.test.ts
+++ b/__tests__/scripts/manual-deploy-routing-guard.test.ts
@@ -161,22 +161,17 @@ function normalizeExpression(expression: string | undefined): string {
   return expression?.replace(/\s+/gu, " ").trim() ?? "";
 }
 
-function notificationSteps(
-  job: WorkflowJob,
-  status: "failure" | "success"
-): readonly WorkflowStep[] {
+function ciWaveSteps(job: WorkflowJob): readonly WorkflowStep[] {
   return job.steps.filter(
-    (step) =>
-      step.run?.endsWith("scripts/notify-ci-wave.mjs") &&
-      step.env?.["CI_PIPELINES_STATUS"] === status
+    (step) => step.run?.endsWith("scripts/notify-ci-wave.mjs") === true
   );
 }
 
-function prerequisiteNotificationRuns(
-  file: string,
+function terminalNotificationRuns(
+  environment: "staging" | "production",
   results: Readonly<Record<string, JobResult>>
 ): boolean {
-  if (file === "deploy-staging.yml") {
+  if (environment === "staging") {
     return (
       results["manual-deployment-guard"] === "failure" &&
       results["deploy-staging"] === "skipped"
@@ -187,38 +182,6 @@ function prerequisiteNotificationRuns(
     (results["manual-deployment-guard"] === "failure" ||
       results["assert-main-ref"] === "failure")
   );
-}
-
-function notificationCounts(
-  file: string,
-  results: Readonly<Record<string, JobResult>>
-): Readonly<{ failure: number; success: number }> {
-  const parsed = workflow(file);
-  const config = MANUAL_WORKFLOWS.find((item) => item.file === file);
-  if (!config) {
-    throw new Error(`Unknown manual workflow: ${file}`);
-  }
-  const deploy = workflowJob(parsed, config.deployJob);
-  const terminalJobName =
-    file === "deploy-staging.yml"
-      ? "notify-staging-prerequisite-failure"
-      : "notify-production-prerequisite-failure";
-  const terminal = workflowJob(parsed, terminalJobName);
-  const deployResult = results[config.deployJob];
-
-  return {
-    failure:
-      (deployResult === "failure"
-        ? notificationSteps(deploy, "failure").length
-        : 0) +
-      (prerequisiteNotificationRuns(file, results)
-        ? notificationSteps(terminal, "failure").length
-        : 0),
-    success:
-      deployResult === "success"
-        ? notificationSteps(deploy, "success").length
-        : 0,
-  };
 }
 
 describe("frontend manual deployment routing guards", () => {
@@ -387,16 +350,17 @@ describe("frontend manual deployment routing guards", () => {
   it.each([
     {
       file: "deploy-staging.yml",
-      job: "notify-staging-prerequisite-failure",
+      deploy: "deploy-staging",
+      terminal: "notify-staging-prerequisite-failure",
       needs: ["manual-deployment-guard", "deploy-staging"],
       condition:
         "${{ always() && needs.manual-deployment-guard.result == 'failure' && needs.deploy-staging.result == 'skipped' }}",
       environment: "staging",
-      title: "Seize STAGING WEB DEPLOY: CI pipeline is broken!!!",
     },
     {
       file: "build-upload-deploy-prod.yml",
-      job: "notify-production-prerequisite-failure",
+      deploy: "build-upload-deploy",
+      terminal: "notify-production-prerequisite-failure",
       needs: [
         "manual-deployment-guard",
         "assert-main-ref",
@@ -405,177 +369,114 @@ describe("frontend manual deployment routing guards", () => {
       condition:
         "${{ always() && needs.build-upload-deploy.result == 'skipped' && ( needs.manual-deployment-guard.result == 'failure' || needs.assert-main-ref.result == 'failure' ) }}",
       environment: "production",
-      title: "Seize PROD WEB DEPLOY: CI pipeline is broken!!!",
     },
   ])(
-    "routes $file prerequisite failures through one terminal notification job",
-    ({ condition, environment, file, job, needs, title }) => {
-      const terminal = workflowJob(workflow(file), job);
-      const ciWaveFailure = notificationSteps(terminal, "failure");
+    "defines one exact-SHA terminal notifier for $file",
+    ({ condition, deploy, environment, file, needs, terminal }) => {
+      const parsed = workflow(file);
+      const deployJob = workflowJob(parsed, deploy);
+      const terminalJob = workflowJob(parsed, terminal);
 
-      expect(terminal.needs).toEqual(needs);
-      expect(normalizeExpression(terminal.if)).toBe(condition);
-      expect(ciWaveFailure).toHaveLength(1);
-      expect(ciWaveFailure[0]).toMatchObject({
+      expect(terminalJob.needs).toEqual(needs);
+      expect(normalizeExpression(terminalJob.if)).toBe(condition);
+      expect(
+        ciWaveSteps(deployJob).map((step) => step.env?.["CI_PIPELINES_STATUS"])
+      ).toEqual(["failure", "success"]);
+      expect(ciWaveSteps(terminalJob)).toHaveLength(1);
+      expect(ciWaveSteps(terminalJob)[0]).toMatchObject({
         if: "always() && hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''",
         "continue-on-error": true,
         env: {
           CI_PIPELINES_ENVIRONMENT: environment,
-          CI_PIPELINES_SERVICE: "web",
           CI_PIPELINES_SHA: "${{ github.sha }}",
           CI_PIPELINES_STATUS: "failure",
           CI_PIPELINES_TARGET_ENV: environment,
-          CI_PIPELINES_TITLE: title,
         },
-        run: "node .ci-wave-notifier/scripts/notify-ci-wave.mjs",
       });
-    }
-  );
-
-  it.each(MANUAL_WORKFLOWS)(
-    "checks out every $environment notifier from the exact workflow SHA",
-    ({ deployJob, file }) => {
-      const parsed = workflow(file);
-      const terminalJobName =
-        file === "deploy-staging.yml"
-          ? "notify-staging-prerequisite-failure"
-          : "notify-production-prerequisite-failure";
-
-      for (const jobName of [deployJob, terminalJobName]) {
-        const job = workflowJob(parsed, jobName);
-        const checkout = job.steps.find(
-          ({ name }) => name === "Check out CI wave notifier"
-        );
-        const verify = job.steps.find(
-          ({ name }) => name === "Verify CI wave notifier checkout"
-        );
-
-        expect(checkout).toMatchObject({
+      for (const job of [deployJob, terminalJob]) {
+        expect(
+          job.steps.find(({ name }) => name === "Check out CI wave notifier")
+        ).toMatchObject({
           "continue-on-error": true,
           with: {
             ref: "${{ github.workflow_sha }}",
-            "persist-credentials": false,
             path: ".ci-wave-notifier",
             "sparse-checkout": "scripts/notify-ci-wave.mjs",
-            "sparse-checkout-cone-mode": false,
           },
-        });
-        expect(verify).toMatchObject({
-          "continue-on-error": true,
-          run: expect.stringContaining(
-            "test -f .ci-wave-notifier/scripts/notify-ci-wave.mjs"
-          ),
         });
       }
     }
   );
 
-  it("keeps production Discord prerequisite alerts non-blocking and singular", () => {
-    const production = workflow("build-upload-deploy-prod.yml");
-    const deploy = workflowJob(production, "build-upload-deploy");
-    const terminal = workflowJob(
-      production,
-      "notify-production-prerequisite-failure"
-    );
-    const discordSteps = [...deploy.steps, ...terminal.steps].filter(
-      ({ uses }) => uses?.startsWith("sarisia/actions-status-discord@")
-    );
-
-    expect(discordSteps).toHaveLength(3);
-    for (const step of discordSteps) {
-      expect(step["continue-on-error"]).toBe(true);
-    }
-    expect(
-      terminal.steps.filter(({ uses }) =>
-        uses?.startsWith("sarisia/actions-status-discord@")
-      )
-    ).toHaveLength(1);
-  });
-
   it.each([
-    {
-      path: "staging guard failure",
-      file: "deploy-staging.yml",
-      results: {
-        "manual-deployment-guard": "failure",
-        "deploy-staging": "skipped",
-      },
-      expected: { failure: 1, success: 0 },
-    },
-    {
-      path: "production guard failure",
-      file: "build-upload-deploy-prod.yml",
-      results: {
-        "manual-deployment-guard": "failure",
-        "assert-main-ref": "success",
-        "build-upload-deploy": "skipped",
-      },
-      expected: { failure: 1, success: 0 },
-    },
-    {
-      path: "production main-ref failure",
-      file: "build-upload-deploy-prod.yml",
-      results: {
-        "manual-deployment-guard": "success",
-        "assert-main-ref": "failure",
-        "build-upload-deploy": "skipped",
-      },
-      expected: { failure: 1, success: 0 },
-    },
-    {
-      path: "both production prerequisites failing",
-      file: "build-upload-deploy-prod.yml",
-      results: {
-        "manual-deployment-guard": "failure",
-        "assert-main-ref": "failure",
-        "build-upload-deploy": "skipped",
-      },
-      expected: { failure: 1, success: 0 },
-    },
-    {
-      path: "ordinary staging deployment failure",
-      file: "deploy-staging.yml",
-      results: {
-        "manual-deployment-guard": "success",
-        "deploy-staging": "failure",
-      },
-      expected: { failure: 1, success: 0 },
-    },
-    {
-      path: "ordinary production deployment failure",
-      file: "build-upload-deploy-prod.yml",
-      results: {
-        "manual-deployment-guard": "success",
-        "assert-main-ref": "success",
-        "build-upload-deploy": "failure",
-      },
-      expected: { failure: 1, success: 0 },
-    },
-    {
-      path: "staging success",
-      file: "deploy-staging.yml",
-      results: {
-        "manual-deployment-guard": "success",
-        "deploy-staging": "success",
-      },
-      expected: { failure: 0, success: 1 },
-    },
-    {
-      path: "production success",
-      file: "build-upload-deploy-prod.yml",
-      results: {
-        "manual-deployment-guard": "success",
-        "assert-main-ref": "success",
-        "build-upload-deploy": "success",
-      },
-      expected: { failure: 0, success: 1 },
-    },
+    ["staging guard failure", "staging", "failure", "success", "skipped", true],
+    [
+      "production guard failure",
+      "production",
+      "failure",
+      "success",
+      "skipped",
+      true,
+    ],
+    [
+      "production main-ref failure",
+      "production",
+      "success",
+      "failure",
+      "skipped",
+      true,
+    ],
+    [
+      "ordinary staging failure",
+      "staging",
+      "success",
+      "success",
+      "failure",
+      false,
+    ],
+    [
+      "ordinary production failure",
+      "production",
+      "success",
+      "success",
+      "failure",
+      false,
+    ],
+    ["staging success", "staging", "success", "success", "success", false],
+    [
+      "production success",
+      "production",
+      "success",
+      "success",
+      "success",
+      false,
+    ],
   ] as const)(
-    "emits the expected CI-wave notifications for $path",
-    ({ expected, file, results }) => {
-      expect(notificationCounts(file, results)).toEqual(expected);
+    "routes $path without duplicating the deployment-job notifier",
+    (_path, environment, guard, mainRef, deployment, expected) => {
+      expect(
+        terminalNotificationRuns(environment, {
+          "manual-deployment-guard": guard,
+          "assert-main-ref": mainRef,
+          "deploy-staging": deployment,
+          "build-upload-deploy": deployment,
+        })
+      ).toBe(expected);
     }
   );
+
+  it("keeps the production prerequisite Discord alert singular and non-blocking", () => {
+    const terminal = workflowJob(
+      workflow("build-upload-deploy-prod.yml"),
+      "notify-production-prerequisite-failure"
+    );
+    const discord = terminal.steps.filter(({ uses }) =>
+      uses?.startsWith("sarisia/actions-status-discord@")
+    );
+
+    expect(discord).toHaveLength(1);
+    expect(discord[0]?.["continue-on-error"]).toBe(true);
+  });
 
   it.each([
     ["staging", "release-bus-deploy-staging.yml"],

--- a/pr-reports/3585.md
+++ b/pr-reports/3585.md
@@ -1,0 +1,31 @@
+# PR Report: Fix Manual Deploy Failure Notifications
+
+PR: https://github.com/6529-Collections/6529seize-frontend/pull/3585
+Branch: `agent-prxt/fix-manual-deploy-ci-wave-notifications` -> `main`
+Related PRs: None
+
+## Summary
+
+Ensures manual staging and production deployments report prerequisite failures even when GitHub skips the main deployment job.
+
+## What Changed
+
+- Added terminal notification jobs for failed staging and production prerequisites, with explicit result checks that prevent duplicate CI-wave alerts.
+- Preserved the existing deployment-job success and failure notifications, including production Discord behavior.
+- Checked out and invoked the existing CI-wave notification script from the exact workflow SHA, with notification delivery remaining non-blocking.
+- Added focused workflow-routing coverage for prerequisite failures, ordinary deployment failures, and successful runs.
+
+## Frontend Impact
+
+- Routes/views: Not affected.
+- Components: Not affected.
+- Generated API/client: Not affected.
+- User-visible behavior: Manual deployment failures now reach the existing operational notification channels consistently.
+
+## Config / Environment
+
+No new or changed configuration. Existing CI-wave and Discord secrets and deployment metadata are preserved.
+
+## Release Notes
+
+Manual staging and production workflows now emit failure alerts when a guard or production main-ref check prevents the deployment job from starting.


### PR DESCRIPTION
## Issue

- Manual staging and production prerequisite failures skip the deployment job, so CI-wave failure notifications located inside that job never run.

## Fix

- Add one terminal prerequisite-failure notification job to each manual deployment workflow.
- Gate each terminal job with `always()` plus explicit prerequisite and skipped-deployment results so an early failure sends exactly one CI-wave notification.

## Changes

- Preserve the existing deployment-job success and failure notification paths.
- Check out `scripts/notify-ci-wave.mjs` from the exact workflow SHA using the sparse notifier checkout pattern.
- Keep CI-wave and production Discord delivery non-blocking.
- Cover staging guard failure, production guard failure, production main-ref failure, ordinary deployment failure, and success routing.

## Validation

- Focused manual deployment routing workflow test (25 assertions).
- Protected PR CI policy bundle test (9 assertions).
- Workflow security validation for both changed workflow files.
- Changed-file quality gate and frontend debt ratchet.

## Risk

- Level: Medium
- Why: This changes failure-only control flow in manual staging and production workflows; deployment execution steps are untouched.
- Rollback: Revert the terminal notification jobs and restore the prior in-job notifier checkout blocks.

## Review Notes

- Confirm the terminal job conditions remain mutually exclusive with ordinary deployment-job failure notifications.
- Confirm both notifier checkouts remain pinned to `github.workflow_sha`.
