### PR TITLE
Restore Main Stage leaderboard controls

### DIFF
--- a/__tests__/components/brain/my-stream/MyStreamWaveLeaderboard.test.tsx
+++ b/__tests__/components/brain/my-stream/MyStreamWaveLeaderboard.test.tsx
@@ -470,6 +470,12 @@ describe("MyStreamWaveLeaderboard", () => {
     renderLeaderboard();
 
     expect(headerProps.viewMode).toBe("grid");
+    expect(screen.getByTestId("header")).toBeInTheDocument();
+    expect(getLeaderboardControlsFrame()).toHaveClass(
+      "tw-max-w-full",
+      "!tw-flex-[1_0_15rem]",
+      "lg:!tw-flex-[1_0_27rem]"
+    );
     expect(galleryProps.isVotingClosed).toBe(false);
     expect(galleryProps.isVotingControlsLocked).toBe(false);
     await user.click(screen.getByTestId("header"));

--- a/components/brain/my-stream/MyStreamWaveLeaderboard.tsx
+++ b/components/brain/my-stream/MyStreamWaveLeaderboard.tsx
@@ -547,7 +547,7 @@ const MyStreamWaveLeaderboard: React.FC<MyStreamWaveLeaderboardProps> = ({
             isSticky
             className={
               isMemesWave
-                ? "tw-min-w-0 tw-flex-[1_1_18rem] !tw-pb-2 lg:tw-flex-[1_1_27rem]"
+                ? "tw-min-w-0 tw-max-w-full !tw-flex-[1_0_15rem] !tw-pb-2 lg:!tw-flex-[1_0_27rem]"
                 : undefined
             }
           >


### PR DESCRIPTION
## Issue

- Follow-up to #3575: the Main Stage leaderboard view and sort control groups could be compressed below their intrinsic width beside the decision timeline, causing both groups to appear missing.

## Fix

- Prevent the Main Stage controls frame from shrinking below its compact and desktop width bases while preserving flex growth when the toolbar wraps.
- Keep the existing responsive behavior: sort tabs at LG and above, the dropdown below LG, the timeline on top when wrapped, and controls on the left when shared.

## Changes

- Use non-shrinking 15rem and 27rem flex bases for the Main Stage controls frame.
- Cap the frame at the available width for narrow screens.
- Add a regression assertion for the Main Stage controls sizing contract.

## Validation

- Targeted Jest component test passed.
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff` (98/100; existing unrelated warnings only)
- Local responsive browser QA at 1440, 1280, 1024, 900, 600, and 390px: both groups visible, correct tab/dropdown mode, no overlap, correct wrap order.
- Browser console: no errors.

## Risk

- Level: Low
- Why: one scoped flex-sizing adjustment and one regression assertion; no data, API, routing, or virtualization behavior changed.
- Rollback: revert the follow-up commit.

## Review Notes

- Please focus on the controls frame sizing at the LG boundary and on wrapped medium/mobile layouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive sizing and layout for the memes-wave leaderboard controls.

* **Tests**
  * Added coverage verifying the leaderboard header and responsive control layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->