### PR TITLE
Remove duplicate GDRC document header

### DIFF
--- a/__tests__/components/about/AboutGDRC1.test.tsx
+++ b/__tests__/components/about/AboutGDRC1.test.tsx
@@ -29,6 +29,25 @@ describe("AboutGDRC1", () => {
     expect(await screen.findByText("Charter Content")).toBeInTheDocument();
   });
 
+  it("removes the duplicated source header without removing charter content", async () => {
+    (fetchAboutSectionFile as jest.Mock).mockResolvedValue(
+      "<div><h2>The Global Digital Rights Charter</h2><div>Version 1.0 - March 2023</div></div><div><h3>Preamble</h3><p>Charter Content</p></div>"
+    );
+
+    render(<AboutGDRC1 />);
+
+    expect(await screen.findByText("Charter Content")).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("heading", {
+        name: "The Global Digital Rights Charter",
+      })
+    ).toHaveLength(1);
+    expect(screen.getAllByText("Version 1.0 - March 2023")).toHaveLength(1);
+    expect(
+      screen.getByRole("heading", { name: "Preamble" })
+    ).toBeInTheDocument();
+  });
+
   it("sanitizes fetched html", async () => {
     (fetchAboutSectionFile as jest.Mock).mockResolvedValue(
       '<div onclick="alert(1)"><p>Safe content</p><script>alert(1)</script><a href="javascript:alert(1)">Unsafe link</a></div>'

--- a/components/about/About.module.css
+++ b/components/about/About.module.css
@@ -56,10 +56,6 @@
 }
 
 .gdrcContent > div:first-child {
-  display: none;
-}
-
-.gdrcContent > div:nth-child(2) {
   padding-top: 0;
 }
 

--- a/components/about/AboutGDRC1.tsx
+++ b/components/about/AboutGDRC1.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useBrowserLocale } from "@/hooks/useBrowserLocale";
-import type { SupportedLocale } from "@/i18n/locales";
+import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
 import { t, tRich, type MessageKey } from "@/i18n/messages";
 import clsx from "clsx";
 import Link from "next/link";
@@ -28,6 +28,8 @@ const GDRC_ALLOWED_TAG_NAMES = new Set([
 ]);
 
 const m = (locale: SupportedLocale, key: GdrcMessageKey) => t(locale, key);
+const GDRC_SOURCE_TITLE = m(DEFAULT_LOCALE, "about.gdrc.title");
+const GDRC_SOURCE_VERSION = m(DEFAULT_LOCALE, "about.gdrc.version");
 
 function isDuplicateGdrcHeader(
   element: Element,
@@ -50,11 +52,7 @@ function isDuplicateGdrcHeader(
   );
 }
 
-function sanitizeGdrcHtml(
-  value: string,
-  title: string,
-  version: string
-): string {
+function sanitizeGdrcHtml(value: string): string {
   const document = new DOMParser().parseFromString(value, "text/html");
 
   for (const element of Array.from(document.body.querySelectorAll("*"))) {
@@ -69,7 +67,14 @@ function sanitizeGdrcHtml(
   }
 
   const firstElement = document.body.firstElementChild;
-  if (firstElement && isDuplicateGdrcHeader(firstElement, title, version)) {
+  if (
+    firstElement &&
+    isDuplicateGdrcHeader(
+      firstElement,
+      GDRC_SOURCE_TITLE,
+      GDRC_SOURCE_VERSION
+    )
+  ) {
     firstElement.remove();
   }
 
@@ -85,12 +90,12 @@ export default function AboutGDRC1() {
   useEffect(() => {
     void fetchAboutSectionFile("gdrc1")
       .then((content) => {
-        setHtml(sanitizeGdrcHtml(content, title, version));
+        setHtml(sanitizeGdrcHtml(content));
       })
       .catch(() => {
         setHtml("");
       });
-  }, [title, version]);
+  }, []);
 
   return (
     <article

--- a/components/about/AboutGDRC1.tsx
+++ b/components/about/AboutGDRC1.tsx
@@ -29,7 +29,32 @@ const GDRC_ALLOWED_TAG_NAMES = new Set([
 
 const m = (locale: SupportedLocale, key: GdrcMessageKey) => t(locale, key);
 
-function sanitizeGdrcHtml(value: string): string {
+function isDuplicateGdrcHeader(
+  element: Element,
+  title: string,
+  version: string
+): boolean {
+  const children = Array.from(element.children);
+  const containsOnlyExpectedElements = Array.from(element.childNodes).every(
+    (node) => node.nodeType === Node.ELEMENT_NODE || !node.textContent?.trim()
+  );
+
+  return (
+    element.tagName === "DIV" &&
+    children.length === 2 &&
+    children[0]?.tagName === "H2" &&
+    children[0].textContent.trim() === title &&
+    children[1]?.tagName === "DIV" &&
+    children[1].textContent.trim() === version &&
+    containsOnlyExpectedElements
+  );
+}
+
+function sanitizeGdrcHtml(
+  value: string,
+  title: string,
+  version: string
+): string {
   const document = new DOMParser().parseFromString(value, "text/html");
 
   for (const element of Array.from(document.body.querySelectorAll("*"))) {
@@ -43,22 +68,29 @@ function sanitizeGdrcHtml(value: string): string {
     }
   }
 
+  const firstElement = document.body.firstElementChild;
+  if (firstElement && isDuplicateGdrcHeader(firstElement, title, version)) {
+    firstElement.remove();
+  }
+
   return document.body.innerHTML;
 }
 
 export default function AboutGDRC1() {
   const locale = useBrowserLocale();
   const [html, setHtml] = useState<string>("");
+  const title = m(locale, "about.gdrc.title");
+  const version = m(locale, "about.gdrc.version");
 
   useEffect(() => {
     void fetchAboutSectionFile("gdrc1")
       .then((content) => {
-        setHtml(sanitizeGdrcHtml(content));
+        setHtml(sanitizeGdrcHtml(content, title, version));
       })
       .catch(() => {
         setHtml("");
       });
-  }, []);
+  }, [title, version]);
 
   return (
     <article
@@ -66,10 +98,10 @@ export default function AboutGDRC1() {
     >
       <header className="tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-white/[0.06] tw-px-1 tw-pb-10 tw-pt-4 sm:tw-px-0 sm:tw-pb-12 sm:tw-pt-8 lg:tw-px-2">
         <h1 className="tw-m-0 tw-text-[22px] tw-font-semibold tw-leading-tight tw-tracking-tight tw-text-iron-50 sm:tw-text-[26px]">
-          {m(locale, "about.gdrc.title")}
+          {title}
         </h1>
         <p className="tw-m-0 tw-mt-3 tw-text-sm tw-leading-6 tw-text-iron-500">
-          {m(locale, "about.gdrc.version")}
+          {version}
         </p>
       </header>
 


### PR DESCRIPTION
## Issue

- The GDRC page rendered its title and version in the React header while the fetched charter HTML retained the same leading header in the DOM.

## Fix

- Remove only the exact leading fetched title/version block after the existing HTML sanitization step.
- Keep the React-rendered title/version as the single page header and preserve all charter wording.

## Changes

- Match the known source header structure and remove it only when both strings exactly match the localized page header.
- Make the Preamble the first charter section instead of hiding the first fetched block with CSS.
- Add regression coverage confirming there is one title, one version, and the charter content remains present.

## Validation

- `./bin/6529 run test --testPathPatterns=__tests__/components/about/AboutGDRC1.test.tsx --runInBand --cacheDirectory=/private/tmp/6529-gdrc-jest-cache`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff` (100/100)
- Browser checked `/about/gdrc1` at desktop and 390 x 844: one title, one version, Preamble and Digital Rights preserved, no horizontal overflow, and no new console errors.

## Risk

- Level: Low
- Why: The change is isolated to the GDRC fetched-content sanitizer, its local CSS, and focused tests. Removal requires an exact structure and exact title/version text match.
- Rollback: Revert the single commit to restore the previous CSS-hidden source header behavior.

## Review Notes

- Please focus on the narrow duplicate-header predicate and preservation of the remaining sanitized charter HTML.
- No documentation or Help index update is needed because the route, terminology, controls, workflow, and charter wording are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicated charter headers appearing in GDRC content.
  * Ensured charter content, version information, and the Preamble heading remain visible.
  * Improved content updates when translated title or version text changes.

* **Tests**
  * Added coverage confirming duplicate headers are removed without hiding valid charter content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->