### PR TITLE
Run staging Git sync as the checkout owner

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -592,21 +592,29 @@ jobs:
             fi
           done
 
-          cd "$REPO_DIR"
-          git fetch --no-tags origin "$BRANCH"
-          remote_sha="$(git rev-parse FETCH_HEAD)"
+          # SSM runs this wrapper as root, while the checkout and its Git
+          # credentials belong to RUN_AS. Keep every repository operation
+          # under that identity; do not weaken Git's ownership protection with
+          # a root-level safe.directory exception.
+          run_git() {
+            sudo -H -u "$RUN_AS" git -C "$REPO_DIR" "$@"
+          }
+
+          run_git fetch --no-tags origin "$BRANCH"
+          remote_sha="$(run_git rev-parse FETCH_HEAD)"
           if [[ "$remote_sha" != "$EXPECTED_SHA" ]]; then
             echo "origin $BRANCH is $remote_sha, expected $EXPECTED_SHA." >&2
             echo "A newer staging push superseded this run; refusing to deploy stale bytes." >&2
             exit 1
           fi
-          git reset --hard HEAD
-          git clean -fd generated
-          git checkout -B "$BRANCH" FETCH_HEAD
-          git config "branch.$BRANCH.remote" origin
-          git config "branch.$BRANCH.merge" "refs/heads/$BRANCH"
-          git reset --hard FETCH_HEAD
-          test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+          run_git reset --hard HEAD
+          run_git clean -fd generated
+          run_git checkout -B "$BRANCH" FETCH_HEAD
+          run_git config "branch.$BRANCH.remote" origin
+          run_git config "branch.$BRANCH.merge" "refs/heads/$BRANCH"
+          run_git reset --hard FETCH_HEAD
+          test "$(run_git rev-parse HEAD)" = "$EXPECTED_SHA"
+          cd "$REPO_DIR"
           bash -n ops/scripts/deploy-staging-artifact.sh
           ARTIFACT_URL="$ARTIFACT_URL" \
           EXPECTED_DIGEST="$EXPECTED_DIGEST" \

--- a/__tests__/scripts/deploy-staging-artifact.test.ts
+++ b/__tests__/scripts/deploy-staging-artifact.test.ts
@@ -99,6 +99,14 @@ describe("manual staging immutable artifact deployment", () => {
     expect(sendStep.run).toContain(
       "bash ops/scripts/deploy-staging-artifact.sh"
     );
+    expect(sendStep.run).toContain(
+      'sudo -H -u "$RUN_AS" git -C "$REPO_DIR" "$@"'
+    );
+    expect(sendStep.run).toContain("run_git fetch --no-tags origin");
+    expect(sendStep.run).toContain("run_git checkout -B");
+    expect(sendStep.run).not.toContain(
+      "git config --global --add safe.directory"
+    );
     expect(sendStep.run).not.toContain("install:frozen");
     expect(sendStep.run).not.toContain("./bin/6529 run build");
     expect(workflowSource).toContain("--expires-in 5400");

--- a/ops/workstreams/ci-release-acceleration/active-context.md
+++ b/ops/workstreams/ci-release-acceleration/active-context.md
@@ -50,3 +50,9 @@
   exposed the legacy workflow's PR-write permission in 28 seconds; label
   recommendations now go to the job summary and the PR workflow is strictly
   read-only.
+- PR #3593 merged as `eaae62f8986a8a0f3f5d219008041b4c1f5f88d2`.
+  Production prebuild run `30959015710` succeeded in 12m08s. Staging run
+  `30959063209` built exact bytes in 11m05s, then failed before activation when
+  root-owned SSM Git commands encountered the `ubuntu`-owned checkout. The
+  active hotfix preserves Git's ownership check and executes repository
+  operations as the configured checkout owner.

--- a/ops/workstreams/ci-release-acceleration/run-log.md
+++ b/ops/workstreams/ci-release-acceleration/run-log.md
@@ -63,3 +63,10 @@
   label-sync step retained PR-write permissions. Label recommendations now
   appear in the job summary and the untrusted PR workflow is strictly
   read-only; mutation is no longer mixed with dependency evaluation.
+- First staging qualification of the merged pipeline built and uploaded the
+  exact artifact in 11m05s, concurrent with the 12m08s production prebuild.
+  Promotion then failed closed in 1m11s before activation: SSM executes as
+  root, but the staging checkout belongs to `ubuntu`, so Git rejected the
+  checkout as dubious ownership. The hotfix runs every repository operation as
+  the configured checkout owner and deliberately avoids a global
+  `safe.directory` exception.


### PR DESCRIPTION
## Outcome\n\nRepairs the first live accelerated staging promotion without weakening Git's ownership protection.\n\nThe exact staging artifact built successfully in 11m05s. SSM then ran repository synchronization as root against an ubuntu-owned checkout, so Git failed closed with dubious ownership before any activation. This patch:\n\n- runs every fetch/rev-parse/reset/clean/checkout/config operation as the configured checkout owner;\n- retains root only for the controlled artifact installation steps that require it;\n- explicitly rejects a global safe.directory bypass in the workflow contract;\n- records the exact production/staging benchmark and failure disposition.\n\n## Evidence\n\n- failed staging run: 30959063209\n- SSM command failed before activation; production was unaffected\n- workflow parses and owner-bound Git contract passes\n- changed-workflow security validation passes\n- portable diff check passes\n- hosted exact-head App CI is authoritative for the full Linux workflow contract