### PR TITLE
Scope production Museum E2E to Museum changes

### DIFF
--- a/.github/workflows/production-e2e.yml
+++ b/.github/workflows/production-e2e.yml
@@ -66,7 +66,8 @@ jobs:
           set -euo pipefail
           [[ "$AUTOMATIC_DEPLOY_RUN_ID" =~ ^[1-9][0-9]{0,19}$ ]]
           response_file="$(mktemp)"
-          trap 'rm -f "$response_file"' EXIT
+          runs_file=''
+          trap 'rm -f "$response_file"; if [ -n "$runs_file" ]; then rm -f "$runs_file"; fi' EXIT
           gh api \
             "repos/${GITHUB_REPOSITORY}/actions/runs/${AUTOMATIC_DEPLOY_RUN_ID}" \
             > "$response_file"
@@ -84,6 +85,36 @@ jobs:
               (.head_sha | test("^[a-f0-9]{40}$"))
             ' "$response_file" >/dev/null
           echo "deployed-sha=$(jq -r .head_sha "$response_file")" >> "$GITHUB_OUTPUT"
+          started_at="$(jq -er .run_started_at "$response_file")"
+          runs_file="$(mktemp)"
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/build-upload-deploy-prod.yml/runs?status=completed&branch=main&event=workflow_dispatch&per_page=100" \
+            > "$runs_file"
+          previous_sha="$(jq -r \
+            --argjson current_run_id "$AUTOMATIC_DEPLOY_RUN_ID" \
+            --arg started_at "$started_at" '
+              [.workflow_runs[] |
+                select(
+                  .id != $current_run_id and
+                  .name == "Web Deploy - PROD" and
+                  .path == ".github/workflows/build-upload-deploy-prod.yml" and
+                  .event == "workflow_dispatch" and
+                  .status == "completed" and
+                  .conclusion == "success" and
+                  .head_branch == "main" and
+                  .run_started_at < $started_at and
+                  (.head_sha | test("^[a-f0-9]{40}$"))
+                )] |
+              sort_by(.run_started_at) |
+              last |
+              .head_sha // empty
+            ' "$runs_file")"
+          if [[ "$previous_sha" =~ ^[a-f0-9]{40}$ ]]; then
+            echo "previous_deployed_sha=$previous_sha" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::No prior successful production deployment could be proven; Museum E2E will be retained."
+            echo "previous_deployed_sha=" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Validate and authorize immutable inputs
         if: inputs.automatic_deploy_run_id == ''
@@ -141,6 +172,35 @@ jobs:
         run: |
           corepack enable pnpm
           corepack prepare "$(node -p 'require("./package.json").packageManager')" --activate
+      - name: Select Museum pack for the deployed change set
+        id: museum-selection
+        env:
+          BASE_SHA: ${{ steps.automatic-deploy.outputs.previous_deployed_sha }}
+          DEPLOYED_SHA: ${{ inputs.expected_sha || steps.automatic-deploy.outputs.deployed-sha }}
+        run: |
+          set -euo pipefail
+          museum_required=true
+          if [[ "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]] &&
+            [[ "$DEPLOYED_SHA" =~ ^[a-f0-9]{40}$ ]]
+          then
+            base_available=true
+            if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null &&
+              ! git fetch --no-tags --depth=1 origin "$BASE_SHA"
+            then
+              base_available=false
+              echo "::warning::Unable to fetch the prior production tree; retaining Museum E2E."
+            fi
+            if [ "$base_available" = true ]; then
+              candidate="$(node scripts/museum-e2e-change-set.cjs \
+                --base "$BASE_SHA" --head "$DEPLOYED_SHA")"
+              case "$candidate" in
+                true|false) museum_required="$candidate" ;;
+                *) echo "::warning::Museum classifier returned an invalid value; retaining Museum E2E." ;;
+              esac
+            fi
+          fi
+          echo "required=$museum_required" >> "$GITHUB_OUTPUT"
+          echo "Museum E2E required: $museum_required"
       - name: Restore pnpm store
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
@@ -186,6 +246,7 @@ jobs:
         if: steps.playwright.outcome == 'success'
         continue-on-error: true
         env:
+          MUSEUM_E2E_REQUIRED: ${{ steps.museum-selection.outputs.required }}
           RELEASE_BUS_E2E_MANIFEST_ID: ${{ inputs.release_manifest_id }}
           RELEASE_BUS_E2E_MANIFEST_IDENTITY_SHA256: ${{ inputs.release_manifest_identity_sha256 }}
           RELEASE_BUS_E2E_SOURCE_SHA: ${{ inputs.expected_sha }}
@@ -202,11 +263,19 @@ jobs:
               .features.readonly_pack_parallelism == {
                 version: 1,
                 max_parallel: 4
-              }
+              } and
+              .features.pack_exclusion == { version: 1 }
             ' <<< "$runner_capabilities" >/dev/null
           then
             args+=(--parallel 3)
+            if [ "$MUSEUM_E2E_REQUIRED" = false ]; then
+              args+=(--exclude-pack museum-institutional-practice)
+            fi
+          elif [ "$MUSEUM_E2E_REQUIRED" = false ]; then
+            echo "::warning::Deployed E2E runner cannot exclude packs; retaining the Museum E2E pack."
+            MUSEUM_E2E_REQUIRED=true
           fi
+          echo "MUSEUM_E2E_REQUIRED=$MUSEUM_E2E_REQUIRED" >> "$GITHUB_ENV"
           ./bin/6529 run e2e:packs -- "${args[@]}"
       - name: Validate exact production E2E evidence
         id: evidence
@@ -222,9 +291,11 @@ jobs:
           test -f production-e2e-artifacts/evidence.json
           expected_inventory="$(./bin/6529 exec node - <<'NODE'
           const { PACKS } = require("./tests/packs.manifest.cjs");
+          const museumRequired = process.env.MUSEUM_E2E_REQUIRED !== "false";
           const keys = PACKS.filter((pack) =>
             pack.environments.includes("production") &&
-            pack.triggers.includes("post-deploy")
+            pack.triggers.includes("post-deploy") &&
+            (museumRequired || pack.alias !== "museum-institutional-practice")
           ).map((pack) => pack.scriptKey);
           process.stdout.write(JSON.stringify(keys));
           NODE

--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -355,23 +355,15 @@ jobs:
           set -euo pipefail
           museum_required=true
           if [ "$SELECTED_PACK" = all ] && [ -n "$DEPLOYED_SHA" ]; then
-            changed_files="$(mktemp)"
-            trap 'rm -f "$changed_files"' EXIT
-            if base_sha="$(git rev-parse "${DEPLOYED_SHA}^1" 2>/dev/null)" &&
-              git diff --no-renames --name-only -z \
-                "$base_sha" "$DEPLOYED_SHA" -- > "$changed_files"
-            then
-              museum_required=false
-              while IFS= read -r -d '' file; do
-                case "$file" in
-                  app/museum/network/*|components/museum/*|lib/museum/*|config/museumPublicationEnv.server.ts|i18n/messages/museum.en-US.json|tests/museum/*)
-                    museum_required=true
-                    break
-                    ;;
-                esac
-              done < "$changed_files"
+            if base_sha="$(git rev-parse "${DEPLOYED_SHA}^1" 2>/dev/null)"; then
+              candidate="$(node scripts/museum-e2e-change-set.cjs \
+                --base "$base_sha" --head "$DEPLOYED_SHA")"
+              case "$candidate" in
+                true|false) museum_required="$candidate" ;;
+                *) echo "::warning::Museum classifier returned an invalid value; retaining Museum E2E." ;;
+              esac
             else
-              echo "::warning::Unable to prove the deployed change range; retaining the Museum E2E pack."
+              echo "::warning::Unable to resolve the deployed change range; retaining Museum E2E."
             fi
           fi
           echo "required=$museum_required" >> "$GITHUB_OUTPUT"

--- a/__tests__/scripts/museum-e2e-change-set.test.ts
+++ b/__tests__/scripts/museum-e2e-change-set.test.ts
@@ -1,0 +1,67 @@
+const classifier = require("../../scripts/museum-e2e-change-set.cjs");
+
+describe("Museum E2E change-set classifier", () => {
+  it.each([
+    "app/museum/network/page.tsx",
+    "components/museum/MuseumShell.tsx",
+    "lib/museum/publication/index.ts",
+    "config/museumPublicationEnv.server.ts",
+    "i18n/messages/museum.en-US.json",
+    "tests/museum/institutional-practice-readonly.spec.ts",
+  ])("selects the Museum pack for %s", (file) => {
+    expect(classifier.isMuseumOwnedPath(file)).toBe(true);
+  });
+
+  it.each([
+    "app/tools/page.tsx",
+    "components/museums/MuseumShell.tsx",
+    "lib/museum-adjacent.ts",
+    "tests/museum-adjacent.spec.ts",
+  ])("omits the Museum pack for %s", (file) => {
+    expect(classifier.isMuseumOwnedPath(file)).toBe(false);
+  });
+
+  it("fails closed when the range is invalid or Git cannot classify it", () => {
+    expect(classifier.classifyGitRange("", "").required).toBe(true);
+    const result = classifier.classifyGitRange(
+      "a".repeat(40),
+      "b".repeat(40),
+      () => ({ status: 128, stdout: Buffer.alloc(0) })
+    );
+    expect(result.required).toBe(true);
+    expect(
+      classifier.classifyGitRange("a".repeat(40), "b".repeat(40), () => ({
+        status: 0,
+      })).required
+    ).toBe(true);
+  });
+
+  it("classifies the complete NUL-delimited tree diff", () => {
+    const spawn = jest.fn(() => ({
+      status: 0,
+      stdout: Buffer.from("app/tools/page.tsx\0lib/museum/records.ts\0"),
+    }));
+    const result = classifier.classifyGitRange(
+      "a".repeat(40),
+      "b".repeat(40),
+      spawn
+    );
+    expect(result.required).toBe(true);
+    expect(result.files).toEqual([
+      "app/tools/page.tsx",
+      "lib/museum/records.ts",
+    ]);
+  });
+
+  it("omits Museum E2E when the proved range contains only unrelated files", () => {
+    const result = classifier.classifyGitRange(
+      "a".repeat(40),
+      "b".repeat(40),
+      () => ({
+        status: 0,
+        stdout: Buffer.from(".github/workflows/production-e2e.yml\0"),
+      })
+    );
+    expect(result.required).toBe(false);
+  });
+});

--- a/__tests__/scripts/production-e2e-dispatch.test.ts
+++ b/__tests__/scripts/production-e2e-dispatch.test.ts
@@ -54,6 +54,10 @@ describe("automatic production E2E dispatch", () => {
       (step: { name?: string }) =>
         step.name === "Run production-safe read-only packs"
     );
+    const selectionIndex = job.steps.findIndex(
+      (step: { name?: string }) =>
+        step.name === "Select Museum pack for the deployed change set"
+    );
 
     expect(
       e2e.on.workflow_dispatch.inputs.automatic_deploy_run_id.required
@@ -64,6 +68,8 @@ describe("automatic production E2E dispatch", () => {
     );
     expect(resolve.run).toContain('.conclusion == "success"');
     expect(resolve.run).toContain('.head_branch == "main"');
+    expect(resolve.run).toContain("previous_deployed_sha=$previous_sha");
+    expect(resolve.run).toContain(".run_started_at < $started_at");
     expect(e2eSource).toContain(
       "inputs.expected_sha || steps.automatic-deploy.outputs.deployed-sha"
     );
@@ -71,6 +77,17 @@ describe("automatic production E2E dispatch", () => {
       "${{ inputs.expected_sha || steps.automatic-deploy.outputs.deployed-sha }}"
     );
     expect(packsIndex).toBeGreaterThan(checkoutIndex);
+    expect(selectionIndex).toBeGreaterThan(checkoutIndex);
+    expect(packsIndex).toBeGreaterThan(selectionIndex);
+    expect(job.steps[selectionIndex].run).toContain(
+      "scripts/museum-e2e-change-set.cjs"
+    );
+    expect(job.steps[packsIndex].run).toContain(
+      "--exclude-pack museum-institutional-practice"
+    );
+    expect(evidence.run).toContain(
+      'pack.alias !== "museum-institutional-practice"'
+    );
     expect(evidence.run).toContain(".release_binding == null");
     expect(e2eSource).toContain("args+=(--parallel 3)");
     expect(e2eSource).toContain("Restore Playwright browser");

--- a/ops/workstreams/ci-release-acceleration/active-context.md
+++ b/ops/workstreams/ci-release-acceleration/active-context.md
@@ -1,85 +1,18 @@
 # Active context
 
-- Current repair branch: `codex/e2e-release-stability`
-- Current base: frontend main `8cfb1d53d2b56d78f49821260d15fe10dc1b9783`
-- Scope: release-duration audit, PR CI matrix, scoped Museum browser lane,
-  secret-free caches, immutable staging activation, production prebuild and
-  promotion, automatic post-deploy E2E, runner indirection, and stale Meme
-  Calendar contract correction.
-- Source input: open PR #3582 was inspected and selectively integrated. Open
-  PR #3586 and older E2E proposals were dispositioned in the audit.
-- Local validation: nine workflow/runner/classifier suites and all 200 tests
-  pass; changed lint, changed application typecheck, the Jest and Playwright
-  typecheck ratchets, E2E manifest synchronization, dependency risk, Debt
-  Ratchet, portable whitespace validation, agent-file synchronization, and
-  React Doctor 100/100 pass. The earlier 17-suite Windows replay had 332
-  passing tests and four platform-specific failures from existing
-  `O_NOFOLLOW`, fake-`gh` PATH and Bash fixture contracts; hosted Linux remains
-  authoritative for those suites.
-- The clean worktree-local optimized production build passed in 334.4 seconds.
-  An earlier attempt failed before compilation because the ignored
-  `node_modules` directory was a cross-worktree junction; a frozen local
-  install removed that host-only caveat before the passing build.
-- Frontend `main` advanced to `aaf35662bf0ca664c05a6f9cdc16db396d99e251`
-  during validation. It merged conflict-free; the exact combined signed head
-  passed the complete short-gate replay and a fresh optimized production build
-  in 371.1 seconds.
-- Release actions still required: merge the narrow E2E stability repair,
-  compose/deploy that exact main to staging, obtain green automatic staging
-  E2E, promote the exact prebuilt production artifact, obtain automatic
-  production E2E, and complete retained endpoint/version evidence.
-- Ready PR #3593 opened at exact signed/signed-off head `9481d5e3...`. Its
-  first hosted plan selected four parallel lanes and correctly omitted the
-  Museum lane. The quality lane exposed two stale public-review artifact
-  assertions that still expected production packaging inside the deploy
-  workflow; sibling lanes were cancelled by fail-fast before long work. The
-  assertions now follow the dedicated production prebuild. Review hardening
-  also gives the staging presigned URL a 90-minute lifetime over the bounded
-  40-minute SSM wait, clears the decoded destination input on every exit,
-  removes an incomplete destination file, and records that all pack code and
-  manifests execute from the exact deployed-SHA checkout. Repository ruleset
-  `18018081` already requires the stable aggregate `Installed app checks`, not
-  a matrix child name.
-- Hosted observation also found the separate dependency-governance workflow
-  repeating a full application typecheck and production build after required
-  App CI had already accepted both responsibilities. It now retains the
-  dependency risk classifier, Socket Firewall, frozen install, package pin
-  lint, unit tests, and risk-label recommendations while using blobless history
-  and the pnpm cache. Required App CI remains the single owner of complete
-  application typechecking and production build evidence. Hosted validation
-  exposed the legacy workflow's PR-write permission in 28 seconds; label
-  recommendations now go to the job summary and the PR workflow is strictly
-  read-only.
-- PR #3593 merged as `eaae62f8986a8a0f3f5d219008041b4c1f5f88d2`.
-  Production prebuild run `30959015710` succeeded in 12m08s. Staging run
-  `30959063209` built exact bytes in 11m05s, then failed before activation when
-  root-owned SSM Git commands encountered the `ubuntu`-owned checkout. The
-  active hotfix preserves Git's ownership check and executes repository
-  operations as the configured checkout owner.
-- PR #3597 merged that hotfix as
-  `8cfb1d53d2b56d78f49821260d15fe10dc1b9783`. Staging run `30961248107`
-  succeeded in about 11m30s and production prebuild `30961224309` succeeded in
-  13m17s. Automatic staging E2E `30961887383` completed its immutable tooling
-  checkout in one second and ten of twelve parallel packs passed. The two
-  failed packs were a transient staging API fetch in the broad shell pack and
-  a stale Meme Calendar test role. Retained desktop/mobile accessibility trees
-  show SZN, Year, and Epoch are now rows with valid date ranges, so the repair
-  asserts their current row contract without suppressing console or response
-  errors.
-- Local authenticated replay showed the broad pack's remaining failure came
-  from tests that navigated one page across two routes. Coinbase Wallet SDK
-  asynchronously checks the current route with `HEAD`; the second navigation
-  aborted that check and produced the exact console error. The notifications,
-  messages, open-data, and block-finder routes now have independent Playwright
-  cases. No console error is allowlisted or suppressed.
-- The staging fixture no longer preloads `/` before every case. Access is
-  already seeded in the context cookie; if a gate still appears, the existing
-  wrapped `page.goto` submits the credential and retries the originally
-  requested route. This removes a duplicate navigation from every staging test
-  without weakening access-gate handling. The corrected broad pack passed all
-  44 applicable desktop/mobile cases in 1m51s, down from the failing 2m26s
-  replay, and the calendar pack passed 10/10 in 36s.
-- `format:changed` now resolves the exact `origin/main` merge base and includes
-  current tracked edits. This replaces its stale local `main...HEAD` range,
-  which selected 552 unrelated files during validation; that accidental output
-  was discarded rather than included.
+- Current branch: `codex/production-e2e-museum-scope`.
+- Current base: frontend main
+  `1b88da6214d1c97c6a22ea40e8e7e0d5285dcd0d`.
+- The accelerated pipeline is live. Merge-to-production was 27m38s and
+  merge-to-complete-production-E2E was 38m46s. Production promotion fell from
+  22m12s to 5m16s; the final PR gate fell from 45m09s to a 10m34s longest lane.
+- Exact live production and its automatic 12-pack E2E are green. Durable run
+  references are staging 30965170461 and production 30965872983.
+- One final efficiency defect remains in the deployed workflow: production E2E
+  selected the 8m14s Museum pack for a non-Museum change. This branch centralizes
+  the exact Museum path boundary, compares production against the prior
+  successful production deployment, excludes Museum only when the range is
+  proven clean, and validates the resulting evidence inventory.
+- Required release work: focused validation, ready PR, bot/check iteration,
+  merge, exact staging deployment and automatic E2E, exact production promotion
+  and automatic E2E, then live version/route readback and durable closeout.

--- a/ops/workstreams/ci-release-acceleration/release-duration-audit.md
+++ b/ops/workstreams/ci-release-acceleration/release-duration-audit.md
@@ -138,3 +138,31 @@ packs, but the second hosted staging E2E run was cancelled before tests and the
 manual production lane created no hosted Production E2E run. This audit does
 not relabel those facts. The new pipeline adds the missing automatic production
 run and removes the staging tooling-fetch failure mode.
+
+## Implemented steady-state evidence
+
+The first complete accelerated release reached production from merge in 27m38s
+and completed automatic production qualification in 38m46s. The exact observed
+steps were:
+
+| Stage               | Run         |                                             Observed result |
+| ------------------- | ----------- | ----------------------------------------------------------: |
+| Final PR App CI     | 30963778437 |                         10m34s longest lane; Museum omitted |
+| Staging deploy      | 30964484960 | 12m53s, including 10m47s artifact build and 1m44s promotion |
+| Production prebuild | 30964439072 |                             13m33s, concurrent with staging |
+| Staging E2E         | 30965170461 |                       6m55s dispatch-to-finish; 12/12 packs |
+| Production deploy   | 30965594547 |                                     5m16s, down from 22m12s |
+| Production E2E      | 30965872983 |                                         10m54s; 12/12 packs |
+
+Production promotion is therefore about 76% faster than the audited 22m12s
+deployment. The final PR gate is about 77% faster than the audited 45m09s gate.
+The first live release met the 40-minute merge-to-production and 55-minute
+merge-to-qualified-production targets.
+
+That run also found one remaining selection defect: production E2E spent 8m14s
+inside the Museum institutional-practice pack even though the deployed change
+set contained no Museum-owned path. The production selector now compares the
+new exact tree with the most recent prior successful production deployment and
+uses the same centralized Museum path classifier as PR and staging. It fails
+closed: missing history, an invalid range, a Git failure, or an older runner
+without pack exclusion retains Museum coverage.

--- a/ops/workstreams/ci-release-acceleration/run-log.md
+++ b/ops/workstreams/ci-release-acceleration/run-log.md
@@ -109,3 +109,25 @@
   `origin/main` merge base and diffs that commit against the current index and
   working tree, matching the changed-lint boundary. A contract test rejects a
   return to the local-main range.
+
+## 2026-08-05
+
+- PR #3598 merged as `1b88da6214d1c97c6a22ea40e8e7e0d5285dcd0d`.
+  Exact App CI run 30963778437 completed with a 10m34s longest lane and omitted
+  Museum coverage for its non-Museum change set.
+- Staging composition `dbc152937798086696f007b43e0c83652ab9074b`
+  deployed in run 30964484960. Automatic staging E2E 30965170461 passed all
+  twelve selected packs in 6m55s dispatch-to-finish. Concurrent production
+  prebuild 30964439072 completed in 13m33s.
+- Production run 30965594547 promoted the verified prebuild in 5m16s, down
+  from the audited 22m12s. Automatic production E2E 30965872983 passed all
+  twelve packs; exact live version and representative Museum/non-Museum routes
+  were healthy.
+- Merge-to-production was 27m38s; merge-to-complete-production-E2E was 38m46s.
+  Both beat the target pipeline's initial service levels.
+- Final live evidence showed the non-Museum production release still selected
+  the 8m14s Museum pack. A shared exact path classifier now owns staging and
+  production selection. Production derives its base from the immediately prior
+  successful production deployment rather than assuming the new commit's first
+  parent. Missing history, invalid SHAs, Git failures, and older runners all
+  retain Museum E2E fail-closed.

--- a/ops/workstreams/ci-release-acceleration/target-pipeline.md
+++ b/ops/workstreams/ci-release-acceleration/target-pipeline.md
@@ -37,10 +37,12 @@ The isolated desktop/mobile Museum browser lane is selected only by:
 - `i18n/messages/museum.en-US.json`
 - `tests/museum/**`
 
-The classifier is table-tested with positive and unrelated negative paths.
-Museum Jest tests continue to follow normal related-test selection. The
-deployed staging selector uses the same path boundary and retains the Museum
-pack if it cannot prove the first-parent diff.
+The classifier is centralized and table-tested with positive and unrelated
+negative paths. Museum Jest tests continue to follow normal related-test
+selection. Staging compares its deployed composition with its first parent.
+Production compares the new exact tree with the most recent prior successful
+production deployment. Both retain the Museum pack when the range cannot be
+proved or the deployed runner cannot honor pack exclusion.
 
 ## Immutable production artifact
 

--- a/scripts/app-pr-ci-effective-plan.cjs
+++ b/scripts/app-pr-ci-effective-plan.cjs
@@ -3,6 +3,9 @@
 
 const fs = require("node:fs");
 const path = require("node:path");
+const {
+  isMuseumOwnedPath,
+} = require("./museum-e2e-change-set.cjs");
 
 const PACKAGE_GOVERNANCE_FILES = new Set([
   ".npmrc",
@@ -32,20 +35,11 @@ const RELEASE_BUS_CONTRACT_PATTERNS = [
   /^\.github\/workflows\//u,
   /^ops\/deployment-bus\//u,
   /^ops\/scripts\/(?:deployment-bus|deploy-staging-artifact|release-bus-status|verify-deployment-version)\./u,
-  /^scripts\/(?:app-pr-ci-effective-plan|e2e-packs|pr-ci-policy-bundle|release-bus-|sync-e2e-manifest)/u,
+  /^scripts\/(?:app-pr-ci-effective-plan|e2e-packs|museum-e2e-change-set|pr-ci-policy-bundle|release-bus-|sync-e2e-manifest)/u,
   /^tests\/packs\.manifest\.cjs$/u,
-  /^__tests__\/scripts\/(?:app-pr-ci-effective-plan|deployment-bus|e2e-packs|manual-deploy-routing-guard|pr-ci-policy-bundle|release-bus-|sync-e2e-manifest)/u,
+  /^__tests__\/scripts\/(?:app-pr-ci-effective-plan|deployment-bus|e2e-packs|manual-deploy-routing-guard|museum-e2e-change-set|pr-ci-policy-bundle|release-bus-|sync-e2e-manifest)/u,
   /^(?:package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml)$/u,
 ];
-const MUSEUM_PLAYWRIGHT_PATTERNS = [
-  /^app\/museum\/network\//u,
-  /^components\/museum\//u,
-  /^lib\/museum\//u,
-  /^config\/museumPublicationEnv\.server\.ts$/u,
-  /^tests\/museum\//u,
-  /^i18n\/messages\/museum\.en-US\.json$/u,
-];
-
 function check(required, reason) {
   return { required, reason };
 }
@@ -99,9 +93,7 @@ function applyEffectiveAppPrCiPlan(plan, { cwd = process.cwd() } = {}) {
   const releaseBusContract = files.some((file) =>
     RELEASE_BUS_CONTRACT_PATTERNS.some((pattern) => pattern.test(file))
   );
-  const playwrightMuseum = files.some((file) =>
-    MUSEUM_PLAYWRIGHT_PATTERNS.some((pattern) => pattern.test(file))
-  );
+  const playwrightMuseum = files.some(isMuseumOwnedPath);
 
   const checks = {
     ...plan.checks,

--- a/scripts/museum-e2e-change-set.cjs
+++ b/scripts/museum-e2e-change-set.cjs
@@ -1,0 +1,87 @@
+const { spawnSync } = require("node:child_process");
+
+const SHA_PATTERN = /^[a-f0-9]{40}$/;
+const MUSEUM_PREFIXES = [
+  "app/museum/network/",
+  "components/museum/",
+  "lib/museum/",
+  "tests/museum/",
+];
+const MUSEUM_FILES = new Set([
+  "config/museumPublicationEnv.server.ts",
+  "i18n/messages/museum.en-US.json",
+]);
+
+function isMuseumOwnedPath(file) {
+  const normalized = file.replaceAll("\\", "/");
+  return (
+    MUSEUM_FILES.has(normalized) ||
+    MUSEUM_PREFIXES.some((prefix) => normalized.startsWith(prefix))
+  );
+}
+
+function museumRequiredForFiles(files) {
+  return files.some(isMuseumOwnedPath);
+}
+
+function classifyGitRange(baseSha, headSha, spawn = spawnSync) {
+  if (!SHA_PATTERN.test(baseSha) || !SHA_PATTERN.test(headSha)) {
+    return {
+      required: true,
+      reason: "The deployed change range is incomplete or invalid.",
+    };
+  }
+
+  const result = spawn(
+    "git",
+    ["diff", "--no-renames", "--name-only", "-z", baseSha, headSha, "--"],
+    { encoding: "buffer", maxBuffer: 16 * 1024 * 1024 }
+  );
+  if (
+    result.status !== 0 ||
+    result.error ||
+    !Buffer.isBuffer(result.stdout)
+  ) {
+    const detail = result.error?.message
+      ? `error=${result.error.message}`
+      : `status=${String(result.status)}, signal=${String(result.signal ?? "none")}`;
+    return {
+      required: true,
+      reason: `Git could not prove the deployed change range (${detail}).`,
+    };
+  }
+
+  const files = result.stdout.toString("utf8").split("\0").filter(Boolean);
+  return {
+    required: museumRequiredForFiles(files),
+    reason:
+      files.length === 0 ? "No files changed." : "Change range classified.",
+    files,
+  };
+}
+
+function readOption(argv, name) {
+  const index = argv.indexOf(name);
+  return index === -1 ? "" : (argv[index + 1] ?? "");
+}
+
+function main(argv = process.argv.slice(2)) {
+  const result = classifyGitRange(
+    readOption(argv, "--base"),
+    readOption(argv, "--head")
+  );
+  if (result.required && result.reason !== "Change range classified.") {
+    process.stderr.write(`::warning::${result.reason} Retaining Museum E2E.\n`);
+  }
+  process.stdout.write(result.required ? "true" : "false");
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  classifyGitRange,
+  isMuseumOwnedPath,
+  museumRequiredForFiles,
+};


### PR DESCRIPTION
## Outcome

Completes the CI/release acceleration by removing the final non-Museum latency leak from automatic production qualification while preserving fail-closed Museum coverage.

## Change

- centralize the exact Museum-owned path classifier used by staging and production
- compare each automatic production release with the immediately prior successful production deployment, not merely the new commit's parent
- exclude `museum-institutional-practice` only when the complete deployed tree diff is proved unrelated
- retain Museum E2E for missing history, invalid identity, Git failure, explicit/manual qualification, or an older runner without exclusion capability
- completeness-check the evidence inventory against the selected pack set
- record the minute-level audit and first live steady-state timings

## Measured evidence already live

- PR gate: 45m09s to 10m34s longest lane
- production deploy: 22m12s to 5m16s
- merge to production: 27m38s
- merge to complete automatic production E2E: 38m46s
- remaining observed leak: Museum consumed 8m14s of a non-Museum production E2E run

The separately merged Keys and Gates media change is correctly Museum-impacting, so the next full release will retain Museum qualification. The following non-Museum closeout release will prove the omission path end to end.

## Validation

- 4 focused suites / 45 tests
- changed lint
- changed typecheck (1,301-file ratchet)
- exact production-history replay selected the prior successful deployment and classified the prior non-Museum release as `museum_required=false`
- YAML parse, formatting, and portable whitespace checks