### PR TITLE
Retry transient staging soft-error documents

### DIFF
--- a/__tests__/playwright/routeReadiness.test.ts
+++ b/__tests__/playwright/routeReadiness.test.ts
@@ -12,13 +12,18 @@ function mockResponse(status: number) {
   return { status: () => status } as Response;
 }
 
-function mockPageWithResponses(responses: Array<Response | null>) {
+function mockPageWithResponses(
+  responses: Array<Response | null>,
+  titles: string[] = []
+) {
   const goto = jest.fn(async () => responses.shift() ?? null);
+  const title = jest.fn(async () => titles.shift() ?? "Ready");
   const waitForTimeout = jest.fn(async () => undefined);
 
   return {
     goto,
-    page: { goto, waitForTimeout } as unknown as Page,
+    page: { goto, title, waitForTimeout } as unknown as Page,
+    title,
     waitForTimeout,
   };
 }
@@ -84,5 +89,49 @@ describe("Playwright route readiness navigation", () => {
     ).resolves.toBeNull();
     expect(goto).toHaveBeenCalledTimes(2);
     expect(waitForTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["6529 Error", "404 | PAGE NOT FOUND"])(
+    "retries once after the app renders the transient %s document",
+    async (transientTitle) => {
+      const response = mockResponse(200);
+      const { goto, page, title, waitForTimeout } = mockPageWithResponses(
+        [mockResponse(200), response],
+        [transientTitle, "NextGen"]
+      );
+
+      await expect(
+        gotoDocumentWithTransientRetry(page, "/nextgen")
+      ).resolves.toBe(response);
+      expect(goto).toHaveBeenCalledTimes(2);
+      expect(title).toHaveBeenCalledTimes(2);
+      expect(waitForTimeout).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it("throws when the app renders a soft failure after the retry", async () => {
+    const { page } = mockPageWithResponses(
+      [mockResponse(200), mockResponse(200)],
+      ["404 | PAGE NOT FOUND", "404 | PAGE NOT FOUND"]
+    );
+
+    await expect(
+      gotoDocumentWithTransientRetry(page, "/nextgen/collection/pebbles/art")
+    ).rejects.toThrow(
+      "Document navigation to /nextgen/collection/pebbles/art remained on the application 404 page after retry."
+    );
+  });
+
+  it("reports a persistent application error shell clearly", async () => {
+    const { page } = mockPageWithResponses(
+      [mockResponse(200), mockResponse(200)],
+      ["6529 Error", "6529 Error"]
+    );
+
+    await expect(
+      gotoDocumentWithTransientRetry(page, "/nextgen")
+    ).rejects.toThrow(
+      "Document navigation to /nextgen remained on the application error shell after retry."
+    );
   });
 });

--- a/ops/workstreams/ci-release-acceleration/active-context.md
+++ b/ops/workstreams/ci-release-acceleration/active-context.md
@@ -1,6 +1,6 @@
 # Active context
 
-- Current branch: `codex/production-e2e-museum-scope`.
+- Current branch: `codex/e2e-soft-route-retry`.
 - Current base: frontend main
   `1b88da6214d1c97c6a22ea40e8e7e0d5285dcd0d`.
 - The accelerated pipeline is live. Merge-to-production was 27m38s and
@@ -8,11 +8,11 @@
   22m12s to 5m16s; the final PR gate fell from 45m09s to a 10m34s longest lane.
 - Exact live production and its automatic 12-pack E2E are green. Durable run
   references are staging 30965170461 and production 30965872983.
-- One final efficiency defect remains in the deployed workflow: production E2E
-  selected the 8m14s Museum pack for a non-Museum change. This branch centralizes
-  the exact Museum path boundary, compares production against the prior
-  successful production deployment, excludes Museum only when the range is
-  proven clean, and validates the resulting evidence inventory.
-- Required release work: focused validation, ready PR, bot/check iteration,
-  merge, exact staging deployment and automatic E2E, exact production promotion
-  and automatic E2E, then live version/route readback and durable closeout.
+- PR #3599 is merged as `8c7f0daec20d3d4d226ebfef74e4d6a7dbe2e189`.
+  Its production prebuild is running. Keys and Gates staging Museum coverage
+  passed, but two independent collections runs observed different HTTP 200
+  soft-error documents. This branch adds one bounded retry for those documents;
+  persistent error/404 pages remain release-blocking.
+- Required release work: merge this narrow harness repair, deploy exact main to
+  staging, obtain green automatic E2E, promote the exact production prebuild,
+  obtain green automatic production E2E, then live readback and closeout.

--- a/ops/workstreams/ci-release-acceleration/run-log.md
+++ b/ops/workstreams/ci-release-acceleration/run-log.md
@@ -131,3 +131,10 @@
   successful production deployment rather than assuming the new commit's first
   parent. Missing history, invalid SHAs, Git failures, and older runners all
   retain Museum E2E fail-closed.
+- Keys and Gates staging E2E 30967900031 proved the full Museum pack green in
+  9m14s. Its only failed pack was unrelated collections coverage: staging
+  returned HTTP 200 documents containing the `6529 Error` shell for `/nextgen`
+  and `/nextgen/about`. A direct replay found those routes healthy, then hit a
+  second HTTP 200 soft failure (`404 | PAGE NOT FOUND`) on the collection-art
+  route. The existing retry recognized only HTTP 502/503/504. Route readiness
+  now retries either soft failure document once, then blocks on persistence.

--- a/tests/support/routeReadiness.ts
+++ b/tests/support/routeReadiness.ts
@@ -8,6 +8,15 @@ import {
 
 export const RESPONSE_TIMEOUT_MS = 20000;
 const TRANSIENT_DOCUMENT_STATUS_CODES = new Set([502, 503, 504]);
+// Keep these exact fixtures aligned with components/not-found/NotFound.tsx and
+// components/error/Error.tsx. Staging has returned both as HTTP 200 documents
+// for routes that passed on an immediate second navigation.
+const NOT_FOUND_DOCUMENT_TITLE = "404 | PAGE NOT FOUND";
+const ERROR_DOCUMENT_TITLE = "6529 Error";
+const RETRYABLE_DOCUMENT_TITLES = new Set([
+  NOT_FOUND_DOCUMENT_TITLE,
+  ERROR_DOCUMENT_TITLE,
+]);
 const TRANSIENT_DOCUMENT_RETRY_DELAY_MS = 1000;
 
 export type ApiResponseMatcher = (url: URL) => boolean;
@@ -27,8 +36,10 @@ export async function gotoDocumentWithTransientRetry(page: Page, path: string) {
       TRANSIENT_DOCUMENT_STATUS_CODES.has(response.status())
         ? response.status()
         : null;
+    const title = transientStatus === null ? await page.title() : "";
+    const retryableTitle = RETRYABLE_DOCUMENT_TITLES.has(title) ? title : null;
 
-    if (transientStatus === null) {
+    if (transientStatus === null && retryableTitle === null) {
       return response;
     }
 
@@ -37,8 +48,18 @@ export async function gotoDocumentWithTransientRetry(page: Page, path: string) {
       continue;
     }
 
+    if (transientStatus !== null) {
+      throw new Error(
+        `Document navigation to ${path} returned transient HTTP ${transientStatus} after retry.`
+      );
+    }
+    if (retryableTitle === NOT_FOUND_DOCUMENT_TITLE) {
+      throw new Error(
+        `Document navigation to ${path} remained on the application 404 page after retry.`
+      );
+    }
     throw new Error(
-      `Document navigation to ${path} returned transient HTTP ${transientStatus} after retry.`
+      `Document navigation to ${path} remained on the application error shell after retry.`
     );
   }
 


### PR DESCRIPTION
## Outcome

Prevents known transient staging documents from wasting a full release cycle while preserving persistent route failures as hard gates.

## Evidence

Keys and Gates staging E2E run 30967900031 passed the complete Museum pack in 9m14s. Its collections pack received HTTP 200 documents titled `6529 Error` for `/nextgen` and `/nextgen/about`. A direct replay found both healthy, then independently received HTTP 200 `404 | PAGE NOT FOUND` for `/nextgen/collection/pebbles/art`. A second exact replay passed all 20 desktop/mobile collection checks.

## Change

- extend the existing single document retry for HTTP 502/503/504 to the two observed HTTP 200 soft-failure titles
- retry only the navigation, once, after a one-second delay
- throw a route-specific error when the second document remains bad
- do not retry assertions, API failures, console errors, or failed responses

## Validation

- route-readiness unit suite: 8/8
- authenticated staging collections replay: 20/20 desktop/mobile
- changed lint, changed typecheck (1,301 files), formatting, portable whitespace