### PR TITLE
Harden Museum production E2E COOP diagnostic

### DIFF
--- a/tests/museum/inside-system-readonly.spec.ts
+++ b/tests/museum/inside-system-readonly.spec.ts
@@ -16,7 +16,7 @@ import { gotoDocumentWithTransientRetry } from "../support/routeReadiness";
 const MOBILE_PROJECT = "web-mobile-chromium";
 const MOBILE_VIEWPORT = { width: 390, height: 844 } as const;
 const SHELL_ALLOWED_CONSOLE_ERROR_PATTERNS = [
-  /^Error checking Cross-Origin-Opener-Policy: Failed to fetch$/,
+  /^Error checking Cross-Origin-Opener-Policy: Failed to fetch(?: \((?:staging\.)?6529\.io\))?$/,
   /^Failed to fetch cookie consent status Error: Network request failed\. Please check your connection and try again\. \(https:\/\/api(?:\.staging)?\.6529\.io\/api\/policies\/country-check\)(?:\n|$)/,
 ];
 


### PR DESCRIPTION
## What changed

- extend the Museum live-site console allowlist to accept the existing benign Cross-Origin-Opener-Policy fetch diagnostic when Chromium appends `6529.io` or `staging.6529.io`
- keep the match exact and Museum-scoped; all other console errors, page errors, and 5xx responses still fail the suite

## Why

The production release rendered all five Inside the System studies with 200 responses, correct titles, and no failed application responses, but Chromium formatted the already-allowed COOP probe as `Error checking Cross-Origin-Opener-Policy: Failed to fetch (6529.io)`. The previous regex only accepted the hostname-less form.

## Verification

- `seize run test:e2e:production:museum-inside-system` — 8 passed, desktop and mobile
- `seize run lint:changed`
- `seize run typecheck:playwright`
- `codex-diff-check -- tests/museum/inside-system-readonly.spec.ts`

## Risk

Test-only and narrowly scoped. It does not change application or deployment behavior and does not permit arbitrary fetch, console, page, or HTTP failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of expected browser console errors across staging and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->