### PR TITLE
Stabilize Museum E2E shell diagnostics

### DIFF
--- a/tests/museum/inside-system-readonly.spec.ts
+++ b/tests/museum/inside-system-readonly.spec.ts
@@ -16,7 +16,8 @@ import { gotoDocumentWithTransientRetry } from "../support/routeReadiness";
 const MOBILE_PROJECT = "web-mobile-chromium";
 const MOBILE_VIEWPORT = { width: 390, height: 844 } as const;
 const SHELL_ALLOWED_CONSOLE_ERROR_PATTERNS = [
-  /^Error checking Cross-Origin-Opener-Policy: Failed to fetch$/,
+  /^Error checking Cross-Origin-Opener-Policy: Failed to fetch(?: \(6529\.io\))?(?:\n|$)/,
+  /^Failed to fetch seize settings TypeError: Failed to fetch(?:\n|$)/,
   /^Failed to fetch cookie consent status Error: Network request failed\. Please check your connection and try again\. \(https:\/\/api(?:\.staging)?\.6529\.io\/api\/policies\/country-check\)(?:\n|$)/,
 ];
 


### PR DESCRIPTION
## Summary
- accept the production hostname suffix emitted by the existing COOP shell fetch diagnostic
- accept the exact transient Seize settings fetch diagnostic in the read-only Inside the System pack
- keep route, content, layout, media, failed-response, and all other console assertions unchanged

## Evidence
- production E2E run 30974147369: the only failing pack emitted `Error checking Cross-Origin-Opener-Policy: Failed to fetch (6529.io)`
- staging E2E run 30972152707 attempts 2-3: the same pack emitted `Failed to fetch seize settings TypeError: Failed to fetch`
- all 70 Museum institutional-practice tests, including Keys and Gates desktop/mobile and all selection pages, passed in production
- direct staging and production browser sweeps loaded the affected Museum routes successfully

## Local validation
- `seize run lint:changed`
- `seize exec playwright test tests/museum/inside-system-readonly.spec.ts --list`
- `codex-diff-check -- tests/museum/inside-system-readonly.spec.ts`