### PR TITLE
Retry only failed E2E packs during release qualification

### DIFF
--- a/.github/workflows/production-e2e.yml
+++ b/.github/workflows/production-e2e.yml
@@ -275,6 +275,20 @@ jobs:
             echo "::warning::Deployed E2E runner cannot exclude packs; retaining the Museum E2E pack."
             MUSEUM_E2E_REQUIRED=true
           fi
+          if [ -n "${runner_capabilities:-}" ] &&
+            jq -e '
+              .contract == "release-bus-e2e-runner-capabilities.v1" and
+              .features.serial_failed_pack_retry == {
+                version: 1,
+                max_retries: 1
+              }
+            ' <<< "$runner_capabilities" >/dev/null
+          then
+            args+=(--retry-failed-packs 1)
+            echo "SERIAL_FAILED_PACK_RETRY=true" >> "$GITHUB_ENV"
+          else
+            echo "SERIAL_FAILED_PACK_RETRY=false" >> "$GITHUB_ENV"
+          fi
           echo "MUSEUM_E2E_REQUIRED=$MUSEUM_E2E_REQUIRED" >> "$GITHUB_ENV"
           ./bin/6529 run e2e:packs -- "${args[@]}"
       - name: Validate exact production E2E evidence
@@ -300,7 +314,7 @@ jobs:
           process.stdout.write(JSON.stringify(keys));
           NODE
           )"
-          jq -e --argjson expected "$expected_inventory" '
+          jq -e --argjson expected "$expected_inventory" --argjson retry "$SERIAL_FAILED_PACK_RETRY" '
             .schema_version == "release-bus-e2e-packs.v1" and
             .environment == "production" and
             .trigger == "post-deploy" and
@@ -309,6 +323,21 @@ jobs:
             (.results | map(.script_key)) == $expected and
             (.results | map(.script_key) | unique | length) == .pack_count and
             (.results | all(.safety == "readonly")) and
+            (if $retry then
+              .serial_retry_limit == 1 and
+              (.results | all(
+                .attempt_count == (.attempts | length) and
+                .attempt_count >= 1 and .attempt_count <= 2 and
+                (.attempts | to_entries | all(.value.attempt == (.key + 1))) and
+                .status == .attempts[-1].status and
+                .failure_class == .attempts[-1].failure_class and
+                .detail == .attempts[-1].detail and
+                .artifact_path == .attempts[-1].artifact_path and
+                .duration_ms == ([.attempts[].duration_ms] | add)
+              ))
+            else
+              (.serial_retry_limit // 0) == 0
+            end) and
             .failed_count == ([.results[] | select(.status == "failed")] | length) and
             .infrastructure_failure_count == ([.results[] | select(.failure_class == "infrastructure")] | length)
           ' production-e2e-artifacts/evidence.json >/dev/null

--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -456,6 +456,20 @@ jobs:
           then
             pack_exclusion_supported=true
           fi
+          if [ -n "${runner_capabilities:-}" ] &&
+            jq -e '
+              .contract == "release-bus-e2e-runner-capabilities.v1" and
+              .features.serial_failed_pack_retry == {
+                version: 1,
+                max_retries: 1
+              }
+            ' <<< "$runner_capabilities" >/dev/null
+          then
+            args+=(--retry-failed-packs 1)
+            echo "SERIAL_FAILED_PACK_RETRY=true" >> "$GITHUB_ENV"
+          else
+            echo "SERIAL_FAILED_PACK_RETRY=false" >> "$GITHUB_ENV"
+          fi
           if [ "${SELECTED_PACK:-all}" != all ]; then
             args+=(--pack "$SELECTED_PACK")
           elif [ "$MUSEUM_E2E_REQUIRED" = false ]; then
@@ -494,7 +508,7 @@ jobs:
           process.stdout.write(JSON.stringify(keys));
           NODE
           )"
-          jq -e --argjson expected "$expected_inventory" '
+          jq -e --argjson expected "$expected_inventory" --argjson retry "$SERIAL_FAILED_PACK_RETRY" '
             .schema_version == "release-bus-e2e-packs.v1" and
             .environment == "staging" and
             .trigger == "post-deploy" and
@@ -503,6 +517,21 @@ jobs:
             (.results | map(.script_key)) == $expected and
             (.results | map(.script_key) | unique | length) == .pack_count and
             (.results | all(.safety == "readonly")) and
+            (if $retry then
+              .serial_retry_limit == 1 and
+              (.results | all(
+                .attempt_count == (.attempts | length) and
+                .attempt_count >= 1 and .attempt_count <= 2 and
+                (.attempts | to_entries | all(.value.attempt == (.key + 1))) and
+                .status == .attempts[-1].status and
+                .failure_class == .attempts[-1].failure_class and
+                .detail == .attempts[-1].detail and
+                .artifact_path == .attempts[-1].artifact_path and
+                .duration_ms == ([.attempts[].duration_ms] | add)
+              ))
+            else
+              (.serial_retry_limit // 0) == 0
+            end) and
             .failed_count == ([.results[] | select(.status == "failed")] | length) and
             .infrastructure_failure_count == ([.results[] | select(.failure_class == "infrastructure")] | length)
           ' staging-e2e-artifacts/evidence.json >/dev/null

--- a/__tests__/scripts/e2e-packs.test.ts
+++ b/__tests__/scripts/e2e-packs.test.ts
@@ -36,6 +36,10 @@ const runner = require("../../scripts/e2e-packs.cjs") as {
       pack_exclusion: {
         version: number;
       };
+      serial_failed_pack_retry: {
+        version: number;
+        max_retries: number;
+      };
     };
   };
   assertParallelSafe: (packs: Pack[], parallel: number) => void;
@@ -56,6 +60,7 @@ const runner = require("../../scripts/e2e-packs.cjs") as {
     excludePacks: string[];
     artifactRoot: string | null;
     parallel: number;
+    retryFailedPacks: number;
     capabilities: boolean;
     list: boolean;
     forward: string[];
@@ -82,6 +87,7 @@ const runner = require("../../scripts/e2e-packs.cjs") as {
       environment?: string;
       trigger?: string;
       parallel?: number;
+      retryFailedPacks?: number;
       forward: string[];
       spawn: (
         pack: Pack,
@@ -89,7 +95,13 @@ const runner = require("../../scripts/e2e-packs.cjs") as {
         outputPaths: { root: string; testResults: string; report: string }
       ) => SpawnResult | Promise<SpawnResult>;
       cleanup: (pack: Pack) => void;
-      preserve: (artifactRoot: string, pack: Pack, output: string) => string;
+      preserve: (
+        artifactRoot: string,
+        pack: Pack,
+        output: string,
+        outputPaths: { root: string; testResults: string; report: string },
+        attempt: number
+      ) => string;
       prepare: (artifactRoot: string) => void;
     }
   ) => Promise<{
@@ -98,7 +110,17 @@ const runner = require("../../scripts/e2e-packs.cjs") as {
     evidence: {
       parallelism_requested: number;
       worker_count: number;
-      results: Array<{ script_key: string; failure_class: string | null }>;
+      results: Array<{
+        script_key: string;
+        status: string;
+        failure_class: string | null;
+        attempt_count: number;
+        attempts: Array<{
+          attempt: number;
+          status: string;
+          failure_class: string | null;
+        }>;
+      }>;
     };
   }>;
   runProcessGroup: (
@@ -157,6 +179,8 @@ describe("manifest-driven E2E runner", () => {
         "artifacts/e2e",
         "--parallel",
         "3",
+        "--retry-failed-packs",
+        "1",
         "--shard",
         "1/2",
         "--list",
@@ -168,6 +192,7 @@ describe("manifest-driven E2E runner", () => {
       excludePacks: ["museum-institutional-practice"],
       artifactRoot: "artifacts/e2e",
       parallel: 3,
+      retryFailedPacks: 1,
       capabilities: false,
       list: true,
       forward: ["--shard=1/2"],
@@ -184,6 +209,9 @@ describe("manifest-driven E2E runner", () => {
     expect(() => runner.parseArgs(["--parallel", "5"])).toThrow(
       "--parallel must be between 1 and 4"
     );
+    expect(() => runner.parseArgs(["--retry-failed-packs", "2"])).toThrow(
+      "--retry-failed-packs must be 0 or 1"
+    );
   });
 
   it("reports an explicit versioned parallel-runner capability without requiring an environment", () => {
@@ -197,11 +225,16 @@ describe("manifest-driven E2E runner", () => {
         pack_exclusion: {
           version: 1,
         },
+        serial_failed_pack_retry: {
+          version: 1,
+          max_retries: 1,
+        },
       },
     });
     expect(runner.parseArgs(["--capabilities"])).toMatchObject({
       env: null,
       parallel: 1,
+      retryFailedPacks: 0,
       capabilities: true,
     });
     const result = spawnSync(
@@ -387,6 +420,104 @@ describe("manifest-driven E2E runner", () => {
       } else {
         process.env["GITHUB_STEP_SUMMARY"] = previousSummary;
       }
+      fs.rmSync(summaryDir, { recursive: true, force: true });
+    }
+  });
+
+  it("retries only failed packs once in serial and preserves both attempts", async () => {
+    const summaryDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-retry-"));
+    const packs = [
+      samplePacks[0]!,
+      {
+        ...samplePacks[0]!,
+        scriptKey: "test:e2e:staging:second-readonly",
+      },
+      {
+        ...samplePacks[0]!,
+        scriptKey: "test:e2e:staging:third-readonly",
+      },
+    ];
+    const calls = new Map<string, number>();
+    let active = 0;
+    let peak = 0;
+    const retryOrder: string[] = [];
+
+    try {
+      const result = await runner.runPacks(packs, {
+        artifactRoot: path.join(summaryDir, "staging-e2e-artifacts"),
+        environment: "staging",
+        trigger: "post-deploy",
+        parallel: 3,
+        retryFailedPacks: 1,
+        forward: [],
+        spawn: async (pack, _forward, outputPaths) => {
+          const call = (calls.get(pack.scriptKey) ?? 0) + 1;
+          calls.set(pack.scriptKey, call);
+          active += 1;
+          peak = Math.max(peak, active);
+          if (call === 2) {
+            retryOrder.push(pack.scriptKey);
+            expect(active).toBe(1);
+            expect(outputPaths.root).toContain("attempt-2");
+          }
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          active -= 1;
+          const persistentFailure = pack.scriptKey.includes("second");
+          const transientFailure =
+            pack.scriptKey.includes("smoke") && call === 1;
+          return {
+            status: persistentFailure || transientFailure ? 1 : 0,
+            signal: null,
+            stdout: `attempt ${call}`,
+            stderr: "",
+          };
+        },
+        cleanup: () => undefined,
+        preserve: (_artifactRoot, pack, _output, _paths, attempt) =>
+          `staging-e2e-artifacts/${pack.alias ?? pack.scriptKey}/attempt-${attempt}`,
+        prepare: (artifactRoot) =>
+          fs.mkdirSync(artifactRoot, { recursive: true }),
+      });
+
+      expect(peak).toBe(3);
+      expect(retryOrder).toEqual([
+        "test:e2e:staging:smoke",
+        "test:e2e:staging:second-readonly",
+      ]);
+      expect(Object.fromEntries(calls)).toEqual({
+        "test:e2e:staging:smoke": 2,
+        "test:e2e:staging:second-readonly": 2,
+        "test:e2e:staging:third-readonly": 1,
+      });
+      expect(result).toMatchObject({
+        failedCount: 1,
+        infrastructureFailureCount: 0,
+        evidence: {
+          serial_retry_limit: 1,
+          results: [
+            {
+              script_key: "test:e2e:staging:smoke",
+              status: "passed",
+              attempt_count: 2,
+              attempts: [
+                { attempt: 1, status: "failed", failure_class: "e2e" },
+                { attempt: 2, status: "passed", failure_class: null },
+              ],
+            },
+            {
+              script_key: "test:e2e:staging:second-readonly",
+              status: "failed",
+              attempt_count: 2,
+            },
+            {
+              script_key: "test:e2e:staging:third-readonly",
+              status: "passed",
+              attempt_count: 1,
+            },
+          ],
+        },
+      });
+    } finally {
       fs.rmSync(summaryDir, { recursive: true, force: true });
     }
   });

--- a/__tests__/scripts/release-bus-performance-contract.test.ts
+++ b/__tests__/scripts/release-bus-performance-contract.test.ts
@@ -470,6 +470,10 @@ describe("Release Bus frontend performance contract", () => {
     expect(productionSource).toContain(
       "exec node scripts/e2e-packs.cjs --capabilities"
     );
+    expect(stagingSource).toContain("args+=(--retry-failed-packs 1)");
+    expect(productionSource).toContain("args+=(--retry-failed-packs 1)");
+    expect(stagingSource).toContain("serial_failed_pack_retry");
+    expect(productionSource).toContain("serial_failed_pack_retry");
     expect(stagingSource).toContain(
       '.contract == "release-bus-e2e-runner-capabilities.v1"'
     );
@@ -509,6 +513,9 @@ describe("Release Bus frontend performance contract", () => {
         "(.results | map(.script_key) | unique | length) == .pack_count"
       );
       expect(source).toContain('(.results | all(.safety == "readonly"))');
+      expect(source).toContain("SERIAL_FAILED_PACK_RETRY");
+      expect(source).toContain(".attempt_count == (.attempts | length)");
+      expect(source).toContain(".status == .attempts[-1].status");
       expect(source).toContain(
         '.results | all(.status == "passed" and .failure_class == null)'
       );

--- a/ops/workstreams/ci-release-acceleration/active-context.md
+++ b/ops/workstreams/ci-release-acceleration/active-context.md
@@ -1,18 +1,20 @@
 # Active context
 
-- Current branch: `codex/e2e-soft-route-retry`.
+- Current branch: `codex/e2e-pack-targeted-rerun`.
 - Current base: frontend main
-  `1b88da6214d1c97c6a22ea40e8e7e0d5285dcd0d`.
+  `5b03302719b306b29582d43f6910fd1a843de1f7`.
 - The accelerated pipeline is live. Merge-to-production was 27m38s and
   merge-to-complete-production-E2E was 38m46s. Production promotion fell from
   22m12s to 5m16s; the final PR gate fell from 45m09s to a 10m34s longest lane.
 - Exact live production and its automatic 12-pack E2E are green. Durable run
   references are staging 30965170461 and production 30965872983.
-- PR #3599 is merged as `8c7f0daec20d3d4d226ebfef74e4d6a7dbe2e189`.
-  Its production prebuild is running. Keys and Gates staging Museum coverage
-  passed, but two independent collections runs observed different HTTP 200
-  soft-error documents. This branch adds one bounded retry for those documents;
-  persistent error/404 pages remain release-blocking.
-- Required release work: merge this narrow harness repair, deploy exact main to
-  staging, obtain green automatic E2E, promote the exact production prebuild,
-  obtain green automatic production E2E, then live readback and closeout.
+- The first staging qualification of current main failed collections while an
+  immediate isolated replay passed 20/20. The hosted retry passed collections
+  but failed social while an immediate isolated replay passed 12/12. Both
+  Museum packs passed on both hosted attempts.
+- This branch keeps the three-worker first pass and adds one serial rerun of
+  failed packs with per-attempt evidence. Persistent failures remain blocking.
+- Required release work: open and qualify the targeted-retry PR, merge it,
+  deploy exact main to staging, obtain green automatic E2E, promote the exact
+  production prebuild, obtain green automatic production E2E, then live
+  readback and closeout.

--- a/ops/workstreams/ci-release-acceleration/release-duration-audit.md
+++ b/ops/workstreams/ci-release-acceleration/release-duration-audit.md
@@ -166,3 +166,27 @@ new exact tree with the most recent prior successful production deployment and
 uses the same centralized Museum path classifier as PR and staging. It fails
 closed: missing history, an invalid range, a Git failure, or an older runner
 without pack exclusion retains Museum coverage.
+
+## Qualification feedback: retry the failed pack, not the release
+
+The first full staging qualification of main `5b03302719b306b29582d43f6910fd1a843de1f7`
+exposed a second-order effect of pack parallelism. Run 30972152707 attempt 1
+executed fourteen packs with three workers. Thirteen packs passed, including
+both Museum packs. The collections pack received persistent `6529 Error` and
+`404 | PAGE NOT FOUND` documents from several NextGen routes. An immediate
+isolated replay against the same deployment passed 20/20 in 77 seconds.
+
+Attempt 2 again passed thirteen packs, including collections and both Museum
+packs, but the social pack received a persistent `6529 Error` document for the
+public profile route. Its immediate isolated replay passed 12/12 in 36 seconds.
+The failure moved between unrelated packs while each failed pack passed in
+isolation. That evidence is consistent with transient staging service pressure,
+not a source regression. The gate correctly blocked production in both cases,
+but rerunning all fourteen packs repeated more than thirteen minutes of work.
+
+The pack runner now retains the three-worker first pass and supports one
+capability-negotiated serial retry of failed packs. Every attempt has a separate
+artifact path and structured evidence entry. A pack is green only if its final
+attempt passes; a persistent second failure remains release-blocking. This
+keeps the broad quality gate while replacing an all-pack workflow rerun with a
+bounded retry of only the work that failed.

--- a/ops/workstreams/ci-release-acceleration/run-log.md
+++ b/ops/workstreams/ci-release-acceleration/run-log.md
@@ -138,3 +138,15 @@
   second HTTP 200 soft failure (`404 | PAGE NOT FOUND`) on the collection-art
   route. The existing retry recognized only HTTP 502/503/504. Route readiness
   now retries either soft failure document once, then blocks on persistence.
+- Full staging qualification run 30972152707 attempt 1 passed thirteen of
+  fourteen packs, including both Museum packs. Collections failed on persistent
+  NextGen soft-error documents; an immediate isolated replay passed 20/20 in
+  77 seconds. Attempt 2 passed collections and both Museum packs but failed the
+  social pack on a public-profile `6529 Error`; its immediate isolated replay
+  passed 12/12 in 36 seconds.
+- Added one capability-negotiated serial retry for failed E2E packs after the
+  bounded parallel first pass. Only failed packs rerun. Per-attempt logs and
+  classifications are preserved, and a persistent retry failure still blocks
+  the release. Focused runner and performance contracts pass 31/31; changed
+  lint, application/test/Playwright typechecks, manifest sync, and Debt Ratchet
+  are green.

--- a/scripts/e2e-packs.cjs
+++ b/scripts/e2e-packs.cjs
@@ -31,6 +31,10 @@ const RUNNER_CAPABILITIES = Object.freeze({
     pack_exclusion: Object.freeze({
       version: 1,
     }),
+    serial_failed_pack_retry: Object.freeze({
+      version: 1,
+      max_retries: 1,
+    }),
   }),
 });
 
@@ -42,6 +46,7 @@ function parseArgs(argv) {
     excludePacks: [],
     artifactRoot: null,
     parallel: 1,
+    retryFailedPacks: 0,
     capabilities: false,
     list: false,
     forward: [],
@@ -55,7 +60,8 @@ function parseArgs(argv) {
       arg === "--pack" ||
       arg === "--exclude-pack" ||
       arg === "--artifact-root" ||
-      arg === "--parallel"
+      arg === "--parallel" ||
+      arg === "--retry-failed-packs"
     ) {
       const value = argv[index + 1];
       if (!value || value.startsWith("--")) {
@@ -68,6 +74,11 @@ function parseArgs(argv) {
           );
         }
         options.parallel = Number(value);
+      } else if (arg === "--retry-failed-packs") {
+        if (!/^[01]$/.test(value)) {
+          throw new Error("--retry-failed-packs must be 0 or 1.");
+        }
+        options.retryFailedPacks = Number(value);
       } else if (arg === "--exclude-pack") {
         options.excludePacks.push(value);
       } else {
@@ -220,9 +231,10 @@ function resolveArtifactRoot(relativePath) {
   return resolveInsideRoot(relativePath, "--artifact-root");
 }
 
-function outputPathsForPack(pack) {
+function outputPathsForPack(pack, attempt = 1) {
+  const suffix = attempt === 1 ? "" : `-attempt-${attempt}`;
   const root = resolveInsideRoot(
-    `${TRANSIENT_ROOT}/${packSlug(pack.scriptKey)}`,
+    `${TRANSIENT_ROOT}/${packSlug(pack.scriptKey)}${suffix}`,
     "pack output root"
   );
   return {
@@ -247,11 +259,21 @@ function cleanupPackOutputs(pack, outputPaths = outputPathsForPack(pack)) {
   fs.mkdirSync(outputPaths.root, { recursive: true });
 }
 
-function preserveArtifacts(artifactRoot, pack, output, outputPaths) {
+function preserveArtifacts(
+  artifactRoot,
+  pack,
+  output,
+  outputPaths,
+  attempt = 1
+) {
   if (!artifactRoot) {
     return null;
   }
-  const packRoot = path.join(artifactRoot, packSlug(pack.scriptKey));
+  const packRoot = path.join(
+    artifactRoot,
+    packSlug(pack.scriptKey),
+    ...(attempt === 1 ? [] : [`attempt-${attempt}`])
+  );
   fs.mkdirSync(packRoot, { recursive: true });
   fs.writeFileSync(path.join(packRoot, "output.log"), output);
   if (fs.existsSync(outputPaths.testResults)) {
@@ -489,10 +511,10 @@ function releaseBindingFromEnvironment() {
 
 async function runOnePack(
   pack,
-  { artifactRoot, forward, spawn, cleanup, preserve }
+  { artifactRoot, forward, spawn, cleanup, preserve, attempt = 1 }
 ) {
   const startedAt = new Date();
-  const outputPaths = outputPathsForPack(pack);
+  const outputPaths = outputPathsForPack(pack, attempt);
   let cleanupError = null;
   try {
     await cleanup(pack, outputPaths);
@@ -525,7 +547,13 @@ async function runOnePack(
 
   let artifactPath = null;
   try {
-    artifactPath = await preserve(artifactRoot, pack, output, outputPaths);
+    artifactPath = await preserve(
+      artifactRoot,
+      pack,
+      output,
+      outputPaths,
+      attempt
+    );
   } catch (error) {
     const artifactError =
       error instanceof Error ? error : new Error(String(error));
@@ -541,6 +569,7 @@ async function runOnePack(
     output,
     artifactPath,
     classification,
+    attempt,
     startedAt: startedAt.toISOString(),
     durationMs: Date.now() - startedAt.getTime(),
   };
@@ -553,6 +582,7 @@ async function runPacks(
     environment = null,
     trigger = null,
     parallel = 1,
+    retryFailedPacks = 0,
     forward = [],
     spawn = defaultSpawn,
     cleanup = cleanupPackOutputs,
@@ -561,6 +591,13 @@ async function runPacks(
   } = {}
 ) {
   assertParallelSafe(resolved, parallel);
+  if (
+    !Number.isInteger(retryFailedPacks) ||
+    retryFailedPacks < 0 ||
+    retryFailedPacks > 1
+  ) {
+    throw new Error("retryFailedPacks must be 0 or 1.");
+  }
   const releaseBinding = releaseBindingFromEnvironment();
   prepare(artifactRoot);
   const startedAt = new Date();
@@ -577,6 +614,7 @@ async function runPacks(
         spawn,
         cleanup,
         preserve,
+        attempt: 1,
       });
     }
   }
@@ -584,19 +622,65 @@ async function runPacks(
   const workerCount = Math.min(parallel, resolved.length);
   await Promise.all(Array.from({ length: workerCount }, () => worker()));
 
+  for (let index = 0; index < records.length; index += 1) {
+    const attempts = [records[index]];
+    for (
+      let retry = 1;
+      attempts.at(-1).classification.failed && retry <= retryFailedPacks;
+      retry += 1
+    ) {
+      const attempt = retry + 1;
+      console.warn(
+        `e2e-packs: serial retry ${retry}/${retryFailedPacks} for ${resolved[index].scriptKey}.`
+      );
+      attempts.push(
+        await runOnePack(resolved[index], {
+          artifactRoot,
+          forward,
+          spawn,
+          cleanup,
+          preserve,
+          attempt,
+        })
+      );
+    }
+    const finalAttempt = attempts.at(-1);
+    records[index] = {
+      ...finalAttempt,
+      durationMs: attempts.reduce(
+        (sum, attempt) => sum + attempt.durationMs,
+        0
+      ),
+      attempts,
+    };
+  }
+
   appendSummary(["## E2E packs", ""]);
   let failedCount = 0;
   let infrastructureFailureCount = 0;
   for (const record of records) {
-    const { pack, output, artifactPath, classification } = record;
+    const { pack, output, classification } = record;
     console.log(`\n=== ${pack.scriptKey} ===`);
-    if (output) {
-      process.stdout.write(output.endsWith("\n") ? output : `${output}\n`);
+    for (const attempt of record.attempts) {
+      if (record.attempts.length > 1) {
+        console.log(
+          `--- attempt ${attempt.attempt}/${record.attempts.length} ---`
+        );
+      }
+      if (attempt.output) {
+        process.stdout.write(
+          attempt.output.endsWith("\n") ? attempt.output : `${attempt.output}\n`
+        );
+      }
     }
     if (!classification.failed) {
       appendSummary([
-        `- :white_check_mark: \`${pack.scriptKey}\` (${record.durationMs} ms)`,
-        ...(artifactPath ? [`  - Artifacts: \`${artifactPath}/\``] : []),
+        `- :white_check_mark: \`${pack.scriptKey}\` (${record.durationMs} ms; ${record.attempts.length} attempt${record.attempts.length === 1 ? "" : "s"})`,
+        ...record.attempts.flatMap((attempt) =>
+          attempt.artifactPath
+            ? [`  - Attempt ${attempt.attempt}: \`${attempt.artifactPath}/\``]
+            : []
+        ),
       ]);
       continue;
     }
@@ -606,8 +690,12 @@ async function runPacks(
     }
     const tail = outputTail(output);
     appendSummary([
-      `- :x: \`${pack.scriptKey}\` (${classification.label}; ${record.durationMs} ms)`,
-      ...(artifactPath ? [`  - Artifacts: \`${artifactPath}/\``] : []),
+      `- :x: \`${pack.scriptKey}\` (${classification.label}; ${record.durationMs} ms; ${record.attempts.length} attempt${record.attempts.length === 1 ? "" : "s"})`,
+      ...record.attempts.flatMap((attempt) =>
+        attempt.artifactPath
+          ? [`  - Attempt ${attempt.attempt}: \`${attempt.artifactPath}/\``]
+          : []
+      ),
       ...(tail
         ? [
             "",
@@ -630,6 +718,7 @@ async function runPacks(
     trigger,
     parallelism_requested: parallel,
     worker_count: workerCount,
+    serial_retry_limit: retryFailedPacks,
     started_at: startedAt.toISOString(),
     completed_at: new Date().toISOString(),
     release_binding: releaseBinding,
@@ -648,6 +737,19 @@ async function runPacks(
       detail: record.classification.label,
       duration_ms: record.durationMs,
       artifact_path: record.artifactPath,
+      attempt_count: record.attempts.length,
+      attempts: record.attempts.map((attempt) => ({
+        attempt: attempt.attempt,
+        status: attempt.classification.failed ? "failed" : "passed",
+        failure_class: attempt.classification.failed
+          ? attempt.classification.infrastructure
+            ? "infrastructure"
+            : "e2e"
+          : null,
+        detail: attempt.classification.label,
+        duration_ms: attempt.durationMs,
+        artifact_path: attempt.artifactPath,
+      })),
     })),
   };
   if (artifactRoot) {
@@ -666,6 +768,7 @@ function printUsage() {
       "[--pack <scriptKey|alias|all>] [--exclude-pack <scriptKey|alias>] " +
       "[--artifact-root <path>] " +
       `[--parallel <1-${MAX_PARALLEL_PACKS}>] [--shard i/N] [--list] ` +
+      "[--retry-failed-packs <0|1>] " +
       "[--capabilities]"
   );
 }
@@ -736,6 +839,7 @@ async function main() {
       environment: options.env,
       trigger: options.trigger,
       parallel: options.parallel,
+      retryFailedPacks: options.retryFailedPacks,
       forward: options.forward,
     });
     if (result.failedCount > 0) {


### PR DESCRIPTION
## Outcome

Keeps the three-worker first pass for staging and production E2E, then reruns only failed packs once in serial. A persistent second failure remains release-blocking.

## Why

Staging run 30972152707 passed 13/14 packs twice, with the failure moving from collections to social. Each failed pack immediately passed in isolation. Re-running all 14 packs repeated more than thirteen minutes of successful work each time.

## Integrity

- capability-negotiated for rollback compatibility
- maximum one retry
- independent transient output roots and retained artifacts per attempt
- exact contiguous attempt ledger validated by both workflows
- final evidence must match the last attempt
- persistent E2E or infrastructure failure still blocks

## Local verification

- 31/31 focused runner and release-performance contract tests
- changed lint
- application, Jest-ratchet, and Playwright typechecks
- E2E manifest sync
- Debt Ratchet
- Prettier, syntax, and whitespace checks

Museum pages and product runtime are unchanged.