### PR TITLE
Scope every Museum E2E pack to Museum changes

### DIFF
--- a/.github/workflows/production-e2e.yml
+++ b/.github/workflows/production-e2e.yml
@@ -271,10 +271,12 @@ jobs:
             if [ "$MUSEUM_E2E_REQUIRED" = false ]; then
               museum_pack_aliases="$(./bin/6529 exec node - <<'NODE'
           const { PACKS } = require("./tests/packs.manifest.cjs");
+          const isMuseumPack = (pack) =>
+            pack.changeScope === "museum" || /^museum-/.test(pack.alias ?? "");
           const aliases = PACKS.filter((pack) =>
             pack.environments.includes("production") &&
             pack.triggers.includes("post-deploy") &&
-            (pack.changeScope === "museum" || /^museum-/.test(pack.alias ?? ""))
+            isMuseumPack(pack)
           ).map((pack) => pack.alias ?? pack.scriptKey);
           if (aliases.length === 0) {
             process.stderr.write("No production Museum packs were identified.\n");
@@ -322,13 +324,12 @@ jobs:
           expected_inventory="$(./bin/6529 exec node - <<'NODE'
           const { PACKS } = require("./tests/packs.manifest.cjs");
           const museumRequired = process.env.MUSEUM_E2E_REQUIRED !== "false";
+          const isMuseumPack = (pack) =>
+            pack.changeScope === "museum" || /^museum-/.test(pack.alias ?? "");
           const keys = PACKS.filter((pack) =>
             pack.environments.includes("production") &&
             pack.triggers.includes("post-deploy") &&
-            (museumRequired || (
-              pack.changeScope !== "museum" &&
-              !/^museum-/.test(pack.alias ?? "")
-            ))
+            (museumRequired || !isMuseumPack(pack))
           ).map((pack) => pack.scriptKey);
           process.stdout.write(JSON.stringify(keys));
           NODE

--- a/.github/workflows/production-e2e.yml
+++ b/.github/workflows/production-e2e.yml
@@ -269,10 +269,26 @@ jobs:
           then
             args+=(--parallel 3)
             if [ "$MUSEUM_E2E_REQUIRED" = false ]; then
-              args+=(--exclude-pack museum-institutional-practice)
+              museum_pack_aliases="$(./bin/6529 exec node - <<'NODE'
+          const { PACKS } = require("./tests/packs.manifest.cjs");
+          const aliases = PACKS.filter((pack) =>
+            pack.environments.includes("production") &&
+            pack.triggers.includes("post-deploy") &&
+            (pack.changeScope === "museum" || /^museum-/.test(pack.alias ?? ""))
+          ).map((pack) => pack.alias ?? pack.scriptKey);
+          if (aliases.length === 0) {
+            process.stderr.write("No production Museum packs were identified.\n");
+            process.exit(1);
+          }
+          process.stdout.write(aliases.join("\n"));
+          NODE
+              )"
+              while IFS= read -r museum_pack_alias; do
+                args+=(--exclude-pack "$museum_pack_alias")
+              done <<< "$museum_pack_aliases"
             fi
           elif [ "$MUSEUM_E2E_REQUIRED" = false ]; then
-            echo "::warning::Deployed E2E runner cannot exclude packs; retaining the Museum E2E pack."
+            echo "::warning::Deployed E2E runner cannot exclude packs; retaining all Museum E2E packs."
             MUSEUM_E2E_REQUIRED=true
           fi
           if [ -n "${runner_capabilities:-}" ] &&
@@ -309,7 +325,10 @@ jobs:
           const keys = PACKS.filter((pack) =>
             pack.environments.includes("production") &&
             pack.triggers.includes("post-deploy") &&
-            (museumRequired || pack.alias !== "museum-institutional-practice")
+            (museumRequired || (
+              pack.changeScope !== "museum" &&
+              !/^museum-/.test(pack.alias ?? "")
+            ))
           ).map((pack) => pack.scriptKey);
           process.stdout.write(JSON.stringify(keys));
           NODE

--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -476,10 +476,12 @@ jobs:
             if [ "$pack_exclusion_supported" = true ]; then
               museum_pack_aliases="$(./bin/6529 exec node - <<'NODE'
           const { PACKS } = require("./tests/packs.manifest.cjs");
+          const isMuseumPack = (pack) =>
+            pack.changeScope === "museum" || /^museum-/.test(pack.alias ?? "");
           const aliases = PACKS.filter((pack) =>
             pack.environments.includes("staging") &&
             pack.triggers.includes("post-deploy") &&
-            (pack.changeScope === "museum" || /^museum-/.test(pack.alias ?? ""))
+            isMuseumPack(pack)
           ).map((pack) => pack.alias ?? pack.scriptKey);
           if (aliases.length === 0) {
             process.stderr.write("No staging Museum packs were identified.\n");
@@ -515,13 +517,12 @@ jobs:
           const { PACKS } = require("./tests/packs.manifest.cjs");
           const selected = process.env.SELECTED_PACK || "all";
           const museumRequired = process.env.MUSEUM_E2E_REQUIRED !== "false";
+          const isMuseumPack = (pack) =>
+            pack.changeScope === "museum" || /^museum-/.test(pack.alias ?? "");
           const keys = PACKS.filter((pack) =>
             pack.environments.includes("staging") &&
             pack.triggers.includes("post-deploy") &&
-            (museumRequired || (
-              pack.changeScope !== "museum" &&
-              !/^museum-/.test(pack.alias ?? "")
-            )) &&
+            (museumRequired || !isMuseumPack(pack)) &&
             (selected === "all" || pack.scriptKey === selected || pack.alias === selected)
           ).map((pack) => pack.scriptKey);
           process.stdout.write(JSON.stringify(keys));

--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -474,9 +474,25 @@ jobs:
             args+=(--pack "$SELECTED_PACK")
           elif [ "$MUSEUM_E2E_REQUIRED" = false ]; then
             if [ "$pack_exclusion_supported" = true ]; then
-              args+=(--exclude-pack museum-institutional-practice)
+              museum_pack_aliases="$(./bin/6529 exec node - <<'NODE'
+          const { PACKS } = require("./tests/packs.manifest.cjs");
+          const aliases = PACKS.filter((pack) =>
+            pack.environments.includes("staging") &&
+            pack.triggers.includes("post-deploy") &&
+            (pack.changeScope === "museum" || /^museum-/.test(pack.alias ?? ""))
+          ).map((pack) => pack.alias ?? pack.scriptKey);
+          if (aliases.length === 0) {
+            process.stderr.write("No staging Museum packs were identified.\n");
+            process.exit(1);
+          }
+          process.stdout.write(aliases.join("\n"));
+          NODE
+              )"
+              while IFS= read -r museum_pack_alias; do
+                args+=(--exclude-pack "$museum_pack_alias")
+              done <<< "$museum_pack_aliases"
             else
-              echo "::warning::Deployed E2E runner cannot exclude packs; retaining the Museum E2E pack."
+              echo "::warning::Deployed E2E runner cannot exclude packs; retaining all Museum E2E packs."
               MUSEUM_E2E_REQUIRED=true
             fi
           fi
@@ -502,7 +518,10 @@ jobs:
           const keys = PACKS.filter((pack) =>
             pack.environments.includes("staging") &&
             pack.triggers.includes("post-deploy") &&
-            (museumRequired || pack.alias !== "museum-institutional-practice") &&
+            (museumRequired || (
+              pack.changeScope !== "museum" &&
+              !/^museum-/.test(pack.alias ?? "")
+            )) &&
             (selected === "all" || pack.scriptKey === selected || pack.alias === selected)
           ).map((pack) => pack.scriptKey);
           process.stdout.write(JSON.stringify(keys));

--- a/__tests__/scripts/e2e-packs.test.ts
+++ b/__tests__/scripts/e2e-packs.test.ts
@@ -911,6 +911,9 @@ describe("E2E runner CLI resolution", () => {
       )
     ).toBe(true);
     expect(
+      museumPacks.filter((pack) => pack.environments[0] === "local")
+    ).toHaveLength(2);
+    expect(
       museumPacks.filter((pack) => pack.environments[0] === "staging")
     ).toHaveLength(2);
     expect(

--- a/__tests__/scripts/e2e-packs.test.ts
+++ b/__tests__/scripts/e2e-packs.test.ts
@@ -14,6 +14,7 @@ type Pack = {
   specs?: string[];
   projects?: string[];
   timeoutMinutes: number;
+  changeScope?: "museum";
 };
 
 type SpawnResult = {
@@ -896,5 +897,24 @@ describe("E2E runner CLI resolution", () => {
     expect(museumPacks[0]?.triggers).toEqual(["manual"]);
     expect(museumPacks[1]?.triggers).toEqual(["post-deploy", "manual"]);
     expect(museumPacks[2]?.triggers).toEqual(["post-deploy", "manual"]);
+  });
+
+  it("classifies every dedicated Museum pack across local and deployed environments", () => {
+    const museumPacks = PACKS.filter((pack) => pack.changeScope === "museum");
+
+    expect(museumPacks).toHaveLength(6);
+    expect(
+      museumPacks.every(
+        (pack) =>
+          (pack.specs?.length ?? 0) > 0 &&
+          pack.specs?.every((spec) => spec.startsWith("tests/museum/"))
+      )
+    ).toBe(true);
+    expect(
+      museumPacks.filter((pack) => pack.environments[0] === "staging")
+    ).toHaveLength(2);
+    expect(
+      museumPacks.filter((pack) => pack.environments[0] === "production")
+    ).toHaveLength(2);
   });
 });

--- a/__tests__/scripts/production-e2e-dispatch.test.ts
+++ b/__tests__/scripts/production-e2e-dispatch.test.ts
@@ -83,11 +83,12 @@ describe("automatic production E2E dispatch", () => {
       "scripts/museum-e2e-change-set.cjs"
     );
     expect(job.steps[packsIndex].run).toContain(
-      "--exclude-pack museum-institutional-practice"
+      'pack.changeScope === "museum"'
     );
-    expect(evidence.run).toContain(
-      'pack.alias !== "museum-institutional-practice"'
+    expect(job.steps[packsIndex].run).toContain(
+      'args+=(--exclude-pack "$museum_pack_alias")'
     );
+    expect(evidence.run).toContain('pack.changeScope !== "museum"');
     expect(evidence.run).toContain(".release_binding == null");
     expect(e2eSource).toContain("args+=(--parallel 3)");
     expect(e2eSource).toContain("Restore Playwright browser");

--- a/__tests__/scripts/production-e2e-dispatch.test.ts
+++ b/__tests__/scripts/production-e2e-dispatch.test.ts
@@ -88,7 +88,7 @@ describe("automatic production E2E dispatch", () => {
     expect(job.steps[packsIndex].run).toContain(
       'args+=(--exclude-pack "$museum_pack_alias")'
     );
-    expect(evidence.run).toContain('pack.changeScope !== "museum"');
+    expect(evidence.run).toContain("!isMuseumPack(pack)");
     expect(evidence.run).toContain(".release_binding == null");
     expect(e2eSource).toContain("args+=(--parallel 3)");
     expect(e2eSource).toContain("Restore Playwright browser");

--- a/__tests__/scripts/release-bus-artifact-compatibility.test.ts
+++ b/__tests__/scripts/release-bus-artifact-compatibility.test.ts
@@ -220,12 +220,15 @@ function createStrictEvidence(root: string, mergeSha: string) {
   });
   fs.writeFileSync(path.join(evidenceRoot, "manifest.json"), manifest);
   fs.writeFileSync(path.join(evidenceRoot, "policy-bundle.txt"), policyBundle);
-  fs.writeFileSync(
-    path.join(evidenceRoot, "SHA256SUMS"),
-    `${sha256(manifest)}  ./manifest.json\n${sha256(
-      policyBundle
-    )}  ./policy-bundle.txt\n`
+  const checksums = spawnSync(
+    "bash",
+    ["-c", "sha256sum ./manifest.json ./policy-bundle.txt"],
+    { cwd: evidenceRoot, encoding: "utf8" }
   );
+  if (checksums.status !== 0) {
+    throw new Error(`Unable to construct strict evidence: ${checksums.stderr}`);
+  }
+  fs.writeFileSync(path.join(evidenceRoot, "SHA256SUMS"), checksums.stdout);
   return evidenceRoot;
 }
 
@@ -343,7 +346,7 @@ set -euo pipefail
 if [ "$*" = "exec node scripts/e2e-packs.cjs --capabilities" ]; then
   case "\${MOCK_RUNNER_CAPABILITY:-old}" in
     current)
-      printf '%s\\n' '{"contract":"release-bus-e2e-runner-capabilities.v1","features":{"readonly_pack_parallelism":{"version":1,"max_parallel":4},"pack_exclusion":{"version":1}}}'
+      printf '%s\\n' '{"contract":"release-bus-e2e-runner-capabilities.v1","features":{"readonly_pack_parallelism":{"version":1,"max_parallel":4},"pack_exclusion":{"version":1},"serial_failed_pack_retry":{"version":1,"max_retries":1}}}'
       exit 0
       ;;
     incompatible)
@@ -354,6 +357,11 @@ if [ "$*" = "exec node scripts/e2e-packs.cjs --capabilities" ]; then
       exit 2
       ;;
   esac
+fi
+if [ "$*" = "exec node -" ] && [ "\${MOCK_MUSEUM_PACK_ALIASES:-0}" = 1 ]; then
+  cat >/dev/null
+  printf '%s\\n' museum-institutional-practice museum-inside-system
+  exit 0
 fi
 printf '%s\\n' "$@" > "$MOCK_6529_ARGS"
 `
@@ -746,6 +754,7 @@ describe("Release Bus artifact rollout compatibility", () => {
           GITHUB_ENV: githubEnv,
           MOCK_6529_ARGS: invocation,
           MUSEUM_E2E_REQUIRED: "false",
+          MOCK_MUSEUM_PACK_ALIASES: "1",
           SELECTED_PACK: "all",
         };
 
@@ -762,14 +771,11 @@ describe("Release Bus artifact rollout compatibility", () => {
         expect(currentArgs).toEqual(
           expect.arrayContaining(["--trigger", "post-deploy"])
         );
-        if (environment === "staging") {
-          expect(currentArgs).toEqual(
-            expect.arrayContaining([
-              "--exclude-pack",
-              "museum-institutional-practice",
-            ])
-          );
-        }
+        expect(
+          currentArgs.flatMap((arg, index) =>
+            arg === "--exclude-pack" ? [currentArgs[index + 1]] : []
+          )
+        ).toEqual(["museum-institutional-practice", "museum-inside-system"]);
 
         expect(
           runShell(step.run!, {
@@ -922,7 +928,7 @@ describe("Release Bus artifact rollout compatibility", () => {
         REUSE_ARTIFACT_DIGEST: artifactDigest,
         REUSE_ARTIFACT_NAME: artifactName,
         REUSE_ARTIFACT_RUN_ID: "1234",
-        RUNNER_TEMP: path.join(root, "runner"),
+        RUNNER_TEMP: path.join(root, "runner").replaceAll("\\", "/"),
         SOURCE_REF: "release-bus-v2/compatibility",
         TRAIN_ID,
         TRAIN_REVISION: "1",
@@ -962,7 +968,7 @@ describe("Release Bus artifact rollout compatibility", () => {
       });
       if (strictEvidenceResult.status !== 0) {
         throw new Error(
-          `strict evidence failed (${strictEvidenceResult.status}): ${strictEvidenceResult.stderr}`
+          `strict evidence failed (${strictEvidenceResult.status}): ${strictEvidenceResult.stderr}\nstdout: ${strictEvidenceResult.stdout}`
         );
       }
       expect(baseEnv.EXPECTED_SHA).not.toBe(baseEnv.MOCK_HEAD_SHA);

--- a/__tests__/scripts/release-bus-performance-contract.test.ts
+++ b/__tests__/scripts/release-bus-performance-contract.test.ts
@@ -16,6 +16,7 @@ const { PACKS: E2E_PACKS } = require("../../tests/packs.manifest.cjs") as {
     environments: string[];
     triggers: string[];
     specs?: string[];
+    changeScope?: "museum";
   }>;
 };
 
@@ -474,6 +475,36 @@ describe("Release Bus frontend performance contract", () => {
     expect(productionSource).toContain("args+=(--retry-failed-packs 1)");
     expect(stagingSource).toContain("serial_failed_pack_retry");
     expect(productionSource).toContain("serial_failed_pack_retry");
+    for (const source of [stagingSource, productionSource]) {
+      expect(source).toContain('pack.changeScope === "museum"');
+      expect(source).toContain('pack.changeScope !== "museum"');
+      expect(source).toContain('args+=(--exclude-pack "$museum_pack_alias")');
+    }
+    for (const [definition, jobName, stepName] of [
+      [staging, "staging-packs", "Run staging packs against staging.6529.io"],
+      [production, "readonly", "Run production-safe read-only packs"],
+    ] as const) {
+      const packStep = definition.jobs[jobName].steps.find(
+        (step: { name?: string }) => step.name === stepName
+      );
+      expect(
+        packStep.run
+          .split("\n")
+          .filter((line: string) => line.trim() === "NODE")
+      ).toEqual(["NODE"]);
+    }
+    const museumPacks = E2E_PACKS.filter(
+      (pack) => pack.changeScope === "museum"
+    );
+    expect(museumPacks).toHaveLength(6);
+    for (const pack of museumPacks.filter((candidate) =>
+      candidate.environments.includes("local")
+    )) {
+      expect(stagingSource).not.toContain(`./bin/6529 run ${pack.scriptKey}`);
+      expect(read(".github/workflows/app-pr-ci.yml")).toContain(
+        `./bin/6529 run ${pack.scriptKey}`
+      );
+    }
     expect(stagingSource).toContain(
       '.contract == "release-bus-e2e-runner-capabilities.v1"'
     );

--- a/__tests__/scripts/release-bus-performance-contract.test.ts
+++ b/__tests__/scripts/release-bus-performance-contract.test.ts
@@ -477,16 +477,51 @@ describe("Release Bus frontend performance contract", () => {
     expect(productionSource).toContain("serial_failed_pack_retry");
     for (const source of [stagingSource, productionSource]) {
       expect(source).toContain('pack.changeScope === "museum"');
-      expect(source).toContain('pack.changeScope !== "museum"');
+      expect(source).toContain("!isMuseumPack(pack)");
       expect(source).toContain('args+=(--exclude-pack "$museum_pack_alias")');
     }
-    for (const [definition, jobName, stepName] of [
-      [staging, "staging-packs", "Run staging packs against staging.6529.io"],
-      [production, "readonly", "Run production-safe read-only packs"],
+    for (const [definition, jobName, stepName, evidenceName] of [
+      [
+        staging,
+        "staging-packs",
+        "Run staging packs against staging.6529.io",
+        "Validate exact manifest-bound E2E evidence",
+      ],
+      [
+        production,
+        "readonly",
+        "Run production-safe read-only packs",
+        "Validate exact production E2E evidence",
+      ],
     ] as const) {
       const packStep = definition.jobs[jobName].steps.find(
         (step: { name?: string }) => step.name === stepName
       );
+      const evidenceStep = definition.jobs[jobName].steps.find(
+        (step: { name?: string }) => step.name === evidenceName
+      );
+      const predicatePattern =
+        /const isMuseumPack = \(pack\) =>\n\s*pack\.changeScope === "museum" \|\| \/\^museum-\/\.test\(pack\.alias \?\? ""\);/;
+      expect(packStep.run.match(predicatePattern)?.[0]).toBe(
+        evidenceStep.run.match(predicatePattern)?.[0]
+      );
+      const predicateSource = packStep.run.match(predicatePattern)?.[0];
+      const isMuseumPack = new Function(
+        `${predicateSource}; return isMuseumPack;`
+      )() as (pack: { alias?: string; changeScope?: string }) => boolean;
+      expect(isMuseumPack({ alias: "museum-rollback-pack" })).toBe(true);
+      expect(
+        isMuseumPack({ alias: "renamed-pack", changeScope: "museum" })
+      ).toBe(true);
+      expect(isMuseumPack({ alias: "ordinary-pack" })).toBe(false);
+      const environment =
+        jobName === "staging-packs" ? "staging" : "production";
+      for (const source of [packStep.run, evidenceStep.run]) {
+        expect(source).toContain(
+          `pack.environments.includes("${environment}")`
+        );
+        expect(source).toContain('pack.triggers.includes("post-deploy")');
+      }
       expect(
         packStep.run
           .split("\n")

--- a/__tests__/scripts/sync-e2e-manifest.test.ts
+++ b/__tests__/scripts/sync-e2e-manifest.test.ts
@@ -15,6 +15,7 @@ type Pack = {
   projects?: string[];
   workers?: number;
   timeoutMinutes: number;
+  changeScope?: "museum";
 };
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -55,6 +56,58 @@ describe("E2E pack manifest", () => {
       )
     );
     expect(checkedInE2eScripts).toEqual(rendered);
+  });
+
+  it("marks every dedicated Museum pack for change-set selection", () => {
+    const museumOnlyPacks = packs.filter(
+      (pack) =>
+        (pack.specs?.length ?? 0) > 0 &&
+        pack.specs?.every((spec) => spec.startsWith("tests/museum/"))
+    );
+
+    expect(museumOnlyPacks).toHaveLength(6);
+    expect(museumOnlyPacks.every((pack) => pack.changeScope === "museum")).toBe(
+      true
+    );
+    expect(
+      museumOnlyPacks.map((pack) => [pack.environments[0], pack.scriptKey])
+    ).toEqual([
+      ["local", "test:e2e:museum-institutional-practice"],
+      ["local", "test:e2e:museum-inside-system"],
+      ["staging", "test:e2e:staging:museum-institutional-practice"],
+      ["staging", "test:e2e:staging:museum-inside-system"],
+      ["production", "test:e2e:production:museum-institutional-practice"],
+      ["production", "test:e2e:production:museum-inside-system"],
+    ]);
+  });
+
+  it("rejects missing, unknown, or overbroad Museum change scopes", () => {
+    const museumPack = clonePack(
+      packs.find(
+        (pack) => pack.scriptKey === "test:e2e:staging:museum-inside-system"
+      ) as Pack
+    );
+    delete museumPack.changeScope;
+    expect(manifestTools.validateManifest([museumPack])).toContain(
+      'pack "test:e2e:staging:museum-inside-system": Museum-only packs must set changeScope "museum".'
+    );
+
+    const unknownScope = clonePack(museumPack);
+    Object.defineProperty(unknownScope, "changeScope", {
+      value: "other",
+      enumerable: true,
+    });
+    expect(manifestTools.validateManifest([unknownScope])).toContain(
+      'pack "test:e2e:staging:museum-inside-system": unknown changeScope "other".'
+    );
+
+    const nonMuseumPack = clonePack(
+      packs.find((pack) => pack.scriptKey === "test:e2e:staging") as Pack
+    );
+    nonMuseumPack.changeScope = "museum";
+    expect(manifestTools.validateManifest([nonMuseumPack])).toContain(
+      'pack "test:e2e:staging": changeScope "museum" requires only tests/museum specs.'
+    );
   });
 
   it("makes deployed packs explicitly read-only and non-empty", () => {

--- a/__tests__/scripts/sync-e2e-manifest.test.ts
+++ b/__tests__/scripts/sync-e2e-manifest.test.ts
@@ -70,15 +70,19 @@ describe("E2E pack manifest", () => {
       true
     );
     expect(
-      museumOnlyPacks.map((pack) => [pack.environments[0], pack.scriptKey])
-    ).toEqual([
-      ["local", "test:e2e:museum-institutional-practice"],
-      ["local", "test:e2e:museum-inside-system"],
-      ["staging", "test:e2e:staging:museum-institutional-practice"],
-      ["staging", "test:e2e:staging:museum-inside-system"],
-      ["production", "test:e2e:production:museum-institutional-practice"],
-      ["production", "test:e2e:production:museum-inside-system"],
-    ]);
+      museumOnlyPacks
+        .map((pack) => `${pack.environments[0]}:${pack.scriptKey}`)
+        .sort()
+    ).toEqual(
+      [
+        "local:test:e2e:museum-institutional-practice",
+        "local:test:e2e:museum-inside-system",
+        "production:test:e2e:production:museum-institutional-practice",
+        "production:test:e2e:production:museum-inside-system",
+        "staging:test:e2e:staging:museum-institutional-practice",
+        "staging:test:e2e:staging:museum-inside-system",
+      ].sort()
+    );
   });
 
   it("rejects missing, unknown, or overbroad Museum change scopes", () => {
@@ -107,6 +111,25 @@ describe("E2E pack manifest", () => {
     nonMuseumPack.changeScope = "museum";
     expect(manifestTools.validateManifest([nonMuseumPack])).toContain(
       'pack "test:e2e:staging": changeScope "museum" requires only tests/museum specs.'
+    );
+
+    const mixedPostDeployPack = clonePack(museumPack);
+    delete mixedPostDeployPack.changeScope;
+    mixedPostDeployPack.specs?.push("tests/home/home.spec.ts");
+    expect(manifestTools.validateManifest([mixedPostDeployPack])).toContain(
+      'pack "test:e2e:staging:museum-inside-system": post-deploy packs must not mix Museum and non-Museum specs.'
+    );
+
+    const mutatedManifest = packs.map(clonePack);
+    delete (
+      mutatedManifest.find(
+        (pack) => pack.scriptKey === "test:e2e:staging:museum-inside-system"
+      ) as Pack
+    ).changeScope;
+    expect(
+      manifestTools.validateManifest(mutatedManifest, { root: ROOT })
+    ).toContain(
+      'pack "test:e2e:staging:museum-inside-system": Museum-only packs must set changeScope "museum".'
     );
   });
 

--- a/__tests__/scripts/testing-strategy.test.ts
+++ b/__tests__/scripts/testing-strategy.test.ts
@@ -457,8 +457,9 @@ describe("testing strategy CI plan", () => {
     expect(stagingWorkflow).toContain("--trigger post-deploy");
     expect(stagingWorkflow).toContain("SELECTED_PACK");
     expect(stagingWorkflow).toContain(
-      "--exclude-pack museum-institutional-practice"
+      'args+=(--exclude-pack "$museum_pack_alias")'
     );
+    expect(stagingWorkflow).toContain("const isMuseumPack = (pack) =>");
     expect(stagingWorkflow).toContain("scripts/museum-e2e-change-set.cjs");
     expect(museumChangeSetClassifier).toContain(
       '["diff", "--no-renames", "--name-only", "-z"'

--- a/ops/workstreams/ci-release-acceleration/active-context.md
+++ b/ops/workstreams/ci-release-acceleration/active-context.md
@@ -1,8 +1,8 @@
 # Active context
 
-- Current branch: `codex/e2e-pack-targeted-rerun`.
+- Current branch: `codex/all-museum-e2e-selection`.
 - Current base: frontend main
-  `5b03302719b306b29582d43f6910fd1a843de1f7`.
+  `a36a5a437e68d03c886471caefe0bf01afc3827c`.
 - The accelerated pipeline is live. Merge-to-production was 27m38s and
   merge-to-complete-production-E2E was 38m46s. Production promotion fell from
   22m12s to 5m16s; the final PR gate fell from 45m09s to a 10m34s longest lane.
@@ -12,9 +12,15 @@
   immediate isolated replay passed 20/20. The hosted retry passed collections
   but failed social while an immediate isolated replay passed 12/12. Both
   Museum packs passed on both hosted attempts.
-- This branch keeps the three-worker first pass and adds one serial rerun of
-  failed packs with per-attempt evidence. Persistent failures remain blocking.
-- Required release work: open and qualify the targeted-retry PR, merge it,
-  deploy exact main to staging, obtain green automatic E2E, promote the exact
-  production prebuild, obtain green automatic production E2E, then live
-  readback and closeout.
+- Targeted failed-pack retry is merged as `852b43fd9dc5af86aaf75c2942aea6e490544e25`.
+  Staging run 30976430422 proved the retry contract but exposed one new Museum
+  pack outside the original single-alias exclusion.
+- Concurrent Museum shell-diagnostic PR #3602 is merged on the current base;
+  its test-only change is preserved and does not overlap this manifest fix.
+- This branch gives every dedicated Museum pack a manifest-owned change scope,
+  excludes every scoped pack on unrelated automatic releases, and ratchets
+  future `tests/museum/` packs into the same policy.
+- Required release work: qualify this manifest fix, merge it, deploy exact main
+  to staging, prove both Museum packs are absent for the tooling-only delta,
+  promote the new exact production prebuild, obtain green automatic production
+  E2E, then live readback and closeout.

--- a/ops/workstreams/ci-release-acceleration/release-duration-audit.md
+++ b/ops/workstreams/ci-release-acceleration/release-duration-audit.md
@@ -190,3 +190,13 @@ artifact path and structured evidence entry. A pack is green only if its final
 attempt passes; a persistent second failure remains release-blocking. This
 keeps the broad quality gate while replacing an all-pack workflow rerun with a
 bounded retry of only the work that failed.
+
+The first green run of that retry contract, staging run 30976430422, exposed a
+separate selection defect before production: `museum-institutional-practice`
+was omitted, but the newer `museum-inside-system` pack still ran because the
+workflow excluded one literal alias. The manifest now owns the `museum` change
+scope for every dedicated Museum pack. Automatic PR and deployed-environment
+selection derive from that scope, with a validator requiring every pack made
+entirely of `tests/museum/` specs to declare it. A legacy `museum-*` alias
+fallback keeps rollback sources compatible. Future Museum packs therefore
+cannot silently enter unrelated release qualification.

--- a/ops/workstreams/ci-release-acceleration/run-log.md
+++ b/ops/workstreams/ci-release-acceleration/run-log.md
@@ -162,3 +162,25 @@
   Production promotion was stopped. Replaced literal single-pack exclusion
   with manifest-owned Museum scope selection plus a validator ratchet and
   rollback-compatible `museum-*` fallback.
+- PR #3604 first head `cb658f7c8e6af83af438ab61a1c368ac964eaf0b`
+  failed the quality lane because one compatibility test still expected a
+  single literal Museum alias. The 6529 reviewer also required a contract that
+  the run-step and evidence-step predicates cannot drift. Updated the mock to
+  enumerate both scoped aliases, asserted both exclusions in staging and
+  production, and added byte-identical predicate plus local-pack-count
+  ratchets. Product lanes were cancelled immediately after the quality failure.
+- The follow-up review also added executable coverage for the legacy
+  `museum-*` rollback classifier, locked both selector snippets to the correct
+  deployed environment and `post-deploy` trigger, and rejected mixed Museum and
+  non-Museum specs in every automatic post-deploy pack. The intentionally mixed
+  production aggregate remains available only as a manual operator diagnostic.
+  The release-bus compatibility fixture now writes checksums with the same
+  platform tool used by the workflow and normalizes its Bash-facing temporary
+  path, eliminating a Windows-only false failure without weakening evidence
+  validation.
+- A full `__tests__/scripts` sweep found and replaced one more stale literal
+  single-pack assertion in `testing-strategy.test.ts`. The same Windows run also
+  reported the repository's existing POSIX-only security-test baseline:
+  `O_NOFOLLOW` is unavailable and directory-descriptor `fchmod` returns `EPERM`.
+  Those twelve platform failures are unrelated; hosted Linux remains the
+  authoritative environment for those fail-closed controls.

--- a/ops/workstreams/ci-release-acceleration/run-log.md
+++ b/ops/workstreams/ci-release-acceleration/run-log.md
@@ -150,3 +150,15 @@
   the release. Focused runner and performance contracts pass 31/31; changed
   lint, application/test/Playwright typechecks, manifest sync, and Debt Ratchet
   are green.
+- PR #3603 merged as `852b43fd9dc5af86aaf75c2942aea6e490544e25`.
+  Its App CI completed in 11m32s; quality/contracts took 2m36s, smoke 3m14s,
+  critical shell 4m23s, and Museum PR CI was omitted.
+- Staging composition `474a04f67701028807fb49747d5aa0e548f7a3a4`
+  deployed successfully in run 30975793722. Production prebuild 30975744759
+  completed concurrently in 13m28s. Automatic staging E2E 30976430422 passed
+  in 7m23s with three workers and the new retry evidence contract.
+- Retained evidence showed 13 packs: institutional-practice was correctly
+  absent, but the newly added Inside the System Museum pack was still present.
+  Production promotion was stopped. Replaced literal single-pack exclusion
+  with manifest-owned Museum scope selection plus a validator ratchet and
+  rollback-compatible `museum-*` fallback.

--- a/scripts/sync-e2e-manifest.cjs
+++ b/scripts/sync-e2e-manifest.cjs
@@ -313,8 +313,21 @@ function validateManifest(packs, { root } = {}) {
     validateRemoteContract(problems, pack, environment);
 
     const hasSpecs = Array.isArray(pack.specs) && pack.specs.length > 0;
+    const hasMuseumSpecs =
+      hasSpecs && pack.specs.some((spec) => spec.startsWith("tests/museum/"));
+    const hasNonMuseumSpecs =
+      hasSpecs && pack.specs.some((spec) => !spec.startsWith("tests/museum/"));
     const isMuseumOnly =
       hasSpecs && pack.specs.every((spec) => spec.startsWith("tests/museum/"));
+    if (
+      pack.triggers?.includes("post-deploy") &&
+      hasMuseumSpecs &&
+      hasNonMuseumSpecs
+    ) {
+      problems.push(
+        `${packLabel(pack)}: post-deploy packs must not mix Museum and non-Museum specs.`
+      );
+    }
     if (isMuseumOnly && pack.changeScope !== "museum") {
       problems.push(
         `${packLabel(pack)}: Museum-only packs must set changeScope "museum".`

--- a/scripts/sync-e2e-manifest.cjs
+++ b/scripts/sync-e2e-manifest.cjs
@@ -33,6 +33,7 @@ const KNOWN_PROJECTS = new Set([
 const KNOWN_SAFETY = new Set(["local", "readonly", "sandbox"]);
 const KNOWN_ENVIRONMENTS = new Set(["local", "staging", "production"]);
 const KNOWN_TRIGGERS = new Set(["manual", "pr-ci", "post-deploy", "cron"]);
+const KNOWN_CHANGE_SCOPES = new Set(["museum"]);
 const KNOWN_FIELDS = new Set([
   "scriptKey",
   "alias",
@@ -48,6 +49,7 @@ const KNOWN_FIELDS = new Set([
   "traceOff",
   "extraArgs",
   "timeoutMinutes",
+  "changeScope",
 ]);
 const REMOTE_CONTRACTS = {
   staging: {
@@ -274,6 +276,14 @@ function validateManifest(packs, { root } = {}) {
     }
     validateStringArray(problems, pack, "environments", KNOWN_ENVIRONMENTS);
     validateStringArray(problems, pack, "triggers", KNOWN_TRIGGERS);
+    if (
+      pack.changeScope !== undefined &&
+      !KNOWN_CHANGE_SCOPES.has(pack.changeScope)
+    ) {
+      problems.push(
+        `${packLabel(pack)}: unknown changeScope "${pack.changeScope}".`
+      );
+    }
     if (pack.environments?.length !== 1) {
       problems.push(
         `${packLabel(pack)}: exactly one environment is required per pack.`
@@ -301,6 +311,20 @@ function validateManifest(packs, { root } = {}) {
     validateEnvironmentVariables(problems, pack);
     validateCommandShape(problems, pack, root);
     validateRemoteContract(problems, pack, environment);
+
+    const hasSpecs = Array.isArray(pack.specs) && pack.specs.length > 0;
+    const isMuseumOnly =
+      hasSpecs && pack.specs.every((spec) => spec.startsWith("tests/museum/"));
+    if (isMuseumOnly && pack.changeScope !== "museum") {
+      problems.push(
+        `${packLabel(pack)}: Museum-only packs must set changeScope "museum".`
+      );
+    }
+    if (pack.changeScope === "museum" && !isMuseumOnly) {
+      problems.push(
+        `${packLabel(pack)}: changeScope "museum" requires only tests/museum specs.`
+      );
+    }
 
     if (pack.safety === "sandbox" && environment !== "local") {
       problems.push(`${packLabel(pack)}: sandbox packs must be local-only.`);

--- a/tests/packs.manifest.cjs
+++ b/tests/packs.manifest.cjs
@@ -160,6 +160,13 @@ function productionPack(
   };
 }
 
+function museumPack(pack) {
+  return {
+    ...pack,
+    changeScope: "museum",
+  };
+}
+
 const PACKS = [
   {
     scriptKey: "test:e2e",
@@ -275,7 +282,7 @@ const PACKS = [
     "Global and wave-local search coverage.",
     READONLY_SPECS.searchWaves
   ),
-  {
+  museumPack({
     ...localReadonlyPack(
       "test:e2e:museum-institutional-practice",
       "Network Museum institutional-practice study route sweep.",
@@ -283,8 +290,8 @@ const PACKS = [
       { timeoutMinutes: 30 }
     ),
     triggers: ["manual"],
-  },
-  {
+  }),
+  museumPack({
     ...localReadonlyPack(
       "test:e2e:museum-inside-system",
       "Network Museum Inside the System project and comparison sweep.",
@@ -292,7 +299,7 @@ const PACKS = [
       { timeoutMinutes: 30 }
     ),
     triggers: ["pr-ci", "manual"],
-  },
+  }),
 
   sandboxPack(
     "test:e2e:composer-sandbox",
@@ -474,18 +481,22 @@ const PACKS = [
     "Staging network and open-data read-only pack.",
     READONLY_SPECS.networkOpenData
   ),
-  stagingPack(
-    "museum-institutional-practice",
-    "museum-institutional-practice",
-    "Staging Network Museum institutional-practice deployed route smoke.",
-    READONLY_SPECS.museumInstitutionalPractice
+  museumPack(
+    stagingPack(
+      "museum-institutional-practice",
+      "museum-institutional-practice",
+      "Staging Network Museum institutional-practice deployed route smoke.",
+      READONLY_SPECS.museumInstitutionalPractice
+    )
   ),
-  stagingPack(
-    "museum-inside-system",
-    "museum-inside-system",
-    "Staging Network Museum Inside the System project and comparison sweep.",
-    READONLY_SPECS.museumInsideSystem,
-    { timeoutMinutes: 30 }
+  museumPack(
+    stagingPack(
+      "museum-inside-system",
+      "museum-inside-system",
+      "Staging Network Museum Inside the System project and comparison sweep.",
+      READONLY_SPECS.museumInsideSystem,
+      { timeoutMinutes: 30 }
+    )
   ),
 
   productionPack(
@@ -544,21 +555,25 @@ const PACKS = [
     "Production search canary.",
     READONLY_SPECS.searchWaves
   ),
-  productionPack(
-    "museum-institutional-practice",
-    "Production Network Museum institutional-practice deployed route smoke.",
-    READONLY_SPECS.museumInstitutionalPractice,
-    ["post-deploy", "manual"],
-    30,
-    [DESKTOP, MOBILE]
+  museumPack(
+    productionPack(
+      "museum-institutional-practice",
+      "Production Network Museum institutional-practice deployed route smoke.",
+      READONLY_SPECS.museumInstitutionalPractice,
+      ["post-deploy", "manual"],
+      30,
+      [DESKTOP, MOBILE]
+    )
   ),
-  productionPack(
-    "museum-inside-system",
-    "Production Network Museum Inside the System project and comparison sweep.",
-    READONLY_SPECS.museumInsideSystem,
-    ["post-deploy", "manual"],
-    30,
-    [DESKTOP, MOBILE]
+  museumPack(
+    productionPack(
+      "museum-inside-system",
+      "Production Network Museum Inside the System project and comparison sweep.",
+      READONLY_SPECS.museumInsideSystem,
+      ["post-deploy", "manual"],
+      30,
+      [DESKTOP, MOBILE]
+    )
   ),
   productionPack(
     "readonly",


### PR DESCRIPTION
## Outcome

Ensures **all** dedicated Network Museum E2E packs run only when Museum-owned paths change, while preserving explicit manual selection and fail-closed rollback behavior.

## Why

Retained evidence from green staging run 30976430422 exposed a gap: the institutional-practice pack was omitted for a tooling-only release, but the newer Inside the System pack still ran because deployed workflows excluded one literal alias.

## Fix

- mark all six dedicated local/staging/production Museum packs with manifest-owned `changeScope: museum`
- derive every staging and production exclusion from the deployed manifest
- retain a `museum-*` fallback for older rollback manifests
- require every pack made entirely of `tests/museum/` specs to declare the Museum scope
- reject unknown or overbroad scopes
- validate exact evidence against the same scoped inventory
- ratchet App PR CI so every local Museum pack is present only in the conditional Museum lane

## Validation

- 84/84 planner, classifier, runner, dispatch, performance, and manifest tests
- application typecheck passed
- Jest diagnostic ratchet unchanged at 2,125 diagnostics / 872 files
- Playwright typecheck passed
- changed lint, E2E manifest sync, Debt Ratchet, Prettier, Bash syntax, syntax, and whitespace checks passed

No application runtime, Museum page, or public copy changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Museum test packs are now identified consistently across local, staging, and production validation.
  * Automated checks ensure Museum packs contain only Museum tests and are correctly classified.
  * Release workflows dynamically exclude all applicable Museum packs, improving evidence accuracy and preventing unintended test execution.
  * Backward-compatible alias handling preserves reliable rollback behavior.

* **Documentation**
  * Updated release records and operational guidance to reflect the revised Museum-pack selection and promotion checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->