### PR TITLE
Make Worth Checking Out wave icons fully clickable

### DIFF
--- a/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
@@ -463,7 +463,7 @@ it("keeps the overlaid score inside the wave link and opens details on hover", a
   expect(
     screen.queryByRole("dialog", { name: "Wave score details" })
   ).not.toBeInTheDocument();
-  fireEvent.mouseEnter(scoreBadgeText);
+  fireEvent.mouseEnter(waveLink);
   expect(
     await screen.findByRole("dialog", { name: "Wave score details" })
   ).toBeInTheDocument();
@@ -526,8 +526,7 @@ it("uses no-message copy in the combined highly rated score card", async () => {
   expect(screen.getByText("No messages yet")).toBeInTheDocument();
 });
 
-it("opens the combined highly rated score card from the focused wave link", async () => {
-  const user = userEvent.setup();
+it("opens the combined highly rated score card when the wave link receives focus", async () => {
   render(
     <UnifiedWavesListWaves
       waves={[
@@ -554,7 +553,6 @@ it("opens the combined highly rated score card from the focused wave link", asyn
       name: "Open Keyboard Discovery, score 86",
     })
     .focus();
-  await user.keyboard("{ArrowDown}");
 
   expect(
     await screen.findByRole("dialog", { name: "Wave score details" })

--- a/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
@@ -407,7 +407,7 @@ it("renders announcement, highly rated preview, pinned, and one filterable botto
   expect(ref.current?.sentinelRef.current).toBeInstanceOf(HTMLElement);
 });
 
-it("uses highly rated preview score semantics instead of unread badges", () => {
+it("keeps the overlaid score inside the wave link and opens details on hover", async () => {
   const latestDropTimestamp = Date.now() - 60 * 60 * 1000;
 
   render(
@@ -440,29 +440,32 @@ it("uses highly rated preview score semantics instead of unread badges", () => {
   const waveLink = screen.getByRole("link", {
     name: "Open Scored Discovery, score 93",
   });
-  expect(waveLink).toHaveClass("tw-cursor-pointer");
-  const scoreDetailsButton = screen.getByRole("button", {
-    name: "Open Scored Discovery score details, score 93",
-  });
-  const scoreBadgeText = screen.getByText("93", { selector: "text" });
-  expect(scoreBadgeText).toBeInTheDocument();
-  expect(scoreBadgeText.closest("button")).toBe(scoreDetailsButton);
-  expect(scoreDetailsButton).toHaveClass(
-    "tw-mt-1",
-    "tw-h-6",
-    "tw-w-8",
+  expect(waveLink).toHaveClass(
+    "tw-relative",
+    "tw-size-8",
     "tw-cursor-pointer"
   );
-  expect(scoreDetailsButton).not.toHaveClass("tw-absolute", "tw-cursor-help");
+  const scoreBadgeText = screen.getByText("93", { selector: "text" });
+  const scoreBadge = scoreBadgeText.closest("span");
+  expect(scoreBadgeText).toBeInTheDocument();
+  expect(scoreBadgeText.closest("a")).toBe(waveLink);
+  expect(scoreBadge).toHaveClass(
+    "tw-absolute",
+    "-tw-bottom-1",
+    "-tw-right-1.5",
+    "tw-h-6",
+    "tw-w-7",
+    "tw-cursor-pointer"
+  );
   expect(scoreBadgeText.closest("svg")).toHaveClass("tw-h-5");
   expect(scoreBadgeText.closest("svg")).toHaveClass("tw-w-6");
-  fireEvent.click(waveLink);
+  fireEvent.click(scoreBadgeText);
   expect(
     screen.queryByRole("dialog", { name: "Wave score details" })
   ).not.toBeInTheDocument();
-  fireEvent.click(scoreDetailsButton);
+  fireEvent.mouseEnter(scoreBadgeText);
   expect(
-    screen.getByRole("dialog", { name: "Wave score details" })
+    await screen.findByRole("dialog", { name: "Wave score details" })
   ).toBeInTheDocument();
   expect(screen.getByText("Scored Discovery")).toBeInTheDocument();
   expect(screen.getByText("Last message")).toBeInTheDocument();
@@ -489,7 +492,7 @@ it("uses highly rated preview score semantics instead of unread badges", () => {
   );
 });
 
-it("uses no-message copy in the combined highly rated score card", () => {
+it("uses no-message copy in the combined highly rated score card", async () => {
   render(
     <UnifiedWavesListWaves
       waves={[
@@ -511,19 +514,19 @@ it("uses no-message copy in the combined highly rated score card", () => {
     />
   );
 
-  fireEvent.click(
-    screen.getByRole("button", {
-      name: "Open Quiet Discovery score details, score 88",
+  fireEvent.mouseEnter(
+    screen.getByRole("link", {
+      name: "Open Quiet Discovery, score 88",
     })
   );
   expect(
-    screen.getByRole("dialog", { name: "Wave score details" })
+    await screen.findByRole("dialog", { name: "Wave score details" })
   ).toBeInTheDocument();
   expect(screen.getByText("Quiet Discovery")).toBeInTheDocument();
   expect(screen.getByText("No messages yet")).toBeInTheDocument();
 });
 
-it("opens the combined highly rated score card from keyboard score activation", async () => {
+it("opens the combined highly rated score card from the focused wave link", async () => {
   const user = userEvent.setup();
   render(
     <UnifiedWavesListWaves
@@ -547,11 +550,11 @@ it("opens the combined highly rated score card from keyboard score activation", 
   );
 
   screen
-    .getByRole("button", {
-      name: "Open Keyboard Discovery score details, score 86",
+    .getByRole("link", {
+      name: "Open Keyboard Discovery, score 86",
     })
     .focus();
-  await user.keyboard("{Enter}");
+  await user.keyboard("{ArrowDown}");
 
   expect(
     await screen.findByRole("dialog", { name: "Wave score details" })

--- a/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import userEvent from "@testing-library/user-event";
 import {
   act,
   fireEvent,

--- a/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
@@ -437,24 +437,26 @@ it("uses highly rated preview score semantics instead of unread badges", () => {
     />
   );
 
-  expect(
-    screen.getByRole("link", { name: "Open Scored Discovery, score 93" })
-  ).toBeInTheDocument();
+  const waveLink = screen.getByRole("link", {
+    name: "Open Scored Discovery, score 93",
+  });
+  expect(waveLink).toHaveClass("tw-cursor-pointer");
   const scoreDetailsButton = screen.getByRole("button", {
     name: "Open Scored Discovery score details, score 93",
   });
   const scoreBadgeText = screen.getByText("93", { selector: "text" });
   expect(scoreBadgeText).toBeInTheDocument();
   expect(scoreBadgeText.closest("button")).toBe(scoreDetailsButton);
-  expect(scoreDetailsButton).toHaveClass("-tw-bottom-1");
-  expect(scoreDetailsButton).toHaveClass("-tw-right-1.5");
-  expect(scoreDetailsButton).toHaveClass("tw-h-6");
-  expect(scoreDetailsButton).toHaveClass("tw-w-7");
+  expect(scoreDetailsButton).toHaveClass(
+    "tw-mt-1",
+    "tw-h-6",
+    "tw-w-8",
+    "tw-cursor-pointer"
+  );
+  expect(scoreDetailsButton).not.toHaveClass("tw-absolute", "tw-cursor-help");
   expect(scoreBadgeText.closest("svg")).toHaveClass("tw-h-5");
   expect(scoreBadgeText.closest("svg")).toHaveClass("tw-w-6");
-  fireEvent.click(
-    screen.getByRole("link", { name: "Open Scored Discovery, score 93" })
-  );
+  fireEvent.click(waveLink);
   expect(
     screen.queryByRole("dialog", { name: "Wave score details" })
   ).not.toBeInTheDocument();

--- a/__tests__/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.test.tsx
@@ -271,6 +271,49 @@ it("keeps the worth checking out info tooltip available on touch devices", () =>
   ).not.toBeInTheDocument();
 });
 
+it("keeps touch wave navigation separate from score details", () => {
+  mockIsTouchDevice = true;
+  const scoredWave = createMockMinimalWave({
+    id: "h-score",
+    name: "Touch Discovery",
+    sidebarSection: "highly-rated",
+    waveScore: {
+      visibility_score: 82,
+      quality_score: 86,
+      hotness_score: 75,
+      rep_sort_score: 64,
+    } as any,
+  });
+
+  renderWebWaves({ waves: [scoredWave] });
+
+  const waveLink = screen.getByRole("link", {
+    name: "Open Touch Discovery, score 82",
+  });
+  const scoreDetailsButton = screen.getByRole("button", {
+    name: "Open Touch Discovery score details, score 82",
+  });
+
+  expect(waveLink).toHaveClass("tw-size-11", "tw-cursor-pointer");
+  expect(scoreDetailsButton).toHaveClass(
+    "tw-mt-1",
+    "tw-h-7",
+    "tw-w-11",
+    "tw-cursor-pointer"
+  );
+  expect(scoreDetailsButton).not.toHaveClass("tw-absolute");
+
+  fireEvent.click(waveLink);
+  expect(
+    screen.queryByRole("dialog", { name: "Wave score details" })
+  ).not.toBeInTheDocument();
+
+  fireEvent.click(scoreDetailsButton);
+  expect(
+    screen.getByRole("dialog", { name: "Wave score details" })
+  ).toBeInTheDocument();
+});
+
 it("hides the worth checking out info tooltip when no profile is connected", () => {
   mockAuthResult = {
     connectedProfile: null,

--- a/__tests__/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.test.tsx
@@ -271,7 +271,7 @@ it("keeps the worth checking out info tooltip available on touch devices", () =>
   ).not.toBeInTheDocument();
 });
 
-it("keeps touch wave navigation separate from score details", () => {
+it("keeps the overlaid touch score inside the wave navigation link", () => {
   mockIsTouchDevice = true;
   const scoredWave = createMockMinimalWave({
     id: "h-score",
@@ -290,28 +290,28 @@ it("keeps touch wave navigation separate from score details", () => {
   const waveLink = screen.getByRole("link", {
     name: "Open Touch Discovery, score 82",
   });
-  const scoreDetailsButton = screen.getByRole("button", {
-    name: "Open Touch Discovery score details, score 82",
-  });
+  const scoreBadgeText = screen.getByText("82", { selector: "text" });
+  const scoreBadge = scoreBadgeText.closest("span");
 
-  expect(waveLink).toHaveClass("tw-size-11", "tw-cursor-pointer");
-  expect(scoreDetailsButton).toHaveClass(
-    "tw-mt-1",
-    "tw-h-7",
-    "tw-w-11",
+  expect(waveLink).toHaveClass(
+    "tw-relative",
+    "tw-size-11",
     "tw-cursor-pointer"
   );
-  expect(scoreDetailsButton).not.toHaveClass("tw-absolute");
+  expect(scoreBadgeText.closest("a")).toBe(waveLink);
+  expect(scoreBadge).toHaveClass(
+    "tw-absolute",
+    "-tw-bottom-1.5",
+    "-tw-right-2",
+    "tw-h-6",
+    "tw-w-7",
+    "tw-cursor-pointer"
+  );
 
-  fireEvent.click(waveLink);
+  fireEvent.click(scoreBadgeText);
   expect(
     screen.queryByRole("dialog", { name: "Wave score details" })
   ).not.toBeInTheDocument();
-
-  fireEvent.click(scoreDetailsButton);
-  expect(
-    screen.getByRole("dialog", { name: "Wave score details" })
-  ).toBeInTheDocument();
 });
 
 it("hides the worth checking out info tooltip when no profile is connected", () => {

--- a/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
+++ b/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
@@ -262,7 +262,7 @@ function HighlyRatedWavePreviewScoreBadge({
       aria-label={ariaLabel}
       onClick={onClick}
       onMouseEnter={onMouseEnter}
-      className={`tw-absolute ${isTouchPreview ? "-tw-bottom-1.5 -tw-right-2" : "-tw-bottom-1 -tw-right-1.5"} tw-z-20 tw-inline-flex tw-h-6 tw-w-7 tw-cursor-help tw-appearance-none tw-items-center tw-justify-center tw-overflow-visible tw-border-0 tw-bg-transparent tw-p-0 tw-drop-shadow-[0_5px_9px_rgba(0,0,0,0.50)] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-1 focus-visible:tw-outline-primary-400`}
+      className={`tw-mt-1 tw-inline-flex ${isTouchPreview ? "tw-h-7 tw-w-11" : "tw-h-6 tw-w-8"} tw-cursor-pointer tw-appearance-none tw-items-center tw-justify-center tw-overflow-visible tw-border-0 tw-bg-transparent tw-p-0 tw-drop-shadow-[0_5px_9px_rgba(0,0,0,0.50)] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-1 focus-visible:tw-outline-primary-400`}
     >
       <svg
         aria-hidden="true"
@@ -368,7 +368,7 @@ function HighlyRatedWavePreviewLink({
       waveScore={wave.waveScore}
     >
       <span
-        className={`tw-relative tw-flex ${isTouchPreview ? "tw-size-11" : "tw-size-8"} tw-flex-shrink-0 tw-items-center tw-justify-center`}
+        className={`tw-flex ${isTouchPreview ? "tw-w-11" : "tw-w-8"} tw-flex-shrink-0 tw-flex-col tw-items-center`}
       >
         <Link
           href={item.href}
@@ -376,7 +376,7 @@ function HighlyRatedWavePreviewLink({
           aria-label={linkLabel}
           onClick={handleLinkClick}
           {...(item.onMouseEnter ? { onMouseEnter: item.onMouseEnter } : {})}
-          className={`tw-group/preview tw-flex ${isTouchPreview ? "tw-size-11" : "tw-size-8"} tw-items-center tw-justify-center tw-rounded-full tw-no-underline focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400`}
+          className={`tw-group/preview tw-flex ${isTouchPreview ? "tw-size-11" : "tw-size-8"} tw-cursor-pointer tw-items-center tw-justify-center tw-rounded-full tw-no-underline focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400`}
         >
           <WaveAvatar
             dropBadgePlacement="bottom-left"

--- a/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
+++ b/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
@@ -240,29 +240,16 @@ export const getVisibleHighlyRatedPreviewItems = ({
 };
 
 function HighlyRatedWavePreviewScoreBadge({
-  ariaLabel,
   isTouchPreview,
-  onClick,
-  onMouseEnter,
   scoreLabel,
 }: {
-  readonly ariaLabel: string;
   readonly isTouchPreview: boolean;
-  readonly onClick: () => void;
-  readonly onMouseEnter?: (() => void) | undefined;
-  readonly scoreLabel: string | null;
+  readonly scoreLabel: string;
 }) {
-  if (scoreLabel === null) {
-    return null;
-  }
-
   return (
-    <button
-      type="button"
-      aria-label={ariaLabel}
-      onClick={onClick}
-      onMouseEnter={onMouseEnter}
-      className={`tw-mt-1 tw-inline-flex ${isTouchPreview ? "tw-h-7 tw-w-11" : "tw-h-6 tw-w-8"} tw-cursor-pointer tw-appearance-none tw-items-center tw-justify-center tw-overflow-visible tw-border-0 tw-bg-transparent tw-p-0 tw-drop-shadow-[0_5px_9px_rgba(0,0,0,0.50)] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-1 focus-visible:tw-outline-primary-400`}
+    <span
+      aria-hidden="true"
+      className={`tw-absolute ${isTouchPreview ? "-tw-bottom-1.5 -tw-right-2" : "-tw-bottom-1 -tw-right-1.5"} tw-z-20 tw-inline-flex tw-h-6 tw-w-7 tw-cursor-pointer tw-items-center tw-justify-center tw-overflow-visible tw-drop-shadow-[0_5px_9px_rgba(0,0,0,0.50)]`}
     >
       <svg
         aria-hidden="true"
@@ -293,7 +280,7 @@ function HighlyRatedWavePreviewScoreBadge({
           {scoreLabel}
         </text>
       </svg>
-    </button>
+    </span>
   );
 }
 
@@ -325,22 +312,11 @@ function HighlyRatedWavePreviewLink({
             score: scoreLabel,
           }
         );
-  const scoreDetailsLabel =
-    scoreLabel === null
-      ? null
-      : t(SIDEBAR_LOCALE, "waves.score.summary.openDetailsAriaLabel", {
-          waveName: wave.name,
-          score: scoreLabel,
-        });
   const handleLinkClick = (event: MouseEvent<HTMLAnchorElement>) => {
     item.onClick(event);
     if (event.defaultPrevented || isModifiedAnchorClick(event)) {
       event.stopPropagation();
     }
-  };
-  const handleScoreBadgeClick = () => {
-    // Keep the click bubbling into WaveScoreSummaryHoverCard so touch, mouse, and keyboard use the shared card state.
-    item.onMouseEnter?.();
   };
 
   return (
@@ -367,37 +343,30 @@ function HighlyRatedWavePreviewLink({
       waveRep={wave.waveRep}
       waveScore={wave.waveScore}
     >
-      <span
-        className={`tw-flex ${isTouchPreview ? "tw-w-11" : "tw-w-8"} tw-flex-shrink-0 tw-flex-col tw-items-center`}
+      <Link
+        href={item.href}
+        prefetch={false}
+        aria-label={linkLabel}
+        onClick={handleLinkClick}
+        {...(item.onMouseEnter ? { onMouseEnter: item.onMouseEnter } : {})}
+        className={`tw-group/preview tw-relative tw-flex ${isTouchPreview ? "tw-size-11" : "tw-size-8"} tw-flex-shrink-0 tw-cursor-pointer tw-items-center tw-justify-center tw-overflow-visible tw-rounded-full tw-no-underline focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400`}
       >
-        <Link
-          href={item.href}
-          prefetch={false}
-          aria-label={linkLabel}
-          onClick={handleLinkClick}
-          {...(item.onMouseEnter ? { onMouseEnter: item.onMouseEnter } : {})}
-          className={`tw-group/preview tw-flex ${isTouchPreview ? "tw-size-11" : "tw-size-8"} tw-cursor-pointer tw-items-center tw-justify-center tw-rounded-full tw-no-underline focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400`}
-        >
-          <WaveAvatar
-            dropBadgePlacement="bottom-left"
-            isActive={item.isActive}
-            isDropWave={isDropWave}
-            showNewDropsBadge={false}
-            showUnreadDropsBadge={false}
-            size={isTouchPreview ? "lg" : "default"}
-            wave={wave}
-          />
-        </Link>
-        {scoreDetailsLabel !== null && (
+        <WaveAvatar
+          dropBadgePlacement="bottom-left"
+          isActive={item.isActive}
+          isDropWave={isDropWave}
+          showNewDropsBadge={false}
+          showUnreadDropsBadge={false}
+          size={isTouchPreview ? "lg" : "default"}
+          wave={wave}
+        />
+        {scoreLabel !== null && (
           <HighlyRatedWavePreviewScoreBadge
-            ariaLabel={scoreDetailsLabel}
             isTouchPreview={isTouchPreview}
-            onClick={handleScoreBadgeClick}
-            onMouseEnter={item.onMouseEnter}
             scoreLabel={scoreLabel}
           />
         )}
-      </span>
+      </Link>
     </WaveScoreSummaryHoverCard>
   );
 }

--- a/ops/docs/waves/sidebars/README.md
+++ b/ops/docs/waves/sidebars/README.md
@@ -32,8 +32,8 @@ Route scope:
 ### Left Sidebar and Lists
 
 - [Wave List Navigation](feature-wave-list-navigation.md):
-  row open/clear behavior, unread `divider` routing, and stale `wave` query
-  cleanup.
+  row open/clear behavior, `Worth Checking Out` avatar and score controls,
+  unread `divider` routing, and stale `wave` query cleanup.
 - [Brain Wave Row Metadata and Last Drop Indicator](feature-brain-list-last-drop-indicator.md):
   canonical owner for row-name labels, web tooltip rules, `Last drop` timestamp
   source, live refresh, and sorting behavior across wave and DM lists.

--- a/ops/docs/waves/sidebars/README.md
+++ b/ops/docs/waves/sidebars/README.md
@@ -32,7 +32,7 @@ Route scope:
 ### Left Sidebar and Lists
 
 - [Wave List Navigation](feature-wave-list-navigation.md):
-  row open/clear behavior, `Worth Checking Out` avatar and score controls,
+  row open/clear behavior, `Worth Checking Out` avatar and score links,
   unread `divider` routing, and stale `wave` query cleanup.
 - [Brain Wave Row Metadata and Last Drop Indicator](feature-brain-list-last-drop-indicator.md):
   canonical owner for row-name labels, web tooltip rules, `Last drop` timestamp

--- a/ops/docs/waves/sidebars/README.md
+++ b/ops/docs/waves/sidebars/README.md
@@ -32,7 +32,7 @@ Route scope:
 ### Left Sidebar and Lists
 
 - [Wave List Navigation](feature-wave-list-navigation.md):
-  row open/clear behavior, `Worth Checking Out` avatar and score links,
+  row open/clear behavior, combined `Worth Checking Out` avatar-and-score links,
   unread `divider` routing, and stale `wave` query cleanup.
 - [Brain Wave Row Metadata and Last Drop Indicator](feature-brain-list-last-drop-indicator.md):
   canonical owner for row-name labels, web tooltip rules, `Last drop` timestamp

--- a/ops/docs/waves/sidebars/feature-wave-list-navigation.md
+++ b/ops/docs/waves/sidebars/feature-wave-list-navigation.md
@@ -77,8 +77,9 @@ Wave and DM rows in the left list control which thread is open.
 - Non-touch devices can prefetch an inactive row on hover.
 - Touch devices do not use hover prefetch.
 - `Worth Checking Out` keeps the avatar and overlaid score in one keyboard and
-  touch target, so the score cannot intercept wave navigation. Keyboard users
-  can open the score details card from the focused link with Arrow Down.
+  touch target, so the score cannot intercept wave navigation. The link's
+  accessible name includes the score; hover or keyboard focus exposes the score
+  details card, while touch activation opens the wave.
 - Edge-swipe navigation applies only to native-app standard wave details. It is
   disabled on web, direct messages, list routes, create overlays, and focused
   drop views.

--- a/ops/docs/waves/sidebars/feature-wave-list-navigation.md
+++ b/ops/docs/waves/sidebars/feature-wave-list-navigation.md
@@ -11,9 +11,9 @@ Wave and DM rows in the left list control which thread is open.
 - On expanded rows, pin/unpin sits in the trailing metadata cluster before the
   wave score instead of beside the wave name, keeping the score at the far
   right.
-- In `Worth Checking Out`, each wave avatar is a full navigation link. Its
-  score shield is a separate control below the avatar that opens score details
-  without covering the navigation target.
+- In `Worth Checking Out`, each avatar and its overlaid score shield form one
+  wave navigation link. Hovering or focusing the combined link shows score
+  details without creating a competing click target.
 - The expanded web Waves panel header includes a secondary `Discover Waves`
   link to `/discover`.
 - Browser back/forward keeps the active row and URL in sync.
@@ -53,8 +53,9 @@ Wave and DM rows in the left list control which thread is open.
 
 - Wave rows open `/waves/{waveId}`.
 - Direct-message rows open `/messages/{waveId}`.
-- `Worth Checking Out` avatars open their wave on the first activation; the
-  adjacent score shield opens the wave score details card instead.
+- `Worth Checking Out` avatars and their overlaid score shields open the wave
+  on the first activation; hovering or focusing either visual shows score
+  details.
 - Active-row re-click returns to `/waves` or `/messages`.
 - Native-app edge swipe from `/waves/{waveId}` returns to `/waves`.
 - Inside the `/waves` or `/messages` shell, row changes update URL/history in
@@ -75,9 +76,9 @@ Wave and DM rows in the left list control which thread is open.
   idle desktop rows do not reserve the hidden pin width.
 - Non-touch devices can prefetch an inactive row on hover.
 - Touch devices do not use hover prefetch.
-- `Worth Checking Out` keeps avatar navigation and score details as separate
-  keyboard and touch targets, so the score control never intercepts an avatar
-  activation.
+- `Worth Checking Out` keeps the avatar and overlaid score in one keyboard and
+  touch target, so the score cannot intercept wave navigation. Keyboard users
+  can open the score details card from the focused link with Arrow Down.
 - Edge-swipe navigation applies only to native-app standard wave details. It is
   disabled on web, direct messages, list routes, create overlays, and focused
   drop views.

--- a/ops/docs/waves/sidebars/feature-wave-list-navigation.md
+++ b/ops/docs/waves/sidebars/feature-wave-list-navigation.md
@@ -11,6 +11,9 @@ Wave and DM rows in the left list control which thread is open.
 - On expanded rows, pin/unpin sits in the trailing metadata cluster before the
   wave score instead of beside the wave name, keeping the score at the far
   right.
+- In `Worth Checking Out`, each wave avatar is a full navigation link. Its
+  score shield is a separate control below the avatar that opens score details
+  without covering the navigation target.
 - The expanded web Waves panel header includes a secondary `Discover Waves`
   link to `/discover`.
 - Browser back/forward keeps the active row and URL in sync.
@@ -50,6 +53,8 @@ Wave and DM rows in the left list control which thread is open.
 
 - Wave rows open `/waves/{waveId}`.
 - Direct-message rows open `/messages/{waveId}`.
+- `Worth Checking Out` avatars open their wave on the first activation; the
+  adjacent score shield opens the wave score details card instead.
 - Active-row re-click returns to `/waves` or `/messages`.
 - Native-app edge swipe from `/waves/{waveId}` returns to `/waves`.
 - Inside the `/waves` or `/messages` shell, row changes update URL/history in
@@ -70,6 +75,9 @@ Wave and DM rows in the left list control which thread is open.
   idle desktop rows do not reserve the hidden pin width.
 - Non-touch devices can prefetch an inactive row on hover.
 - Touch devices do not use hover prefetch.
+- `Worth Checking Out` keeps avatar navigation and score details as separate
+  keyboard and touch targets, so the score control never intercepts an avatar
+  activation.
 - Edge-swipe navigation applies only to native-app standard wave details. It is
   disabled on web, direct messages, list routes, create overlays, and focused
   drop views.

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -2013,7 +2013,8 @@
         "Waves are the main social threads for conversations, drops, reactions, voting, and wave-specific activity.",
         "Standard wave threads live at /waves/{waveId}; direct messages live at /messages/{waveId}.",
         "Public wave content can remain readable for authenticated wallets without a profile, but posting and other participation actions require profile setup.",
-        "The Waves panel includes wave lists, pinned waves, highly rated waves, a Discover Waves link, and create controls."
+        "The Waves panel includes wave lists, pinned waves, highly rated waves, a Discover Waves link, and create controls.",
+        "In Worth Checking Out, each avatar is a full wave navigation link, while the separate score shield below it opens score details without covering the avatar."
       ],
       "canonical_path": "/waves",
       "related_paths": ["/waves?create=wave", "/messages"],

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -2014,7 +2014,7 @@
         "Standard wave threads live at /waves/{waveId}; direct messages live at /messages/{waveId}.",
         "Public wave content can remain readable for authenticated wallets without a profile, but posting and other participation actions require profile setup.",
         "The Waves panel includes wave lists, pinned waves, highly rated waves, a Discover Waves link, and create controls.",
-        "In Worth Checking Out, each avatar is a full wave navigation link, while the separate score shield below it opens score details without covering the avatar."
+        "In Worth Checking Out, each avatar and its overlaid score shield form one wave navigation link; hovering or focusing the combined link shows score details."
       ],
       "canonical_path": "/waves",
       "related_paths": ["/waves?create=wave", "/messages"],

--- a/public/glossary.json
+++ b/public/glossary.json
@@ -790,7 +790,8 @@
         "Waves are the main social threads for conversations, drops, reactions, voting, and wave-specific activity.",
         "Standard wave threads live at /waves/{waveId}; direct messages live at /messages/{waveId}.",
         "Public wave content can remain readable for authenticated wallets without a profile, but posting and other participation actions require profile setup.",
-        "The Waves panel includes wave lists, pinned waves, highly rated waves, a Discover Waves link, and create controls."
+        "The Waves panel includes wave lists, pinned waves, highly rated waves, a Discover Waves link, and create controls.",
+        "In Worth Checking Out, each avatar and its overlaid score shield form one wave navigation link; hovering or focusing the combined link shows score details."
       ],
       "canonical_path": "/waves",
       "related_paths": [

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -2010,7 +2010,7 @@
         "Standard wave threads live at /waves/{waveId}; direct messages live at /messages/{waveId}.",
         "Public wave content can remain readable for authenticated wallets without a profile, but posting and other participation actions require profile setup.",
         "The Waves panel includes wave lists, pinned waves, highly rated waves, a Discover Waves link, and create controls.",
-        "In Worth Checking Out, each avatar is a full wave navigation link, while the separate score shield below it opens score details without covering the avatar."
+        "In Worth Checking Out, each avatar and its overlaid score shield form one wave navigation link; hovering or focusing the combined link shows score details."
       ],
       "canonical_path": "/waves",
       "related_paths": ["/waves?create=wave", "/messages"],

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -2009,7 +2009,8 @@
         "Waves are the main social threads for conversations, drops, reactions, voting, and wave-specific activity.",
         "Standard wave threads live at /waves/{waveId}; direct messages live at /messages/{waveId}.",
         "Public wave content can remain readable for authenticated wallets without a profile, but posting and other participation actions require profile setup.",
-        "The Waves panel includes wave lists, pinned waves, highly rated waves, a Discover Waves link, and create controls."
+        "The Waves panel includes wave lists, pinned waves, highly rated waves, a Discover Waves link, and create controls.",
+        "In Worth Checking Out, each avatar is a full wave navigation link, while the separate score shield below it opens score details without covering the avatar."
       ],
       "canonical_path": "/waves",
       "related_paths": ["/waves?create=wave", "/messages"],


### PR DESCRIPTION
## Issue

- The score-details button overlapped roughly half of each `Worth Checking Out` avatar, so clicks in the lower-right area opened score details instead of navigating to the wave.
- The overlap split the avatar between pointer and help cursors, making the primary discovery action feel unreliable.

## Fix

- Restore the score shield to its original overlaid position inside the wave link.
- Treat the avatar and shield as one semantic navigation target: hovering or focusing the combined link shows score details, while clicking any painted part opens the wave.

## Changes

- Replace the competing overlaid score button with presentational shield content inside the existing link.
- Preserve the combined score card on hover and keyboard focus.
- Keep the existing desktop density and 44px touch link target while ensuring the score cannot intercept navigation.
- Extend shared and web sidebar coverage for score-overlay navigation, hover details, keyboard access, and touch behavior.
- Update the wave sidebar guide and generated Help Bot knowledge index.

## Validation

- `./bin/6529 run test --runInBand --testPathPatterns='__tests__/components/brain/left-sidebar/(waves/UnifiedWavesListWaves|web/WebUnifiedWavesListWaves)\\.test\\.tsx'` — 42 tests passed.
- `./bin/6529 run lint:changed` — passed.
- `./bin/6529 run typecheck:changed` — passed.
- `./bin/6529 run typecheck:jest` — passed (2,125 baseline diagnostics; no added diagnostic).
- `./bin/6529 run react-doctor:diff` — 100/100, no issues.
- `./bin/6529 run help-index:sync` — 202 records synced.
- `./bin/6529 run agent-files:sync` — public glossary and agent artifacts synced.
- `./bin/6529 run test:no-coverage -- __tests__/scripts/sync-agent-files.test.ts` — 11 tests passed.
- Docs link validation — 290 Markdown files passed.
- `git diff --check` — passed.
- Desktop browser QA against the staging API confirmed the shield is back over the avatar, both visuals use the pointer cursor, hovering the shield opens score details, and clicking the shield navigates to the exact wave on the first activation.
- Touch activation and target sizing are covered by the focused web component test. A second mobile-width browser pass remains blocked because viewport emulation resets the local staging access session; staging validation should repeat that responsive check.

## Risk

- Level: Low
- Why: The change removes a competing control and keeps routing, score data, and score-card content unchanged.
- Rollback: Revert this PR to restore the previous trigger structure.

## Review Notes

- The final placement follows product feedback: the shield remains overlaid in its original corner rather than stacked below the avatar.
- Review the combined hit area, hover/focus score details, and first-click navigation behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Combined “Worth Checking Out” avatars and score badges into a single wave-navigation link.
  - Hovering or focusing the link reveals score details, while touch activation opens the wave directly.
  - Improved keyboard, touch, sizing, positioning, and cursor behavior for wave previews.

- **Documentation**
  - Updated help content and navigation documentation to explain the combined avatar-and-score link behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->