### PR TITLE
ci: skip non-runtime production prebuilds

### DIFF
--- a/.github/workflows/production-build-artifact.yml
+++ b/.github/workflows/production-build-artifact.yml
@@ -3,6 +3,9 @@ name: Build Production Artifact
 on:
   push:
     branches: [main]
+    # A non-runtime-only merge intentionally has no automatic deploy artifact.
+    # If that exact SHA must be promoted, dispatch this workflow manually first;
+    # production deployment otherwise fails closed on the missing artifact.
     paths-ignore:
       - ".github/**"
       - "__tests__/**"

--- a/.github/workflows/production-build-artifact.yml
+++ b/.github/workflows/production-build-artifact.yml
@@ -3,6 +3,11 @@ name: Build Production Artifact
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - ".github/**"
+      - "__tests__/**"
+      - "ops/**"
+      - "tests/**"
   workflow_dispatch:
 
 permissions:

--- a/__tests__/scripts/production-build-artifact.test.ts
+++ b/__tests__/scripts/production-build-artifact.test.ts
@@ -16,6 +16,12 @@ describe("production prebuild and promotion contract", () => {
 
   it("builds exact main bytes without deployment authority", () => {
     expect(build.on.push.branches).toEqual(["main"]);
+    expect(build.on.push["paths-ignore"]).toEqual([
+      ".github/**",
+      "__tests__/**",
+      "ops/**",
+      "tests/**",
+    ]);
     const job = build.jobs["build-production-artifact"];
     const serialized = JSON.stringify(job);
     const verifyIndex = job.steps.findIndex(

--- a/__tests__/scripts/production-build-artifact.test.ts
+++ b/__tests__/scripts/production-build-artifact.test.ts
@@ -44,6 +44,7 @@ describe("production prebuild and promotion contract", () => {
     expect(buildSource).toContain("find manifest.json target -type f -print0");
     expect(buildSource).toContain("production-frontend-${{ github.sha }}");
     expect(job["runs-on"]).toContain("PRODUCTION_BUILD_RUNNER");
+    expect(JSON.stringify(build.jobs)).not.toContain('"uses":"./.github/');
   });
 
   it("promotes only a successful exact-workflow artifact and never rebuilds", () => {
@@ -73,6 +74,9 @@ describe("production prebuild and promotion contract", () => {
     expect(locate.run).toContain('.conclusion == "success"');
     expect(locate.run).toContain(
       '(.event == "push" or .event == "workflow_dispatch")'
+    );
+    expect(locate.run).toContain(
+      "No successful exact production prebuild is available"
     );
     expect(verifyIndex).toBeGreaterThan(-1);
     expect(verifyIndex).toBeLessThan(awsIndex);

--- a/__tests__/scripts/production-build-artifact.test.ts
+++ b/__tests__/scripts/production-build-artifact.test.ts
@@ -16,6 +16,7 @@ describe("production prebuild and promotion contract", () => {
 
   it("builds exact main bytes without deployment authority", () => {
     expect(build.on.push.branches).toEqual(["main"]);
+    expect(build.on.workflow_dispatch).toBeDefined();
     expect(build.on.push["paths-ignore"]).toEqual([
       ".github/**",
       "__tests__/**",

--- a/ops/workstreams/ci-release-acceleration/run-log.md
+++ b/ops/workstreams/ci-release-acceleration/run-log.md
@@ -221,3 +221,9 @@
   exclusion is deliberately narrow: public or build-input Markdown remains
   deployment-triggering. Focused workflow tests pass 62/62 and the Jest type,
   changed-lint, Bash-parse, formatting, and whitespace ratchets are green.
+- The post-merge sweep observed production-prebuild run 30983293737 start for
+  the closeout's `.github`, `__tests__`, and `ops`-only delta. The run was
+  cancelled because it could not produce deployable application changes.
+  Production prebuild now ignores `.github/**`, `__tests__/**`, `ops/**`, and
+  `tests/**`-only pushes; any source, configuration, dependency, script, or
+  public-content change still triggers the fail-closed exact prebuild.

--- a/ops/workstreams/ci-release-acceleration/run-log.md
+++ b/ops/workstreams/ci-release-acceleration/run-log.md
@@ -225,5 +225,9 @@
   the closeout's `.github`, `__tests__`, and `ops`-only delta. The run was
   cancelled because it could not produce deployable application changes.
   Production prebuild now ignores `.github/**`, `__tests__/**`, `ops/**`, and
-  `tests/**`-only pushes; any source, configuration, dependency, script, or
-  public-content change still triggers the fail-closed exact prebuild.
+  `tests/**`-only pushes; any application source, application configuration,
+  dependency, script, or public-content change still triggers the fail-closed
+  exact prebuild. An ignored-only main SHA deliberately has no automatic
+  deployable artifact. If an operator intentionally promotes that SHA, the
+  existing manual dispatch must first build its exact artifact; production
+  deployment otherwise fails closed.

--- a/ops/workstreams/ci-release-acceleration/run-log.md
+++ b/ops/workstreams/ci-release-acceleration/run-log.md
@@ -230,4 +230,6 @@
   exact prebuild. An ignored-only main SHA deliberately has no automatic
   deployable artifact. If an operator intentionally promotes that SHA, the
   existing manual dispatch must first build its exact artifact; production
-  deployment otherwise fails closed.
+  deployment otherwise fails closed. The contract also proves that the build
+  workflow consumes no ignored local `.github` action; introducing one must
+  first narrow the trigger exclusion.


### PR DESCRIPTION
## Outcome

Prevents the production artifact workflow from spending a 14-minute build on a main push made entirely of internal workflows, tests, or operations records.

The post-closeout push exposed this gap immediately: run 30983293737 started for a `.github`, `__tests__`, and `ops`-only delta and was cancelled. The exact-production prebuild now ignores pushes whose complete changed-file set is contained in:

- `.github/**`
- `__tests__/**`
- `ops/**`
- `tests/**`

Any application source, configuration, dependency, build script, or public-content input still triggers the exact prebuild. Manual dispatch remains available.

## Validation

- Focused production-artifact / CI-plan / performance contracts green.
- Changed lint and application/Jest type ratchets green.
- Debt ratchet, Bash parsing, formatting, and whitespace green.
- Hosted Linux remains authoritative for the existing POSIX-only policy-bundle suite.

Workflow/test/ledger only. No staging or production deployment is required; qualified runtime remains `2edfb2610c0cca9f49d45c5465c43bba8a20077e`.