### PR TITLE
Make subscription minting cards consistent

### DIFF
--- a/__tests__/components/home/LatestDropNextMintSubscribe.test.tsx
+++ b/__tests__/components/home/LatestDropNextMintSubscribe.test.tsx
@@ -143,7 +143,20 @@ describe("LatestDropNextMintSubscribe", () => {
   it("renders the subscribe section for the connected profile", () => {
     const { container } = renderWithAuth(<LatestDropNextMintSubscribe />);
 
-    expect(screen.getByText("Subscription Minting")).toBeInTheDocument();
+    const awarenessLabel = screen.getByText("Subscription Minting");
+    expect(awarenessLabel).toBeInTheDocument();
+    const awarenessRow = awarenessLabel.closest(".tw-group");
+    expect(awarenessRow).toHaveClass(
+      "tw-rounded-2xl",
+      "tw-border-primary-400/25",
+      "tw-bg-primary-500/10",
+      "tw-p-5"
+    );
+    expect(awarenessRow).not.toHaveClass(
+      "tw-rounded-lg",
+      "tw-border-white/5",
+      "tw-bg-iron-900/60"
+    );
     expect(screen.getByText("x12 subscribers")).toBeInTheDocument();
     expect(screen.getByText("x1")).toBeInTheDocument();
     expectReadonlySubscriptionToggle(

--- a/components/home/now-minting/LatestDropNextMintPanel.tsx
+++ b/components/home/now-minting/LatestDropNextMintPanel.tsx
@@ -227,7 +227,6 @@ export default function LatestDropNextMintPanel({
               {nextMintCardId && (
                 <div className="tw-mt-8">
                   <LatestDropNextMintSubscribe
-                    appearance="featured"
                     tokenId={nextMintCardId}
                   />
                 </div>

--- a/components/home/now-minting/LatestDropNextMintSubscribe.tsx
+++ b/components/home/now-minting/LatestDropNextMintSubscribe.tsx
@@ -139,7 +139,6 @@ function getToggleTooltipLabel({
 
 export default function LatestDropNextMintSubscribe(
   props: Readonly<{
-    appearance?: "default" | "featured" | "quiet";
     tokenId?: number;
     statusSource?: SubscriptionStatusSource;
   }> = {}
@@ -265,7 +264,6 @@ export default function LatestDropNextMintSubscribe(
 
   return (
     <MemeSubscriptionAwarenessRow
-      appearance={props.appearance}
       onProfileSubscriptionsAction={openProfileSubscriptions}
       profileSubscriptionsActionPending={isConnecting}
       profileSubscriptionsHref={

--- a/components/home/now-minting/MemeSubscriptionAwarenessRow.tsx
+++ b/components/home/now-minting/MemeSubscriptionAwarenessRow.tsx
@@ -15,15 +15,11 @@ import { useId, type ReactNode } from "react";
 import { Tooltip } from "react-tooltip";
 import { ABOUT_SUBSCRIPTIONS_HREF } from "../../user/subscriptions/subscriptionNavigation";
 
-const SUBSCRIPTION_ROW_CLASS_NAME = "tw-border tw-border-solid";
-
 function ReadonlySubscriptionToggle({
   checked,
-  featured,
   tooltipLabel,
 }: Readonly<{
   checked: boolean;
-  featured: boolean;
   tooltipLabel: string;
 }>) {
   const tooltipId = buildTooltipId("readonly-subscription-toggle", useId());
@@ -44,30 +40,18 @@ function ReadonlySubscriptionToggle({
           data-checked={checked ? "true" : "false"}
           data-testid="readonly-subscription-toggle-visual"
           className={clsx(
-            "tw-pointer-events-none tw-inline-flex tw-items-center tw-rounded-full tw-p-0.5 tw-ring-1 tw-ring-inset tw-transition-colors",
-            featured ? "tw-h-5 tw-w-9" : "tw-h-5 tw-w-10 md:tw-h-6 md:tw-w-12",
-            checked &&
-              (featured
-                ? "tw-bg-primary-500 tw-shadow-[0_0_14px_rgba(64,106,254,0.35)] tw-ring-primary-300/70"
-                : "tw-bg-primary-500 tw-shadow-[0_0_14px_rgba(74,119,255,0.45)] tw-ring-primary-300"),
-            !checked &&
-              (featured
-                ? "tw-bg-black/35 tw-ring-primary-400/30"
-                : "tw-bg-black/35 tw-opacity-80 tw-ring-primary-400/25")
+            "tw-pointer-events-none tw-inline-flex tw-h-5 tw-w-9 tw-items-center tw-rounded-full tw-p-0.5 tw-ring-1 tw-ring-inset tw-transition-colors",
+            checked
+              ? "tw-bg-primary-500 tw-shadow-[0_0_14px_rgba(64,106,254,0.35)] tw-ring-primary-300/70"
+              : "tw-bg-black/35 tw-ring-primary-400/30"
           )}
         >
           <span
             className={clsx(
-              "tw-rounded-full tw-shadow-sm tw-transition-transform",
-              featured ? "tw-size-3.5" : "tw-size-4 md:tw-size-5",
-              checked &&
-                (featured
-                  ? "tw-bg-primary-200 tw-translate-x-4"
-                  : "tw-translate-x-5 tw-bg-white md:tw-translate-x-6"),
-              !checked &&
-                (featured
-                  ? "tw-translate-x-0 tw-bg-iron-400"
-                  : "tw-translate-x-0 tw-bg-iron-500")
+              "tw-size-3.5 tw-rounded-full tw-shadow-sm tw-transition-transform",
+              checked
+                ? "tw-translate-x-4 tw-bg-primary-200"
+                : "tw-translate-x-0 tw-bg-iron-400"
             )}
           />
         </span>
@@ -92,7 +76,6 @@ function ReadonlySubscriptionToggle({
 function SubscriptionAction({
   children,
   disabled,
-  featured,
   href,
   label,
   onClick,
@@ -101,15 +84,10 @@ function SubscriptionAction({
   href?: string | undefined;
   label: string;
   disabled?: boolean | undefined;
-  featured: boolean;
   onClick?: (() => void | Promise<void>) | undefined;
 }>) {
-  const className = clsx(
-    "tw-group/action tw-inline-flex tw-cursor-pointer tw-items-center tw-justify-center tw-gap-1.5 tw-whitespace-nowrap tw-rounded-md tw-font-semibold tw-leading-none tw-no-underline tw-transition-colors tw-duration-300 tw-ease-out focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-black disabled:tw-cursor-wait disabled:tw-opacity-60 motion-reduce:tw-transition-none",
-    featured
-      ? "tw-text-[10.5px] tw-uppercase tw-tracking-[0.14em] tw-text-primary-300 desktop-hover:hover:tw-text-white"
-      : "desktop-hover:hover:tw-text-primary-200 tw-text-xs tw-text-primary-300 md:tw-text-sm"
-  );
+  const className =
+    "tw-group/action tw-inline-flex tw-cursor-pointer tw-items-center tw-justify-center tw-gap-1.5 tw-whitespace-nowrap tw-rounded-md tw-text-[10.5px] tw-font-semibold tw-uppercase tw-leading-none tw-tracking-[0.14em] tw-text-primary-300 tw-no-underline tw-transition-colors tw-duration-300 tw-ease-out desktop-hover:hover:tw-text-white focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-black disabled:tw-cursor-wait disabled:tw-opacity-60 motion-reduce:tw-transition-none";
   const handleClick = () => {
     Promise.resolve(onClick?.()).catch((error: unknown) => {
       console.error("Failed to open profile subscriptions", error);
@@ -139,12 +117,10 @@ function SubscriptionAction({
 
 function SubscriptionInfoLink({
   children,
-  featured,
   href,
   label,
 }: Readonly<{
   children: ReactNode;
-  featured: boolean;
   href: string;
   label: string;
 }>) {
@@ -157,12 +133,7 @@ function SubscriptionInfoLink({
         aria-label={label}
         data-tooltip-id={tooltipId}
         data-tooltip-content={label}
-        className={clsx(
-          "tw-inline-flex tw-size-7 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-full tw-no-underline tw-transition-colors focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-black",
-          featured
-            ? "desktop-hover:hover:tw-text-primary-200 tw-text-primary-300/70"
-            : "tw-text-primary-300 desktop-hover:hover:tw-text-primary-400"
-        )}
+        className="tw-inline-flex tw-size-7 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-full tw-text-primary-300/70 tw-no-underline tw-transition-colors desktop-hover:hover:tw-text-primary-200 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-black"
       >
         {children}
       </Link>
@@ -221,7 +192,6 @@ function SubscribersCountText({
 }
 
 export default function MemeSubscriptionAwarenessRow({
-  appearance = "default",
   onProfileSubscriptionsAction,
   profileCoverageSummary,
   profileSubscriptionsActionLabel,
@@ -233,7 +203,6 @@ export default function MemeSubscriptionAwarenessRow({
   subscribersCountLoading,
   tooltipLabel,
 }: Readonly<{
-  appearance?: "default" | "featured" | "quiet" | undefined;
   onProfileSubscriptionsAction?: (() => void | Promise<void>) | undefined;
   profileCoverageSummary?: string | undefined;
   profileSubscriptionsActionLabel?: string | undefined;
@@ -262,57 +231,23 @@ export default function MemeSubscriptionAwarenessRow({
         ? "home.mintSubscriptions.action.manage"
         : "home.mintSubscriptions.action.setUp"
     );
-  const isFeatured = appearance === "featured";
-
   return (
-    <div
-      className={clsx(
-        SUBSCRIPTION_ROW_CLASS_NAME,
-        isFeatured
-          ? "tw-group tw-relative tw-overflow-hidden tw-rounded-2xl tw-border-primary-400/25 tw-bg-primary-500/10 tw-p-5 tw-shadow-[0_15px_40px_rgba(0,0,0,0.38)]"
-          : "tw-rounded-lg tw-px-3 tw-py-3 md:tw-px-4",
-        appearance === "quiet" && "tw-border-white/5 tw-bg-iron-900/60",
-        appearance === "default" &&
-          "tw-border-primary-400/45 tw-bg-primary-500/10"
-      )}
-    >
-      {isFeatured && (
-        <span
-          aria-hidden="true"
-          className="tw-pointer-events-none tw-absolute tw-inset-0 tw-bg-primary-400/[0.045] tw-opacity-0 tw-transition-opacity tw-duration-500 tw-ease-[cubic-bezier(0.22,1,0.36,1)] group-focus-within:tw-opacity-100 desktop-hover:group-hover:tw-opacity-100 motion-reduce:tw-transition-none"
-        />
-      )}
-      <div
-        className={clsx(
-          "tw-grid tw-grid-cols-[minmax(0,1fr)_auto] tw-gap-x-4 tw-gap-y-3",
-          isFeatured && "tw-relative tw-z-10"
-        )}
-      >
+    <div className="tw-group tw-relative tw-overflow-hidden tw-rounded-2xl tw-border tw-border-solid tw-border-primary-400/25 tw-bg-primary-500/10 tw-p-5 tw-shadow-[0_15px_40px_rgba(0,0,0,0.38)]">
+      <span
+        aria-hidden="true"
+        className="tw-pointer-events-none tw-absolute tw-inset-0 tw-bg-primary-400/[0.045] tw-opacity-0 tw-transition-opacity tw-duration-500 tw-ease-[cubic-bezier(0.22,1,0.36,1)] group-focus-within:tw-opacity-100 desktop-hover:group-hover:tw-opacity-100 motion-reduce:tw-transition-none"
+      />
+      <div className="tw-relative tw-z-10 tw-grid tw-grid-cols-[minmax(0,1fr)_auto] tw-gap-x-4 tw-gap-y-3">
         <div className="tw-flex tw-min-w-0 tw-flex-wrap tw-items-center tw-gap-x-2 tw-gap-y-1">
-          <div
-            className={clsx(
-              "tw-text-sm tw-leading-none",
-              isFeatured
-                ? "tw-font-semibold tw-tracking-[-0.01em] tw-text-primary-300"
-                : "tw-font-semibold tw-text-primary-300 md:tw-text-base"
-            )}
-          >
+          <div className="tw-text-sm tw-font-semibold tw-leading-none tw-tracking-[-0.01em] tw-text-primary-300">
             {t(locale, "home.mintSubscriptions.awarenessLabel")}
           </div>
           <ReadonlySubscriptionToggle
             checked={subscribed}
-            featured={isFeatured}
             tooltipLabel={tooltipLabel}
           />
           {safeSubscribedCount !== undefined && (
-            <span
-              className={clsx(
-                "tw-whitespace-nowrap tw-text-xs tw-font-medium tw-leading-none",
-                isFeatured
-                  ? "tw-text-primary-300/70"
-                  : "tw-text-primary-300/75 md:tw-text-sm"
-              )}
-            >
+            <span className="tw-whitespace-nowrap tw-text-xs tw-font-medium tw-leading-none tw-text-primary-300/70">
               x
               {formatNumber(locale, safeSubscribedCount, {
                 maximumFractionDigits: 0,
@@ -323,30 +258,18 @@ export default function MemeSubscriptionAwarenessRow({
 
         <SubscriptionAction
           disabled={profileSubscriptionsActionPending}
-          featured={isFeatured}
           href={profileSubscriptionsHref}
           label={actionLabel}
           onClick={onProfileSubscriptionsAction}
         >
           <span aria-hidden="true">{actionLabel}</span>
           <ArrowRightIcon
-            className={clsx(
-              "tw-size-4",
-              isFeatured &&
-                "tw-transform-gpu tw-transition-transform tw-duration-300 tw-ease-out desktop-hover:group-hover/action:tw-translate-x-0.5 motion-reduce:tw-transform-none motion-reduce:tw-transition-none"
-            )}
+            className="tw-size-4 tw-transform-gpu tw-transition-transform tw-duration-300 tw-ease-out desktop-hover:group-hover/action:tw-translate-x-0.5 motion-reduce:tw-transform-none motion-reduce:tw-transition-none"
             aria-hidden="true"
           />
         </SubscriptionAction>
 
-        <div
-          className={clsx(
-            "tw-flex tw-min-h-7 tw-min-w-0 tw-flex-wrap tw-items-center tw-gap-x-1.5 tw-gap-y-1 tw-text-xs tw-leading-4",
-            isFeatured
-              ? "tw-font-medium tw-text-primary-300/70"
-              : "tw-text-primary-300/70 md:tw-text-sm"
-          )}
-        >
+        <div className="tw-flex tw-min-h-7 tw-min-w-0 tw-flex-wrap tw-items-center tw-gap-x-1.5 tw-gap-y-1 tw-text-xs tw-font-medium tw-leading-4 tw-text-primary-300/70">
           {profileCoverageSummary ? (
             <span className="tw-font-semibold tw-text-iron-200">
               {profileCoverageSummary}
@@ -365,7 +288,6 @@ export default function MemeSubscriptionAwarenessRow({
         </div>
         <div className="tw-flex tw-min-h-7 tw-items-center tw-justify-end">
           <SubscriptionInfoLink
-            featured={isFeatured}
             href={ABOUT_SUBSCRIPTIONS_HREF}
             label={t(locale, "home.mintSubscriptions.infoLinkAriaLabel")}
           >

--- a/components/home/now-minting/NowMintingDetails.tsx
+++ b/components/home/now-minting/NowMintingDetails.tsx
@@ -36,7 +36,6 @@ export default function NowMintingDetails({ nft }: NowMintingDetailsProps) {
         />
         <NowMintingStatsGrid nftId={nft.id} floorPrice={floorPrice} />
         <LatestDropNextMintSubscribe
-          appearance="featured"
           tokenId={nft.id}
           statusSource="none"
         />

--- a/components/the-memes/MemePage.tsx
+++ b/components/the-memes/MemePage.tsx
@@ -518,7 +518,6 @@ export default function MemePage({
                 fullWidth
               />
               <LatestDropNextMintSubscribe
-                appearance="quiet"
                 tokenId={nft.id}
                 statusSource="none"
               />


### PR DESCRIPTION
## Issue

- The same `Subscription Minting` awareness card used the polished blue treatment on the homepage but a compact neutral treatment on current Meme detail pages.
- The divergence came from an `appearance` prop inside the shared component, so identical content and behavior could render as different products.

## Fix

- Make the established homepage treatment the single design for the shared awareness card.
- Remove the appearance variants instead of selecting another variant at the Meme-page call site, preventing future callers from reintroducing the inconsistency.

## Changes

- Removed the `default`, `featured`, and `quiet` Tailwind branches from `MemeSubscriptionAwarenessRow`.
- Removed appearance plumbing from all homepage and Meme-page callers.
- Preserved the existing read-only toggle, subscriber counts, coverage summary, action and info links, i18n formatting, focus styles, and reduced-motion behavior.
- Extended the existing focused test to assert the shared blue card contract.

## Validation

- `git diff --check`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff` — 96/100; only pre-existing structural warnings in `MemePage`
- `./bin/6529 run test --testPathPatterns=__tests__/components/home/LatestDropNextMintSubscribe.test.tsx --cacheDirectory=<temp>`
- Browser-checked `/` and `/the-memes/531` at 1440×1000 and 390×844 against staging-backed data:
  - identical class lists and computed radius, border, background, padding, shadow, and action treatment
  - no card or document overflow at the mobile width
  - read-only toggle remained non-mutating
  - Manage and subscription-info destinations resolved correctly
  - primary label contrast measured approximately 7.6:1 on the blue surface
  - no new browser console warnings or errors

## Risk

- Level: Low
- Why: This is a presentational simplification of one shared component. It removes variant branches without changing data fetching, routes, copy, auth, or mutation behavior.
- Rollback: Revert the single commit to restore the former appearance variants.

## Review Notes

- The homepage output intentionally keeps its existing featured treatment unchanged; the visible change is on Meme detail pages.
- Please focus on the narrow Meme-page column and confirm the shared card remains readable with longer coverage and subscriber-count text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized subscription sections with a consistent rounded, bordered, translucent card design.
  * Unified subscription toggles, actions, links, typography, hover effects, and animated navigation cues.
  * Applied the updated styling across minting details and static card views.
* **Tests**
  * Updated coverage to verify the new “Subscription Minting” appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->