### PR TITLE
Keep About pages readable beside the open menu

### DIFF
--- a/app/about/AboutRouteLayout.module.css
+++ b/app/about/AboutRouteLayout.module.css
@@ -1,0 +1,27 @@
+.root {
+  min-width: 0;
+  width: 100%;
+  transition-duration: 300ms;
+  transition-property: width;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+:global(.layout-root):has(
+  > :global(
+      .layout-main[data-mobile="false"][data-narrow="true"][data-offcanvas="true"][data-right-open="false"]
+    )
+    > .root
+) {
+  overflow-x: clip;
+}
+
+@media (min-width: 1024px) {
+  /* Match the narrow desktop sidebar's horizontal shift so the route's right
+     edge remains anchored to the viewport throughout the shared transition. */
+  :global(
+      .layout-main[data-mobile="false"][data-narrow="true"][data-offcanvas="true"][data-right-open="false"]
+    )
+    > .root {
+    width: calc(100% - (var(--expanded-width) - var(--collapsed-width)));
+  }
+}

--- a/app/about/AboutRouteLayout.module.css
+++ b/app/about/AboutRouteLayout.module.css
@@ -6,18 +6,15 @@
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-:global(.layout-root):has(
-  > :global(
-      .layout-main[data-mobile="false"][data-narrow="true"][data-offcanvas="true"][data-right-open="false"]
-    )
-    > .root
+:global(
+  .layout-root[data-mobile="false"][data-narrow="true"][data-offcanvas="true"][data-right-open="false"]
 ) {
   overflow-x: clip;
 }
 
 @media (min-width: 1024px) {
-  /* Match the narrow desktop sidebar's horizontal shift so the route's right
-     edge remains anchored to the viewport throughout the shared transition. */
+  /* Mirror WebLayout.tsx and styles/globals.css: match the narrow desktop
+     sidebar shift so the route's right edge stays anchored during transition. */
   :global(
       .layout-main[data-mobile="false"][data-narrow="true"][data-offcanvas="true"][data-right-open="false"]
     )

--- a/app/about/AboutRouteLayout.module.css
+++ b/app/about/AboutRouteLayout.module.css
@@ -1,6 +1,6 @@
 .root {
   min-width: 0;
-  width: 100%;
+  width: var(--about-route-width, 100%);
   transition-duration: 300ms;
   transition-property: width;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
@@ -16,9 +16,10 @@
   /* Mirror WebLayout.tsx and styles/globals.css: match the narrow desktop
      sidebar shift so the route's right edge stays anchored during transition. */
   :global(
-      .layout-main[data-mobile="false"][data-narrow="true"][data-offcanvas="true"][data-right-open="false"]
-    )
-    > .root {
-    width: calc(100% - (var(--expanded-width) - var(--collapsed-width)));
+    .layout-root[data-mobile="false"][data-narrow="true"][data-offcanvas="true"][data-right-open="false"]
+  ) {
+    --about-route-width: calc(
+      100% - (var(--expanded-width) - var(--collapsed-width))
+    );
   }
 }

--- a/app/about/AboutRouteLayout.module.css
+++ b/app/about/AboutRouteLayout.module.css
@@ -6,6 +6,12 @@
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .root {
+    transition: none;
+  }
+}
+
 :global(
   .layout-root[data-mobile="false"][data-narrow="true"][data-offcanvas="true"][data-right-open="false"]
 ) {

--- a/app/about/layout.tsx
+++ b/app/about/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from "react";
+
+import styles from "./AboutRouteLayout.module.css";
+
+export default function AboutRouteLayout({
+  children,
+}: {
+  readonly children: ReactNode;
+}) {
+  return <div className={styles["root"]}>{children}</div>;
+}

--- a/components/about/AboutSubscriptions.tsx
+++ b/components/about/AboutSubscriptions.tsx
@@ -92,7 +92,7 @@ function SubscriptionHeader({ locale }: { readonly locale: SupportedLocale }) {
         </div>
         <div className="tw-mt-3">
           <Link
-            className="tw-group/report -tw-ml-1 tw-inline-flex tw-max-w-full tw-items-start tw-gap-2 tw-rounded-md tw-px-1 tw-py-1 tw-text-left tw-text-sm tw-leading-6 tw-text-iron-400 tw-no-underline tw-transition-colors hover:tw-text-iron-300 hover:tw-no-underline focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-[#00f0ff]/50 sm:tw-items-center lg:tw-whitespace-nowrap"
+            className="tw-group/report -tw-ml-1 tw-inline-flex tw-max-w-full tw-items-start tw-gap-2 tw-rounded-md tw-px-1 tw-py-1 tw-text-left tw-text-sm tw-leading-6 tw-text-iron-400 tw-no-underline tw-transition-colors hover:tw-text-iron-300 hover:tw-no-underline focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-[#00f0ff]/50 sm:tw-items-center"
             href="/tools/subscriptions-report"
           >
             <FontAwesomeIcon

--- a/tests/pages/about.spec.ts
+++ b/tests/pages/about.spec.ts
@@ -86,6 +86,7 @@ test.describe("About Pages @smoke @medium @large", () => {
   test("should keep GDRC in view beside the narrow desktop menu", async ({
     page,
   }) => {
+    // Reproduce the reported failure inside the narrow desktop sidebar band.
     await page.setViewportSize({ width: 1054, height: 900 });
     await page.goto("/about/gdrc1", { waitUntil: "domcontentloaded" });
     await waitForRouteReady(page);
@@ -95,9 +96,11 @@ test.describe("About Pages @smoke @medium @large", () => {
     await page.getByRole("button", { name: "Toggle right sidebar" }).click();
     await expect(layoutMain).toHaveAttribute("data-offcanvas", "true");
 
+    const gdrcArticle = layoutMain.getByRole("article");
+    await expect(gdrcArticle).toHaveCount(1);
     await expect
       .poll(() =>
-        page.locator("article").evaluate((article) => {
+        gdrcArticle.evaluate((article) => {
           const articleRight = article.getBoundingClientRect().right;
           return articleRight <= document.documentElement.clientWidth;
         })

--- a/tests/pages/about.spec.ts
+++ b/tests/pages/about.spec.ts
@@ -82,4 +82,27 @@ test.describe("About Pages @smoke @medium @large", () => {
     ).toBeVisible();
     await expectNoHorizontalOverflow(page);
   });
+
+  test("should keep GDRC in view beside the narrow desktop menu", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1054, height: 900 });
+    await page.goto("/about/gdrc1", { waitUntil: "domcontentloaded" });
+    await waitForRouteReady(page);
+
+    const layoutMain = page.locator(".layout-main");
+    await expect(layoutMain).toHaveAttribute("data-narrow", "true");
+    await page.getByRole("button", { name: "Toggle right sidebar" }).click();
+    await expect(layoutMain).toHaveAttribute("data-offcanvas", "true");
+
+    await expect
+      .poll(() =>
+        page.locator("article").evaluate((article) => {
+          const articleRight = article.getBoundingClientRect().right;
+          return articleRight <= document.documentElement.clientWidth;
+        })
+      )
+      .toBe(true);
+    await expectNoHorizontalOverflow(page);
+  });
 });

--- a/tests/pages/about.spec.ts
+++ b/tests/pages/about.spec.ts
@@ -91,18 +91,20 @@ test.describe("About Pages @smoke @medium @large", () => {
     await page.goto("/about/gdrc1", { waitUntil: "domcontentloaded" });
     await waitForRouteReady(page);
 
-    const layoutMain = page.locator(".layout-main");
-    await expect(layoutMain).toHaveAttribute("data-narrow", "true");
+    const layoutRoot = page.locator(".layout-root");
+    await expect(layoutRoot).toHaveAttribute("data-mobile", "false");
+    await expect(layoutRoot).toHaveAttribute("data-narrow", "true");
+    await expect(layoutRoot).toHaveAttribute("data-right-open", "false");
     await page.getByRole("button", { name: "Toggle right sidebar" }).click();
-    await expect(layoutMain).toHaveAttribute("data-offcanvas", "true");
+    await expect(layoutRoot).toHaveAttribute("data-offcanvas", "true");
 
-    const gdrcArticle = layoutMain.getByRole("article");
+    const gdrcArticle = layoutRoot.getByRole("article");
     await expect(gdrcArticle).toHaveCount(1);
     await expect
       .poll(() =>
         gdrcArticle.evaluate((article) => {
-          const articleRight = article.getBoundingClientRect().right;
-          return articleRight <= document.documentElement.clientWidth;
+          const { left, right } = article.getBoundingClientRect();
+          return left >= 0 && right <= document.documentElement.clientWidth;
         })
       )
       .toBe(true);


### PR DESCRIPTION
## Issue

- About pages could extend beyond the viewport when the primary menu opened at narrow desktop widths, clipping the right side of long-form content.
- The subscriptions report link also forced a single line at that width and could protrude past the content edge.

## Fix

- Add an About-route layout wrapper that compensates for the narrow desktop menu's horizontal shift, keeping the route's right edge anchored to the viewport throughout the existing transition.
- Scope horizontal clipping to the active narrow desktop menu state without relying on `:has()`.

## Changes

- Add a shared layout and CSS module for every `/about/*` route.
- Allow the subscriptions report link to wrap when horizontal space is constrained.
- Add a browser regression that opens the menu at the reproduced 1054px width and asserts both the GDRC article and document remain in the viewport.
- No user-facing copy, route, data, dependency, generated-code, documentation, or Help Bot corpus changes.

## Validation

- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff` (100/100 on the working diff)
- `./bin/6529 run test:e2e tests/pages/about.spec.ts --project=web-mobile-chromium --workers=1` (10 passed across desktop Chromium and Pixel mobile)
- `./bin/6529 run build`
- Manually swept all 22 About routes with the menu open and closed at narrow and wide desktop widths, including the 1024px, 1279px, and 1280px boundaries; no document or descendant overflow remained.
- Verified Escape closes the narrow menu while focus remains on the toggle, and confirmed Next.js reported no runtime or configuration errors.
- Confirmed no existing source selector depends on About pages being a direct child of `.layout-main`.

## Risk

- Level: Low
- Why: the width adjustment is route-scoped and state-scoped to the existing narrow desktop menu mode; mobile and wide desktop layout paths are unchanged.
- Rollback: revert these commits to restore the previous About layout behavior.

## Review Notes

- Please focus on the CSS selector's alignment with the existing `.layout-main` transform state and the route-level width scope.
- The state contract is documented beside the selector, and the 1054px E2E regression protects the menu-open geometry.
- The width transition intentionally matches the existing sidebar transition timing so the content edge remains stable during animation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added responsive layout behavior for the About section, including smoother sidebar transitions and improved narrow-screen support.
  * Added a dedicated layout wrapper for About pages.

* **Bug Fixes**
  * Subscription report links now wrap on larger screens.
  * Improved narrow desktop layouts to keep content within the viewport.

* **Tests**
  * Added coverage for narrow-screen About page behavior and sidebar toggling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->