### PR TITLE
Strengthen About overflow regression

### DIFF
--- a/tests/pages/about.spec.ts
+++ b/tests/pages/about.spec.ts
@@ -95,8 +95,35 @@ test.describe("About Pages @smoke @medium @large", () => {
     await expect(layoutRoot).toHaveAttribute("data-mobile", "false");
     await expect(layoutRoot).toHaveAttribute("data-narrow", "true");
     await expect(layoutRoot).toHaveAttribute("data-right-open", "false");
+
+    const aboutRoute = layoutRoot.locator(".layout-main > div").first();
+    await expect(aboutRoute).toHaveCount(1);
+    const closedRouteWidth = await aboutRoute.evaluate(
+      (route) => route.getBoundingClientRect().width
+    );
+    const menuWidthDelta = await layoutRoot.evaluate((root) => {
+      const probe = document.createElement("div");
+      probe.style.cssText =
+        "position:absolute;visibility:hidden;width:calc(var(--expanded-width) - var(--collapsed-width))";
+      root.append(probe);
+      const width = probe.getBoundingClientRect().width;
+      probe.remove();
+      return width;
+    });
+    expect(menuWidthDelta).toBeGreaterThan(0);
+
     await page.getByRole("button", { name: "Toggle right sidebar" }).click();
     await expect(layoutRoot).toHaveAttribute("data-offcanvas", "true");
+
+    await expect
+      .poll(() =>
+        aboutRoute.evaluate(
+          (route, expectedWidth) =>
+            Math.abs(route.getBoundingClientRect().width - expectedWidth) < 1,
+          closedRouteWidth - menuWidthDelta
+        )
+      )
+      .toBe(true);
 
     const gdrcArticle = layoutRoot.getByRole("article");
     await expect(gdrcArticle).toHaveCount(1);


### PR DESCRIPTION
## Issue

- Follow-up review on #3619 found that the new GDRC browser regression proved the article remained visible but did not directly prove the narrow-desktop width compensation was active.

## Fix

- Measure the closed About route width and the live expanded-minus-collapsed sidebar delta, then require the opened route width to shrink by that exact amount.

## Changes

- Strengthen the existing 1054px GDRC Playwright regression only.
- Keep the existing article-edge and document-overflow assertions.
- No runtime, user-facing copy, route, dependency, generated-code, documentation, or Help Bot corpus changes.

## Validation

- `./bin/6529 run format:changed`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- Isolated-port targeted GDRC Playwright run (2 passed across desktop Chromium and Pixel mobile).
- Isolated-port full About Playwright suite (10 passed across desktop Chromium and Pixel mobile).

## Risk

- Level: Low
- Why: test-only change that makes the existing layout regression fail if the sidebar compensation stops inheriting or applying.
- Rollback: revert this commit to restore the prior assertion coverage.

## Review Notes

- The temporary hidden probe resolves the live rem-based CSS custom-property delta into browser pixels and is removed immediately.
- This directly closes the final test-coverage finding from the post-merge review on #3619.