### PR TITLE
Remove unnecessary About width measurement

### DIFF
--- a/tests/pages/about.spec.ts
+++ b/tests/pages/about.spec.ts
@@ -96,34 +96,8 @@ test.describe("About Pages @smoke @medium @large", () => {
     await expect(layoutRoot).toHaveAttribute("data-narrow", "true");
     await expect(layoutRoot).toHaveAttribute("data-right-open", "false");
 
-    const aboutRoute = layoutRoot.locator(".layout-main > div").first();
-    await expect(aboutRoute).toHaveCount(1);
-    const closedRouteWidth = await aboutRoute.evaluate(
-      (route) => route.getBoundingClientRect().width
-    );
-    const menuWidthDelta = await layoutRoot.evaluate((root) => {
-      const probe = document.createElement("div");
-      probe.style.cssText =
-        "position:absolute;visibility:hidden;width:calc(var(--expanded-width) - var(--collapsed-width))";
-      root.append(probe);
-      const width = probe.getBoundingClientRect().width;
-      probe.remove();
-      return width;
-    });
-    expect(menuWidthDelta).toBeGreaterThan(0);
-
     await page.getByRole("button", { name: "Toggle right sidebar" }).click();
     await expect(layoutRoot).toHaveAttribute("data-offcanvas", "true");
-
-    await expect
-      .poll(() =>
-        aboutRoute.evaluate(
-          (route, expectedWidth) =>
-            Math.abs(route.getBoundingClientRect().width - expectedWidth) < 1,
-          closedRouteWidth - menuWidthDelta
-        )
-      )
-      .toBe(true);
 
     const gdrcArticle = layoutRoot.getByRole("article");
     await expect(gdrcArticle).toHaveCount(1);


### PR DESCRIPTION
## Issue

- PR #3620 added an over-engineered browser measurement solely to satisfy a late automated coverage suggestion.
- The added hidden DOM probe and exact width-delta assertion are not needed to protect the reported user-facing regression.

## Fix

- Remove only the measurement/probe block introduced by #3620.
- Preserve the actual About layout fix and the useful browser assertions that the GDRC article remains inside both viewport edges and the document does not overflow.

## Changes

- Delete 26 lines from `tests/pages/about.spec.ts`.
- No runtime code, user-facing behavior, routes, copy, dependencies, generated code, documentation, or Help Bot corpus changes.

## Validation

- `./bin/6529 run format:changed`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- Isolated-port focused GDRC Playwright regression: 2 passed across desktop Chromium and Pixel mobile.

## Risk

- Level: Low
- Why: test-only removal; the original viewport-edge and document-overflow regression remains.
- Rollback: revert this commit if the exact width-delta assertion is intentionally wanted later.

## Review Notes

- This is the direct corrective follow-up to #3620 and intentionally makes no runtime changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated narrow-desktop layout coverage to verify that opening the right sidebar uses an off-canvas layout.
  * Added checks confirming GDRC article content remains within the viewport without horizontal overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->