### PR TITLE
Improve Museum About typography

### DIFF
--- a/__tests__/components/museum/MuseumNetworkProposition.test.tsx
+++ b/__tests__/components/museum/MuseumNetworkProposition.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { MuseumNetworkProposition } from "@/components/museum/MuseumNetworkProposition";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
+import type { MuseumPublicDocument } from "@/lib/museum/publication";
+
+function document(
+  kind: "open_museum_statement" | "onchain_transition",
+  sourcePath: string
+): MuseumPublicDocument {
+  return {
+    id: kind,
+    kind,
+    title: kind,
+    markdown: "",
+    sha256: null,
+    sourcePath,
+    artistIds: [],
+    projectIds: [],
+    giftIds: [],
+    artworkIds: [],
+  };
+}
+
+describe("MuseumNetworkProposition", () => {
+  it("keeps public labels at 14px and narrative copy at 16px or larger", () => {
+    render(
+      <MuseumNetworkProposition
+        commit={"a".repeat(40)}
+        missionSourceUrl="https://github.com/6529-Collections/6529networkmuseum/blob/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/policies/founding-principles.md"
+        openMuseum={document(
+          "open_museum_statement",
+          "docs/open-museum-statement.md"
+        )}
+        transition={document(
+          "onchain_transition",
+          "docs/onchain-transition.md"
+        )}
+      />
+    );
+
+    for (const key of [
+      "museum.network.proposition.eyebrow",
+      "museum.network.proposition.final.eyebrow",
+      "museum.network.proposition.sources.title",
+    ] as const) {
+      expect(screen.getByText(t(DEFAULT_LOCALE, key))).toHaveClass(
+        "tw-text-sm"
+      );
+    }
+
+    for (const key of [
+      "museum.network.proposition.ofNetwork.body4",
+      "museum.network.proposition.today.collection.body",
+      "museum.network.proposition.next.decisions.body",
+    ] as const) {
+      expect(screen.getByText(t(DEFAULT_LOCALE, key))).toHaveClass(
+        "tw-text-base",
+        "tw-leading-7"
+      );
+    }
+  });
+});

--- a/components/museum/MuseumNetworkProposition.tsx
+++ b/components/museum/MuseumNetworkProposition.tsx
@@ -134,7 +134,7 @@ export function MuseumNetworkProposition({
   return (
     <div className="tw-min-w-0">
       <header className="tw-max-w-5xl">
-        <p className="tw-m-0 tw-text-xs tw-font-semibold tw-uppercase tw-tracking-[0.16em] tw-text-primary-300">
+        <p className="tw-m-0 tw-text-sm tw-font-semibold tw-uppercase tw-tracking-[0.16em] tw-text-primary-300">
           {t(DEFAULT_LOCALE, "museum.network.proposition.eyebrow")}
         </p>
         <h1 className="tw-m-0 tw-mt-4 tw-max-w-4xl tw-text-4xl tw-font-semibold tw-leading-[1.06] tw-tracking-tight tw-text-iron-50 sm:tw-text-5xl xl:tw-text-6xl">
@@ -168,7 +168,7 @@ export function MuseumNetworkProposition({
           <p className="tw-m-0">
             {t(DEFAULT_LOCALE, "museum.network.proposition.ofNetwork.body3")}
           </p>
-          <p className="tw-m-0 tw-text-sm tw-leading-6 tw-text-iron-400">
+          <p className="tw-m-0 tw-text-base tw-leading-7 tw-text-iron-400">
             {t(DEFAULT_LOCALE, "museum.network.proposition.ofNetwork.body4")}
           </p>
         </div>
@@ -193,7 +193,7 @@ export function MuseumNetworkProposition({
               <h3 className="tw-m-0 tw-text-lg tw-font-semibold tw-uppercase tw-tracking-[0.08em] tw-text-iron-100">
                 {t(DEFAULT_LOCALE, pillar.titleKey)}
               </h3>
-              <div className="tw-mt-4 tw-space-y-4 tw-text-sm tw-leading-6 tw-text-iron-400 sm:tw-text-base sm:tw-leading-7">
+              <div className="tw-mt-4 tw-space-y-4 tw-text-base tw-leading-7 tw-text-iron-400">
                 {pillar.bodyKeys.map((bodyKey) => (
                   <p key={bodyKey} className="tw-m-0">
                     {t(DEFAULT_LOCALE, bodyKey)}
@@ -234,7 +234,7 @@ export function MuseumNetworkProposition({
               <h3 className="tw-m-0 tw-text-lg tw-font-semibold tw-text-iron-100">
                 {t(DEFAULT_LOCALE, item.titleKey)}
               </h3>
-              <p className="tw-m-0 tw-mt-3 tw-flex-1 tw-text-sm tw-leading-6 tw-text-iron-400">
+              <p className="tw-m-0 tw-mt-3 tw-flex-1 tw-text-base tw-leading-7 tw-text-iron-400">
                 {t(DEFAULT_LOCALE, item.bodyKey)}
               </p>
               {item.external ? (
@@ -281,7 +281,7 @@ export function MuseumNetworkProposition({
               <h3 className="tw-m-0 tw-text-lg tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-iron-100">
                 {t(DEFAULT_LOCALE, item.titleKey)}
               </h3>
-              <p className="tw-m-0 tw-mt-4 tw-text-sm tw-leading-6 tw-text-iron-400">
+              <p className="tw-m-0 tw-mt-4 tw-text-base tw-leading-7 tw-text-iron-400">
                 {t(DEFAULT_LOCALE, item.bodyKey)}
               </p>
             </article>
@@ -319,7 +319,7 @@ export function MuseumNetworkProposition({
         aria-labelledby="public-institution-title"
         className="tw-mt-20 tw-max-w-5xl"
       >
-        <p className="tw-m-0 tw-text-xs tw-font-semibold tw-uppercase tw-tracking-[0.16em] tw-text-primary-300">
+        <p className="tw-m-0 tw-text-sm tw-font-semibold tw-uppercase tw-tracking-[0.16em] tw-text-primary-300">
           {t(DEFAULT_LOCALE, "museum.network.proposition.final.eyebrow")}
         </p>
         <h2
@@ -366,7 +366,7 @@ export function MuseumNetworkProposition({
       >
         <h2
           id="museum-proposition-sources-title"
-          className="tw-m-0 tw-text-xs tw-font-semibold tw-uppercase tw-tracking-[0.16em] tw-text-iron-500"
+          className="tw-m-0 tw-text-sm tw-font-semibold tw-uppercase tw-tracking-[0.16em] tw-text-iron-500"
         >
           {t(DEFAULT_LOCALE, "museum.network.proposition.sources.title")}
         </h2>


### PR DESCRIPTION
## Outcome

Raises the Museum About page's readable type floor without changing its copy, layout, or the wider 6529 shell.

- About-page labels and eyebrows: 12px → 14px
- Substantive About-page copy: 14px/24px → 16px/28px
- Action links and the shared Museum source strip remain unchanged
- Adds a focused regression test for the floor

## Verification

- Focused Jest: 1/1 passed (5.1s)
- Changed-file lint: passed (40.2s)
- Changed-file typecheck: passed (62s)
- Rendered About page: representative labels 14px; narrative 16px/28px
- Local viewport: clientWidth = scrollWidth (no horizontal overflow)
- Whitespace/path checks: passed

## Timed release

Timer began at **2026-08-05 16:27:15 UTC**. The PR/review/merge/staging/E2E/production/E2E milestones and hands-on versus queue time will be recorded in the closeout comment.

Local setup note: the clean worktree required a cold frozen dependency install (4m57s). That is tracked separately from implementation time because it is process overhead worth optimizing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved typography on the museum network proposition page.
  * Increased label and narrative text sizes for better readability.
  * Adjusted paragraph line spacing to improve content legibility.

* **Tests**
  * Added coverage to verify text sizing and line-height styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->