### PR TITLE
Normalize Museum About paragraph hierarchy

### DIFF
--- a/__tests__/components/museum/MuseumNetworkProposition.test.tsx
+++ b/__tests__/components/museum/MuseumNetworkProposition.test.tsx
@@ -23,7 +23,7 @@ function document(
 }
 
 describe("MuseumNetworkProposition", () => {
-  it("keeps public labels at 14px and narrative copy at 16px or larger", () => {
+  it("keeps public labels readable without demoting section conclusions", () => {
     render(
       <MuseumNetworkProposition
         commit={"a".repeat(40)}
@@ -50,7 +50,6 @@ describe("MuseumNetworkProposition", () => {
     }
 
     for (const key of [
-      "museum.network.proposition.ofNetwork.body4",
       "museum.network.proposition.today.collection.body",
       "museum.network.proposition.next.decisions.body",
     ] as const) {
@@ -59,5 +58,22 @@ describe("MuseumNetworkProposition", () => {
         "tw-leading-7"
       );
     }
+
+    const principle = screen.getByText(
+      t(DEFAULT_LOCALE, "museum.network.proposition.principle")
+    );
+    expect(principle).toHaveClass(
+      "tw-text-lg",
+      "tw-leading-8",
+      "tw-text-iron-200",
+      "sm:tw-text-xl",
+      "sm:tw-leading-9"
+    );
+
+    const conclusion = screen.getByText(
+      t(DEFAULT_LOCALE, "museum.network.proposition.ofNetwork.body4")
+    );
+    expect(conclusion).toHaveClass("tw-m-0");
+    expect(conclusion).not.toHaveClass("tw-text-iron-400");
   });
 });

--- a/components/museum/MuseumNetworkProposition.tsx
+++ b/components/museum/MuseumNetworkProposition.tsx
@@ -143,7 +143,7 @@ export function MuseumNetworkProposition({
         <p className="tw-m-0 tw-mt-7 tw-max-w-4xl tw-text-lg tw-leading-8 tw-text-iron-200 sm:tw-text-xl sm:tw-leading-9">
           {t(DEFAULT_LOCALE, "museum.network.proposition.intro")}
         </p>
-        <p className="tw-m-0 tw-mt-5 tw-max-w-3xl tw-text-base tw-leading-7 tw-text-iron-400">
+        <p className="tw-m-0 tw-mt-5 tw-max-w-4xl tw-text-lg tw-leading-8 tw-text-iron-200 sm:tw-text-xl sm:tw-leading-9">
           {t(DEFAULT_LOCALE, "museum.network.proposition.principle")}
         </p>
       </header>
@@ -168,7 +168,7 @@ export function MuseumNetworkProposition({
           <p className="tw-m-0">
             {t(DEFAULT_LOCALE, "museum.network.proposition.ofNetwork.body3")}
           </p>
-          <p className="tw-m-0 tw-text-base tw-leading-7 tw-text-iron-400">
+          <p className="tw-m-0">
             {t(DEFAULT_LOCALE, "museum.network.proposition.ofNetwork.body4")}
           </p>
         </div>


### PR DESCRIPTION
## What changed

- Removes the smaller, dimmer treatment from the two concluding paragraphs called out on the Museum About page.
- Gives the opening principle the same lead typography as the paragraph above it.
- Lets the final paragraph in “The Museum of the Network” inherit the section’s ordinary body typography.
- Updates the focused regression test so these conclusions cannot silently be demoted again.

## Why

Both paragraphs carry core institutional arguments. Their former treatment made them read as optional footnotes and introduced a repeated artificial coda pattern.

## Verification

- Focused Jest: 1/1 passed
- `lint:changed`: passed
- `typecheck:changed`: passed
- Prettier and whitespace checks: passed
- Local desktop: opening pairs match at 20px/36px; section body pairs match at 16px/28px and identical color; no overflow
- Local mobile: opening pairs match at 18px/32px; section body pairs match at 16px/28px and identical color; no overflow
- Browser console: no errors

Timed release start: `2026-08-05T18:38:36.810Z`.