### PR TITLE
Restore complete Museum PR browser coverage

### DIFF
--- a/.github/workflows/app-pr-ci.yml
+++ b/.github/workflows/app-pr-ci.yml
@@ -714,6 +714,7 @@ jobs:
         run: |
           ./bin/6529 exec playwright test \
             tests/museum/data-architecture-readonly.spec.ts \
+            tests/museum/institutional-practice-readonly.spec.ts \
             tests/museum/about-readonly.spec.ts \
             tests/museum/inside-system-readonly.spec.ts \
             tests/museum/rights-readonly.spec.ts \

--- a/__tests__/app/museum/network/publicationRoutes.test.tsx
+++ b/__tests__/app/museum/network/publicationRoutes.test.tsx
@@ -233,9 +233,7 @@ describe("Museum finished publication routes", () => {
     try {
       render(await MuseumGiftPage({ accessionId: "6529NM.2026.001" }));
 
-      expect(consoleError.mock.calls.flat().join(" ")).not.toContain(
-        'unique "key"'
-      );
+      expect(consoleError).not.toHaveBeenCalled();
     } finally {
       consoleError.mockRestore();
     }

--- a/__tests__/app/museum/network/publicationRoutes.test.tsx
+++ b/__tests__/app/museum/network/publicationRoutes.test.tsx
@@ -225,6 +225,22 @@ describe("Museum finished publication routes", () => {
     ).toHaveAttribute("href", "/museum/network/projects/century/system");
   });
 
+  it("renders the gift dossier slots without React list-key warnings", async () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    try {
+      render(await MuseumGiftPage({ accessionId: "6529NM.2026.001" }));
+
+      expect(consoleError.mock.calls.flat().join(" ")).not.toContain(
+        'unique "key"'
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it("renders the source matrix onsite with an accessible table region", async () => {
     render(await MuseumSourceAndChronologyPage());
 

--- a/__tests__/scripts/testing-strategy.test.ts
+++ b/__tests__/scripts/testing-strategy.test.ts
@@ -524,7 +524,7 @@ describe("testing strategy CI plan", () => {
           needs?: string | string[];
           strategy?: { matrix?: string };
           "runs-on"?: string;
-          steps?: Array<{ name?: string; if?: string }>;
+          steps?: Array<{ name?: string; if?: string; run?: string }>;
         }
       >;
     };
@@ -555,6 +555,22 @@ describe("testing strategy CI plan", () => {
         }),
       ])
     );
+    const museumBrowserStep = parsed.jobs["app-checks"]?.steps?.find(
+      (step) => step.name === "Run Network Museum Playwright packs"
+    );
+    const museumBrowserRun = museumBrowserStep?.run ?? "";
+    expect(
+      museumBrowserRun.match(/tests\/museum\/[a-z-]+\.spec\.ts/gu) ?? []
+    ).toEqual([
+      "tests/museum/data-architecture-readonly.spec.ts",
+      "tests/museum/institutional-practice-readonly.spec.ts",
+      "tests/museum/about-readonly.spec.ts",
+      "tests/museum/inside-system-readonly.spec.ts",
+      "tests/museum/rights-readonly.spec.ts",
+    ]);
+    expect(museumBrowserRun).toContain("--project=web-desktop-chromium");
+    expect(museumBrowserRun).toContain("--project=web-mobile-chromium");
+    expect(museumBrowserRun).toContain("--workers=1");
     expect(parsed.jobs["installed-checks"]).toMatchObject({
       name: "Installed app checks",
       needs: ["plan", "app-checks"],

--- a/__tests__/scripts/testing-strategy.test.ts
+++ b/__tests__/scripts/testing-strategy.test.ts
@@ -452,7 +452,15 @@ describe("testing strategy CI plan", () => {
     expect(workflow).toContain("playwright install --with-deps chromium");
     expect(workflow).toContain("test:e2e:smoke");
     expect(workflow).toContain("test:e2e:critical-shell");
-    expect(workflow).toContain("test:e2e:museum-institutional-practice");
+    for (const museumBrowserSpec of [
+      "tests/museum/data-architecture-readonly.spec.ts",
+      "tests/museum/institutional-practice-readonly.spec.ts",
+      "tests/museum/about-readonly.spec.ts",
+      "tests/museum/inside-system-readonly.spec.ts",
+      "tests/museum/rights-readonly.spec.ts",
+    ]) {
+      expect(workflow).toContain(museumBrowserSpec);
+    }
     expect(workflow).toContain("PLAYWRIGHT_WEB_SERVER_COMMAND");
     expect(stagingWorkflow).toContain("--trigger post-deploy");
     expect(stagingWorkflow).toContain("SELECTED_PACK");
@@ -483,9 +491,8 @@ describe("testing strategy CI plan", () => {
     expect(workflow).toContain(
       "MUSEUM_PUBLICATION_TEST_COMMIT: ${{ steps.museum_publication.outputs.commit }}"
     );
-    expect(workflow).toContain(
-      "./bin/6529 run test:e2e:museum-institutional-practice"
-    );
+    expect(workflow).toContain("./bin/6529 exec playwright test");
+    expect(workflow).toContain("--workers=1");
     expect(stagingWorkflow).toContain(
       "Unable to prove the deployed change range; retaining the Museum E2E pack."
     );

--- a/components/museum/MuseumGiftPage.tsx
+++ b/components/museum/MuseumGiftPage.tsx
@@ -214,6 +214,8 @@ export async function MuseumGiftPage({
               publication,
               descriptor.path
             );
+            // React re-lists these server-rendered slots at the client boundary.
+            // Stable keys keep their identity explicit across that handoff.
             return (
               <MuseumDossierDocument
                 key={descriptor.path}

--- a/components/museum/MuseumGiftPage.tsx
+++ b/components/museum/MuseumGiftPage.tsx
@@ -219,7 +219,10 @@ export async function MuseumGiftPage({
                 key={descriptor.path}
                 anchor={anchor}
                 summary={
-                  <summary className="hover:tw-text-primary-200 tw-flex tw-min-h-16 tw-cursor-pointer tw-list-none tw-items-center tw-justify-between tw-gap-4 tw-py-4 tw-text-base tw-font-semibold tw-text-iron-100 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400">
+                  <summary
+                    key={`${descriptor.path}:summary`}
+                    className="hover:tw-text-primary-200 tw-flex tw-min-h-16 tw-cursor-pointer tw-list-none tw-items-center tw-justify-between tw-gap-4 tw-py-4 tw-text-base tw-font-semibold tw-text-iron-100 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
+                  >
                     <span>{descriptor.title}</span>
                     <span className="tw-text-sm tw-font-normal tw-text-iron-500 group-open:tw-text-primary-300">
                       {t(DEFAULT_LOCALE, "museum.network.gift.readDocument")}
@@ -227,7 +230,10 @@ export async function MuseumGiftPage({
                   </summary>
                 }
               >
-                <div className="tw-max-w-4xl tw-pb-10 tw-pt-2">
+                <div
+                  key={`${descriptor.path}:body`}
+                  className="tw-max-w-4xl tw-pb-10 tw-pt-2"
+                >
                   {document ? (
                     <MuseumMarkdown
                       sourceCommit={publication.identity.commit}

--- a/ops/workstreams/museum-data-architecture/run-log.md
+++ b/ops/workstreams/museum-data-architecture/run-log.md
@@ -164,3 +164,12 @@
 - Manifest-bound production E2E workflow `31061460637` also passed on exact
   deployed SHA `81ddbf2a6dce7df785c87d9a3192d3ed7a74f1cf`, including evidence
   validation and upload.
+- Post-merge Coverage Floor run `31062582473` passed 2,173 of 2,174 suites and
+  exposed one stale CI contract. The combined Museum PR browser invocation had
+  omitted the institutional-practice spec when the ontology pack was added.
+  The follow-up restores all five Museum specs in one shared Playwright process
+  and makes the contract assert every exact spec path.
+- The restored local institutional-practice pack then exposed a React child-key
+  warning in the gift dossier. `MuseumGiftPage` now keys the summary and body
+  slots that cross its client-component boundary. A focused route regression
+  test covers the warning contract.


### PR DESCRIPTION
## Outcome

Restores the institutional-practice Museum browser suite that was accidentally replaced when the ontology pack entered PR CI, while preserving the one-server combined Playwright invocation.

The restored suite exposed a real React list-key warning on the Casey gift dossier. This PR fixes the server-to-client dossier slot keys and adds a route-level regression assertion.

## Exact scope

- add institutional-practice-readonly.spec.ts to the combined five-pack Museum PR lane
- make the CI contract assert all five exact Museum spec paths and the shared Playwright process
- key the gift dossier summary and body slots at their server component source
- add a focused warning regression
- record the post-merge Coverage Floor diagnosis and correction

## Evidence

- post-merge Coverage Floor 31062582473: 2,173/2,174 suites and 13,687/13,688 tests passed; only the stale Museum CI assertion failed
- focused Jest: 6 suites, 134 tests passed
- corrected gift browser case: 1/1 passed in 44.5s with the React warning gone
- lint:changed passed
- typecheck:changed passed across 1,371 files
- Jest and Playwright typecheck ratchets passed
- workflow security, Prettier, whitespace, and no-em-dash checks passed

## Runtime impact

The key correction affects only the gift dossier React identity bookkeeping and has no copy or styling change. The workflow change affects only Museum-impacting PRs. It restores quality coverage without adding another server startup.