### PR TITLE
Preserve production E2E control checkout

### DIFF
--- a/.github/workflows/production-e2e.yml
+++ b/.github/workflows/production-e2e.yml
@@ -221,7 +221,11 @@ jobs:
           set -euo pipefail
           [[ "$WORKFLOW_SHA" =~ ^[a-f0-9]{40}$ ]]
           test "$(git -C .release-bus-control rev-parse HEAD)" = "$WORKFLOW_SHA"
-          test -z "$(git -C .release-bus-control status --porcelain=v1 --untracked-files=all)"
+          if ! control_status="$(git -C .release-bus-control status --porcelain=v1 --untracked-files=all)"; then
+            echo "::error::Unable to verify the Museum selection control working tree."
+            exit 1
+          fi
+          test -z "$control_status"
           test -f .release-bus-control/scripts/museum-release-tier.cjs
           test -f .release-bus-control/scripts/museum-release-selection.cjs
       - name: Select fail-closed Museum packs for the exact deployed range
@@ -422,10 +426,12 @@ jobs:
       # workflow-SHA-bound copy for evidence verification so tested app code
       # cannot alter the verifier used to qualify its own output.
       - name: Require an unused Museum evidence control path
+        id: museum-evidence-path
         if: always() && steps.dependencies.outcome == 'success' && steps.playwright.outcome == 'success'
         run: test ! -e .release-bus-evidence-control
       - name: Check out immutable Release Bus Museum evidence tooling
-        if: always() && steps.dependencies.outcome == 'success' && steps.playwright.outcome == 'success'
+        id: museum-evidence-checkout
+        if: always() && steps.museum-evidence-path.outcome == 'success'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.workflow_sha }}
@@ -438,19 +444,24 @@ jobs:
             scripts/museum-release-selection.cjs
           sparse-checkout-cone-mode: false
       - name: Verify immutable Museum evidence tooling
-        if: always() && steps.dependencies.outcome == 'success' && steps.playwright.outcome == 'success'
+        id: museum-evidence-tooling
+        if: always() && steps.museum-evidence-checkout.outcome == 'success'
         env:
           WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
           [[ "$WORKFLOW_SHA" =~ ^[a-f0-9]{40}$ ]]
           test "$(git -C .release-bus-evidence-control rev-parse HEAD)" = "$WORKFLOW_SHA"
-          test -z "$(git -C .release-bus-evidence-control status --porcelain=v1 --untracked-files=all)"
+          if ! control_status="$(git -C .release-bus-evidence-control status --porcelain=v1 --untracked-files=all)"; then
+            echo "::error::Unable to verify the Museum evidence control working tree."
+            exit 1
+          fi
+          test -z "$control_status"
           test -f .release-bus-evidence-control/scripts/museum-release-tier.cjs
           test -f .release-bus-evidence-control/scripts/museum-release-selection.cjs
       - name: Validate exact production E2E evidence
         id: evidence
-        if: always() && steps.dependencies.outcome == 'success' && steps.playwright.outcome == 'success'
+        if: always() && steps.museum-evidence-tooling.outcome == 'success'
         env:
           E2E_OUTCOME: ${{ steps.e2e.outcome }}
           AUTOMATIC_DEPLOY_RUN_ID: ${{ inputs.automatic_deploy_run_id }}
@@ -587,6 +598,9 @@ jobs:
           DEPENDENCIES_OUTCOME: ${{ steps.dependencies.outcome }}
           PLAYWRIGHT_OUTCOME: ${{ steps.playwright.outcome }}
           E2E_OUTCOME: ${{ steps.e2e.outcome }}
+          MUSEUM_EVIDENCE_PATH_OUTCOME: ${{ steps.museum-evidence-path.outcome }}
+          MUSEUM_EVIDENCE_CHECKOUT_OUTCOME: ${{ steps.museum-evidence-checkout.outcome }}
+          MUSEUM_EVIDENCE_TOOLING_OUTCOME: ${{ steps.museum-evidence-tooling.outcome }}
           EVIDENCE_OUTCOME: ${{ steps.evidence.outcome }}
           TRAIN_ID: ${{ inputs.release_train_id }}
           OPERATION_KEY: ${{ inputs.operation_key }}
@@ -601,7 +615,10 @@ jobs:
             failure_class=INFRASTRUCTURE
             failure_phase=production_e2e_setup
             retryable=true
-          elif [ "$EVIDENCE_OUTCOME" != success ]; then
+          elif [ "$MUSEUM_EVIDENCE_PATH_OUTCOME" != success ] || \
+            [ "$MUSEUM_EVIDENCE_CHECKOUT_OUTCOME" != success ] || \
+            [ "$MUSEUM_EVIDENCE_TOOLING_OUTCOME" != success ] || \
+            [ "$EVIDENCE_OUTCOME" != success ]; then
             status=FAILED
             failure_class=CONTROL_PLANE
             failure_phase=production_e2e_evidence
@@ -635,10 +652,16 @@ jobs:
           DEPENDENCIES_OUTCOME: ${{ steps.dependencies.outcome }}
           PLAYWRIGHT_OUTCOME: ${{ steps.playwright.outcome }}
           E2E_OUTCOME: ${{ steps.e2e.outcome }}
+          MUSEUM_EVIDENCE_PATH_OUTCOME: ${{ steps.museum-evidence-path.outcome }}
+          MUSEUM_EVIDENCE_CHECKOUT_OUTCOME: ${{ steps.museum-evidence-checkout.outcome }}
+          MUSEUM_EVIDENCE_TOOLING_OUTCOME: ${{ steps.museum-evidence-tooling.outcome }}
           EVIDENCE_OUTCOME: ${{ steps.evidence.outcome }}
         run: |
           test "$SOCKET_OUTCOME" = success
           test "$DEPENDENCIES_OUTCOME" = success
           test "$PLAYWRIGHT_OUTCOME" = success
+          test "$MUSEUM_EVIDENCE_PATH_OUTCOME" = success
+          test "$MUSEUM_EVIDENCE_CHECKOUT_OUTCOME" = success
+          test "$MUSEUM_EVIDENCE_TOOLING_OUTCOME" = success
           test "$EVIDENCE_OUTCOME" = success
           test "$E2E_OUTCOME" = success

--- a/.github/workflows/production-e2e.yml
+++ b/.github/workflows/production-e2e.yml
@@ -153,6 +153,22 @@ jobs:
             -H 'Content-Type: application/json' \
             --data "$payload" \
             "$RELEASE_BUS_API_URL/deploy/release-bus-v2/authorize"
+      - name: Check out exact production SHA
+        # workflow_dispatch itself is trusted orchestration from the selected
+        # default-branch ref. All pack code, the pack manifest, dependencies,
+        # and evidence below come from this independently read-back deployed
+        # SHA, so a later main advance cannot change the tested inventory.
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.expected_sha || steps.automatic-deploy.outputs.deployed-sha }}
+          persist-credentials: false
+      - name: Verify immutable source
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha || steps.automatic-deploy.outputs.deployed-sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+      # The exact-source checkout cleans the workspace. Stage trusted control
+      # tooling only after it, otherwise checkout removes .release-bus-control
+      # before Museum pack selection executes.
       - name: Check out immutable Release Bus Museum selection tooling
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -174,19 +190,6 @@ jobs:
           test "$(git -C .release-bus-control rev-parse HEAD)" = "$WORKFLOW_SHA"
           test -f .release-bus-control/scripts/museum-release-tier.cjs
           test -f .release-bus-control/scripts/museum-release-selection.cjs
-      - name: Check out exact production SHA
-        # workflow_dispatch itself is trusted orchestration from the selected
-        # default-branch ref. All pack code, the pack manifest, dependencies,
-        # and evidence below come from this independently read-back deployed
-        # SHA, so a later main advance cannot change the tested inventory.
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          ref: ${{ inputs.expected_sha || steps.automatic-deploy.outputs.deployed-sha }}
-          persist-credentials: false
-      - name: Verify immutable source
-        env:
-          EXPECTED_SHA: ${{ inputs.expected_sha || steps.automatic-deploy.outputs.deployed-sha }}
-        run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
       - name: Install Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with: { node-version: "22.17.1" }

--- a/.github/workflows/production-e2e.yml
+++ b/.github/workflows/production-e2e.yml
@@ -166,30 +166,6 @@ jobs:
         env:
           EXPECTED_SHA: ${{ inputs.expected_sha || steps.automatic-deploy.outputs.deployed-sha }}
         run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
-      # The exact-source checkout cleans the workspace. Stage trusted control
-      # tooling only after it, otherwise checkout removes .release-bus-control
-      # before Museum pack selection executes.
-      - name: Check out immutable Release Bus Museum selection tooling
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          ref: ${{ github.workflow_sha }}
-          path: .release-bus-control
-          filter: blob:none
-          fetch-depth: 1
-          persist-credentials: false
-          sparse-checkout: |
-            scripts/museum-release-tier.cjs
-            scripts/museum-release-selection.cjs
-          sparse-checkout-cone-mode: false
-      - name: Verify immutable Museum selection tooling
-        env:
-          WORKFLOW_SHA: ${{ github.workflow_sha }}
-        run: |
-          set -euo pipefail
-          [[ "$WORKFLOW_SHA" =~ ^[a-f0-9]{40}$ ]]
-          test "$(git -C .release-bus-control rev-parse HEAD)" = "$WORKFLOW_SHA"
-          test -f .release-bus-control/scripts/museum-release-tier.cjs
-          test -f .release-bus-control/scripts/museum-release-selection.cjs
       - name: Install Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with: { node-version: "22.17.1" }
@@ -218,6 +194,36 @@ jobs:
         env:
           SFW_BIN: ${{ steps.socket-firewall.outputs.firewall-path-binary }}
         run: ./bin/6529 install:frozen
+      # The deployed tree and its dependency lifecycle run before trusted
+      # control tooling is staged. This keeps untrusted install code from
+      # mutating the Museum selector after its immutable-source verification.
+      - name: Require an unused Museum selection control path
+        if: steps.dependencies.outcome == 'success'
+        run: test ! -e .release-bus-control
+      - name: Check out immutable Release Bus Museum selection tooling
+        if: steps.dependencies.outcome == 'success'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .release-bus-control
+          filter: blob:none
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: |
+            scripts/museum-release-tier.cjs
+            scripts/museum-release-selection.cjs
+          sparse-checkout-cone-mode: false
+      - name: Verify immutable Museum selection tooling
+        if: steps.dependencies.outcome == 'success'
+        env:
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$WORKFLOW_SHA" =~ ^[a-f0-9]{40}$ ]]
+          test "$(git -C .release-bus-control rev-parse HEAD)" = "$WORKFLOW_SHA"
+          test -z "$(git -C .release-bus-control status --porcelain=v1 --untracked-files=all)"
+          test -f .release-bus-control/scripts/museum-release-tier.cjs
+          test -f .release-bus-control/scripts/museum-release-selection.cjs
       - name: Select fail-closed Museum packs for the exact deployed range
         id: museum-selection
         if: steps.dependencies.outcome == 'success'
@@ -412,6 +418,36 @@ jobs:
           fi
           echo "MUSEUM_SELECTED_PACKS_JSON=$MUSEUM_SELECTED_PACKS_JSON" >> "$GITHUB_ENV"
           ./bin/6529 run e2e:packs -- "${args[@]}"
+      # The deployed E2E runner has now completed. Stage a second, fresh,
+      # workflow-SHA-bound copy for evidence verification so tested app code
+      # cannot alter the verifier used to qualify its own output.
+      - name: Require an unused Museum evidence control path
+        if: always() && steps.dependencies.outcome == 'success' && steps.playwright.outcome == 'success'
+        run: test ! -e .release-bus-evidence-control
+      - name: Check out immutable Release Bus Museum evidence tooling
+        if: always() && steps.dependencies.outcome == 'success' && steps.playwright.outcome == 'success'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .release-bus-evidence-control
+          filter: blob:none
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: |
+            scripts/museum-release-tier.cjs
+            scripts/museum-release-selection.cjs
+          sparse-checkout-cone-mode: false
+      - name: Verify immutable Museum evidence tooling
+        if: always() && steps.dependencies.outcome == 'success' && steps.playwright.outcome == 'success'
+        env:
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$WORKFLOW_SHA" =~ ^[a-f0-9]{40}$ ]]
+          test "$(git -C .release-bus-evidence-control rev-parse HEAD)" = "$WORKFLOW_SHA"
+          test -z "$(git -C .release-bus-evidence-control status --porcelain=v1 --untracked-files=all)"
+          test -f .release-bus-evidence-control/scripts/museum-release-tier.cjs
+          test -f .release-bus-evidence-control/scripts/museum-release-selection.cjs
       - name: Validate exact production E2E evidence
         id: evidence
         if: always() && steps.dependencies.outcome == 'success' && steps.playwright.outcome == 'success'
@@ -423,7 +459,7 @@ jobs:
           MANIFEST_IDENTITY: ${{ inputs.release_manifest_identity_sha256 }}
           MUSEUM_SOURCE_COMMIT: ${{ steps.museum-selection.outputs.source_commit }}
           MUSEUM_SELECTION_FILE: ${{ steps.museum-selection.outputs.file }}
-          MUSEUM_RELEASE_SELECTION_TOOL: .release-bus-control/scripts/museum-release-selection.cjs
+          MUSEUM_RELEASE_SELECTION_TOOL: .release-bus-evidence-control/scripts/museum-release-selection.cjs
         run: |
           set -euo pipefail
           test -f production-e2e-artifacts/evidence.json
@@ -436,7 +472,7 @@ jobs:
             (.selected_packs | type == "array") and
             (.selection_digest | test("^[a-f0-9]{64}$"))
           ' "$MUSEUM_SELECTION_FILE" >/dev/null
-          ./bin/6529 exec node - "$MUSEUM_SELECTION_FILE" <<'NODE'
+          node - "$MUSEUM_SELECTION_FILE" <<'NODE'
           const fs = require("node:fs");
           const path = require("node:path");
           const selection = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));

--- a/__tests__/scripts/production-e2e-dispatch.test.ts
+++ b/__tests__/scripts/production-e2e-dispatch.test.ts
@@ -50,6 +50,17 @@ describe("automatic production E2E dispatch", () => {
       (step: { name?: string }) =>
         step.name === "Check out exact production SHA"
     );
+    const sourceVerificationIndex = job.steps.findIndex(
+      (step: { name?: string }) => step.name === "Verify immutable source"
+    );
+    const controlCheckoutIndex = job.steps.findIndex(
+      (step: { name?: string }) =>
+        step.name === "Check out immutable Release Bus Museum selection tooling"
+    );
+    const controlVerificationIndex = job.steps.findIndex(
+      (step: { name?: string }) =>
+        step.name === "Verify immutable Museum selection tooling"
+    );
     const packsIndex = job.steps.findIndex(
       (step: { name?: string }) =>
         step.name === "Run production-safe read-only packs"
@@ -77,7 +88,11 @@ describe("automatic production E2E dispatch", () => {
     expect(job.steps[checkoutIndex].with.ref).toBe(
       "${{ inputs.expected_sha || steps.automatic-deploy.outputs.deployed-sha }}"
     );
+    expect(sourceVerificationIndex).toBeGreaterThan(checkoutIndex);
+    expect(controlCheckoutIndex).toBeGreaterThan(sourceVerificationIndex);
+    expect(controlVerificationIndex).toBeGreaterThan(controlCheckoutIndex);
     expect(packsIndex).toBeGreaterThan(checkoutIndex);
+    expect(selectionIndex).toBeGreaterThan(controlVerificationIndex);
     expect(selectionIndex).toBeGreaterThan(checkoutIndex);
     expect(packsIndex).toBeGreaterThan(selectionIndex);
     expect(job.steps[selectionIndex].run).toContain(

--- a/__tests__/scripts/production-e2e-dispatch.test.ts
+++ b/__tests__/scripts/production-e2e-dispatch.test.ts
@@ -85,6 +85,17 @@ describe("automatic production E2E dispatch", () => {
       (step: { name?: string }) =>
         step.name === "Validate exact production E2E evidence"
     );
+    const evidencePath = job.steps[evidenceControlCheckoutIndex - 1];
+    const evidenceControlCheckout = job.steps[evidenceControlCheckoutIndex];
+    const evidenceControlVerification =
+      job.steps[evidenceControlVerificationIndex];
+    const report = job.steps.find(
+      (step: { name?: string }) =>
+        step.name === "Report structured Release Bus E2E result"
+    );
+    const result = job.steps.find(
+      (step: { name?: string }) => step.name === "Return production E2E result"
+    );
 
     expect(
       e2e.on.workflow_dispatch.inputs.automatic_deploy_run_id.required
@@ -122,6 +133,18 @@ describe("automatic production E2E dispatch", () => {
     expect(job.steps[evidenceControlCheckoutIndex].with.path).toBe(
       ".release-bus-evidence-control"
     );
+    expect(evidencePath.id).toBe("museum-evidence-path");
+    expect(evidenceControlCheckout.id).toBe("museum-evidence-checkout");
+    expect(evidenceControlCheckout.if).toContain(
+      "steps.museum-evidence-path.outcome == 'success'"
+    );
+    expect(evidenceControlVerification.id).toBe("museum-evidence-tooling");
+    expect(evidenceControlVerification.if).toContain(
+      "steps.museum-evidence-checkout.outcome == 'success'"
+    );
+    expect(job.steps[evidenceIndex].if).toContain(
+      "steps.museum-evidence-tooling.outcome == 'success'"
+    );
     expect(job.steps[selectionIndex].run).toContain(
       "scripts/museum-release-selection.cjs"
     );
@@ -140,6 +163,22 @@ describe("automatic production E2E dispatch", () => {
       ".release-bus-evidence-control/scripts/museum-release-selection.cjs"
     );
     expect(evidence.run).toContain('node - "$MUSEUM_SELECTION_FILE"');
+    for (const outcome of [
+      "MUSEUM_EVIDENCE_PATH_OUTCOME",
+      "MUSEUM_EVIDENCE_CHECKOUT_OUTCOME",
+      "MUSEUM_EVIDENCE_TOOLING_OUTCOME",
+    ]) {
+      expect(report.env[outcome]).toContain("steps.museum-evidence-");
+      expect(report.run).toContain(`$${outcome}`);
+      expect(result.env[outcome]).toContain("steps.museum-evidence-");
+      expect(result.run).toContain(`$${outcome}`);
+    }
+    expect(e2eSource).toContain(
+      'if ! control_status="$(git -C .release-bus-control status --porcelain=v1 --untracked-files=all)"; then'
+    );
+    expect(e2eSource).toContain(
+      'if ! control_status="$(git -C .release-bus-evidence-control status --porcelain=v1 --untracked-files=all)"; then'
+    );
     expect(e2eSource).toContain("args+=(--parallel 3)");
     expect(e2eSource).toContain("Restore Playwright browser");
   });

--- a/__tests__/scripts/production-e2e-dispatch.test.ts
+++ b/__tests__/scripts/production-e2e-dispatch.test.ts
@@ -61,6 +61,9 @@ describe("automatic production E2E dispatch", () => {
       (step: { name?: string }) =>
         step.name === "Verify immutable Museum selection tooling"
     );
+    const dependenciesIndex = job.steps.findIndex(
+      (step: { name?: string }) => step.name === "Install frozen dependencies"
+    );
     const packsIndex = job.steps.findIndex(
       (step: { name?: string }) =>
         step.name === "Run production-safe read-only packs"
@@ -69,6 +72,18 @@ describe("automatic production E2E dispatch", () => {
       (step: { name?: string }) =>
         step.name ===
         "Select fail-closed Museum packs for the exact deployed range"
+    );
+    const evidenceControlCheckoutIndex = job.steps.findIndex(
+      (step: { name?: string }) =>
+        step.name === "Check out immutable Release Bus Museum evidence tooling"
+    );
+    const evidenceControlVerificationIndex = job.steps.findIndex(
+      (step: { name?: string }) =>
+        step.name === "Verify immutable Museum evidence tooling"
+    );
+    const evidenceIndex = job.steps.findIndex(
+      (step: { name?: string }) =>
+        step.name === "Validate exact production E2E evidence"
     );
 
     expect(
@@ -89,12 +104,24 @@ describe("automatic production E2E dispatch", () => {
       "${{ inputs.expected_sha || steps.automatic-deploy.outputs.deployed-sha }}"
     );
     expect(sourceVerificationIndex).toBeGreaterThan(checkoutIndex);
-    expect(controlCheckoutIndex).toBeGreaterThan(sourceVerificationIndex);
+    expect(dependenciesIndex).toBeGreaterThan(sourceVerificationIndex);
+    expect(controlCheckoutIndex).toBeGreaterThan(dependenciesIndex);
     expect(controlVerificationIndex).toBeGreaterThan(controlCheckoutIndex);
     expect(packsIndex).toBeGreaterThan(checkoutIndex);
     expect(selectionIndex).toBeGreaterThan(controlVerificationIndex);
     expect(selectionIndex).toBeGreaterThan(checkoutIndex);
     expect(packsIndex).toBeGreaterThan(selectionIndex);
+    expect(evidenceControlCheckoutIndex).toBeGreaterThan(packsIndex);
+    expect(evidenceControlVerificationIndex).toBeGreaterThan(
+      evidenceControlCheckoutIndex
+    );
+    expect(evidenceIndex).toBeGreaterThan(evidenceControlVerificationIndex);
+    expect(job.steps[controlCheckoutIndex].with.path).toBe(
+      ".release-bus-control"
+    );
+    expect(job.steps[evidenceControlCheckoutIndex].with.path).toBe(
+      ".release-bus-evidence-control"
+    );
     expect(job.steps[selectionIndex].run).toContain(
       "scripts/museum-release-selection.cjs"
     );
@@ -109,6 +136,10 @@ describe("automatic production E2E dispatch", () => {
     );
     expect(evidence.run).toContain("!isMuseumPack(pack)");
     expect(evidence.run).toContain(".release_binding == null");
+    expect(evidence.env.MUSEUM_RELEASE_SELECTION_TOOL).toBe(
+      ".release-bus-evidence-control/scripts/museum-release-selection.cjs"
+    );
+    expect(evidence.run).toContain('node - "$MUSEUM_SELECTION_FILE"');
     expect(e2eSource).toContain("args+=(--parallel 3)");
     expect(e2eSource).toContain("Restore Playwright browser");
   });


### PR DESCRIPTION
## Outcome

Fixes automatic Production E2E failing before browser execution because the exact deployed-source checkout cleaned the earlier immutable control checkout.

## Change

- check out and verify the exact deployed application SHA first
- check out and verify immutable Museum selection tooling afterward
- assert that ordering in the automatic production-E2E contract test

## Evidence

- failed production E2E: https://github.com/6529-Collections/6529seize-frontend/actions/runs/31079280391
- exact failure: museum-release-selection.cjs missing after the later clean checkout
- 80 focused workflow/deployment tests pass
- changed lint and changed TypeScript ratchet pass
- Prettier and codex-diff-check pass
- local pr-ci-policy-bundle remains intentionally Linux-authoritative because Windows lacks O_NOFOLLOW; hosted CI will run it

No application runtime code changes. After merge, Production E2E will be dispatched with successful exact deploy run 31078927972, binding pack execution to deployed SHA 4f5af95a044d8a46af9d549f479a8d59f335d73e.