### PR TITLE
Refine 6529bot Usage and Tech Updates pages

### DIFF
--- a/app/about/[section]/page.tsx
+++ b/app/about/[section]/page.tsx
@@ -1,5 +1,3 @@
-import styles from "@/styles/Home.module.css";
-
 import About from "@/components/about/About";
 import {
   getAboutSectionDocumentTitle,
@@ -41,8 +39,7 @@ export default async function AboutPage(props: Readonly<Props>) {
   return (
     <main
       className={clsx(
-        styles["main"],
-        "tailwind-scope",
+        "tailwind-scope tw-min-h-screen",
         (usesFeatureLayout || usesLegalLayout) &&
           "tw-border-y-0 tw-border-l-0 tw-border-r tw-border-solid tw-border-iron-900 tw-bg-[#0D0D0F]"
       )}

--- a/app/open-data/6529bot/loading.tsx
+++ b/app/open-data/6529bot/loading.tsx
@@ -1,0 +1,11 @@
+import {
+  ReviewbotUsageLoading,
+} from "@/components/reviewbot-usage/ReviewbotUsageDashboard";
+
+export default function Loading() {
+  return (
+    <main className="tw-min-h-screen">
+      <ReviewbotUsageLoading />
+    </main>
+  );
+}

--- a/app/open-data/6529bot/loading.tsx
+++ b/app/open-data/6529bot/loading.tsx
@@ -1,6 +1,4 @@
-import {
-  ReviewbotUsageLoading,
-} from "@/components/reviewbot-usage/ReviewbotUsageDashboard";
+import { ReviewbotUsageLoading } from "@/components/reviewbot-usage/ReviewbotUsageDashboard";
 
 export default function Loading() {
   return (

--- a/components/about/about.routes.ts
+++ b/components/about/about.routes.ts
@@ -247,6 +247,7 @@ const ABOUT_SECTION_DOCUMENT_TITLE_KEYS = new Map<AboutSection, MessageKey>([
 ]);
 
 const ABOUT_FEATURE_SECTIONS = new Set<AboutSection>([
+  AboutSection.TECH,
   AboutSection.SUBSCRIPTIONS,
   AboutSection.MEME_LAB,
   AboutSection.GRADIENTS,

--- a/components/about/tech/AboutTech.tsx
+++ b/components/about/tech/AboutTech.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 import { formatInteger } from "@/i18n/format";
 import { DEFAULT_LOCALE } from "@/i18n/locales";
-import { t } from "@/i18n/messages";
+import { t, tRich } from "@/i18n/messages";
 import { ABOUT_MOBILE_COLUMN_GUTTER_BREAKOUT_CLASS } from "../AboutLayout";
 
 import {
@@ -21,33 +21,31 @@ export default function AboutTech() {
     >
       <header className="tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-white/[0.06] tw-px-1 tw-pb-[34px] tw-pt-[21px] sm:tw-px-0 sm:tw-pb-[55px] sm:tw-pt-[34px] lg:tw-px-2">
         <p className="tw-m-0 tw-mb-[13px] tw-text-xs tw-font-semibold tw-uppercase tw-leading-5 tw-tracking-[0.1em] tw-text-primary-300">
-          About / Tech
+          {t(locale, "about.tech.index.eyebrow")}
         </p>
         <h1 className="tw-m-0 tw-max-w-3xl tw-text-balance tw-text-3xl tw-font-semibold tw-leading-[1.03] tw-tracking-[-0.04em] tw-text-iron-50 md:tw-text-4xl">
-          Tech Updates
+          {t(locale, "about.tech.index.title")}
         </h1>
         <div className="tw-mt-[21px] tw-max-w-4xl">
           <p className="tw-m-0 tw-text-pretty tw-text-lg tw-leading-7 tw-text-iron-100">
-            This is a current casual area for longer 6529 tech updates: repo
-            work, bot notes, release context, and build reports that are too
-            large for a single wave drop.
+            {t(locale, "about.tech.index.intro")}
           </p>
           <ul className="tw-m-0 tw-mt-[21px] tw-grid tw-gap-[13px] tw-pl-[21px] tw-text-base tw-leading-7 tw-text-iron-300 marker:tw-text-iron-600">
+            <li>{t(locale, "about.tech.index.longUpdates")}</li>
             <li>
-              Long updates, repo analysis, bot context, and links back into the
-              wave conversation.
-            </li>
-            <li>
-              Shorter live repo activity still belongs in{" "}
-              <a
-                href={FOLLOW_THE_REPO_WAVE_URL}
-                target="_blank"
-                rel="noreferrer"
-                className="hover:tw-text-primary-200 tw-rounded-sm tw-font-semibold tw-text-primary-300 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
-              >
-                Follow The Repo
-              </a>
-              . This page is the linkable longer-form shelf beside it.
+              {tRich(locale, "about.tech.index.liveActivity", {
+                followTheRepo: (
+                  <a
+                    className="hover:tw-text-primary-200 tw-rounded-sm tw-font-semibold tw-text-primary-300 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-[#0D0D0F]"
+                    href={FOLLOW_THE_REPO_WAVE_URL}
+                    key="follow-the-repo"
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    {t(locale, "about.tech.index.followTheRepo")}
+                  </a>
+                ),
+              })}
             </li>
           </ul>
         </div>
@@ -61,7 +59,7 @@ export default function AboutTech() {
           id="tech-notes-heading"
           className="tw-m-0 tw-mb-[21px] tw-text-lg tw-font-semibold tw-leading-tight tw-tracking-tight tw-text-iron-100 sm:tw-text-xl"
         >
-          Active Technical Notes
+          {t(locale, "about.tech.index.activeTechnicalNotes")}
         </h2>
         <Link
           href="/about/tech/wallet-authentication"
@@ -72,14 +70,13 @@ export default function AboutTech() {
           )}
         >
           <p className="tw-m-0 tw-text-xs tw-font-semibold tw-uppercase tw-leading-5 tw-tracking-[0.1em] tw-text-iron-500">
-            Auth changes
+            {t(locale, "about.tech.index.authChanges")}
           </p>
           <h3 className="tw-m-0 tw-mt-[13px] tw-text-base tw-font-semibold tw-leading-6 tw-text-iron-50 tw-transition-colors group-hover:tw-text-primary-300 group-focus-visible:tw-text-primary-300 motion-reduce:tw-transition-none">
-            Wallet authentication upgrade
+            {t(locale, "about.tech.index.walletAuthenticationTitle")}
           </h3>
           <p className="tw-m-0 tw-mt-[13px] tw-max-w-4xl tw-text-sm tw-leading-6 tw-text-iron-400">
-            What is changing with the new secure session, why users may be asked
-            to upgrade, and what to expect during rollout.
+            {t(locale, "about.tech.index.walletAuthenticationDescription")}
           </p>
         </Link>
       </section>
@@ -91,20 +88,20 @@ export default function AboutTech() {
         <div className="tw-mb-[21px] tw-flex tw-flex-col tw-gap-[13px] sm:tw-flex-row sm:tw-items-end sm:tw-justify-between">
           <div>
             <p className="tw-m-0 tw-mb-[13px] tw-text-xs tw-font-semibold tw-uppercase tw-leading-5 tw-tracking-[0.1em] tw-text-iron-500">
-              Index
+              {t(locale, "about.tech.index.reportsEyebrow")}
             </p>
             <h2
               id="tech-reports-heading"
               className="tw-m-0 tw-text-lg tw-font-semibold tw-leading-tight tw-tracking-tight tw-text-iron-100 sm:tw-text-xl"
             >
-              Reports
+              {t(locale, "about.tech.index.reportsTitle")}
             </h2>
           </div>
           <Link
             href={`/about/tech/${TECH_WEEKLY_PR_REPORT.slug}`}
-            className="hover:tw-text-primary-200 tw-w-fit tw-rounded-sm tw-text-sm tw-font-semibold tw-text-primary-300 tw-no-underline focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
+            className="hover:tw-text-primary-200 tw-w-fit tw-rounded-sm tw-text-sm tw-font-semibold tw-text-primary-300 tw-no-underline focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-[#0D0D0F]"
           >
-            Open latest report
+            {t(locale, "about.tech.index.openLatestReport")}
           </Link>
         </div>
 
@@ -123,7 +120,7 @@ export default function AboutTech() {
                     <h3 className="tw-m-0 tw-mt-[13px] tw-text-base tw-font-semibold tw-leading-6 tw-text-iron-50 sm:tw-text-lg">
                       <Link
                         href={`/about/tech/${report.slug}`}
-                        className="hover:tw-text-primary-200 tw-rounded-sm tw-text-iron-50 tw-no-underline focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
+                        className="hover:tw-text-primary-200 tw-rounded-sm tw-text-iron-50 tw-no-underline focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-iron-950"
                       >
                         {report.title}
                       </Link>

--- a/components/about/tech/AboutTech.tsx
+++ b/components/about/tech/AboutTech.tsx
@@ -63,7 +63,7 @@ export default function AboutTech() {
         </h2>
         <Link
           href="/about/tech/wallet-authentication"
-          className="tw-group tw-block tw-rounded-xl tw-border tw-border-solid tw-border-iron-800/50 tw-bg-iron-900/55 tw-p-[21px] tw-text-current tw-no-underline tw-transition-colors tw-duration-200 hover:tw-border-primary-400/60 hover:tw-bg-iron-900/75 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-[#0D0D0F] motion-reduce:tw-transition-none"
+          className="tw-group tw-block tw-rounded-xl tw-border tw-border-solid tw-border-iron-800/50 tw-bg-iron-900/55 tw-p-[21px] tw-text-current tw-no-underline tw-transition-colors tw-duration-200 hover:tw-border-primary-400/60 hover:tw-bg-iron-900/75 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-primary-400 motion-reduce:tw-transition-none"
           aria-label={t(
             locale,
             "about.tech.notes.walletAuthentication.ariaLabel"

--- a/components/about/tech/AboutTech.tsx
+++ b/components/about/tech/AboutTech.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { formatInteger } from "@/i18n/format";
 import { DEFAULT_LOCALE } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
+import { ABOUT_MOBILE_COLUMN_GUTTER_BREAKOUT_CLASS } from "../AboutLayout";
 
 import {
   FOLLOW_THE_REPO_WAVE_URL,
@@ -15,21 +16,23 @@ export default function AboutTech() {
   const locale = DEFAULT_LOCALE;
 
   return (
-    <div className="tw-flex tw-w-full tw-flex-col tw-gap-10 tw-px-4 tw-text-iron-50 sm:tw-px-6 lg:tw-px-8">
-      <section className="tw-pb-2">
-        <p className="tw-mb-2 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-50">
+    <article
+      className={`tw-w-full tw-overflow-hidden tw-bg-[#0D0D0F] tw-pb-[55px] tw-text-iron-100 ${ABOUT_MOBILE_COLUMN_GUTTER_BREAKOUT_CLASS}`}
+    >
+      <header className="tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-white/[0.06] tw-px-1 tw-pb-[34px] tw-pt-[21px] sm:tw-px-0 sm:tw-pb-[55px] sm:tw-pt-[34px] lg:tw-px-2">
+        <p className="tw-m-0 tw-mb-[13px] tw-text-xs tw-font-semibold tw-uppercase tw-leading-5 tw-tracking-[0.1em] tw-text-primary-300">
           About / Tech
         </p>
-        <h1 className="tw-mb-4 tw-text-3xl tw-font-semibold tw-leading-tight tw-text-iron-50 md:tw-text-4xl">
+        <h1 className="tw-m-0 tw-max-w-3xl tw-text-balance tw-text-3xl tw-font-semibold tw-leading-[1.03] tw-tracking-[-0.04em] tw-text-iron-50 md:tw-text-4xl">
           Tech Updates
         </h1>
-        <div className="tw-flex tw-w-full tw-flex-col tw-gap-5 tw-text-base tw-leading-7 tw-text-iron-50">
-          <p className="tw-mb-0">
+        <div className="tw-mt-[21px] tw-max-w-4xl">
+          <p className="tw-m-0 tw-text-pretty tw-text-lg tw-leading-7 tw-text-iron-100">
             This is a current casual area for longer 6529 tech updates: repo
             work, bot notes, release context, and build reports that are too
             large for a single wave drop.
           </p>
-          <ul className="tw-mb-0 tw-grid tw-gap-3 tw-pl-5">
+          <ul className="tw-m-0 tw-mt-[21px] tw-grid tw-gap-[13px] tw-pl-[21px] tw-text-base tw-leading-7 tw-text-iron-300 marker:tw-text-iron-600">
             <li>
               Long updates, repo analysis, bot context, and links back into the
               wave conversation.
@@ -40,7 +43,7 @@ export default function AboutTech() {
                 href={FOLLOW_THE_REPO_WAVE_URL}
                 target="_blank"
                 rel="noreferrer"
-                className="hover:tw-text-primary-200 tw-font-semibold tw-text-primary-300"
+                className="hover:tw-text-primary-200 tw-rounded-sm tw-font-semibold tw-text-primary-300 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
               >
                 Follow The Repo
               </a>
@@ -48,94 +51,101 @@ export default function AboutTech() {
             </li>
           </ul>
         </div>
-      </section>
+      </header>
 
-      <section className="tw-w-full" aria-labelledby="tech-notes-heading">
+      <section
+        aria-labelledby="tech-notes-heading"
+        className="tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-white/[0.06] tw-px-1 tw-py-[34px] sm:tw-px-0 sm:tw-py-[55px] lg:tw-px-2"
+      >
         <h2
           id="tech-notes-heading"
-          className="tw-mb-5 tw-text-2xl tw-font-semibold tw-text-iron-50"
+          className="tw-m-0 tw-mb-[21px] tw-text-lg tw-font-semibold tw-leading-tight tw-tracking-tight tw-text-iron-100 sm:tw-text-xl"
         >
           Active Technical Notes
         </h2>
         <Link
           href="/about/tech/wallet-authentication"
-          className="tw-block tw-rounded-lg tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-950/50 tw-p-5 tw-text-current tw-no-underline tw-transition-colors hover:tw-border-primary-500 hover:tw-bg-iron-900/60 focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-primary-400 focus:tw-ring-offset-2 focus:tw-ring-offset-black"
+          className="tw-group tw-block tw-rounded-xl tw-border tw-border-solid tw-border-iron-800/50 tw-bg-iron-900/55 tw-p-[21px] tw-text-current tw-no-underline tw-transition-colors tw-duration-200 hover:tw-border-primary-400/60 hover:tw-bg-iron-900/75 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-[#0D0D0F] motion-reduce:tw-transition-none"
           aria-label={t(
             locale,
             "about.tech.notes.walletAuthentication.ariaLabel"
           )}
         >
-          <p className="tw-mb-2 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-50">
+          <p className="tw-m-0 tw-text-xs tw-font-semibold tw-uppercase tw-leading-5 tw-tracking-[0.1em] tw-text-iron-500">
             Auth changes
           </p>
-          <h3 className="tw-mb-2 tw-text-xl tw-font-semibold tw-leading-snug tw-text-iron-50">
+          <h3 className="tw-m-0 tw-mt-[13px] tw-text-base tw-font-semibold tw-leading-6 tw-text-iron-50 tw-transition-colors group-hover:tw-text-primary-300 group-focus-visible:tw-text-primary-300 motion-reduce:tw-transition-none">
             Wallet authentication upgrade
           </h3>
-          <p className="tw-mb-0 tw-text-sm tw-leading-6 tw-text-iron-50">
+          <p className="tw-m-0 tw-mt-[13px] tw-max-w-4xl tw-text-sm tw-leading-6 tw-text-iron-400">
             What is changing with the new secure session, why users may be asked
             to upgrade, and what to expect during rollout.
           </p>
         </Link>
       </section>
 
-      <section className="tw-w-full" aria-labelledby="tech-reports-heading">
-        <div className="tw-mb-5 tw-flex tw-flex-col tw-gap-2 sm:tw-flex-row sm:tw-items-end sm:tw-justify-between">
+      <section
+        aria-labelledby="tech-reports-heading"
+        className="tw-px-1 tw-py-[34px] sm:tw-px-0 sm:tw-py-[55px] lg:tw-px-2"
+      >
+        <div className="tw-mb-[21px] tw-flex tw-flex-col tw-gap-[13px] sm:tw-flex-row sm:tw-items-end sm:tw-justify-between">
           <div>
-            <p className="tw-mb-2 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-50">
+            <p className="tw-m-0 tw-mb-[13px] tw-text-xs tw-font-semibold tw-uppercase tw-leading-5 tw-tracking-[0.1em] tw-text-iron-500">
               Index
             </p>
             <h2
               id="tech-reports-heading"
-              className="tw-mb-0 tw-text-2xl tw-font-semibold tw-text-iron-50"
+              className="tw-m-0 tw-text-lg tw-font-semibold tw-leading-tight tw-tracking-tight tw-text-iron-100 sm:tw-text-xl"
             >
               Reports
             </h2>
           </div>
-          <p>
-            <Link
-              href={`/about/tech/${TECH_WEEKLY_PR_REPORT.slug}`}
-              className="hover:tw-text-primary-200 tw-text-sm tw-font-semibold tw-text-primary-300 tw-no-underline"
-            >
-              Open latest report
-            </Link>
-          </p>
+          <Link
+            href={`/about/tech/${TECH_WEEKLY_PR_REPORT.slug}`}
+            className="hover:tw-text-primary-200 tw-w-fit tw-rounded-sm tw-text-sm tw-font-semibold tw-text-primary-300 tw-no-underline focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
+          >
+            Open latest report
+          </Link>
         </div>
 
-        <article className="tw-overflow-hidden tw-rounded-lg tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-950/50">
-          <ul className="tw-mb-0 tw-list-none tw-divide-y tw-divide-iron-800 tw-p-0">
+        <div className="tw-overflow-hidden tw-rounded-xl tw-bg-iron-950 tw-ring-1 tw-ring-inset tw-ring-white/10">
+          <ul className="tw-m-0 tw-list-none tw-p-0">
             {TECH_PR_REPORTS.map((report) => (
-              <li key={report.slug}>
-                <div className="tw-grid tw-gap-0 md:tw-grid-cols-[minmax(0,1fr)_12rem]">
-                  <div className="tw-p-5">
-                    <p className="tw-mb-2 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-50">
+              <li
+                className="tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-white/10 last:tw-border-b-0"
+                key={report.slug}
+              >
+                <article className="tw-grid tw-gap-0 md:tw-grid-cols-[minmax(0,1fr)_12rem]">
+                  <div className="tw-p-[21px]">
+                    <p className="tw-m-0 tw-text-xs tw-font-semibold tw-uppercase tw-leading-5 tw-tracking-[0.1em] tw-text-iron-500">
                       {report.dateLabel}
                     </p>
-                    <h3 className="tw-mb-2 tw-text-xl tw-font-semibold tw-leading-snug tw-text-iron-50">
+                    <h3 className="tw-m-0 tw-mt-[13px] tw-text-base tw-font-semibold tw-leading-6 tw-text-iron-50 sm:tw-text-lg">
                       <Link
                         href={`/about/tech/${report.slug}`}
-                        className="hover:tw-text-primary-200 tw-text-iron-50 tw-no-underline"
+                        className="hover:tw-text-primary-200 tw-rounded-sm tw-text-iron-50 tw-no-underline focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
                       >
                         {report.title}
                       </Link>
                     </h3>
-                    <p className="tw-mb-0 tw-text-sm tw-leading-6 tw-text-iron-50">
+                    <p className="tw-m-0 tw-mt-[13px] tw-text-sm tw-leading-6 tw-text-iron-400">
                       {report.description}
                     </p>
                   </div>
-                  <div className="tw-border-t tw-border-solid tw-border-iron-800 tw-p-5 md:tw-border-l md:tw-border-t-0">
-                    <p className="tw-mb-1 tw-text-3xl tw-font-semibold tw-leading-none tw-text-iron-50">
+                  <div className="tw-flex tw-flex-col tw-justify-center tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/10 tw-bg-iron-900/30 tw-p-[21px] md:tw-border-l md:tw-border-t-0">
+                    <p className="tw-m-0 tw-text-3xl tw-font-semibold tw-leading-none tw-text-iron-50 tw-tabular-nums">
                       {formatInteger(locale, getTechReportTotal(report))}
                     </p>
-                    <p className="tw-mb-0 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-50">
+                    <p className="tw-m-0 tw-mt-[13px] tw-text-xs tw-font-semibold tw-uppercase tw-leading-5 tw-tracking-[0.1em] tw-text-iron-500">
                       {t(locale, "about.tech.index.prsCovered")}
                     </p>
                   </div>
-                </div>
+                </article>
               </li>
             ))}
           </ul>
-        </article>
+        </div>
       </section>
-    </div>
+    </article>
   );
 }

--- a/components/reviewbot-usage/ReviewbotUsageDashboard.tsx
+++ b/components/reviewbot-usage/ReviewbotUsageDashboard.tsx
@@ -4,10 +4,12 @@ import type {
   ReviewbotUsageResult,
 } from "@/services/reviewbot-usage-api";
 import {
+  CalendarDaysIcon,
   ChartBarIcon,
   CpuChipIcon,
   CurrencyDollarIcon,
   DocumentTextIcon,
+  ExclamationTriangleIcon,
   ShieldCheckIcon,
 } from "@heroicons/react/24/outline";
 import type { ReactNode } from "react";
@@ -33,118 +35,196 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
   year: "numeric",
 });
 
+const LOADING_METRIC_KEYS = [
+  "review-runs",
+  "unique-prs",
+  "estimated-spend",
+  "average-run",
+  "average-pr",
+  "tokens",
+  "budget-skips",
+] as const;
+
+const LOADING_ANALYSIS_KEYS = [
+  "skip-rate",
+  "tokens-run",
+  "tokens-pr",
+  "top-repo",
+  "top-provider",
+  "top-review-type",
+] as const;
+
+const TABLE_HEADER_CELL_CLASS =
+  "tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-iron-800 tw-py-3 tw-text-xs tw-font-semibold tw-uppercase tw-tracking-wider tw-text-iron-400";
+
+const TABLE_BODY_CELL_CLASS =
+  "tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-iron-900 tw-py-4 tw-text-sm";
+
 export default function ReviewbotUsageDashboard({
   result,
 }: ReviewbotUsageDashboardProps) {
   const summary = result.status === "ok" ? result.summary : null;
-  const totals = summary?.totals ?? {
-    budgetSkippedRuns: 0,
-    costUsd: 0,
-    averageCostPerPrUsd: 0,
-    averageCostPerReviewRunUsd: 0,
-    reviewRuns: 0,
-    totalTokens: 0,
-    uniquePrs: 0,
-  };
   const unavailableMessage = result.status === "ok" ? "" : result.message;
 
   return (
-    <div className="tw-container tw-mx-auto tw-px-4 tw-py-4 sm:tw-px-6 lg:tw-px-8">
-      <div className="tw-max-w-5xl">
-        <p className="tw-mb-2 tw-text-sm tw-font-semibold tw-uppercase tw-text-primary-300">
-          Open Data
-        </p>
-        <h1 className="tw-mb-4">6529bot Usage</h1>
-        <p className="tw-max-w-3xl tw-text-base tw-leading-7 tw-text-iron-300">
-          Public AI review activity across configured 6529 repositories.
-        </p>
-      </div>
-
-      <div className="tw-mt-8 tw-grid tw-grid-cols-1 tw-gap-3 sm:tw-grid-cols-2 xl:tw-grid-cols-3">
-        <MetricCard
-          icon={<ChartBarIcon className="tw-h-6 tw-w-6" />}
-          label="Review Runs"
-          tone="tw-text-primary-300"
-          value={formatInteger(totals.reviewRuns)}
-        />
-        <MetricCard
-          icon={<DocumentTextIcon className="tw-h-6 tw-w-6" />}
-          label="Unique PRs"
-          tone="tw-text-primary-300"
-          value={formatInteger(totals.uniquePrs)}
-        />
-        <MetricCard
-          icon={<CurrencyDollarIcon className="tw-h-6 tw-w-6" />}
-          label="Estimated Spend"
-          tone="tw-text-success"
-          value={formatCurrency(totals.costUsd)}
-        />
-        <MetricCard
-          icon={<CurrencyDollarIcon className="tw-h-6 tw-w-6" />}
-          label="Avg / Run"
-          tone="tw-text-success"
-          value={formatCurrency(totals.averageCostPerReviewRunUsd)}
-        />
-        <MetricCard
-          icon={<CurrencyDollarIcon className="tw-h-6 tw-w-6" />}
-          label="Avg / PR"
-          tone="tw-text-success"
-          value={formatCurrency(totals.averageCostPerPrUsd)}
-        />
-        <MetricCard
-          icon={<CpuChipIcon className="tw-h-6 tw-w-6" />}
-          label="Tokens"
-          tone="tw-text-iron-100"
-          value={formatInteger(totals.totalTokens)}
-        />
-        <MetricCard
-          icon={<ShieldCheckIcon className="tw-h-6 tw-w-6" />}
-          label="Budget Skips"
-          tone="tw-text-amber-300"
-          value={formatInteger(totals.budgetSkippedRuns)}
-        />
-      </div>
-
-      {summary ? <AnalysisHighlights analysis={summary.analysis} /> : null}
+    <div className="tailwind-scope tw-mx-auto tw-w-full tw-min-w-0 tw-px-3 tw-pb-12 tw-pt-8 sm:tw-px-6 lg:tw-px-8 lg:tw-pt-10">
+      <DashboardHeader />
 
       {summary ? (
         <>
+          <div className="tw-mt-6 tw-grid tw-grid-cols-1 tw-gap-3 sm:tw-grid-cols-2 lg:tw-grid-cols-4">
+            <MetricCard
+              icon={<ChartBarIcon aria-hidden="true" className="tw-size-5" />}
+              label="Review Runs"
+              tone="tw-text-primary-300"
+              value={formatInteger(summary.totals.reviewRuns)}
+            />
+            <MetricCard
+              icon={
+                <DocumentTextIcon aria-hidden="true" className="tw-size-5" />
+              }
+              label="Unique PRs"
+              tone="tw-text-primary-300"
+              value={formatInteger(summary.totals.uniquePrs)}
+            />
+            <MetricCard
+              icon={
+                <CurrencyDollarIcon aria-hidden="true" className="tw-size-5" />
+              }
+              label="Estimated Spend"
+              tone="tw-text-success"
+              value={formatCurrency(summary.totals.costUsd)}
+            />
+            <MetricCard
+              icon={
+                <CurrencyDollarIcon aria-hidden="true" className="tw-size-5" />
+              }
+              label="Avg / Run"
+              tone="tw-text-success"
+              value={formatCurrency(
+                summary.totals.averageCostPerReviewRunUsd
+              )}
+            />
+            <MetricCard
+              icon={
+                <CurrencyDollarIcon aria-hidden="true" className="tw-size-5" />
+              }
+              label="Avg / PR"
+              tone="tw-text-success"
+              value={formatCurrency(summary.totals.averageCostPerPrUsd)}
+            />
+            <MetricCard
+              icon={<CpuChipIcon aria-hidden="true" className="tw-size-5" />}
+              label="Tokens"
+              tone="tw-text-iron-100"
+              value={formatInteger(summary.totals.totalTokens)}
+            />
+            <MetricCard
+              icon={
+                <ShieldCheckIcon aria-hidden="true" className="tw-size-5" />
+              }
+              label="Budget Skips"
+              tone="tw-text-amber-300"
+              value={formatInteger(summary.totals.budgetSkippedRuns)}
+            />
+          </div>
+
+          <AnalysisHighlights analysis={summary.analysis} />
           <UsageSection
             groups={summary.byDay}
+            id="reviewbot-daily-usage"
             keyHeader="Day"
             title="Daily Usage"
           />
           <UsageSection
             groups={summary.byRepo}
+            id="reviewbot-repositories"
             keyHeader="Repository"
             title="Repositories"
           />
           <UsageSection
             groups={summary.byProviderModel}
+            id="reviewbot-providers-models"
             keyHeader="Provider and Model"
             title="Providers and Models"
           />
           <UsageSection
             groups={summary.byReviewKind}
+            id="reviewbot-review-types"
             keyHeader="Review Type"
             title="Review Types"
           />
-          <p className="tw-mt-8 tw-text-sm tw-text-iron-400">
-            Window: {formatDate(summary.range.from)} to{" "}
-            {formatDate(summary.range.to)}
-          </p>
+          <div className="tw-mt-6 tw-flex tw-w-fit tw-max-w-full tw-items-center tw-gap-2 tw-rounded-lg tw-bg-iron-950 tw-px-3 tw-py-2 tw-ring-1 tw-ring-inset tw-ring-iron-800">
+            <CalendarDaysIcon
+              aria-hidden="true"
+              className="tw-size-4 tw-flex-none tw-text-iron-500"
+            />
+            <p className="tw-m-0 tw-text-sm tw-leading-5 tw-text-iron-400">
+              Window: {formatDate(summary.range.from)} to{" "}
+              {formatDate(summary.range.to)}
+            </p>
+          </div>
         </>
       ) : (
-        <div className="tw-mt-10 tw-border-l-4 tw-border-primary-500 tw-bg-iron-950 tw-px-5 tw-py-4">
-          <h2 className="tw-mb-2 tw-text-xl tw-font-semibold tw-text-white">
-            Usage Data Unavailable
-          </h2>
-          <p className="tw-mb-0 tw-text-sm tw-leading-6 tw-text-iron-300">
-            {unavailableMessage}
-          </p>
-        </div>
+        <UnavailableState message={unavailableMessage} />
       )}
     </div>
+  );
+}
+
+export function ReviewbotUsageLoading() {
+  return (
+    <div
+      aria-busy="true"
+      className="tailwind-scope tw-mx-auto tw-w-full tw-min-w-0 tw-px-3 tw-pb-12 tw-pt-8 sm:tw-px-6 lg:tw-px-8 lg:tw-pt-10"
+    >
+      <span className="tw-sr-only" role="status">
+        Loading 6529bot usage data.
+      </span>
+      <DashboardHeader />
+      <div className="tw-mt-6 tw-grid tw-grid-cols-1 tw-gap-3 sm:tw-grid-cols-2 lg:tw-grid-cols-4">
+        {LOADING_METRIC_KEYS.map((key) => (
+          <div
+            className="tw-h-[8.75rem] tw-animate-pulse tw-rounded-xl tw-bg-iron-950 tw-p-4 tw-ring-1 tw-ring-inset tw-ring-iron-800 motion-reduce:tw-animate-none"
+            key={key}
+          >
+            <div className="tw-size-5 tw-rounded-md tw-bg-iron-800" />
+            <div className="tw-mt-4 tw-h-3 tw-w-24 tw-rounded-full tw-bg-iron-800" />
+            <div className="tw-mt-3 tw-h-7 tw-w-32 tw-rounded-lg tw-bg-iron-800" />
+          </div>
+        ))}
+      </div>
+      <div className="tw-mt-6 tw-animate-pulse tw-rounded-xl tw-bg-iron-950 tw-p-5 tw-ring-1 tw-ring-inset tw-ring-iron-800 motion-reduce:tw-animate-none">
+        <div className="tw-h-6 tw-w-40 tw-rounded-lg tw-bg-iron-800" />
+        <div className="tw-mt-6 tw-grid tw-grid-cols-1 tw-gap-5 sm:tw-grid-cols-2 xl:tw-grid-cols-3">
+          {LOADING_ANALYSIS_KEYS.map((key) => (
+            <div key={key}>
+              <div className="tw-h-3 tw-w-28 tw-rounded-full tw-bg-iron-800" />
+              <div className="tw-mt-2 tw-h-5 tw-w-36 tw-rounded-md tw-bg-iron-800" />
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="tw-mt-8 tw-h-64 tw-animate-pulse tw-rounded-xl tw-bg-iron-950 tw-ring-1 tw-ring-inset tw-ring-iron-800 motion-reduce:tw-animate-none" />
+    </div>
+  );
+}
+
+function DashboardHeader() {
+  return (
+    <header className="tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-iron-900 tw-pb-8">
+      <div className="tw-max-w-3xl">
+        <p className="tw-m-0 tw-text-xs tw-font-semibold tw-uppercase tw-tracking-[0.14em] tw-text-primary-300">
+          Open Data
+        </p>
+        <h1 className="tw-mb-0 tw-mt-[8px] tw-text-[22px] tw-font-semibold tw-leading-tight tw-tracking-tight tw-text-iron-50 sm:tw-text-[26px]">
+          6529bot Usage
+        </h1>
+        <p className="tw-mb-0 tw-mt-[13px] tw-text-sm tw-leading-6 tw-text-iron-300 sm:tw-text-base sm:tw-leading-7">
+          Public AI review activity across configured 6529 repositories.
+        </p>
+      </div>
+    </header>
   );
 }
 
@@ -154,11 +234,11 @@ function AnalysisHighlights({
   readonly analysis: ReviewbotUsageAnalysis;
 }) {
   return (
-    <section className="tw-mt-8 tw-rounded-lg tw-border tw-border-solid tw-border-white/10 tw-bg-iron-950 tw-p-5">
-      <h2 className="tw-mb-4 tw-text-xl tw-font-semibold tw-text-white">
+    <section className="tw-mt-6 tw-rounded-xl tw-bg-iron-950 tw-p-5 tw-ring-1 tw-ring-inset tw-ring-iron-800 sm:tw-p-6">
+      <h2 className="tw-m-0 tw-text-lg tw-font-semibold tw-tracking-tight tw-text-iron-50 sm:tw-text-xl">
         Cost Analysis
       </h2>
-      <dl className="tw-grid tw-grid-cols-1 tw-gap-4 sm:tw-grid-cols-2 xl:tw-grid-cols-3">
+      <dl className="tw-mb-0 tw-mt-5 tw-grid tw-grid-cols-1 tw-gap-x-6 tw-gap-y-5 sm:tw-grid-cols-2 xl:tw-grid-cols-3">
         <MetricPair
           label="Budget Skip Rate"
           value={formatPercent(analysis.budgetSkipRate)}
@@ -200,47 +280,61 @@ function MetricCard({
   readonly value: string;
 }) {
   return (
-    <dl className="tw-rounded-lg tw-border tw-border-solid tw-border-white/10 tw-bg-iron-950 tw-p-5">
-      <div className={`tw-mb-4 tw-inline-flex ${tone}`}>{icon}</div>
-      <dt className="tw-text-sm tw-font-medium tw-text-iron-400">{label}</dt>
-      <dd className="tw-mb-0 tw-mt-2 tw-text-2xl tw-font-semibold tw-text-white">
-        {value}
-      </dd>
-    </dl>
+    <div className="tw-min-w-0 tw-rounded-xl tw-bg-iron-950 tw-p-4 tw-text-left tw-ring-1 tw-ring-inset tw-ring-iron-800 sm:tw-p-5">
+      <div className={`tw-inline-flex ${tone}`}>
+        {icon}
+      </div>
+      <dl className="tw-mb-0 tw-mt-3 tw-text-left">
+        <dt className="tw-text-left tw-text-[0.6875rem] tw-font-medium tw-uppercase tw-leading-4 tw-tracking-[0.1em] tw-text-iron-500">
+          {label}
+        </dt>
+        <dd className="tw-mb-0 tw-ml-0 tw-mt-2 tw-break-words tw-text-left tw-text-2xl tw-font-semibold tw-leading-none tw-tracking-tight tw-text-iron-50 tw-tabular-nums">
+          {value}
+        </dd>
+      </dl>
+    </div>
   );
 }
 
 function UsageSection({
   groups,
+  id,
   keyHeader,
   title,
 }: {
   readonly groups: readonly ReviewbotUsageGroup[];
+  readonly id: string;
   readonly keyHeader: string;
   readonly title: string;
 }) {
   return (
-    <section className="tw-mt-10">
-      <div className="tw-mb-4 tw-flex tw-items-baseline tw-justify-between tw-gap-4">
-        <h2 className="tw-mb-0 tw-text-2xl tw-font-semibold tw-text-white">
+    <section
+      aria-labelledby={id}
+      className="tw-mt-8 tw-overflow-hidden tw-rounded-xl tw-bg-iron-950 tw-ring-1 tw-ring-inset tw-ring-iron-800"
+    >
+      <div className="tw-flex tw-items-center tw-justify-between tw-gap-4 tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-iron-800 tw-px-4 tw-py-4 sm:tw-px-5">
+        <h2
+          className="tw-m-0 tw-min-w-0 tw-text-lg tw-font-semibold tw-tracking-tight tw-text-iron-50 sm:tw-text-xl"
+          id={id}
+        >
           {title}
         </h2>
-        <span className="tw-text-sm tw-text-iron-400">
+        <span className="tw-whitespace-nowrap tw-rounded-full tw-bg-iron-900 tw-px-2.5 tw-py-1 tw-text-xs tw-font-medium tw-text-iron-400 tw-ring-1 tw-ring-inset tw-ring-iron-800">
           {groups.length} rows
         </span>
       </div>
       {groups.length > 0 ? (
         <>
-          <div className="tw-space-y-3 sm:tw-hidden">
+          <div className="tw-space-y-2 tw-bg-iron-900/40 tw-p-3 sm:tw-hidden">
             {groups.map((group) => (
-              <dl
-                className="tw-rounded-lg tw-border tw-border-solid tw-border-white/10 tw-bg-iron-950 tw-p-4"
+              <article
+                className="tw-rounded-lg tw-bg-iron-900/70 tw-p-4 tw-ring-1 tw-ring-inset tw-ring-iron-800"
                 key={group.key}
               >
-                <dt className="tw-text-sm tw-font-semibold tw-text-white">
+                <h3 className="tw-m-0 tw-break-words tw-text-sm tw-font-semibold tw-leading-5 tw-text-iron-100">
                   {group.key}
-                </dt>
-                <div className="tw-mt-4 tw-grid tw-grid-cols-2 tw-gap-4">
+                </h3>
+                <dl className="tw-mb-0 tw-mt-4 tw-grid tw-grid-cols-2 tw-gap-x-3 tw-gap-y-4">
                   <MetricPair
                     label="Runs"
                     value={formatInteger(group.reviewRuns)}
@@ -261,18 +355,29 @@ function UsageSection({
                     label="Skips"
                     value={formatInteger(group.budgetSkippedRuns)}
                   />
-                </div>
-              </dl>
+                </dl>
+              </article>
             ))}
           </div>
-          <div className="tw-hidden tw-overflow-x-auto sm:tw-block">
-            <UsageTable groups={groups} keyHeader={keyHeader} />
+          <div
+            aria-labelledby={id}
+            className="tw-hidden tw-overflow-x-auto focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-iron-400 sm:tw-block"
+            role="region"
+            tabIndex={0}
+          >
+            <UsageTable
+              groups={groups}
+              keyHeader={keyHeader}
+              title={title}
+            />
           </div>
         </>
       ) : (
-        <p className="tw-mb-0 tw-border-t tw-border-solid tw-border-white/10 tw-pt-4 tw-text-sm tw-text-iron-400">
-          No usage recorded.
-        </p>
+        <div className="tw-bg-iron-900/40 tw-px-4 tw-py-8 sm:tw-px-5">
+          <p className="tw-m-0 tw-text-sm tw-leading-6 tw-text-iron-400">
+            No usage recorded.
+          </p>
+        </div>
       )}
     </section>
   );
@@ -286,11 +391,11 @@ function MetricPair({
   readonly value: string;
 }) {
   return (
-    <div>
-      <dt className="tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
+    <div className="tw-min-w-0">
+      <dt className="tw-text-left tw-text-[0.6875rem] tw-font-medium tw-uppercase tw-leading-4 tw-tracking-[0.1em] tw-text-iron-500">
         {label}
       </dt>
-      <dd className="tw-mb-0 tw-mt-1 tw-text-sm tw-font-semibold tw-text-iron-100">
+      <dd className="tw-mb-0 tw-ml-0 tw-mt-1 tw-break-words tw-text-left tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-200 tw-tabular-nums">
         {value}
       </dd>
     </div>
@@ -300,64 +405,123 @@ function MetricPair({
 function UsageTable({
   groups,
   keyHeader,
+  title,
 }: {
   readonly groups: readonly ReviewbotUsageGroup[];
   readonly keyHeader: string;
+  readonly title: string;
 }) {
   return (
-    <div className="tw-overflow-x-auto">
-      <table className="tw-min-w-full tw-border-collapse">
-        <thead>
-          <tr className="tw-border-b tw-border-solid tw-border-white/10">
-            <th className="tw-py-3 tw-pr-6 tw-text-left tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
-              {keyHeader}
-            </th>
-            <th className="tw-px-6 tw-py-3 tw-text-right tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
-              Runs
-            </th>
-            <th className="tw-px-6 tw-py-3 tw-text-right tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
-              Spend
-            </th>
-            <th className="tw-px-6 tw-py-3 tw-text-right tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
-              Avg
-            </th>
-            <th className="tw-px-6 tw-py-3 tw-text-right tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
-              Tokens
-            </th>
-            <th className="tw-py-3 tw-pl-6 tw-text-right tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
-              Skips
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {groups.map((group) => (
-            <tr
-              className="tw-border-b tw-border-solid tw-border-white/5"
-              key={group.key}
+    <table className="tw-min-w-[44rem] tw-w-full tw-border-collapse">
+      <caption className="tw-sr-only">{title}</caption>
+      <thead>
+        <tr className="tw-bg-iron-900/70">
+          <th
+            className={`${TABLE_HEADER_CELL_CLASS} tw-px-5 tw-text-left`}
+            scope="col"
+          >
+            {keyHeader}
+          </th>
+          <th
+            className={`${TABLE_HEADER_CELL_CLASS} tw-px-4 tw-text-right`}
+            scope="col"
+          >
+            Runs
+          </th>
+          <th
+            className={`${TABLE_HEADER_CELL_CLASS} tw-px-4 tw-text-right`}
+            scope="col"
+          >
+            Spend
+          </th>
+          <th
+            className={`${TABLE_HEADER_CELL_CLASS} tw-px-4 tw-text-right`}
+            scope="col"
+          >
+            Avg
+          </th>
+          <th
+            className={`${TABLE_HEADER_CELL_CLASS} tw-px-4 tw-text-right`}
+            scope="col"
+          >
+            Tokens
+          </th>
+          <th
+            className={`${TABLE_HEADER_CELL_CLASS} tw-px-5 tw-text-right`}
+            scope="col"
+          >
+            Skips
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {groups.map((group) => (
+          <tr
+            className="tw-transition-colors desktop-hover:hover:tw-bg-iron-900/50"
+            key={group.key}
+          >
+            <td
+              className={`${TABLE_BODY_CELL_CLASS} tw-break-words tw-px-5 tw-font-medium tw-leading-5 tw-text-iron-100`}
             >
-              <td className="tw-py-4 tw-pr-6 tw-text-sm tw-font-medium tw-text-white">
-                {group.key}
-              </td>
-              <td className="tw-px-6 tw-py-4 tw-text-right tw-text-sm tw-text-iron-200">
-                {formatInteger(group.reviewRuns)}
-              </td>
-              <td className="tw-px-6 tw-py-4 tw-text-right tw-text-sm tw-text-iron-200">
-                {formatCurrency(group.costUsd)}
-              </td>
-              <td className="tw-px-6 tw-py-4 tw-text-right tw-text-sm tw-text-iron-200">
-                {formatCurrency(group.averageCostUsd)}
-              </td>
-              <td className="tw-px-6 tw-py-4 tw-text-right tw-text-sm tw-text-iron-200">
-                {formatInteger(group.totalTokens)}
-              </td>
-              <td className="tw-py-4 tw-pl-6 tw-text-right tw-text-sm tw-text-iron-200">
-                {formatInteger(group.budgetSkippedRuns)}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+              {group.key}
+            </td>
+            <td
+              className={`${TABLE_BODY_CELL_CLASS} tw-px-4 tw-text-right tw-text-iron-300 tw-tabular-nums`}
+            >
+              {formatInteger(group.reviewRuns)}
+            </td>
+            <td
+              className={`${TABLE_BODY_CELL_CLASS} tw-px-4 tw-text-right tw-text-iron-300 tw-tabular-nums`}
+            >
+              {formatCurrency(group.costUsd)}
+            </td>
+            <td
+              className={`${TABLE_BODY_CELL_CLASS} tw-px-4 tw-text-right tw-text-iron-300 tw-tabular-nums`}
+            >
+              {formatCurrency(group.averageCostUsd)}
+            </td>
+            <td
+              className={`${TABLE_BODY_CELL_CLASS} tw-px-4 tw-text-right tw-text-iron-300 tw-tabular-nums`}
+            >
+              {formatInteger(group.totalTokens)}
+            </td>
+            <td
+              className={`${TABLE_BODY_CELL_CLASS} tw-px-5 tw-text-right tw-text-iron-300 tw-tabular-nums`}
+            >
+              {formatInteger(group.budgetSkippedRuns)}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function UnavailableState({ message }: { readonly message: string }) {
+  return (
+    <section
+      aria-labelledby="reviewbot-usage-unavailable"
+      className="tw-mt-6 tw-flex tw-items-start tw-gap-4 tw-rounded-xl tw-bg-iron-950 tw-p-5 tw-ring-1 tw-ring-inset tw-ring-iron-800 sm:tw-p-6"
+      role="alert"
+    >
+      <span className="tw-flex tw-size-10 tw-flex-none tw-items-center tw-justify-center tw-rounded-lg tw-bg-iron-900 tw-text-iron-300">
+        <ExclamationTriangleIcon
+          aria-hidden="true"
+          className="tw-size-5"
+        />
+      </span>
+      <div className="tw-min-w-0">
+        <h2
+          className="tw-m-0 tw-text-lg tw-font-semibold tw-tracking-tight tw-text-iron-50 sm:tw-text-xl"
+          id="reviewbot-usage-unavailable"
+        >
+          Usage Data Unavailable
+        </h2>
+        <p className="tw-mb-0 tw-mt-2 tw-break-words tw-text-sm tw-leading-6 tw-text-iron-300">
+          {message}
+        </p>
+      </div>
+    </section>
   );
 }
 

--- a/components/reviewbot-usage/ReviewbotUsageDashboard.tsx
+++ b/components/reviewbot-usage/ReviewbotUsageDashboard.tsx
@@ -1,3 +1,11 @@
+import {
+  formatDate as formatLocalizedDate,
+  formatInteger as formatLocalizedInteger,
+  formatNumber,
+  formatPercent as formatLocalizedPercent,
+} from "@/i18n/format";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import type {
   ReviewbotUsageAnalysis,
   ReviewbotUsageGroup,
@@ -18,22 +26,14 @@ interface ReviewbotUsageDashboardProps {
   readonly result: ReviewbotUsageResult;
 }
 
-const compactNumberFormatter = new Intl.NumberFormat("en-US", {
-  maximumFractionDigits: 0,
-});
-
-const currencyFormatter = new Intl.NumberFormat("en-US", {
-  currency: "USD",
-  maximumFractionDigits: 2,
-  style: "currency",
-});
-
-const dateFormatter = new Intl.DateTimeFormat("en-US", {
+const USAGE_DATE_FORMAT = {
   day: "numeric",
   month: "short",
   timeZone: "UTC",
   year: "numeric",
-});
+} satisfies Intl.DateTimeFormatOptions;
+
+const locale = DEFAULT_LOCALE;
 
 const LOADING_METRIC_KEYS = [
   "review-runs",
@@ -72,10 +72,16 @@ export default function ReviewbotUsageDashboard({
 
       {summary ? (
         <>
+          <span className="tw-sr-only" role="status">
+            {t(locale, "reviewbotUsage.status.loaded", {
+              dailyRows: summary.byDay.length,
+              reviewRuns: formatInteger(summary.totals.reviewRuns),
+            })}
+          </span>
           <div className="tw-mt-6 tw-grid tw-grid-cols-1 tw-gap-3 sm:tw-grid-cols-2 lg:tw-grid-cols-4">
             <MetricCard
               icon={<ChartBarIcon aria-hidden="true" className="tw-size-5" />}
-              label="Review Runs"
+              label={t(locale, "reviewbotUsage.metrics.reviewRuns")}
               tone="tw-text-primary-300"
               value={formatInteger(summary.totals.reviewRuns)}
             />
@@ -83,7 +89,7 @@ export default function ReviewbotUsageDashboard({
               icon={
                 <DocumentTextIcon aria-hidden="true" className="tw-size-5" />
               }
-              label="Unique PRs"
+              label={t(locale, "reviewbotUsage.metrics.uniquePrs")}
               tone="tw-text-primary-300"
               value={formatInteger(summary.totals.uniquePrs)}
             />
@@ -91,7 +97,7 @@ export default function ReviewbotUsageDashboard({
               icon={
                 <CurrencyDollarIcon aria-hidden="true" className="tw-size-5" />
               }
-              label="Estimated Spend"
+              label={t(locale, "reviewbotUsage.metrics.estimatedSpend")}
               tone="tw-text-success"
               value={formatCurrency(summary.totals.costUsd)}
             />
@@ -99,7 +105,7 @@ export default function ReviewbotUsageDashboard({
               icon={
                 <CurrencyDollarIcon aria-hidden="true" className="tw-size-5" />
               }
-              label="Avg / Run"
+              label={t(locale, "reviewbotUsage.metrics.averageRun")}
               tone="tw-text-success"
               value={formatCurrency(
                 summary.totals.averageCostPerReviewRunUsd
@@ -109,13 +115,13 @@ export default function ReviewbotUsageDashboard({
               icon={
                 <CurrencyDollarIcon aria-hidden="true" className="tw-size-5" />
               }
-              label="Avg / PR"
+              label={t(locale, "reviewbotUsage.metrics.averagePr")}
               tone="tw-text-success"
               value={formatCurrency(summary.totals.averageCostPerPrUsd)}
             />
             <MetricCard
               icon={<CpuChipIcon aria-hidden="true" className="tw-size-5" />}
-              label="Tokens"
+              label={t(locale, "reviewbotUsage.metrics.tokens")}
               tone="tw-text-iron-100"
               value={formatInteger(summary.totals.totalTokens)}
             />
@@ -123,7 +129,7 @@ export default function ReviewbotUsageDashboard({
               icon={
                 <ShieldCheckIcon aria-hidden="true" className="tw-size-5" />
               }
-              label="Budget Skips"
+              label={t(locale, "reviewbotUsage.metrics.budgetSkips")}
               tone="tw-text-amber-300"
               value={formatInteger(summary.totals.budgetSkippedRuns)}
             />
@@ -133,26 +139,26 @@ export default function ReviewbotUsageDashboard({
           <UsageSection
             groups={summary.byDay}
             id="reviewbot-daily-usage"
-            keyHeader="Day"
-            title="Daily Usage"
+            keyHeader={t(locale, "reviewbotUsage.columns.day")}
+            title={t(locale, "reviewbotUsage.sections.dailyUsage")}
           />
           <UsageSection
             groups={summary.byRepo}
             id="reviewbot-repositories"
-            keyHeader="Repository"
-            title="Repositories"
+            keyHeader={t(locale, "reviewbotUsage.columns.repository")}
+            title={t(locale, "reviewbotUsage.sections.repositories")}
           />
           <UsageSection
             groups={summary.byProviderModel}
             id="reviewbot-providers-models"
-            keyHeader="Provider and Model"
-            title="Providers and Models"
+            keyHeader={t(locale, "reviewbotUsage.columns.providerModel")}
+            title={t(locale, "reviewbotUsage.sections.providersModels")}
           />
           <UsageSection
             groups={summary.byReviewKind}
             id="reviewbot-review-types"
-            keyHeader="Review Type"
-            title="Review Types"
+            keyHeader={t(locale, "reviewbotUsage.columns.reviewType")}
+            title={t(locale, "reviewbotUsage.sections.reviewTypes")}
           />
           <div className="tw-mt-6 tw-flex tw-w-fit tw-max-w-full tw-items-center tw-gap-2 tw-rounded-lg tw-bg-iron-950 tw-px-3 tw-py-2 tw-ring-1 tw-ring-inset tw-ring-iron-800">
             <CalendarDaysIcon
@@ -160,8 +166,10 @@ export default function ReviewbotUsageDashboard({
               className="tw-size-4 tw-flex-none tw-text-iron-500"
             />
             <p className="tw-m-0 tw-text-sm tw-leading-5 tw-text-iron-400">
-              Window: {formatDate(summary.range.from)} to{" "}
-              {formatDate(summary.range.to)}
+              {t(locale, "reviewbotUsage.window", {
+                from: formatDate(summary.range.from),
+                to: formatDate(summary.range.to),
+              })}
             </p>
           </div>
         </>
@@ -179,7 +187,7 @@ export function ReviewbotUsageLoading() {
       className="tailwind-scope tw-mx-auto tw-w-full tw-min-w-0 tw-px-3 tw-pb-12 tw-pt-8 sm:tw-px-6 lg:tw-px-8 lg:tw-pt-10"
     >
       <span className="tw-sr-only" role="status">
-        Loading 6529bot usage data.
+        {t(locale, "reviewbotUsage.status.loading")}
       </span>
       <DashboardHeader />
       <div className="tw-mt-6 tw-grid tw-grid-cols-1 tw-gap-3 sm:tw-grid-cols-2 lg:tw-grid-cols-4">
@@ -215,13 +223,13 @@ function DashboardHeader() {
     <header className="tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-iron-900 tw-pb-8">
       <div className="tw-max-w-3xl">
         <p className="tw-m-0 tw-text-xs tw-font-semibold tw-uppercase tw-tracking-[0.14em] tw-text-primary-300">
-          Open Data
+          {t(locale, "reviewbotUsage.header.eyebrow")}
         </p>
         <h1 className="tw-mb-0 tw-mt-[8px] tw-text-[22px] tw-font-semibold tw-leading-tight tw-tracking-tight tw-text-iron-50 sm:tw-text-[26px]">
-          6529bot Usage
+          {t(locale, "reviewbotUsage.header.title")}
         </h1>
         <p className="tw-mb-0 tw-mt-[13px] tw-text-sm tw-leading-6 tw-text-iron-300 sm:tw-text-base sm:tw-leading-7">
-          Public AI review activity across configured 6529 repositories.
+          {t(locale, "reviewbotUsage.header.description")}
         </p>
       </div>
     </header>
@@ -236,31 +244,31 @@ function AnalysisHighlights({
   return (
     <section className="tw-mt-6 tw-rounded-xl tw-bg-iron-950 tw-p-5 tw-ring-1 tw-ring-inset tw-ring-iron-800 sm:tw-p-6">
       <h2 className="tw-m-0 tw-text-lg tw-font-semibold tw-tracking-tight tw-text-iron-50 sm:tw-text-xl">
-        Cost Analysis
+        {t(locale, "reviewbotUsage.analysis.title")}
       </h2>
       <dl className="tw-mb-0 tw-mt-5 tw-grid tw-grid-cols-1 tw-gap-x-6 tw-gap-y-5 sm:tw-grid-cols-2 xl:tw-grid-cols-3">
         <MetricPair
-          label="Budget Skip Rate"
+          label={t(locale, "reviewbotUsage.analysis.budgetSkipRate")}
           value={formatPercent(analysis.budgetSkipRate)}
         />
         <MetricPair
-          label="Avg Tokens / Run"
+          label={t(locale, "reviewbotUsage.analysis.averageTokensRun")}
           value={formatInteger(analysis.averageTokensPerReviewRun)}
         />
         <MetricPair
-          label="Avg Tokens / PR"
+          label={t(locale, "reviewbotUsage.analysis.averageTokensPr")}
           value={formatInteger(analysis.averageTokensPerPr)}
         />
         <MetricPair
-          label="Top Repo"
+          label={t(locale, "reviewbotUsage.analysis.topRepo")}
           value={formatTopCost(analysis.topCostRepo)}
         />
         <MetricPair
-          label="Top Provider"
+          label={t(locale, "reviewbotUsage.analysis.topProvider")}
           value={formatTopCost(analysis.topCostProviderModel)}
         />
         <MetricPair
-          label="Top Review Type"
+          label={t(locale, "reviewbotUsage.analysis.topReviewType")}
           value={formatTopCost(analysis.topCostReviewKind)}
         />
       </dl>
@@ -320,7 +328,9 @@ function UsageSection({
           {title}
         </h2>
         <span className="tw-whitespace-nowrap tw-rounded-full tw-bg-iron-900 tw-px-2.5 tw-py-1 tw-text-xs tw-font-medium tw-text-iron-400 tw-ring-1 tw-ring-inset tw-ring-iron-800">
-          {groups.length} rows
+          {t(locale, "reviewbotUsage.table.rows", {
+            count: groups.length,
+          })}
         </span>
       </div>
       {groups.length > 0 ? (
@@ -336,23 +346,23 @@ function UsageSection({
                 </h3>
                 <dl className="tw-mb-0 tw-mt-4 tw-grid tw-grid-cols-2 tw-gap-x-3 tw-gap-y-4">
                   <MetricPair
-                    label="Runs"
+                    label={t(locale, "reviewbotUsage.columns.runs")}
                     value={formatInteger(group.reviewRuns)}
                   />
                   <MetricPair
-                    label="Spend"
+                    label={t(locale, "reviewbotUsage.columns.spend")}
                     value={formatCurrency(group.costUsd)}
                   />
                   <MetricPair
-                    label="Avg"
+                    label={t(locale, "reviewbotUsage.columns.average")}
                     value={formatCurrency(group.averageCostUsd)}
                   />
                   <MetricPair
-                    label="Tokens"
+                    label={t(locale, "reviewbotUsage.columns.tokens")}
                     value={formatInteger(group.totalTokens)}
                   />
                   <MetricPair
-                    label="Skips"
+                    label={t(locale, "reviewbotUsage.columns.skips")}
                     value={formatInteger(group.budgetSkippedRuns)}
                   />
                 </dl>
@@ -360,7 +370,9 @@ function UsageSection({
             ))}
           </div>
           <div
-            aria-labelledby={id}
+            aria-label={t(locale, "reviewbotUsage.table.scrollableLabel", {
+              title,
+            })}
             className="tw-hidden tw-overflow-x-auto focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-iron-400 sm:tw-block"
             role="region"
             tabIndex={0}
@@ -375,7 +387,7 @@ function UsageSection({
       ) : (
         <div className="tw-bg-iron-900/40 tw-px-4 tw-py-8 sm:tw-px-5">
           <p className="tw-m-0 tw-text-sm tw-leading-6 tw-text-iron-400">
-            No usage recorded.
+            {t(locale, "reviewbotUsage.table.empty")}
           </p>
         </div>
       )}
@@ -426,31 +438,31 @@ function UsageTable({
             className={`${TABLE_HEADER_CELL_CLASS} tw-px-4 tw-text-right`}
             scope="col"
           >
-            Runs
+            {t(locale, "reviewbotUsage.columns.runs")}
           </th>
           <th
             className={`${TABLE_HEADER_CELL_CLASS} tw-px-4 tw-text-right`}
             scope="col"
           >
-            Spend
+            {t(locale, "reviewbotUsage.columns.spend")}
           </th>
           <th
             className={`${TABLE_HEADER_CELL_CLASS} tw-px-4 tw-text-right`}
             scope="col"
           >
-            Avg
+            {t(locale, "reviewbotUsage.columns.average")}
           </th>
           <th
             className={`${TABLE_HEADER_CELL_CLASS} tw-px-4 tw-text-right`}
             scope="col"
           >
-            Tokens
+            {t(locale, "reviewbotUsage.columns.tokens")}
           </th>
           <th
             className={`${TABLE_HEADER_CELL_CLASS} tw-px-5 tw-text-right`}
             scope="col"
           >
-            Skips
+            {t(locale, "reviewbotUsage.columns.skips")}
           </th>
         </tr>
       </thead>
@@ -515,7 +527,7 @@ function UnavailableState({ message }: { readonly message: string }) {
           className="tw-m-0 tw-text-lg tw-font-semibold tw-tracking-tight tw-text-iron-50 sm:tw-text-xl"
           id="reviewbot-usage-unavailable"
         >
-          Usage Data Unavailable
+          {t(locale, "reviewbotUsage.unavailable.title")}
         </h2>
         <p className="tw-mb-0 tw-mt-2 tw-break-words tw-text-sm tw-leading-6 tw-text-iron-300">
           {message}
@@ -526,33 +538,39 @@ function UnavailableState({ message }: { readonly message: string }) {
 }
 
 function formatCurrency(value: number): string {
-  return currencyFormatter.format(value);
+  return formatNumber(locale, value, {
+    currency: "USD",
+    maximumFractionDigits: 2,
+    style: "currency",
+  });
 }
 
 function formatDate(value: string | undefined): string {
   if (!value) {
-    return "unknown";
+    return t(locale, "reviewbotUsage.values.unknown");
   }
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) {
-    return "unknown";
+    return t(locale, "reviewbotUsage.values.unknown");
   }
-  return dateFormatter.format(date);
+  return formatLocalizedDate(locale, date, USAGE_DATE_FORMAT);
 }
 
 function formatInteger(value: number): string {
-  return compactNumberFormatter.format(value);
+  return formatLocalizedInteger(locale, value);
 }
 
 function formatPercent(value: number): string {
-  return `${value.toFixed(1)}%`;
+  return formatLocalizedPercent(locale, value / 100);
 }
 
 function formatTopCost(group: ReviewbotUsageAnalysis["topCostRepo"]): string {
   if (!group) {
-    return "None";
+    return t(locale, "reviewbotUsage.values.none");
   }
-  return `${group.key} (${formatCurrency(group.costUsd)}, ${formatPercent(
-    group.costSharePercent
-  )})`;
+  return t(locale, "reviewbotUsage.values.topCost", {
+    cost: formatCurrency(group.costUsd),
+    name: group.key,
+    percent: formatPercent(group.costSharePercent),
+  });
 }

--- a/components/reviewbot-usage/ReviewbotUsageDashboard.tsx
+++ b/components/reviewbot-usage/ReviewbotUsageDashboard.tsx
@@ -74,7 +74,7 @@ export default function ReviewbotUsageDashboard({
         <>
           <span className="tw-sr-only" role="status">
             {t(locale, "reviewbotUsage.status.loaded", {
-              dailyRows: summary.byDay.length,
+              dailyRows: formatInteger(summary.byDay.length),
               reviewRuns: formatInteger(summary.totals.reviewRuns),
             })}
           </span>

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -1301,6 +1301,23 @@ const USER_RATE_MESSAGES = objectMessages("user.rate", {
 const ABOUT_TECH_MESSAGES = objectMessages("about.tech", {
   "metadata.title": "Tech",
   "metadata.description": "About",
+  "index.eyebrow": "About / Tech",
+  "index.title": "Tech Updates",
+  "index.intro":
+    "This is a current casual area for longer 6529 tech updates: repo work, bot notes, release context, and build reports that are too large for a single wave drop.",
+  "index.longUpdates":
+    "Long updates, repo analysis, bot context, and links back into the wave conversation.",
+  "index.liveActivity":
+    "Shorter live repo activity still belongs in {followTheRepo}. This page is the linkable longer-form shelf beside it.",
+  "index.followTheRepo": "Follow The Repo",
+  "index.activeTechnicalNotes": "Active Technical Notes",
+  "index.authChanges": "Auth changes",
+  "index.walletAuthenticationTitle": "Wallet authentication upgrade",
+  "index.walletAuthenticationDescription":
+    "What is changing with the new secure session, why users may be asked to upgrade, and what to expect during rollout.",
+  "index.reportsEyebrow": "Index",
+  "index.reportsTitle": "Reports",
+  "index.openLatestReport": "Open latest report",
   "index.prsCovered": "PRs Covered",
   "notes.walletAuthentication.ariaLabel":
     "Wallet authentication upgrade: what is changing with the new secure session",
@@ -1347,6 +1364,51 @@ const ABOUT_TECH_MESSAGES = objectMessages("about.tech", {
   "walletAuth.builders.body":
     "External clients should use the session-v2 API authentication guide instead of the user upgrade notes on this page.",
   "walletAuth.builders.link": "Open API authentication guide",
+} as const);
+
+const REVIEWBOT_USAGE_MESSAGES = objectMessages("reviewbotUsage", {
+  "header.eyebrow": "Open Data",
+  "header.title": "6529bot Usage",
+  "header.description":
+    "Public AI review activity across configured 6529 repositories.",
+  "status.loading": "Loading 6529bot usage data.",
+  "status.loaded":
+    "6529bot usage data loaded. {reviewRuns} review runs across {dailyRows} daily rows.",
+  "metrics.reviewRuns": "Review Runs",
+  "metrics.uniquePrs": "Unique PRs",
+  "metrics.estimatedSpend": "Estimated Spend",
+  "metrics.averageRun": "Avg / Run",
+  "metrics.averagePr": "Avg / PR",
+  "metrics.tokens": "Tokens",
+  "metrics.budgetSkips": "Budget Skips",
+  "analysis.title": "Cost Analysis",
+  "analysis.budgetSkipRate": "Budget Skip Rate",
+  "analysis.averageTokensRun": "Avg Tokens / Run",
+  "analysis.averageTokensPr": "Avg Tokens / PR",
+  "analysis.topRepo": "Top Repo",
+  "analysis.topProvider": "Top Provider",
+  "analysis.topReviewType": "Top Review Type",
+  "sections.dailyUsage": "Daily Usage",
+  "sections.repositories": "Repositories",
+  "sections.providersModels": "Providers and Models",
+  "sections.reviewTypes": "Review Types",
+  "columns.day": "Day",
+  "columns.repository": "Repository",
+  "columns.providerModel": "Provider and Model",
+  "columns.reviewType": "Review Type",
+  "columns.runs": "Runs",
+  "columns.spend": "Spend",
+  "columns.average": "Avg",
+  "columns.tokens": "Tokens",
+  "columns.skips": "Skips",
+  "table.rows": "{count} rows",
+  "table.scrollableLabel": "{title} table, scrollable",
+  "table.empty": "No usage recorded.",
+  window: "Window: {from} to {to}",
+  "unavailable.title": "Usage Data Unavailable",
+  "values.none": "None",
+  "values.unknown": "unknown",
+  "values.topCost": "{name} ({cost}, {percent})",
 } as const);
 
 const ATTACHMENT_MESSAGES = namespaceMessages("attachment", [
@@ -2476,6 +2538,7 @@ export const EN_US_MESSAGES = {
   ...networkTdhMessages,
   ...toolsMessages,
   ...ABOUT_TECH_MESSAGES,
+  ...REVIEWBOT_USAGE_MESSAGES,
   ...REMEMES_DETAIL_MESSAGES,
   ...REP_CATEGORY_MESSAGES,
   ...REP_CATEGORY_VALIDATION_MESSAGES,


### PR DESCRIPTION
## Issue

- The 6529bot Usage and Tech Updates pages needed a small visual consistency pass alongside the newer About surfaces.

## Fix

- Refined the existing Tailwind styling and responsive presentation without changing page content, data, or behavior.

## Changes

- Tightened the Usage dashboard hierarchy, metric cards, tables/mobile cards, and loading/error/empty presentation.
- Aligned Tech Updates with the About surface, including spacing, typography, borders, report summaries, dropdown divider, and hover/focus states.
- Preserved all existing wording and usage data sections.

## Validation

- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff` — 100/100, no findings
- `./bin/6529 run test --testPathPatterns=__tests__/components/about/tech/AboutTech.test.tsx --runInBand`
- Manual desktop browser review of both routes, including table layout, Tech hover/focus, dropdown keyboard dismissal, and computed border/alignment checks.
- Narrow responsive classes were reviewed, but a true mobile screenshot was not captured because the local browser viewport override did not resize.

## Risk

- Level: Low
- Why: presentation-only changes on two public pages; no API, dependency, data-shape, or configuration changes.
- Rollback: revert the refinement commits.

## Review Notes

- Please focus on dense-table readability, responsive card presentation, and the Tech report summary borders/alignment.