### PR TITLE
ci: isolate production E2E evidence verification

### DIFF
--- a/.github/workflows/production-e2e.yml
+++ b/.github/workflows/production-e2e.yml
@@ -31,6 +31,8 @@ jobs:
   readonly:
     runs-on: ${{ vars.E2E_RUNNER || vars.CI_LINUX_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 90
+    outputs:
+      expected-sha: ${{ inputs.expected_sha || steps.automatic-deploy.outputs.deployed-sha }}
     permissions:
       actions: read
       contents: read
@@ -169,39 +171,12 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with: { node-version: "22.17.1" }
-      - name: Activate pinned pnpm
-        run: |
-          corepack enable pnpm
-          corepack prepare "$(node -p 'require("./package.json").packageManager')" --activate
-      - name: Restore pnpm store
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-node22-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node22-pnpm-
-      - name: Use cached pnpm store
-        run: ./bin/6529 exec pnpm config set store-dir ~/.pnpm-store
-      - name: Install Socket Firewall
-        id: socket-firewall
-        continue-on-error: true
-        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
-        with: { mode: firewall }
-      - name: Install frozen dependencies
-        id: dependencies
-        if: steps.socket-firewall.outcome == 'success'
-        continue-on-error: true
-        env:
-          SFW_BIN: ${{ steps.socket-firewall.outputs.firewall-path-binary }}
-        run: ./bin/6529 install:frozen
-      # The deployed tree and its dependency lifecycle run before trusted
-      # control tooling is staged. This keeps untrusted install code from
-      # mutating the Museum selector after its immutable-source verification.
+      # Select and upload the Museum control record before any deployed
+      # package manager, dependency lifecycle, or E2E process executes. The
+      # v4 artifact is immutable and is independently verified on a new runner.
       - name: Require an unused Museum selection control path
-        if: steps.dependencies.outcome == 'success'
         run: test ! -e .release-bus-control
       - name: Check out immutable Release Bus Museum selection tooling
-        if: steps.dependencies.outcome == 'success'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.workflow_sha }}
@@ -214,7 +189,6 @@ jobs:
             scripts/museum-release-selection.cjs
           sparse-checkout-cone-mode: false
       - name: Verify immutable Museum selection tooling
-        if: steps.dependencies.outcome == 'success'
         env:
           WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
@@ -230,7 +204,6 @@ jobs:
           test -f .release-bus-control/scripts/museum-release-selection.cjs
       - name: Select fail-closed Museum packs for the exact deployed range
         id: museum-selection
-        if: steps.dependencies.outcome == 'success'
         env:
           BASE_SHA: ${{ steps.automatic-deploy.outputs.previous_deployed_sha }}
           DEPLOYED_SHA: ${{ inputs.expected_sha || steps.automatic-deploy.outputs.deployed-sha }}
@@ -291,16 +264,15 @@ jobs:
           [[ "$source_commit" =~ ^[a-f0-9]{40}$ ]]
 
           selection_file="$RUNNER_TEMP/museum-release-selection.json"
-          NODE_PATH="$GITHUB_WORKSPACE/node_modules${NODE_PATH:+:$NODE_PATH}" \
-            node .release-bus-control/scripts/museum-release-selection.cjs \
-              --base "$base_sha" \
-              --head "$head_sha" \
-              --environment production \
-              --activation-mode "$MUSEUM_RELEASE_TIER_MODE" \
-              --hold-state "$hold_state" \
-              --repository-root "$GITHUB_WORKSPACE" \
-              --source-commit "$source_commit" \
-              --output "$selection_file"
+          node .release-bus-control/scripts/museum-release-selection.cjs \
+            --base "$base_sha" \
+            --head "$head_sha" \
+            --environment production \
+            --activation-mode "$MUSEUM_RELEASE_TIER_MODE" \
+            --hold-state "$hold_state" \
+            --repository-root "$GITHUB_WORKSPACE" \
+            --source-commit "$source_commit" \
+            --output "$selection_file"
           jq -e --arg source_commit "$source_commit" '
             .contract == "museum-release-selection-v1" and
             .environment == "production" and
@@ -329,6 +301,38 @@ jobs:
             echo "Source: $source_commit"
             echo "Packs: $(jq -r '.selected_packs | join(", ") // "none"' "$selection_file")"
           } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload immutable Museum selection evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: production-e2e-selection-${{ inputs.release_train_id || inputs.automatic_deploy_run_id || github.run_id }}
+          path: ${{ steps.museum-selection.outputs.file }}
+          retention-days: 30
+          if-no-files-found: error
+      - name: Activate pinned pnpm
+        run: |
+          corepack enable pnpm
+          corepack prepare "$(node -p 'require("./package.json").packageManager')" --activate
+      - name: Restore pnpm store
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-node22-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node22-pnpm-
+      - name: Use cached pnpm store
+        run: ./bin/6529 exec pnpm config set store-dir ~/.pnpm-store
+      - name: Install Socket Firewall
+        id: socket-firewall
+        continue-on-error: true
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with: { mode: firewall }
+      - name: Install frozen dependencies
+        id: dependencies
+        if: steps.socket-firewall.outcome == 'success'
+        continue-on-error: true
+        env:
+          SFW_BIN: ${{ steps.socket-firewall.outputs.firewall-path-binary }}
+        run: ./bin/6529 install:frozen
       - name: Restore Playwright browser
         if: steps.dependencies.outcome == 'success'
         id: playwright-cache
@@ -422,68 +426,177 @@ jobs:
           fi
           echo "MUSEUM_SELECTED_PACKS_JSON=$MUSEUM_SELECTED_PACKS_JSON" >> "$GITHUB_ENV"
           ./bin/6529 run e2e:packs -- "${args[@]}"
-      # The deployed E2E runner has now completed. Stage a second, fresh,
-      # workflow-SHA-bound copy for evidence verification so tested app code
-      # cannot alter the verifier used to qualify its own output.
-      - name: Require an unused Museum evidence control path
-        id: museum-evidence-path
-        if: always() && steps.dependencies.outcome == 'success' && steps.playwright.outcome == 'success'
-        run: test ! -e .release-bus-evidence-control
-      - name: Check out immutable Release Bus Museum evidence tooling
-        id: museum-evidence-checkout
-        if: always() && steps.museum-evidence-path.outcome == 'success'
+      - name: Upload manifest-bound Playwright evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: production-e2e-artifacts-${{ inputs.release_train_id || inputs.automatic_deploy_run_id || github.run_id }}
+          path: production-e2e-artifacts/
+          retention-days: 30
+          if-no-files-found: ignore
+      - name: Return production E2E result
+        if: always()
+        env:
+          SOCKET_OUTCOME: ${{ steps.socket-firewall.outcome }}
+          DEPENDENCIES_OUTCOME: ${{ steps.dependencies.outcome }}
+          PLAYWRIGHT_OUTCOME: ${{ steps.playwright.outcome }}
+          E2E_OUTCOME: ${{ steps.e2e.outcome }}
+        run: |
+          test "$SOCKET_OUTCOME" = success
+          test "$DEPENDENCIES_OUTCOME" = success
+          test "$PLAYWRIGHT_OUTCOME" = success
+          test "$E2E_OUTCOME" = success
+
+  verify-evidence:
+    name: Verify production evidence on isolated runner
+    if: always()
+    needs: readonly
+    # This job intentionally ignores configurable/self-hosted runner labels.
+    # No deployed source, dependency lifecycle, or E2E process runs here.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Resolve isolated verifier release identity
+        id: release-identity
+        continue-on-error: true
+        env:
+          AUTOMATIC_DEPLOY_RUN_ID: ${{ inputs.automatic_deploy_run_id }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          GH_TOKEN: ${{ github.token }}
+          MANIFEST_ID: ${{ inputs.release_manifest_id }}
+          MANIFEST_IDENTITY: ${{ inputs.release_manifest_identity_sha256 }}
+          READONLY_EXPECTED_SHA: ${{ needs.readonly.outputs.expected-sha }}
+        run: |
+          set -euo pipefail
+          if [ -n "$AUTOMATIC_DEPLOY_RUN_ID" ]; then
+            [[ "$AUTOMATIC_DEPLOY_RUN_ID" =~ ^[1-9][0-9]{0,19}$ ]]
+            test -z "$EXPECTED_SHA$MANIFEST_ID$MANIFEST_IDENTITY"
+            response_file="$(mktemp)"
+            trap 'rm -f "$response_file"' EXIT
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${AUTOMATIC_DEPLOY_RUN_ID}" \
+              > "$response_file"
+            jq -e \
+              --arg repository "$GITHUB_REPOSITORY" \
+              --argjson run_id "$AUTOMATIC_DEPLOY_RUN_ID" '
+                .id == $run_id and
+                .name == "Web Deploy - PROD" and
+                .path == ".github/workflows/build-upload-deploy-prod.yml" and
+                .event == "workflow_dispatch" and
+                .status == "completed" and
+                .conclusion == "success" and
+                .head_branch == "main" and
+                .repository.full_name == $repository and
+                (.head_sha | test("^[a-f0-9]{40}$"))
+              ' "$response_file" >/dev/null
+            resolved_sha="$(jq -r .head_sha "$response_file")"
+          else
+            [[ "$EXPECTED_SHA" =~ ^[a-f0-9]{40}$ ]]
+            [[ "$MANIFEST_ID" =~ ^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]]
+            [[ "$MANIFEST_IDENTITY" =~ ^[a-f0-9]{64}$ ]]
+            resolved_sha="$EXPECTED_SHA"
+          fi
+          test "$resolved_sha" = "$READONLY_EXPECTED_SHA"
+          echo "expected-sha=$resolved_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Install trusted verifier Node.js
+        id: verifier-node
+        if: always() && steps.release-identity.outcome == 'success'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with: { node-version: "22.17.1" }
+
+      - name: Require an unused isolated verifier path
+        id: verifier-path
+        if: always() && steps.verifier-node.outcome == 'success'
+        run: test ! -e .release-bus-verifier
+
+      - name: Check out immutable isolated verifier tooling
+        id: verifier-checkout
+        if: always() && steps.verifier-path.outcome == 'success'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.workflow_sha }}
-          path: .release-bus-evidence-control
+          path: .release-bus-verifier
           filter: blob:none
           fetch-depth: 1
           persist-credentials: false
           sparse-checkout: |
             scripts/museum-release-tier.cjs
             scripts/museum-release-selection.cjs
+            tests/packs.manifest.cjs
           sparse-checkout-cone-mode: false
-      - name: Verify immutable Museum evidence tooling
-        id: museum-evidence-tooling
-        if: always() && steps.museum-evidence-checkout.outcome == 'success'
+
+      - name: Verify immutable isolated verifier tooling
+        id: verifier-tooling
+        if: always() && steps.verifier-checkout.outcome == 'success'
         env:
           WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
           [[ "$WORKFLOW_SHA" =~ ^[a-f0-9]{40}$ ]]
-          test "$(git -C .release-bus-evidence-control rev-parse HEAD)" = "$WORKFLOW_SHA"
-          if ! control_status="$(git -C .release-bus-evidence-control status --porcelain=v1 --untracked-files=all)"; then
-            echo "::error::Unable to verify the Museum evidence control working tree."
+          test "$(git -C .release-bus-verifier rev-parse HEAD)" = "$WORKFLOW_SHA"
+          if ! control_status="$(git -C .release-bus-verifier status --porcelain=v1 --untracked-files=all)"; then
+            echo "::error::Unable to verify the isolated E2E verifier working tree."
             exit 1
           fi
           test -z "$control_status"
-          test -f .release-bus-evidence-control/scripts/museum-release-tier.cjs
-          test -f .release-bus-evidence-control/scripts/museum-release-selection.cjs
-      - name: Validate exact production E2E evidence
-        id: evidence
-        if: always() && steps.museum-evidence-tooling.outcome == 'success'
+          test -f .release-bus-verifier/scripts/museum-release-tier.cjs
+          test -f .release-bus-verifier/scripts/museum-release-selection.cjs
+          test -f .release-bus-verifier/tests/packs.manifest.cjs
+
+      - name: Download untrusted production E2E evidence
+        id: evidence-download
+        if: always()
+        continue-on-error: true
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: production-e2e-artifacts-${{ inputs.release_train_id || inputs.automatic_deploy_run_id || github.run_id }}
+          path: isolated-production-e2e-artifacts
+
+      - name: Download immutable Museum selection evidence
+        id: selection-download
+        if: always()
+        continue-on-error: true
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: production-e2e-selection-${{ inputs.release_train_id || inputs.automatic_deploy_run_id || github.run_id }}
+          path: isolated-production-e2e-selection
+
+      - name: Validate production E2E evidence on isolated runner
+        id: isolated-evidence
+        if: always() && needs.readonly.result == 'success' && steps.release-identity.outcome == 'success' && steps.verifier-tooling.outcome == 'success' && steps.evidence-download.outcome == 'success' && steps.selection-download.outcome == 'success'
+        continue-on-error: true
         env:
-          E2E_OUTCOME: ${{ steps.e2e.outcome }}
           AUTOMATIC_DEPLOY_RUN_ID: ${{ inputs.automatic_deploy_run_id }}
-          EXPECTED_SHA: ${{ inputs.expected_sha || steps.automatic-deploy.outputs.deployed-sha }}
+          EXPECTED_SHA: ${{ steps.release-identity.outputs.expected-sha }}
           MANIFEST_ID: ${{ inputs.release_manifest_id }}
           MANIFEST_IDENTITY: ${{ inputs.release_manifest_identity_sha256 }}
-          MUSEUM_SOURCE_COMMIT: ${{ steps.museum-selection.outputs.source_commit }}
-          MUSEUM_SELECTION_FILE: ${{ steps.museum-selection.outputs.file }}
-          MUSEUM_RELEASE_SELECTION_TOOL: .release-bus-evidence-control/scripts/museum-release-selection.cjs
+          MUSEUM_RELEASE_SELECTION_TOOL: .release-bus-verifier/scripts/museum-release-selection.cjs
+          PACK_MANIFEST: .release-bus-verifier/tests/packs.manifest.cjs
         run: |
           set -euo pipefail
-          test -f production-e2e-artifacts/evidence.json
-          test -f "$MUSEUM_SELECTION_FILE"
-          jq -e --arg source_commit "$MUSEUM_SOURCE_COMMIT" '
+          evidence_file='isolated-production-e2e-artifacts/evidence.json'
+          selection_file='isolated-production-e2e-selection/museum-release-selection.json'
+          test -f "$evidence_file"
+          test ! -L "$evidence_file"
+          test -f "$selection_file"
+          test ! -L "$selection_file"
+          test "$(find isolated-production-e2e-selection -mindepth 1 | wc -l)" -eq 1
+          test "$(stat -c %s "$selection_file")" -le 1048576
+          test "$(stat -c %s "$evidence_file")" -le 16777216
+          jq -e '
             .contract == "museum-release-selection-v1" and
             .environment == "production" and
-            .source_commit == $source_commit and
             (.source_commit | test("^[a-f0-9]{40}$")) and
             (.selected_packs | type == "array") and
+            (.selected_packs | all(IN("museum-data-architecture", "museum-institutional-practice", "museum-about", "museum-inside-system", "museum-rights"))) and
+            (.selected_packs | unique | length) == (.selected_packs | length) and
             (.selection_digest | test("^[a-f0-9]{64}$"))
-          ' "$MUSEUM_SELECTION_FILE" >/dev/null
-          node - "$MUSEUM_SELECTION_FILE" <<'NODE'
+          ' "$selection_file" >/dev/null
+          node - "$selection_file" <<'NODE'
           const fs = require("node:fs");
           const path = require("node:path");
           const selection = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
@@ -494,138 +607,107 @@ jobs:
             throw new Error("Museum selection digest verification failed.");
           }
           NODE
-          validated_museum_packs="$(jq -c .selected_packs "$MUSEUM_SELECTION_FILE")"
-          complete_museum_packs='["museum-data-architecture","museum-institutional-practice","museum-about","museum-inside-system","museum-rights"]'
-          effective_museum_packs="${MUSEUM_SELECTED_PACKS_JSON:-}"
-          if [ "$effective_museum_packs" != "$validated_museum_packs" ] && \
-            [ "$effective_museum_packs" != "$complete_museum_packs" ]
-          then
-            echo "Museum pack inventory is not bound to the validated selection." >&2
-            exit 1
-          fi
-          export MUSEUM_SELECTED_PACKS_JSON="$effective_museum_packs"
-          expected_inventory="$(./bin/6529 exec node - <<'NODE'
-          const { PACKS } = require("./tests/packs.manifest.cjs");
-          const selectedMuseumPacks = JSON.parse(
-            process.env.MUSEUM_SELECTED_PACKS_JSON || "null"
+          inventories="$(node - "$selection_file" <<'NODE'
+          const fs = require("node:fs");
+          const path = require("node:path");
+          const selection = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const { PACKS } = require(path.resolve(process.env.PACK_MANIFEST));
+          const eligible = PACKS.filter(
+            (pack) =>
+              pack.environments.includes("production") &&
+              pack.triggers.includes("post-deploy")
           );
-          if (!Array.isArray(selectedMuseumPacks)) {
-            throw new Error("Museum selection evidence is missing.");
-          }
           const isMuseumPack = (pack) =>
             pack.changeScope === "museum" || /^museum-/.test(pack.alias ?? "");
-          const keys = PACKS.filter((pack) =>
-            pack.environments.includes("production") &&
-            pack.triggers.includes("post-deploy") &&
-            (!isMuseumPack(pack) || selectedMuseumPacks.includes(pack.alias ?? pack.scriptKey))
-          ).map((pack) => pack.scriptKey);
-          process.stdout.write(JSON.stringify(keys));
+          const inventory = (selectedMuseumPacks) =>
+            eligible
+              .filter(
+                (pack) =>
+                  !isMuseumPack(pack) ||
+                  selectedMuseumPacks.includes(pack.alias ?? pack.scriptKey)
+              )
+              .map((pack) => pack.scriptKey);
+          const completeMuseumPacks = eligible
+            .filter(isMuseumPack)
+            .map((pack) => pack.alias ?? pack.scriptKey);
+          process.stdout.write(
+            JSON.stringify({
+              complete: inventory(completeMuseumPacks),
+              selected: inventory(selection.selected_packs),
+            })
+          );
           NODE
           )"
-          jq -e --argjson expected "$expected_inventory" --argjson retry "$SERIAL_FAILED_PACK_RETRY" '
-            .schema_version == "release-bus-e2e-packs.v1" and
-            .environment == "production" and
-            .trigger == "post-deploy" and
-            (.worker_count | type == "number" and . >= 1 and . <= 3) and
-            .pack_count == ($expected | length) and
-            (.results | map(.script_key)) == $expected and
-            (.results | map(.script_key) | unique | length) == .pack_count and
-            (.results | all(.safety == "readonly")) and
-            (if $retry then
-              .serial_retry_limit == 1 and
+          selected_inventory="$(jq -c .selected <<< "$inventories")"
+          complete_inventory="$(jq -c .complete <<< "$inventories")"
+          jq -e \
+            --argjson selected "$selected_inventory" \
+            --argjson complete "$complete_inventory" '
+              (.results | map(.script_key)) as $actual |
+              (.serial_retry_limit // 0) as $retry_limit |
+              .schema_version == "release-bus-e2e-packs.v1" and
+              .environment == "production" and
+              .trigger == "post-deploy" and
+              (.worker_count | type == "number" and . >= 1 and . <= 3) and
+              ($retry_limit == 0 or $retry_limit == 1) and
+              .pack_count == ($actual | length) and
+              ($actual == $selected or $actual == $complete) and
+              ($actual | unique | length) == .pack_count and
+              (.results | all(.safety == "readonly")) and
               (.results | all(
                 .attempt_count == (.attempts | length) and
-                .attempt_count >= 1 and .attempt_count <= 2 and
+                .attempt_count >= 1 and .attempt_count <= ($retry_limit + 1) and
                 (.attempts | to_entries | all(.value.attempt == (.key + 1))) and
                 .status == .attempts[-1].status and
                 .failure_class == .attempts[-1].failure_class and
                 .detail == .attempts[-1].detail and
                 .artifact_path == .attempts[-1].artifact_path and
                 .duration_ms == ([.attempts[].duration_ms] | add)
-              ))
-            else
-              (.serial_retry_limit // 0) == 0
-            end) and
-            .failed_count == ([.results[] | select(.status == "failed")] | length) and
-            .infrastructure_failure_count == ([.results[] | select(.failure_class == "infrastructure")] | length)
-          ' production-e2e-artifacts/evidence.json >/dev/null
-          if [ -n "$AUTOMATIC_DEPLOY_RUN_ID" ]; then
-            test -z "$MANIFEST_ID$MANIFEST_IDENTITY"
-            jq -e '.release_binding == null' \
-              production-e2e-artifacts/evidence.json >/dev/null
-          else
-            jq -e --arg manifest_id "$MANIFEST_ID" --arg identity "$MANIFEST_IDENTITY" --arg source_sha "$EXPECTED_SHA" '
-              .release_binding == {
-                manifest_id:$manifest_id,
-                manifest_identity_sha256:$identity,
-                source_sha:$source_sha
-              }
-            ' production-e2e-artifacts/evidence.json >/dev/null
-          fi
-          if [ "$E2E_OUTCOME" = success ]; then
-            jq -e '
+              )) and
               .failed_count == 0 and
               .infrastructure_failure_count == 0 and
               (.results | all(.status == "passed" and .failure_class == null))
-            ' production-e2e-artifacts/evidence.json >/dev/null
+            ' "$evidence_file" >/dev/null
+          if [ -n "$AUTOMATIC_DEPLOY_RUN_ID" ]; then
+            test -z "$MANIFEST_ID$MANIFEST_IDENTITY"
+            jq -e '.release_binding == null' "$evidence_file" >/dev/null
+          else
+            jq -e \
+              --arg manifest_id "$MANIFEST_ID" \
+              --arg identity "$MANIFEST_IDENTITY" \
+              --arg source_sha "$EXPECTED_SHA" '
+                .release_binding == {
+                  manifest_id:$manifest_id,
+                  manifest_identity_sha256:$identity,
+                  source_sha:$source_sha
+                }
+              ' "$evidence_file" >/dev/null
           fi
-      - name: Stage Museum selection with production evidence
-        if: always()
-        env:
-          MUSEUM_SELECTION_FILE: ${{ steps.museum-selection.outputs.file }}
-        run: |
-          set -euo pipefail
-          mkdir -p production-e2e-artifacts
-          if [ -n "$MUSEUM_SELECTION_FILE" ] && [ -f "$MUSEUM_SELECTION_FILE" ]; then
-            install -m 0644 \
-              "$MUSEUM_SELECTION_FILE" \
-              production-e2e-artifacts/museum-release-selection.json
-          fi
-      - name: Upload manifest-bound Playwright evidence
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: production-e2e-artifacts-${{ inputs.release_train_id || inputs.automatic_deploy_run_id || github.run_id }}
-          path: production-e2e-artifacts/
-          retention-days: 30
-          if-no-files-found: ignore
+
       - name: Report structured Release Bus E2E result
         if: always() && inputs.operation_key != ''
         env:
+          EVIDENCE_DOWNLOAD_OUTCOME: ${{ steps.evidence-download.outcome }}
+          IDENTITY_OUTCOME: ${{ steps.release-identity.outcome }}
+          ISOLATED_EVIDENCE_OUTCOME: ${{ steps.isolated-evidence.outcome }}
+          OPERATION_KEY: ${{ inputs.operation_key }}
+          READONLY_RESULT: ${{ needs.readonly.result }}
           RELEASE_BUS_API_URL: ${{ vars.RELEASE_BUS_API_URL }}
           RELEASE_BUS_WORKFLOW_AUTH_TOKEN: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
-          SOCKET_OUTCOME: ${{ steps.socket-firewall.outcome }}
-          DEPENDENCIES_OUTCOME: ${{ steps.dependencies.outcome }}
-          PLAYWRIGHT_OUTCOME: ${{ steps.playwright.outcome }}
-          E2E_OUTCOME: ${{ steps.e2e.outcome }}
-          MUSEUM_EVIDENCE_PATH_OUTCOME: ${{ steps.museum-evidence-path.outcome }}
-          MUSEUM_EVIDENCE_CHECKOUT_OUTCOME: ${{ steps.museum-evidence-checkout.outcome }}
-          MUSEUM_EVIDENCE_TOOLING_OUTCOME: ${{ steps.museum-evidence-tooling.outcome }}
-          EVIDENCE_OUTCOME: ${{ steps.evidence.outcome }}
+          SELECTION_DOWNLOAD_OUTCOME: ${{ steps.selection-download.outcome }}
           TRAIN_ID: ${{ inputs.release_train_id }}
-          OPERATION_KEY: ${{ inputs.operation_key }}
+          VERIFIER_TOOLING_OUTCOME: ${{ steps.verifier-tooling.outcome }}
         run: |
           set -euo pipefail
           status=SUCCEEDED
           failure_class=null
           failure_phase=null
           retryable=false
-          if [ "$SOCKET_OUTCOME" != success ] || [ "$DEPENDENCIES_OUTCOME" != success ] || [ "$PLAYWRIGHT_OUTCOME" != success ]; then
+          evidence_file='isolated-production-e2e-artifacts/evidence.json'
+          if [ "$READONLY_RESULT" != success ]; then
             status=FAILED
-            failure_class=INFRASTRUCTURE
-            failure_phase=production_e2e_setup
-            retryable=true
-          elif [ "$MUSEUM_EVIDENCE_PATH_OUTCOME" != success ] || \
-            [ "$MUSEUM_EVIDENCE_CHECKOUT_OUTCOME" != success ] || \
-            [ "$MUSEUM_EVIDENCE_TOOLING_OUTCOME" != success ] || \
-            [ "$EVIDENCE_OUTCOME" != success ]; then
-            status=FAILED
-            failure_class=CONTROL_PLANE
-            failure_phase=production_e2e_evidence
-          elif [ "$E2E_OUTCOME" != success ]; then
-            status=FAILED
-            if [ -f production-e2e-artifacts/evidence.json ] && \
-              [ "$(jq -r '.infrastructure_failure_count // 0' production-e2e-artifacts/evidence.json)" -gt 0 ]; then
+            if [ -f "$evidence_file" ] && \
+              [ "$(jq -r '.infrastructure_failure_count // 0' "$evidence_file")" -gt 0 ]; then
               failure_class=INFRASTRUCTURE
               failure_phase=production_e2e_infrastructure
               retryable=true
@@ -633,9 +715,17 @@ jobs:
               failure_class=E2E
               failure_phase=production_e2e
             fi
+          elif [ "$IDENTITY_OUTCOME" != success ] || \
+            [ "$VERIFIER_TOOLING_OUTCOME" != success ] || \
+            [ "$EVIDENCE_DOWNLOAD_OUTCOME" != success ] || \
+            [ "$SELECTION_DOWNLOAD_OUTCOME" != success ] || \
+            [ "$ISOLATED_EVIDENCE_OUTCOME" != success ]; then
+            status=FAILED
+            failure_class=CONTROL_PLANE
+            failure_phase=production_e2e_evidence
           fi
-          if [ -f production-e2e-artifacts/evidence.json ]; then
-            evidence_digest="$(sha256sum production-e2e-artifacts/evidence.json | cut -d' ' -f1)"
+          if [ -f "$evidence_file" ]; then
+            evidence_digest="$(sha256sum "$evidence_file" | cut -d' ' -f1)"
           else
             evidence_digest=''
           fi
@@ -645,23 +735,20 @@ jobs:
             -H 'Content-Type: application/json' \
             --data "$payload" \
             "$RELEASE_BUS_API_URL/deploy/release-bus-v2/report-progress"
-      - name: Return production E2E result
+
+      - name: Return isolated production E2E result
         if: always()
         env:
-          SOCKET_OUTCOME: ${{ steps.socket-firewall.outcome }}
-          DEPENDENCIES_OUTCOME: ${{ steps.dependencies.outcome }}
-          PLAYWRIGHT_OUTCOME: ${{ steps.playwright.outcome }}
-          E2E_OUTCOME: ${{ steps.e2e.outcome }}
-          MUSEUM_EVIDENCE_PATH_OUTCOME: ${{ steps.museum-evidence-path.outcome }}
-          MUSEUM_EVIDENCE_CHECKOUT_OUTCOME: ${{ steps.museum-evidence-checkout.outcome }}
-          MUSEUM_EVIDENCE_TOOLING_OUTCOME: ${{ steps.museum-evidence-tooling.outcome }}
-          EVIDENCE_OUTCOME: ${{ steps.evidence.outcome }}
+          EVIDENCE_DOWNLOAD_OUTCOME: ${{ steps.evidence-download.outcome }}
+          IDENTITY_OUTCOME: ${{ steps.release-identity.outcome }}
+          ISOLATED_EVIDENCE_OUTCOME: ${{ steps.isolated-evidence.outcome }}
+          READONLY_RESULT: ${{ needs.readonly.result }}
+          SELECTION_DOWNLOAD_OUTCOME: ${{ steps.selection-download.outcome }}
+          VERIFIER_TOOLING_OUTCOME: ${{ steps.verifier-tooling.outcome }}
         run: |
-          test "$SOCKET_OUTCOME" = success
-          test "$DEPENDENCIES_OUTCOME" = success
-          test "$PLAYWRIGHT_OUTCOME" = success
-          test "$MUSEUM_EVIDENCE_PATH_OUTCOME" = success
-          test "$MUSEUM_EVIDENCE_CHECKOUT_OUTCOME" = success
-          test "$MUSEUM_EVIDENCE_TOOLING_OUTCOME" = success
-          test "$EVIDENCE_OUTCOME" = success
-          test "$E2E_OUTCOME" = success
+          test "$READONLY_RESULT" = success
+          test "$IDENTITY_OUTCOME" = success
+          test "$VERIFIER_TOOLING_OUTCOME" = success
+          test "$EVIDENCE_DOWNLOAD_OUTCOME" = success
+          test "$SELECTION_DOWNLOAD_OUTCOME" = success
+          test "$ISOLATED_EVIDENCE_OUTCOME" = success

--- a/.github/workflows/production-e2e.yml
+++ b/.github/workflows/production-e2e.yml
@@ -32,7 +32,14 @@ jobs:
     runs-on: ${{ vars.E2E_RUNNER || vars.CI_LINUX_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 90
     outputs:
+      dependencies-outcome: ${{ steps.dependencies.outcome }}
+      e2e-outcome: ${{ steps.e2e.outcome }}
+      evidence-upload-outcome: ${{ steps.evidence-upload.outcome }}
       expected-sha: ${{ inputs.expected_sha || steps.automatic-deploy.outputs.deployed-sha }}
+      playwright-outcome: ${{ steps.playwright.outcome }}
+      selection-outcome: ${{ steps.museum-selection.outcome }}
+      selection-upload-outcome: ${{ steps.museum-selection-upload.outcome }}
+      socket-outcome: ${{ steps.socket-firewall.outcome }}
     permissions:
       actions: read
       contents: read
@@ -302,6 +309,7 @@ jobs:
             echo "Packs: $(jq -r '.selected_packs | join(", ") // "none"' "$selection_file")"
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Upload immutable Museum selection evidence
+        id: museum-selection-upload
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: production-e2e-selection-${{ inputs.release_train_id || inputs.automatic_deploy_run_id || github.run_id }}
@@ -427,6 +435,7 @@ jobs:
           echo "MUSEUM_SELECTED_PACKS_JSON=$MUSEUM_SELECTED_PACKS_JSON" >> "$GITHUB_ENV"
           ./bin/6529 run e2e:packs -- "${args[@]}"
       - name: Upload manifest-bound Playwright evidence
+        id: evidence-upload
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -691,7 +700,14 @@ jobs:
           IDENTITY_OUTCOME: ${{ steps.release-identity.outcome }}
           ISOLATED_EVIDENCE_OUTCOME: ${{ steps.isolated-evidence.outcome }}
           OPERATION_KEY: ${{ inputs.operation_key }}
+          READONLY_DEPENDENCIES_OUTCOME: ${{ needs.readonly.outputs.dependencies-outcome }}
+          READONLY_E2E_OUTCOME: ${{ needs.readonly.outputs.e2e-outcome }}
+          READONLY_EVIDENCE_UPLOAD_OUTCOME: ${{ needs.readonly.outputs.evidence-upload-outcome }}
+          READONLY_PLAYWRIGHT_OUTCOME: ${{ needs.readonly.outputs.playwright-outcome }}
           READONLY_RESULT: ${{ needs.readonly.result }}
+          READONLY_SELECTION_OUTCOME: ${{ needs.readonly.outputs.selection-outcome }}
+          READONLY_SELECTION_UPLOAD_OUTCOME: ${{ needs.readonly.outputs.selection-upload-outcome }}
+          READONLY_SOCKET_OUTCOME: ${{ needs.readonly.outputs.socket-outcome }}
           RELEASE_BUS_API_URL: ${{ vars.RELEASE_BUS_API_URL }}
           RELEASE_BUS_WORKFLOW_AUTH_TOKEN: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
           SELECTION_DOWNLOAD_OUTCOME: ${{ steps.selection-download.outcome }}
@@ -706,14 +722,31 @@ jobs:
           evidence_file='isolated-production-e2e-artifacts/evidence.json'
           if [ "$READONLY_RESULT" != success ]; then
             status=FAILED
-            if [ -f "$evidence_file" ] && \
+            if [ "$READONLY_SELECTION_OUTCOME" != success ] || \
+              [ "$READONLY_SELECTION_UPLOAD_OUTCOME" != success ]; then
+              failure_class=CONTROL_PLANE
+              failure_phase=production_e2e_selection
+            elif [ "$READONLY_SOCKET_OUTCOME" != success ] || \
+              [ "$READONLY_DEPENDENCIES_OUTCOME" != success ] || \
+              [ "$READONLY_PLAYWRIGHT_OUTCOME" != success ]; then
+              failure_class=INFRASTRUCTURE
+              failure_phase=production_e2e_setup
+              retryable=true
+            elif [ "$READONLY_E2E_OUTCOME" != success ] && \
+              [ -f "$evidence_file" ] && \
               [ "$(jq -r '.infrastructure_failure_count // 0' "$evidence_file")" -gt 0 ]; then
               failure_class=INFRASTRUCTURE
               failure_phase=production_e2e_infrastructure
               retryable=true
-            else
+            elif [ "$READONLY_E2E_OUTCOME" != success ]; then
               failure_class=E2E
               failure_phase=production_e2e
+            elif [ "$READONLY_EVIDENCE_UPLOAD_OUTCOME" != success ]; then
+              failure_class=CONTROL_PLANE
+              failure_phase=production_e2e_evidence
+            else
+              failure_class=CONTROL_PLANE
+              failure_phase=production_e2e_control
             fi
           elif [ "$IDENTITY_OUTCOME" != success ] || \
             [ "$VERIFIER_TOOLING_OUTCOME" != success ] || \

--- a/__tests__/scripts/production-e2e-dispatch.test.ts
+++ b/__tests__/scripts/production-e2e-dispatch.test.ts
@@ -120,6 +120,7 @@ describe("automatic production E2E dispatch", () => {
     expect(selectionUpload.uses).toBe(
       "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
     );
+    expect(selectionUpload.id).toBe("museum-selection-upload");
     expect(selectionUpload.with.name).toContain("production-e2e-selection-");
     expect(selectionUpload.with.path).toBe(
       "${{ steps.museum-selection.outputs.file }}"
@@ -141,6 +142,7 @@ describe("automatic production E2E dispatch", () => {
         SOCKET_OUTCOME: "${{ steps.socket-firewall.outcome }}",
       })
     );
+    expect(job.steps[evidenceUploadIndex].id).toBe("evidence-upload");
     expect(e2eSource).toContain(
       'if ! control_status="$(git -C .release-bus-control status --porcelain=v1 --untracked-files=all)"; then'
     );
@@ -181,6 +183,18 @@ describe("automatic production E2E dispatch", () => {
 
     expect(readonly.outputs["expected-sha"]).toContain(
       "steps.automatic-deploy.outputs.deployed-sha"
+    );
+    expect(readonly.outputs).toEqual(
+      expect.objectContaining({
+        "dependencies-outcome": "${{ steps.dependencies.outcome }}",
+        "e2e-outcome": "${{ steps.e2e.outcome }}",
+        "evidence-upload-outcome": "${{ steps.evidence-upload.outcome }}",
+        "playwright-outcome": "${{ steps.playwright.outcome }}",
+        "selection-outcome": "${{ steps.museum-selection.outcome }}",
+        "selection-upload-outcome":
+          "${{ steps.museum-selection-upload.outcome }}",
+        "socket-outcome": "${{ steps.socket-firewall.outcome }}",
+      })
     );
     expect(
       readonly.steps.some(
@@ -236,6 +250,14 @@ describe("automatic production E2E dispatch", () => {
     expect(evidence.run).toContain("$actual == $complete");
     expect(evidence.run).toContain(".release_binding == null");
     expect(report.env.READONLY_RESULT).toContain("needs.readonly.result");
+    expect(report.env.READONLY_SOCKET_OUTCOME).toContain(
+      "needs.readonly.outputs.socket-outcome"
+    );
+    expect(report.env.READONLY_E2E_OUTCOME).toContain(
+      "needs.readonly.outputs.e2e-outcome"
+    );
+    expect(report.run).toContain("failure_phase=production_e2e_setup");
+    expect(report.run).toContain("failure_phase=production_e2e_selection");
     expect(report.env.ISOLATED_EVIDENCE_OUTCOME).toContain(
       "steps.isolated-evidence.outcome"
     );

--- a/__tests__/scripts/production-e2e-dispatch.test.ts
+++ b/__tests__/scripts/production-e2e-dispatch.test.ts
@@ -42,10 +42,6 @@ describe("automatic production E2E dispatch", () => {
       (step: { name?: string }) =>
         step.name === "Resolve successful automatic production deploy"
     );
-    const evidence = job.steps.find(
-      (step: { name?: string }) =>
-        step.name === "Validate exact production E2E evidence"
-    );
     const checkoutIndex = job.steps.findIndex(
       (step: { name?: string }) =>
         step.name === "Check out exact production SHA"
@@ -61,6 +57,18 @@ describe("automatic production E2E dispatch", () => {
       (step: { name?: string }) =>
         step.name === "Verify immutable Museum selection tooling"
     );
+    const selectionIndex = job.steps.findIndex(
+      (step: { name?: string }) =>
+        step.name ===
+        "Select fail-closed Museum packs for the exact deployed range"
+    );
+    const selectionUploadIndex = job.steps.findIndex(
+      (step: { name?: string }) =>
+        step.name === "Upload immutable Museum selection evidence"
+    );
+    const packageManagerIndex = job.steps.findIndex(
+      (step: { name?: string }) => step.name === "Activate pinned pnpm"
+    );
     const dependenciesIndex = job.steps.findIndex(
       (step: { name?: string }) => step.name === "Install frozen dependencies"
     );
@@ -68,31 +76,12 @@ describe("automatic production E2E dispatch", () => {
       (step: { name?: string }) =>
         step.name === "Run production-safe read-only packs"
     );
-    const selectionIndex = job.steps.findIndex(
+    const evidenceUploadIndex = job.steps.findIndex(
       (step: { name?: string }) =>
-        step.name ===
-        "Select fail-closed Museum packs for the exact deployed range"
+        step.name === "Upload manifest-bound Playwright evidence"
     );
-    const evidenceControlCheckoutIndex = job.steps.findIndex(
-      (step: { name?: string }) =>
-        step.name === "Check out immutable Release Bus Museum evidence tooling"
-    );
-    const evidenceControlVerificationIndex = job.steps.findIndex(
-      (step: { name?: string }) =>
-        step.name === "Verify immutable Museum evidence tooling"
-    );
-    const evidenceIndex = job.steps.findIndex(
-      (step: { name?: string }) =>
-        step.name === "Validate exact production E2E evidence"
-    );
-    const evidencePath = job.steps[evidenceControlCheckoutIndex - 1];
-    const evidenceControlCheckout = job.steps[evidenceControlCheckoutIndex];
-    const evidenceControlVerification =
-      job.steps[evidenceControlVerificationIndex];
-    const report = job.steps.find(
-      (step: { name?: string }) =>
-        step.name === "Report structured Release Bus E2E result"
-    );
+    const selection = job.steps[selectionIndex];
+    const selectionUpload = job.steps[selectionUploadIndex];
     const result = job.steps.find(
       (step: { name?: string }) => step.name === "Return production E2E result"
     );
@@ -115,71 +104,148 @@ describe("automatic production E2E dispatch", () => {
       "${{ inputs.expected_sha || steps.automatic-deploy.outputs.deployed-sha }}"
     );
     expect(sourceVerificationIndex).toBeGreaterThan(checkoutIndex);
-    expect(dependenciesIndex).toBeGreaterThan(sourceVerificationIndex);
-    expect(controlCheckoutIndex).toBeGreaterThan(dependenciesIndex);
+    expect(controlCheckoutIndex).toBeGreaterThan(sourceVerificationIndex);
     expect(controlVerificationIndex).toBeGreaterThan(controlCheckoutIndex);
-    expect(packsIndex).toBeGreaterThan(checkoutIndex);
     expect(selectionIndex).toBeGreaterThan(controlVerificationIndex);
     expect(selectionIndex).toBeGreaterThan(checkoutIndex);
+    expect(selectionUploadIndex).toBeGreaterThan(selectionIndex);
+    expect(packageManagerIndex).toBeGreaterThan(selectionUploadIndex);
+    expect(dependenciesIndex).toBeGreaterThan(packageManagerIndex);
     expect(packsIndex).toBeGreaterThan(selectionIndex);
-    expect(evidenceControlCheckoutIndex).toBeGreaterThan(packsIndex);
-    expect(evidenceControlVerificationIndex).toBeGreaterThan(
-      evidenceControlCheckoutIndex
-    );
-    expect(evidenceIndex).toBeGreaterThan(evidenceControlVerificationIndex);
+    expect(packsIndex).toBeGreaterThan(dependenciesIndex);
+    expect(evidenceUploadIndex).toBeGreaterThan(packsIndex);
     expect(job.steps[controlCheckoutIndex].with.path).toBe(
       ".release-bus-control"
     );
-    expect(job.steps[evidenceControlCheckoutIndex].with.path).toBe(
-      ".release-bus-evidence-control"
+    expect(selectionUpload.uses).toBe(
+      "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
     );
-    expect(evidencePath.id).toBe("museum-evidence-path");
-    expect(evidenceControlCheckout.id).toBe("museum-evidence-checkout");
-    expect(evidenceControlCheckout.if).toContain(
-      "steps.museum-evidence-path.outcome == 'success'"
+    expect(selectionUpload.with.name).toContain("production-e2e-selection-");
+    expect(selectionUpload.with.path).toBe(
+      "${{ steps.museum-selection.outputs.file }}"
     );
-    expect(evidenceControlVerification.id).toBe("museum-evidence-tooling");
-    expect(evidenceControlVerification.if).toContain(
-      "steps.museum-evidence-checkout.outcome == 'success'"
-    );
-    expect(job.steps[evidenceIndex].if).toContain(
-      "steps.museum-evidence-tooling.outcome == 'success'"
-    );
-    expect(job.steps[selectionIndex].run).toContain(
-      "scripts/museum-release-selection.cjs"
-    );
-    expect(job.steps[selectionIndex].run).toContain(
-      'test "$head_sha" = "$DEPLOYED_SHA"'
-    );
+    expect(selection.run).toContain("scripts/museum-release-selection.cjs");
+    expect(selection.run).toContain('test "$head_sha" = "$DEPLOYED_SHA"');
+    expect(selection.run).not.toContain("NODE_PATH=");
     expect(job.steps[packsIndex].run).toContain(
       'pack.changeScope === "museum"'
     );
     expect(job.steps[packsIndex].run).toContain(
       'args+=(--exclude-pack "$museum_pack_alias")'
     );
-    expect(evidence.run).toContain("!isMuseumPack(pack)");
-    expect(evidence.run).toContain(".release_binding == null");
-    expect(evidence.env.MUSEUM_RELEASE_SELECTION_TOOL).toBe(
-      ".release-bus-evidence-control/scripts/museum-release-selection.cjs"
+    expect(result.env).toEqual(
+      expect.objectContaining({
+        DEPENDENCIES_OUTCOME: "${{ steps.dependencies.outcome }}",
+        E2E_OUTCOME: "${{ steps.e2e.outcome }}",
+        PLAYWRIGHT_OUTCOME: "${{ steps.playwright.outcome }}",
+        SOCKET_OUTCOME: "${{ steps.socket-firewall.outcome }}",
+      })
     );
-    expect(evidence.run).toContain('node - "$MUSEUM_SELECTION_FILE"');
-    for (const outcome of [
-      "MUSEUM_EVIDENCE_PATH_OUTCOME",
-      "MUSEUM_EVIDENCE_CHECKOUT_OUTCOME",
-      "MUSEUM_EVIDENCE_TOOLING_OUTCOME",
-    ]) {
-      expect(report.env[outcome]).toContain("steps.museum-evidence-");
-      expect(report.run).toContain(`$${outcome}`);
-      expect(result.env[outcome]).toContain("steps.museum-evidence-");
-      expect(result.run).toContain(`$${outcome}`);
-    }
     expect(e2eSource).toContain(
       'if ! control_status="$(git -C .release-bus-control status --porcelain=v1 --untracked-files=all)"; then'
     );
-    expect(e2eSource).toContain(
-      'if ! control_status="$(git -C .release-bus-evidence-control status --porcelain=v1 --untracked-files=all)"; then'
-    );
+    expect(e2eSource).not.toContain(".release-bus-evidence-control");
     expect(e2eSource).toContain("args+=(--parallel 3)");
     expect(e2eSource).toContain("Restore Playwright browser");
+  });
+
+  it("qualifies uploaded evidence on a clean GitHub-hosted runner", () => {
+    const readonly = e2e.jobs.readonly;
+    const verifier = e2e.jobs["verify-evidence"];
+    const stepIndex = (name: string) =>
+      verifier.steps.findIndex((step: { name?: string }) => step.name === name);
+    const identityIndex = stepIndex(
+      "Resolve isolated verifier release identity"
+    );
+    const toolingIndex = stepIndex(
+      "Verify immutable isolated verifier tooling"
+    );
+    const evidenceDownloadIndex = stepIndex(
+      "Download untrusted production E2E evidence"
+    );
+    const selectionDownloadIndex = stepIndex(
+      "Download immutable Museum selection evidence"
+    );
+    const evidenceIndex = stepIndex(
+      "Validate production E2E evidence on isolated runner"
+    );
+    const reportIndex = stepIndex("Report structured Release Bus E2E result");
+    const resultIndex = stepIndex("Return isolated production E2E result");
+    const checkout = verifier.steps.find(
+      (step: { name?: string }) =>
+        step.name === "Check out immutable isolated verifier tooling"
+    );
+    const evidence = verifier.steps[evidenceIndex];
+    const report = verifier.steps[reportIndex];
+    const result = verifier.steps[resultIndex];
+
+    expect(readonly.outputs["expected-sha"]).toContain(
+      "steps.automatic-deploy.outputs.deployed-sha"
+    );
+    expect(
+      readonly.steps.some(
+        (step: { name?: string }) =>
+          step.name === "Report structured Release Bus E2E result"
+      )
+    ).toBe(false);
+    expect(verifier.if).toBe("always()");
+    expect(verifier.needs).toBe("readonly");
+    expect(verifier["runs-on"]).toBe("ubuntu-latest");
+    expect(verifier.permissions).toEqual({ actions: "read", contents: "read" });
+    expect(identityIndex).toBeGreaterThanOrEqual(0);
+    expect(toolingIndex).toBeGreaterThan(identityIndex);
+    expect(evidenceDownloadIndex).toBeGreaterThan(identityIndex);
+    expect(selectionDownloadIndex).toBeGreaterThan(identityIndex);
+    expect(evidenceIndex).toBeGreaterThan(toolingIndex);
+    expect(evidenceIndex).toBeGreaterThan(evidenceDownloadIndex);
+    expect(evidenceIndex).toBeGreaterThan(selectionDownloadIndex);
+    expect(reportIndex).toBeGreaterThan(evidenceIndex);
+    expect(resultIndex).toBeGreaterThan(reportIndex);
+    expect(checkout.with.ref).toBe("${{ github.workflow_sha }}");
+    expect(checkout.with.path).toBe(".release-bus-verifier");
+    expect(checkout.with["sparse-checkout"]).toContain(
+      "tests/packs.manifest.cjs"
+    );
+    expect(verifier.steps[evidenceDownloadIndex].uses).toBe(
+      "actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131"
+    );
+    expect(verifier.steps[selectionDownloadIndex].uses).toBe(
+      "actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131"
+    );
+    expect(verifier.steps[evidenceDownloadIndex].with.name).toContain(
+      "inputs.automatic_deploy_run_id"
+    );
+    expect(verifier.steps[selectionDownloadIndex].with.name).toContain(
+      "production-e2e-selection-"
+    );
+    expect(evidence.if).toContain("needs.readonly.result == 'success'");
+    expect(evidence.if).toContain(
+      "steps.verifier-tooling.outcome == 'success'"
+    );
+    expect(evidence.if).toContain(
+      "steps.evidence-download.outcome == 'success'"
+    );
+    expect(evidence.if).toContain(
+      "steps.selection-download.outcome == 'success'"
+    );
+    expect(evidence.run).toContain(
+      "isolated-production-e2e-selection/museum-release-selection.json"
+    );
+    expect(evidence.run).toContain("verifySelectionDigest");
+    expect(evidence.run).toContain("$actual == $selected");
+    expect(evidence.run).toContain("$actual == $complete");
+    expect(evidence.run).toContain(".release_binding == null");
+    expect(report.env.READONLY_RESULT).toContain("needs.readonly.result");
+    expect(report.env.ISOLATED_EVIDENCE_OUTCOME).toContain(
+      "steps.isolated-evidence.outcome"
+    );
+    expect(report.env.SELECTION_DOWNLOAD_OUTCOME).toContain(
+      "steps.selection-download.outcome"
+    );
+    expect(result.run).toContain('test "$READONLY_RESULT" = success');
+    expect(result.run).toContain(
+      'test "$SELECTION_DOWNLOAD_OUTCOME" = success'
+    );
+    expect(result.run).toContain('test "$ISOLATED_EVIDENCE_OUTCOME" = success');
   });
 });

--- a/__tests__/scripts/release-bus-artifact-compatibility.test.ts
+++ b/__tests__/scripts/release-bus-artifact-compatibility.test.ts
@@ -843,10 +843,10 @@ describe("Release Bus artifact rollout compatibility", () => {
       );
       const evidence = findStep(
         workflow,
-        environment === "staging" ? "staging-packs" : "readonly",
+        environment === "staging" ? "staging-packs" : "verify-evidence",
         environment === "staging"
           ? "Validate exact manifest-bound E2E evidence"
-          : "Validate exact production E2E evidence"
+          : "Validate production E2E evidence on isolated runner"
       );
       const root = fs.mkdtempSync(
         path.join(os.tmpdir(), `release-bus-${environment}-runner-`)

--- a/__tests__/scripts/release-bus-artifact-compatibility.test.ts
+++ b/__tests__/scripts/release-bus-artifact-compatibility.test.ts
@@ -931,6 +931,83 @@ describe("Release Bus artifact rollout compatibility", () => {
     });
   }
 
+  it("preserves retryable setup classification across the isolated production boundary", () => {
+    const workflow = readWorkflow("production-e2e.yml");
+    const report = findStep(
+      workflow,
+      "verify-evidence",
+      "Report structured Release Bus E2E result"
+    );
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), "release-bus-production-e2e-report-")
+    );
+    try {
+      const mockBin = path.join(root, "bin");
+      fs.mkdirSync(mockBin);
+      createMockCurl(mockBin);
+      const curlPayload = path.join(root, "report-payload.json");
+      const baseEnv = {
+        EVIDENCE_DOWNLOAD_OUTCOME: "failure",
+        GITHUB_RUN_ID: "9876",
+        IDENTITY_OUTCOME: "success",
+        ISOLATED_EVIDENCE_OUTCOME: "skipped",
+        MOCK_CURL_PAYLOAD: curlPayload,
+        OPERATION_KEY: "rb2:production:e2e:a1",
+        PATH: `${mockBin}:${process.env["PATH"]}`,
+        READONLY_EVIDENCE_UPLOAD_OUTCOME: "skipped",
+        READONLY_RESULT: "failure",
+        READONLY_SELECTION_OUTCOME: "success",
+        READONLY_SELECTION_UPLOAD_OUTCOME: "success",
+        RELEASE_BUS_API_URL: "https://release-bus.invalid",
+        RELEASE_BUS_WORKFLOW_AUTH_TOKEN: "test-token",
+        SELECTION_DOWNLOAD_OUTCOME: "success",
+        TRAIN_ID,
+        VERIFIER_TOOLING_OUTCOME: "success",
+      };
+
+      expect(
+        runShell(report.run!, {
+          cwd: root,
+          env: {
+            ...baseEnv,
+            READONLY_DEPENDENCIES_OUTCOME: "skipped",
+            READONLY_E2E_OUTCOME: "skipped",
+            READONLY_PLAYWRIGHT_OUTCOME: "skipped",
+            READONLY_SOCKET_OUTCOME: "failure",
+          },
+        }).status
+      ).toBe(0);
+      expect(JSON.parse(fs.readFileSync(curlPayload, "utf8"))).toMatchObject({
+        failure_class: "INFRASTRUCTURE",
+        failure_phase: "production_e2e_setup",
+        retryable: true,
+        status: "FAILED",
+      });
+
+      expect(
+        runShell(report.run!, {
+          cwd: root,
+          env: {
+            ...baseEnv,
+            READONLY_DEPENDENCIES_OUTCOME: "success",
+            READONLY_E2E_OUTCOME: "failure",
+            READONLY_EVIDENCE_UPLOAD_OUTCOME: "success",
+            READONLY_PLAYWRIGHT_OUTCOME: "success",
+            READONLY_SOCKET_OUTCOME: "success",
+          },
+        }).status
+      ).toBe(0);
+      expect(JSON.parse(fs.readFileSync(curlPayload, "utf8"))).toMatchObject({
+        failure_class: "E2E",
+        failure_phase: "production_e2e",
+        retryable: false,
+        status: "FAILED",
+      });
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("rejects partial staging E2E operation identity before checkout", () => {
     const workflow = readWorkflow("staging-e2e.yml");
     const steps = (workflow.jobs["staging-packs"]?.steps ??

--- a/__tests__/scripts/release-bus-performance-contract.test.ts
+++ b/__tests__/scripts/release-bus-performance-contract.test.ts
@@ -520,24 +520,32 @@ describe("Release Bus frontend performance contract", () => {
       expect(source).toContain("!isMuseumPack(pack)");
       expect(source).toContain('args+=(--exclude-pack "$museum_pack_alias")');
     }
-    for (const [definition, jobName, stepName, evidenceName] of [
+    for (const [
+      definition,
+      jobName,
+      stepName,
+      evidenceJobName,
+      evidenceName,
+    ] of [
       [
         staging,
         "staging-packs",
         "Run staging packs against staging.6529.io",
+        "staging-packs",
         "Validate exact manifest-bound E2E evidence",
       ],
       [
         production,
         "readonly",
         "Run production-safe read-only packs",
-        "Validate exact production E2E evidence",
+        "verify-evidence",
+        "Validate production E2E evidence on isolated runner",
       ],
     ] as const) {
       const packStep = definition.jobs[jobName].steps.find(
         (step: { name?: string }) => step.name === stepName
       );
-      const evidenceStep = definition.jobs[jobName].steps.find(
+      const evidenceStep = definition.jobs[evidenceJobName].steps.find(
         (step: { name?: string }) => step.name === evidenceName
       );
       const predicatePattern =
@@ -643,7 +651,7 @@ describe("Release Bus frontend performance contract", () => {
       "staging-e2e-artifacts/museum-release-selection.json"
     );
     expect(productionSource).toContain(
-      "production-e2e-artifacts/museum-release-selection.json"
+      "isolated-production-e2e-selection/museum-release-selection.json"
     );
     expect(stagingSource).toContain(
       '.contract == "release-bus-e2e-runner-capabilities.v1"'
@@ -676,13 +684,11 @@ describe("Release Bus frontend performance contract", () => {
       "Validate exact manifest-bound E2E evidence"
     );
     expect(productionSource).toContain(
-      "Validate exact production E2E evidence"
+      "Validate production E2E evidence on isolated runner"
     );
     for (const source of [stagingSource, productionSource]) {
       expect(source).toContain('.schema_version == "release-bus-e2e-packs.v1"');
-      expect(source).toContain(
-        "(.results | map(.script_key) | unique | length) == .pack_count"
-      );
+      expect(source).toContain("unique | length) == .pack_count");
       expect(source).toContain('(.results | all(.safety == "readonly"))');
       expect(source).toContain("SERIAL_FAILED_PACK_RETRY");
       expect(source).toContain(".attempt_count == (.attempts | length)");
@@ -691,8 +697,11 @@ describe("Release Bus frontend performance contract", () => {
         '.results | all(.status == "passed" and .failure_class == null)'
       );
       expect(source).toContain("manifest_identity_sha256:$identity");
-      expect(source).toContain('test "$EVIDENCE_OUTCOME" = success');
     }
+    expect(stagingSource).toContain('test "$EVIDENCE_OUTCOME" = success');
+    expect(productionSource).toContain(
+      'test "$ISOLATED_EVIDENCE_OUTCOME" = success'
+    );
     const runnerSource = read("scripts/e2e-packs.cjs");
     expect(runnerSource).toContain("process.kill(-child.pid, signal)");
     expect(runnerSource).toContain('killGroup("SIGKILL")');


### PR DESCRIPTION
## Outcome

Moves production E2E qualification across a real runner boundary. The deployed source still executes the read-only browser packs, but it can no longer modify the Museum selector or the verifier that qualifies its evidence.

## Control boundary

- selects Museum packs and uploads the selection as an immutable v4 artifact before pnpm, dependency lifecycle scripts, or E2E code run
- removes same-runner post-E2E control checkout/verification
- re-resolves the exact automatic deploy or Release Bus identity in a separate literal `ubuntu-latest` job
- checks out verifier code and the pack manifest from `github.workflow_sha` only
- downloads the immutable selection and untrusted Playwright evidence as separate artifacts
- validates selection digest, exact allowed pack inventory, retry/attempt consistency, read-only safety, zero failures, and release binding
- reports structured Release Bus completion only after isolated verification
- fails closed on missing, oversized, substituted, partial, or malformed evidence

## Why

PR #3645 fixed exact-SHA checkout and same-job verifier mutation. The final adversarial review found a deeper residual boundary: deployed dependency/E2E code can write `GITHUB_ENV` or `GITHUB_PATH` and poison tools or shell startup for later steps on the same runner. A new job is the enforceable isolation boundary.

## Local evidence

- 6 release-contract suites / 131 tests pass
- `lint:changed` passes
- `typecheck:changed` passes (1,373-file ratchet)
- Prettier and `codex-diff-check` pass
- actionlint YAML checks pass locally with external shellcheck integration disabled because the Windows actionlint/shellcheck bridge hangs; hosted Linux checks remain authoritative

## Release qualification

After merge, rerun `.github/workflows/production-e2e.yml` with only `automatic_deploy_run_id=31078927972`. Both `readonly` and `Verify production evidence on isolated runner` must succeed before the serialized frontend hold is cleared.