### PR TITLE
Fix portability inventory source

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -252,9 +252,9 @@ jobs:
           node ops/scripts/artifact-portability.cjs inventory \
             --manifest staging-artifact/manifest.json \
             --package staging-artifact/package.zip \
-            --extracted-root .staging-bundle \
-            --runtime-config .staging-bundle/.next/PUBLIC_RUNTIME.json \
-            --assets-flag .staging-bundle/.next/ASSETS_FROM_S3 \
+            --extracted-root "$zip_extract" \
+            --runtime-config "$zip_extract/.next/PUBLIC_RUNTIME.json" \
+            --assets-flag "$zip_extract/.next/ASSETS_FROM_S3" \
             --source-root . \
             --content-roots "public,content/public-reviews,config/public-reviews,public/review-data" \
             --environment staging \

--- a/.github/workflows/production-build-artifact.yml
+++ b/.github/workflows/production-build-artifact.yml
@@ -171,9 +171,9 @@ jobs:
           node ops/scripts/artifact-portability.cjs inventory \
             --manifest production-artifact/manifest.json \
             --package production-artifact/target/package.zip \
-            --extracted-root .production-bundle \
-            --runtime-config .production-bundle/.next/PUBLIC_RUNTIME.json \
-            --assets-flag .production-bundle/.next/ASSETS_FROM_S3 \
+            --extracted-root "$zip_extract" \
+            --runtime-config "$zip_extract/.next/PUBLIC_RUNTIME.json" \
+            --assets-flag "$zip_extract/.next/ASSETS_FROM_S3" \
             --source-root . \
             --content-roots "public,content/public-reviews,config/public-reviews,public/review-data" \
             --environment production \

--- a/.github/workflows/release-bus-v2-preflight.yml
+++ b/.github/workflows/release-bus-v2-preflight.yml
@@ -542,6 +542,7 @@ jobs:
           package_profile() {
             local profile="$1"
             local destination="$2"
+            local portability_extract="$destination/portability-extract"
             rm -rf "$destination"
             mkdir -p "$destination/target/_next" "$destination/bundle/.next"
             cp -r .next/standalone/. "$destination/bundle/"
@@ -561,20 +562,20 @@ jobs:
             test -z "$(find "$destination/target/_next" -type l -print -quit)"
             (cd "$destination/bundle" && zip -qry ../target/package.zip .)
             zip_listing="$(mktemp)"
-            zip_extract="$(mktemp -d)"
+            rm -rf "$portability_extract"
+            mkdir -p "$portability_extract"
             unzip -Z1 "$destination/target/package.zip" > "$zip_listing"
             node scripts/package-public-review-artifacts.cjs assert-listing \
               --profile "$profile" \
               --bundle-root "$destination/bundle" \
               --listing-file "$zip_listing"
-            unzip -q "$destination/target/package.zip" -d "$zip_extract"
+            unzip -q "$destination/target/package.zip" -d "$portability_extract"
             node scripts/package-public-review-artifacts.cjs assert-zip \
               --profile "$profile" \
               --bundle-root "$destination/bundle" \
               --listing-file "$zip_listing" \
-              --extracted-root "$zip_extract"
+              --extracted-root "$portability_extract"
             rm -f "$zip_listing"
-            rm -rf "$zip_extract"
           }
 
           build_profile() {
@@ -626,15 +627,16 @@ jobs:
             node ops/scripts/artifact-portability.cjs inventory \
               --manifest release-bus-artifact/manifest.json \
               --package release-bus-artifact/target/package.zip \
-              --extracted-root release-bus-artifact/bundle \
-              --runtime-config release-bus-artifact/bundle/.next/PUBLIC_RUNTIME.json \
-              --assets-flag release-bus-artifact/bundle/.next/ASSETS_FROM_S3 \
+              --extracted-root release-bus-artifact/portability-extract \
+              --runtime-config release-bus-artifact/portability-extract/.next/PUBLIC_RUNTIME.json \
+              --assets-flag release-bus-artifact/portability-extract/.next/ASSETS_FROM_S3 \
               --source-root . \
               --content-roots "public,content/public-reviews,config/public-reviews,public/review-data" \
               --environment "$ARTIFACT_ENVIRONMENT" \
               --node-version "$(node --version)" \
               --pnpm-version "$(pnpm --version)" \
               --output release-bus-artifact/artifact-portability.json
+            rm -rf release-bus-artifact/portability-extract
           else
             # Bounded rollout bridge only. Old reconcilers do not send the v3
             # contract input and older deploy workflows understand only this
@@ -658,15 +660,16 @@ jobs:
               node ops/scripts/artifact-portability.cjs inventory \
                 --manifest release-bus-artifact/manifest.json \
                 --package "release-bus-artifact/profiles/$profile/target/package.zip" \
-                --extracted-root "release-bus-artifact/profiles/$profile/bundle" \
-                --runtime-config "release-bus-artifact/profiles/$profile/bundle/.next/PUBLIC_RUNTIME.json" \
-                --assets-flag "release-bus-artifact/profiles/$profile/bundle/.next/ASSETS_FROM_S3" \
+                --extracted-root "release-bus-artifact/profiles/$profile/portability-extract" \
+                --runtime-config "release-bus-artifact/profiles/$profile/portability-extract/.next/PUBLIC_RUNTIME.json" \
+                --assets-flag "release-bus-artifact/profiles/$profile/portability-extract/.next/ASSETS_FROM_S3" \
                 --source-root . \
                 --content-roots "public,content/public-reviews,config/public-reviews,public/review-data" \
                 --environment "$profile" \
                 --node-version "$(node --version)" \
                 --pnpm-version "$(pnpm --version)" \
                 --output "release-bus-artifact/profiles/$profile/artifact-portability.json"
+              rm -rf "release-bus-artifact/profiles/$profile/portability-extract"
             done
           fi
           (cd release-bus-artifact && find . -type f ! -path ./SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)

--- a/__tests__/scripts/public-review-artifact-workflows.test.ts
+++ b/__tests__/scripts/public-review-artifact-workflows.test.ts
@@ -68,7 +68,9 @@ describe("public-review artifact workflow contract", () => {
     expect(releaseBusPreflight).toContain(
       'test -z "$(find "$destination/target/_next" -type l -print -quit)"'
     );
-    expect(releaseBusPreflight).toContain('--extracted-root "$zip_extract"');
+    expect(releaseBusPreflight).toContain(
+      '--extracted-root "$portability_extract"'
+    );
     expect(releaseBusPreflight).not.toMatch(/\bcp -r public\b/);
   });
 
@@ -91,6 +93,15 @@ describe("public-review artifact workflow contract", () => {
       'test -z "$(find production-artifact/target/_next -type l -print -quit)"'
     );
     expect(productionBuild).toContain('--extracted-root "$zip_extract"');
+    expect(productionBuild).toContain(
+      '--runtime-config "$zip_extract/.next/PUBLIC_RUNTIME.json"'
+    );
+    expect(productionBuild).toContain(
+      '--assets-flag "$zip_extract/.next/ASSETS_FROM_S3"'
+    );
+    expect(productionBuild).not.toContain(
+      "--extracted-root .production-bundle"
+    );
     expect(productionBuild).not.toMatch(/\bcp -r public\b/);
   });
 
@@ -113,6 +124,14 @@ describe("public-review artifact workflow contract", () => {
     expect(stagingWorkflow).toContain(`${helper} prepare`);
     expect(stagingWorkflow).toContain(`${helper} assert-listing`);
     expect(stagingWorkflow).toContain(`${helper} assert-zip`);
+    expect(stagingWorkflow).toContain('--extracted-root "$zip_extract"');
+    expect(stagingWorkflow).toContain(
+      '--runtime-config "$zip_extract/.next/PUBLIC_RUNTIME.json"'
+    );
+    expect(stagingWorkflow).toContain(
+      '--assets-flag "$zip_extract/.next/ASSETS_FROM_S3"'
+    );
+    expect(stagingWorkflow).not.toContain("--extracted-root .staging-bundle");
     expect(stagingWorkflow).toContain("./bin/6529 run base-build");
     expect(stagingWorkflow).toContain(
       "bash ops/scripts/deploy-staging-artifact.sh"
@@ -145,6 +164,33 @@ describe("public-review artifact workflow contract", () => {
     );
     expect(standaloneStart).toContain(
       'delete packagingEnv["PUBLIC_REVIEW_DISCUSSION_DESTINATIONS_FILE"]'
+    );
+  });
+
+  it("inventories the exact extracted release package rather than the symlinked build tree", () => {
+    expect(releaseBusPreflight).toContain(
+      'local portability_extract="$destination/portability-extract"'
+    );
+    expect(releaseBusPreflight).toContain(
+      'unzip -q "$destination/target/package.zip" -d "$portability_extract"'
+    );
+    expect(releaseBusPreflight).toContain(
+      "--extracted-root release-bus-artifact/portability-extract"
+    );
+    expect(releaseBusPreflight).toContain(
+      '--extracted-root "release-bus-artifact/profiles/$profile/portability-extract"'
+    );
+    expect(releaseBusPreflight).not.toContain(
+      "--extracted-root release-bus-artifact/bundle"
+    );
+    expect(releaseBusPreflight).not.toContain(
+      '--extracted-root "release-bus-artifact/profiles/$profile/bundle"'
+    );
+    expect(releaseBusPreflight).toContain(
+      "rm -rf release-bus-artifact/portability-extract"
+    );
+    expect(releaseBusPreflight).toContain(
+      'rm -rf "release-bus-artifact/profiles/$profile/portability-extract"'
     );
   });
 

--- a/ops/workstreams/ci-release-acceleration/run-log.md
+++ b/ops/workstreams/ci-release-acceleration/run-log.md
@@ -233,3 +233,19 @@
   deployment otherwise fails closed. The contract also proves that the build
   workflow consumes no ignored local `.github` action; introducing one must
   first narrow the trigger exclusion.
+- Post-rollout qualification of the six-PR extension found a constructor defect
+  in staging run 31099280984 and the contemporaneous production prebuilds. The
+  portability inventory was pointed at the unzipped Next.js build workspace,
+  whose standalone dependency tree legitimately contains symbolic links. The
+  verifier therefore failed closed after a successful build and package check,
+  before any deployment mutation.
+- The correction makes the manual staging, exact production prebuild, and
+  Release Bus preflight constructors inventory the package ZIP's extracted
+  bytes. Runtime configuration and the asset-profile flag are read from that
+  same extraction. Temporary Release Bus extractions are removed before the
+  artifact checksum is written or bytes are uploaded. The build workspace is
+  no longer treated as if it were the deployable package.
+- Focused workflow, production-constructor, performance, and portability tests
+  pass 39/39. Changed lint, changed TypeScript validation, targeted formatting,
+  and the Windows-aware whitespace check are green. Exact staging and
+  production reruns remain the authoritative end-to-end proof.


### PR DESCRIPTION
## Outcome

Fixes the fail-closed portability inventory error observed after the six-PR release-acceleration train merged.

## Root cause

The artifact verifier scanned the pre-ZIP Next.js standalone workspace, which legitimately contains dependency symlinks. The deployable ZIP had already passed listing and extraction validation, but the inventory never inspected those extracted bytes.

## Change

- inventory the exact extracted ZIP in manual staging and production prebuilds
- read runtime configuration and asset profile from that same extraction
- retain a bounded extraction through Release Bus inventory, then remove it before checksums/upload
- add workflow-contract regressions preventing a return to build-tree inventory

The portability decision remains fail-closed `NOT_PORTABLE`; this does not authorize cross-environment artifact reuse.

## Evidence

- staging failure reproduced in run 31099280984 before any deployment mutation
- focused workflow/portability suites: 39/39
- changed lint: pass
- changed TypeScript validation: pass
- targeted Prettier and whitespace checks: pass

Exact staging and production reruns remain required before release closeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment artifact validation by checking packaged ZIP contents instead of intermediate build directories.
  * Prevented legitimate build symlinks from incorrectly blocking staging and production deployments.
  * Added cleanup of temporary extraction files before checksums and uploads.

* **Tests**
  * Expanded workflow validation for package extraction, portability checks, and cleanup behavior.

* **Documentation**
  * Documented the corrected portability validation and rollout results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->