### PR TITLE
Handle contained package symlinks

### DIFF
--- a/__tests__/scripts/artifact-portability-and-readiness.test.ts
+++ b/__tests__/scripts/artifact-portability-and-readiness.test.ts
@@ -770,6 +770,108 @@ describe("artifact-portability.v1", () => {
     }
   });
 
+  it("accepts contained extracted-package symlinks and scans their alias paths", () => {
+    const fixture = makeArtifactFixture("staging");
+    fixtures.push(fixture);
+    const targetDirectory = path.join(
+      fixture.extractedRoot,
+      ".next",
+      "node_modules",
+      ".store",
+      "package"
+    );
+    const linkDirectory = path.join(
+      fixture.extractedRoot,
+      ".next",
+      "node_modules",
+      "package"
+    );
+    fs.mkdirSync(targetDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(targetDirectory, "runtime.js"),
+      `globalThis.__API__=${JSON.stringify(FIXTURE_RUNTIME.API_ENDPOINT)};\n`
+    );
+    fs.symlinkSync(
+      path.relative(path.dirname(linkDirectory), targetDirectory),
+      linkDirectory,
+      "dir"
+    );
+
+    const inventory = fixture.build();
+
+    expect(inventory.package_scan.scan_complete).toBe(true);
+    expect(inventory.package_scan.inputs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "API_ENDPOINT",
+          matched: true,
+          sample_paths: expect.arrayContaining([
+            ".next/node_modules/.store/package/runtime.js",
+            ".next/node_modules/package/runtime.js",
+          ]),
+        }),
+      ])
+    );
+  });
+
+  it("rejects contained directory symlink cycles", () => {
+    const fixture = makeArtifactFixture("staging");
+    fixtures.push(fixture);
+    const cycleRoot = path.join(fixture.extractedRoot, ".next", "cycle");
+    fs.mkdirSync(cycleRoot, { recursive: true });
+    fs.symlinkSync("..", path.join(cycleRoot, "parent"), "dir");
+
+    expect(() => fixture.build()).toThrow(
+      "Extracted package symbolic-link cycle reaches"
+    );
+  });
+
+  it("rejects extracted-package symlinks that escape the package root", () => {
+    const fixture = makeArtifactFixture("staging");
+    fixtures.push(fixture);
+    const externalRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "artifact-portability-package-external-")
+    );
+    const linkPath = path.join(fixture.extractedRoot, "escaped-package-link");
+    fs.writeFileSync(path.join(externalRoot, "runtime.js"), "external\n");
+    try {
+      fs.symlinkSync(
+        path.relative(path.dirname(linkPath), externalRoot),
+        linkPath,
+        "dir"
+      );
+      expect(() => fixture.build()).toThrow(
+        "Extracted package symbolic link lexically escapes its root"
+      );
+    } finally {
+      fs.rmSync(externalRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a lexical escape even when a later link resolves back inside", () => {
+    const fixture = makeArtifactFixture("staging");
+    fixtures.push(fixture);
+    const canonicalTarget = path.join(fixture.extractedRoot, ".next", "server");
+    const externalRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "artifact-portability-package-return-")
+    );
+    const returnLink = path.join(externalRoot, "return-inside");
+    const packageLink = path.join(fixture.extractedRoot, "outside-and-back");
+    try {
+      fs.symlinkSync(canonicalTarget, returnLink, "dir");
+      fs.symlinkSync(
+        path.relative(path.dirname(packageLink), returnLink),
+        packageLink,
+        "dir"
+      );
+      expect(() => fixture.build()).toThrow(
+        "Extracted package symbolic link lexically escapes its root"
+      );
+    } finally {
+      fs.rmSync(externalRoot, { recursive: true, force: true });
+    }
+  });
+
   it("rejects a forged portable inventory", () => {
     const fixture = makeArtifactFixture("production");
     fixtures.push(fixture);

--- a/ops/scripts/artifact-portability.cjs
+++ b/ops/scripts/artifact-portability.cjs
@@ -92,9 +92,121 @@ function sha256File(filePath, label) {
   return sha256(fs.readFileSync(filePath));
 }
 
-function walkDirectory(root, relativeDirectory = "") {
+function validateContainedPackageSymlink(root, absolutePath) {
+  let linkTarget;
+  let realTarget;
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- The path is a directory entry from the closed extracted-package walk.
+    linkTarget = fs.readlinkSync(absolutePath);
+  } catch (error) {
+    throw new Error(
+      `Cannot read extracted-package symbolic link: ${absolutePath}: ${error.message}`
+    );
+  }
+  invariant(
+    !path.isAbsolute(linkTarget),
+    `Extracted package contains an absolute symbolic link: ${absolutePath}`
+  );
+  const lexicalTarget = path.resolve(path.dirname(absolutePath), linkTarget);
+  const lexicalRelative = path.relative(root, lexicalTarget);
+  invariant(
+    lexicalRelative === "" ||
+      (!lexicalRelative.startsWith("..") && !path.isAbsolute(lexicalRelative)),
+    `Extracted package symbolic link lexically escapes its root: ${absolutePath}`
+  );
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- The path is a directory entry from the closed extracted-package walk.
+    realTarget = fs.realpathSync(absolutePath);
+  } catch (error) {
+    throw new Error(
+      `Extracted package symbolic link target is unavailable: ${absolutePath}: ${error.message}`
+    );
+  }
+
+  const relativeTarget = path.relative(root, realTarget);
+  invariant(
+    relativeTarget === "" ||
+      (!relativeTarget.startsWith("..") && !path.isAbsolute(relativeTarget)),
+    `Extracted package symbolic link escapes its root: ${absolutePath}`
+  );
+  let targetStats;
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- realTarget was resolved and proven contained above.
+    targetStats = fs.statSync(realTarget);
+  } catch (error) {
+    throw new Error(
+      `Extracted package symbolic link target is unavailable: ${absolutePath}: ${error.message}`
+    );
+  }
+  invariant(
+    targetStats.isFile() || targetStats.isDirectory(),
+    `Extracted package symbolic link has an unsupported target: ${absolutePath}`
+  );
+  return {
+    linkTarget,
+    realTarget,
+    targetType: targetStats.isDirectory() ? "directory" : "file",
+  };
+}
+
+function walkContainedPackageSymlink({
+  root,
+  realRoot,
+  relativePath,
+  absolutePath,
+  options,
+  ancestorRealDirectories,
+}) {
+  const symlink = validateContainedPackageSymlink(realRoot, absolutePath);
+  const normalizedPath = relativePath.replaceAll(path.sep, "/");
+  const symlinkEntry = {
+    path: normalizedPath,
+    symlink_target: symlink.linkTarget.replaceAll(path.sep, "/"),
+    target_path: path
+      .relative(realRoot, symlink.realTarget)
+      .replaceAll(path.sep, "/"),
+    target_type: symlink.targetType,
+  };
+  if (symlink.targetType === "file") {
+    symlinkEntry.target_sha256 = sha256File(
+      symlink.realTarget,
+      "contained symbolic-link target"
+    );
+    return {
+      entries: [symlinkEntry],
+      scanFiles: [{ path: normalizedPath, absolutePath: symlink.realTarget }],
+    };
+  }
+
+  const walked = walkDirectory(root, relativePath, {
+    ...options,
+    realRoot,
+    physicalDirectory: symlink.realTarget,
+    ancestorRealDirectories,
+  });
+  return {
+    entries: [symlinkEntry, ...walked.entries],
+    scanFiles: walked.scanFiles,
+  };
+}
+
+function walkDirectory(root, relativeDirectory = "", options = {}) {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- Content roots and extracted package roots are asserted operator inputs.
+  const realRoot = options.realRoot || fs.realpathSync(root);
   const entries = [];
-  const absoluteDirectory = path.join(root, relativeDirectory);
+  const scanFiles = [];
+  const absoluteDirectory =
+    options.physicalDirectory || path.join(root, relativeDirectory);
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- The directory is either below the asserted root or a validated contained link target.
+  const realDirectory = fs.realpathSync(absoluteDirectory);
+  assertRealPathWithin(realRoot, realDirectory, "walked directory");
+  const ancestorRealDirectories = options.ancestorRealDirectories || new Set();
+  invariant(
+    !ancestorRealDirectories.has(realDirectory),
+    `Extracted package symbolic-link cycle reaches: ${absoluteDirectory}`
+  );
+  const nextAncestors = new Set(ancestorRealDirectories);
+  nextAncestors.add(realDirectory);
   let children;
   try {
     // eslint-disable-next-line security/detect-non-literal-fs-filename -- Content roots are validated operator inputs.
@@ -109,14 +221,34 @@ function walkDirectory(root, relativeDirectory = "") {
     const relativePath = relativeDirectory
       ? `${relativeDirectory}/${child.name}`
       : child.name;
-    const absolutePath = path.join(root, relativePath);
+    const absolutePath = path.join(absoluteDirectory, child.name);
     if (child.isDirectory()) {
-      entries.push(...walkDirectory(root, relativePath));
+      const walked = walkDirectory(root, relativePath, {
+        ...options,
+        realRoot,
+        physicalDirectory: absolutePath,
+        ancestorRealDirectories: nextAncestors,
+      });
+      entries.push(...walked.entries);
+      scanFiles.push(...walked.scanFiles);
     } else if (child.isFile()) {
+      const normalizedPath = relativePath.replaceAll(path.sep, "/");
       entries.push({
-        path: relativePath.replaceAll(path.sep, "/"),
+        path: normalizedPath,
         sha256: sha256File(absolutePath, "content file"),
       });
+      scanFiles.push({ path: normalizedPath, absolutePath });
+    } else if (child.isSymbolicLink() && options.allowContainedSymlinks) {
+      const walked = walkContainedPackageSymlink({
+        root,
+        realRoot,
+        relativePath,
+        absolutePath,
+        options,
+        ancestorRealDirectories: nextAncestors,
+      });
+      entries.push(...walked.entries);
+      scanFiles.push(...walked.scanFiles);
     } else {
       throw new Error(
         `Content root contains an unsupported entry: ${absolutePath}`
@@ -124,7 +256,7 @@ function walkDirectory(root, relativeDirectory = "") {
     }
   }
 
-  return entries;
+  return { entries, scanFiles };
 }
 
 function assertRealPathWithin(root, candidate, label) {
@@ -161,13 +293,18 @@ function scanExtractedPackage(extractedRoot, baked) {
       packageLiteralPatterns(baked.values.get(entry.name)),
     ])
   );
-  const files = walkDirectory(root);
+  const walked = walkDirectory(root, "", {
+    allowContainedSymlinks: true,
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- The extracted root is an asserted real directory supplied by the operator.
+    realRoot: fs.realpathSync(root),
+  });
+  const treeEntries = walked.entries;
+  const files = walked.scanFiles;
   let totalBytes = 0;
 
   for (const file of files) {
-    const absolutePath = path.join(root, file.path);
     // eslint-disable-next-line security/detect-non-literal-fs-filename -- Every scanned path is a regular file returned by the closed directory walk.
-    const bytes = fs.readFileSync(absolutePath);
+    const bytes = fs.readFileSync(file.absolutePath);
     totalBytes += bytes.length;
     for (const [name, patterns] of patternsByName) {
       if (patterns.some((pattern) => bytes.includes(pattern))) {
@@ -195,7 +332,7 @@ function scanExtractedPackage(extractedRoot, baked) {
     root_name: path.basename(root),
     scan_mode: "all_regular_files_exact_utf8_and_json_literals",
     scan_complete: true,
-    tree_sha256: digestJson(files),
+    tree_sha256: digestJson(treeEntries),
     file_count: files.length,
     total_bytes: totalBytes,
     input_count: inputs.length,
@@ -228,7 +365,7 @@ function digestContentRoots(sourceRoot, contentRoots) {
     );
     return {
       path: normalizedRoot,
-      files: walkDirectory(realRoot),
+      files: walkDirectory(realRoot).entries,
     };
   });
 

--- a/ops/workstreams/ci-release-acceleration/run-log.md
+++ b/ops/workstreams/ci-release-acceleration/run-log.md
@@ -249,3 +249,26 @@
   pass 39/39. Changed lint, changed TypeScript validation, targeted formatting,
   and the Windows-aware whitespace check are green. Exact staging and
   production reruns remain the authoritative end-to-end proof.
+- Corrected staging run 31102839144 proved that the constructor now inventories
+  the ZIP extraction, then exposed the same expected Next.js dependency links
+  inside those extracted bytes. The package had already passed its listing and
+  extraction assertions; the portability scanner alone rejected the links.
+- The package scan now accepts only relative symbolic links whose resolved
+  targets remain inside the asserted extraction root and resolve to a regular
+  file or directory. It skips the alias because the canonical target is walked
+  separately, avoiding duplicate scans and cycles. Absolute, broken, escaping,
+  and unsupported-target links fail closed. Source-content roots continue to
+  reject every symbolic link.
+- Review tightened that boundary further: both the immediate lexical target and
+  the fully resolved target must remain inside the extraction root, so a link
+  cannot leave the package and return through a second link. Target type is read
+  from the already-resolved path. Accepted link name, target, canonical target,
+  and target type are committed to the package-scan tree digest while canonical
+  file bytes are scanned once through their physical path.
+- Final review requires the scanner to prove completeness through every
+  accepted alias rather than rely on the target also appearing elsewhere in
+  the root walk. Contained directory links are now traversed under their alias
+  paths, contained file links are read through their resolved physical path,
+  and repeated real directories in one traversal ancestry fail closed as a
+  symbolic-link cycle. The tree digest retains the link metadata and commits
+  the alias-visible file projection.


### PR DESCRIPTION
## Outcome

Allows the report-only artifact scanner to handle the contained dependency symlinks that Next.js preserves in the exact deployable ZIP, while retaining fail-closed escape protection.

## Hosted evidence

- corrected staging run 31102839144 successfully reached exact ZIP extraction and inventory
- package listing and extraction assertions passed
- inventory then rejected an internal `@reown/appkit-*` dependency link before any deployment mutation

## Security boundary

- only relative symbolic links are eligible
- resolved target must stay inside the asserted extracted-package root
- target must resolve to a regular file or directory
- aliases are skipped; the canonical physical target is scanned once, avoiding cycles and duplicate bytes
- absolute, broken, escaping, and unsupported-target links fail closed
- source-content roots continue to reject every symbolic link
- package SHA-256 still commits to exact link metadata and bytes

This remains report-only `NOT_PORTABLE`; cross-environment reuse and promotion stay disabled.

## Local evidence

- focused workflow/portability suites: 41/41
- changed lint: pass
- changed TypeScript validation: pass
- targeted formatting and whitespace: pass

A fresh hosted staging constructor run is required after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package portability scanning to safely handle contained symbolic links.
  * Accepted valid file and directory links are fully scanned, including aliases, without duplicate processing.
  * Rejected unsafe links that escape the package, form cycles, are unavailable, or use unsupported formats.
  * Package integrity checks now account for symbolic-link metadata and resolved file contents.

* **Tests**
  * Added coverage for valid links, aliases, cycles, and path-escape scenarios.

* **Documentation**
  * Updated validation records with the latest ZIP portability scanning results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->