### PR TITLE
fix: Removed the competing TitleProvider repair and returned the draft PR to its narrow five-file Sentry filte

### DIFF
--- a/__tests__/fixtures/reactDomRawRemoveChildFixtures.ts
+++ b/__tests__/fixtures/reactDomRawRemoveChildFixtures.ts
@@ -1,0 +1,26 @@
+import type { SentryStackFrame } from "@/utils/sentry-client-filters";
+
+type ReactDomRawRemoveChildGeneration = "earlier" | "latest";
+
+const sanitizedReactDomChunkPaths = {
+  earlier: "app:///_next/static/chunks/0example-react-dom-runtime-a.js",
+  latest: "app:///_next/static/chunks/0example-react-dom-runtime-b.js",
+} as const;
+
+const observedRawFunctionNames = Array.from({ length: 50 }, (_, index) =>
+  index % 2 === 0 ? "s9" : "s7"
+);
+
+// Sanitized from both observed production bundle generations. Only the shared
+// vendor function order remains; chunk names and event context are omitted.
+export function createObservedReactDomRawRemoveChildFrames(
+  generation: ReactDomRawRemoveChildGeneration = "latest"
+): SentryStackFrame[] {
+  const chunkPath = sanitizedReactDomChunkPaths[generation];
+  return observedRawFunctionNames.map((functionName) => ({
+    filename: chunkPath,
+    abs_path: chunkPath,
+    function: functionName,
+    in_app: true,
+  }));
+}

--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -3,6 +3,7 @@ import {
   createLatestReactDomRawFrames,
   createObservedReactDomRawInsertBeforeFrames,
 } from "@/__tests__/fixtures/reactDomRawInsertBeforeFixtures";
+import { createObservedReactDomRawRemoveChildFrames } from "@/__tests__/fixtures/reactDomRawRemoveChildFixtures";
 
 const mockInit = jest.fn();
 const mockReplayIntegration = jest.fn(() => ({ name: "replay" }));
@@ -1285,6 +1286,68 @@ describe("instrumentation-client", () => {
     const result = beforeSend(event);
 
     expect(result).toBeNull();
+  });
+
+  it("drops the production-shaped raw React DOM removeChild stack on waves", () => {
+    const beforeSend = loadBeforeSend();
+    const event = {
+      event_id: "raw-react-dom-remove-child-event",
+      transaction: "/waves/:wave",
+      exception: {
+        values: [
+          {
+            type: "NotFoundError",
+            value: reactDomRemoveChildMessage,
+            mechanism: {
+              type: "generic",
+              handled: true,
+            },
+            stacktrace: {
+              frames: createObservedReactDomRawRemoveChildFrames(),
+            },
+          },
+        ],
+      },
+      tags: {
+        transaction: "/waves/:wave",
+        url: "/waves/example-wave",
+      },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result).toBeNull();
+  });
+
+  it("keeps the production-shaped raw React DOM removeChild stack outside waves", () => {
+    const beforeSend = loadBeforeSend();
+    const event = {
+      event_id: "raw-react-dom-remove-child-non-waves-event",
+      transaction: "/6529-gradient",
+      exception: {
+        values: [
+          {
+            type: "NotFoundError",
+            value: reactDomRemoveChildMessage,
+            mechanism: {
+              type: "generic",
+              handled: true,
+            },
+            stacktrace: {
+              frames: createObservedReactDomRawRemoveChildFrames(),
+            },
+          },
+        ],
+      },
+      tags: {
+        transaction: "/6529-gradient",
+        url: "/6529-gradient",
+      },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result).toEqual(event);
   });
 
   it("drops injected WebAssembly CSP unsafe-eval errors", () => {

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -2,6 +2,7 @@ import {
   createLatestReactDomRawFrames,
   createObservedReactDomRawInsertBeforeFrames,
 } from "@/__tests__/fixtures/reactDomRawInsertBeforeFixtures";
+import { createObservedReactDomRawRemoveChildFrames } from "@/__tests__/fixtures/reactDomRawRemoveChildFixtures";
 import {
   __testing,
   getLowValueNetworkErrorDecision,
@@ -1438,8 +1439,7 @@ describe("sentry-client-filters", () => {
     osName = "iOS",
     osVersion = "26.5.2",
     includeContexts = true,
-    userAgent =
-      "Mozilla/5.0 (iPhone; CPU iPhone OS 26_5_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/150.0.7871.1 Mobile/TEST Safari/604.1",
+    userAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 26_5_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/150.0.7871.1 Mobile/TEST Safari/604.1",
     includeUserAgent = false,
     transaction = "/nextgen/collection/:collection/art",
     requestUrl = "https://6529.io/nextgen/collection/pebbles/art",
@@ -2568,6 +2568,62 @@ describe("sentry-client-filters", () => {
     ...overrides,
   });
 
+  const createReactDomRawRemoveChildEvent = (
+    options: {
+      exceptionType?: string;
+      exceptionValue?: string;
+      frames?: SentryStackFrame[];
+      transaction?: string;
+      includeAdditionalException?: boolean;
+      includeMechanism?: boolean;
+      mechanismType?: string;
+      mechanismHandled?: boolean;
+    } = {}
+  ): SentryClientEvent => ({
+    transaction: options.transaction ?? "/waves/:wave",
+    exception: {
+      values: [
+        {
+          type: options.exceptionType ?? "NotFoundError",
+          value: options.exceptionValue ?? reactDomRemoveChildMessage,
+          ...(options.includeMechanism === false
+            ? {}
+            : {
+                mechanism: {
+                  type: options.mechanismType ?? "generic",
+                  handled: options.mechanismHandled ?? true,
+                },
+              }),
+          stacktrace: {
+            frames:
+              options.frames ?? createObservedReactDomRawRemoveChildFrames(),
+          },
+        },
+        ...(options.includeAdditionalException
+          ? [
+              {
+                type: "Error",
+                value: "Independent application failure",
+                stacktrace: {
+                  frames: [
+                    {
+                      filename: "app:///components/waves/Wave.tsx",
+                      function: "Wave",
+                      in_app: true,
+                    },
+                  ],
+                },
+              },
+            ]
+          : []),
+      ],
+    },
+    tags: {
+      transaction: options.transaction ?? "/waves/:wave",
+      url: options.transaction ?? "/waves/:wave",
+    },
+  });
+
   it("filters events when a stack frame matches a filename exception", () => {
     // Arrange
     const frames: SentryStackFrame[] = [
@@ -3031,6 +3087,106 @@ describe("sentry-client-filters", () => {
     );
 
     expect(result).toBe(true);
+  });
+
+  it.each([
+    { generation: "earlier", transaction: "/waves" },
+    { generation: "latest", transaction: "/waves/:wave" },
+  ] as const)(
+    "filters the $generation production-shaped raw removeChild stack on $transaction",
+    ({ generation, transaction }) => {
+      const result = shouldFilterReactDomRemoveChildNotFoundError(
+        createReactDomRawRemoveChildEvent({
+          frames: createObservedReactDomRawRemoveChildFrames(generation),
+          transaction,
+        })
+      );
+
+      expect(result).toBe(true);
+    }
+  );
+
+  it.each([
+    {
+      name: "a changed frame count",
+      options: {
+        frames: createObservedReactDomRawRemoveChildFrames().slice(1),
+      },
+    },
+    {
+      name: "a changed function sequence",
+      options: {
+        frames: createObservedReactDomRawRemoveChildFrames().map(
+          (frame, index) => (index === 1 ? { ...frame, function: "s9" } : frame)
+        ),
+      },
+    },
+    {
+      name: "multiple chunks",
+      options: {
+        frames: createObservedReactDomRawRemoveChildFrames().map(
+          (frame, index) =>
+            index === 1
+              ? {
+                  ...frame,
+                  filename: "app:///_next/static/chunks/0different-runtime.js",
+                  abs_path: "app:///_next/static/chunks/0different-runtime.js",
+                }
+              : frame
+        ),
+      },
+    },
+    {
+      name: "an app-owned frame",
+      options: {
+        frames: createObservedReactDomRawRemoveChildFrames().map(
+          (frame, index) =>
+            index === 1
+              ? {
+                  ...frame,
+                  filename: "app:///components/waves/Wave.tsx",
+                  abs_path: "app:///components/waves/Wave.tsx",
+                }
+              : frame
+        ),
+      },
+    },
+    {
+      name: "a different exception type",
+      options: { exceptionType: "TypeError" },
+    },
+    {
+      name: "a different message",
+      options: { exceptionValue: "The requested node was not found." },
+    },
+    {
+      name: "a different mechanism",
+      options: {
+        mechanismType: "auto.browser.global_handlers.onerror",
+      },
+    },
+    {
+      name: "an unhandled mechanism",
+      options: { mechanismHandled: false },
+    },
+    {
+      name: "no mechanism",
+      options: { includeMechanism: false },
+    },
+    {
+      name: "a non-waves affected route",
+      options: { transaction: "/6529-gradient" },
+    },
+    {
+      name: "an additional exception",
+      options: { includeAdditionalException: true },
+    },
+  ])("keeps the observed raw removeChild stack with $name", ({ options }) => {
+    const result = shouldFilterReactDomRemoveChildNotFoundError(
+      createReactDomRawRemoveChildEvent(options)
+    );
+
+    expect(result).toBe(false);
   });
 
   it("keeps React DOM removeChild NotFoundError events when an app frame is present", () => {

--- a/utils/sentry-client-filters/app-frame-utils.ts
+++ b/utils/sentry-client-filters/app-frame-utils.ts
@@ -32,6 +32,7 @@ import {
 } from "./value-utils";
 
 const reactDomInsertBeforeRawFrameCount = 50;
+const reactDomRemoveChildRawFrameCount = 50;
 // These pre-symbolication minified names are intentionally separate from
 // REACT_DOM_INSERT_BEFORE_RUNTIME_FUNCTIONS, which contains source-mapped
 // semantic React DOM function names.
@@ -44,6 +45,7 @@ const reactDomInsertBeforeRawRuntimeFunctions = new Set([
 ]);
 const reactDomInsertBeforeRawRequiredFunctions = ["lo", "li", "lr"];
 const reactDomInsertBeforeRawTerminalFunctions = new Set(["sN", "sR"]);
+const reactDomRemoveChildRawFunctionSequence = ["s9", "s7"] as const;
 
 function isReactDomRuntimeFrame(frame: SentryStackFrame): boolean {
   const paths = getFramePaths(frame);
@@ -151,6 +153,29 @@ function hasRawReactDomInsertBeforeFrameSignature(
   );
 }
 
+function hasRawReactDomRemoveChildFrameSignature(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  // beforeSend sees this minified stack before Sentry applies source maps.
+  // Keep the cohort-backed alternating sequence exact so minifier drift fails open.
+  if (
+    !Array.isArray(frames) ||
+    frames.length !== reactDomRemoveChildRawFrameCount
+  ) {
+    return false;
+  }
+
+  const hasObservedFunctionSequence = frames.every((frame, index) => {
+    const expectedFunction =
+      reactDomRemoveChildRawFunctionSequence[
+        index % reactDomRemoveChildRawFunctionSequence.length
+      ];
+    return frame.function?.trim() === expectedFunction;
+  });
+
+  return hasObservedFunctionSequence && hasOnlyOneNextStaticChunk(frames);
+}
+
 function getReactDomNotFoundErrorValue(
   event: SentryClientEvent,
   message: string
@@ -193,6 +218,18 @@ export function hasReactDomInsertBeforeRawNotFoundErrorSignature(
     value?.mechanism?.type === "generic" &&
     value.mechanism.handled === true &&
     hasRawReactDomInsertBeforeFrameSignature(value.stacktrace?.frames)
+  );
+}
+
+export function hasReactDomRemoveChildRawNotFoundErrorSignature(
+  event: SentryClientEvent,
+  message: string
+): boolean {
+  const value = getReactDomNotFoundErrorValue(event, message);
+  return (
+    value?.mechanism?.type === "generic" &&
+    value.mechanism.handled === true &&
+    hasRawReactDomRemoveChildFrameSignature(value.stacktrace?.frames)
   );
 }
 

--- a/utils/sentry-client-filters/react-dom.ts
+++ b/utils/sentry-client-filters/react-dom.ts
@@ -11,6 +11,7 @@ import {
 import {
   hasReactDomInsertBeforeRawNotFoundErrorSignature,
   hasReactDomNotFoundErrorSignature,
+  hasReactDomRemoveChildRawNotFoundErrorSignature,
 } from "./app-frame-utils";
 
 export function shouldFilterReactDomInsertBeforeNotFoundError(
@@ -41,6 +42,16 @@ export function shouldFilterReactDomInsertBeforeNotFoundError(
 export function shouldFilterReactDomRemoveChildNotFoundError(
   event: SentryClientEvent
 ): boolean {
+  if (
+    hasWavesRoute(event) &&
+    hasReactDomRemoveChildRawNotFoundErrorSignature(
+      event,
+      REACT_DOM_REMOVE_CHILD_NOT_FOUND_ERROR_MESSAGE
+    )
+  ) {
+    return true;
+  }
+
   if (!hasReactDomRemoveChildRoute(event)) {
     return false;
   }


### PR DESCRIPTION
<!-- sentry-fix-job:47 issue:7505391775 -->
## Issue

- Sentry: [6529-FRONTEND-CE](https://seize-ff.sentry.io/issues/7505391775/)
- First seen: 2026-05-25T18:15:26.906Z
- Latest occurrence: 2026-08-07T20:21:49.000Z
- Automatic triage confidence: 98%

Add a waves-only pre-symbolication matcher for the exact React DOM removeChild event. The existing source-mapped telemetry filter shipped in production but cannot recognize the raw minified stack received by beforeSend.

## Fix

A prior repair treated a preceding TitleProvider breadcrumb as part of this removeChild issue. It is a separate defect already handled by draft PR #3688. The original PR correctly targets only the verified pre-symbolication React DOM signature.

## Changes

- Restored six shared error/title files exactly to the published PR head.
- Removed the two repair-only provider component/test files.
- Preserved the exact waves-only matcher and its positive and fail-open regression coverage.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Focused Jest passed: 2 suites, 646 tests.
- lint:changed passed.
- typecheck:changed passed for 2 changed TypeScript files.
- React Doctor completed and skipped because no React source remains changed.
- Worktree and full PR-range git diff checks passed.

## Risk

- Assessed risk: low
- Changed files: 5
- Changed lines: 297
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

The precise external DOM mutator remains unidentified, and the fix is not production-proven. The newer Firefox/global-error-shaped occurrence intentionally remains reportable for the separate provider repair. Two removed intent-to-add paths remain visible in porcelain status because the sandbox cannot update the shared Git index; there is no content or staged diff against HEAD, and publisher staging should clear them.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
