### PR TITLE
fix: No repair edit was needed. The advisory’s requested coverage and safe fail-open behavior are already pres

### DIFF
--- a/__tests__/fixtures/reactDomRawRemoveChildFixtures.ts
+++ b/__tests__/fixtures/reactDomRawRemoveChildFixtures.ts
@@ -1,0 +1,88 @@
+import type { SentryStackFrame } from "@/utils/sentry-client-filters";
+
+export type ReactDomRawRemoveChildVariant = "base" | "with-s9";
+
+const sanitizedReactDomChunkPath =
+  "app:///_next/static/chunks/0example-react-dom-runtime.js";
+
+// Sanitized from the two observed production raw-stack shapes. Only the
+// vendor function order remains; chunk names and event context are omitted.
+const baseRawFunctionNames = [
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "li",
+  "lr",
+  "s7",
+] as const;
+
+const rawFunctionNamesWithS9 = [
+  ...baseRawFunctionNames.slice(0, 41),
+  "s7",
+  "s9",
+  "s7",
+  "s9",
+  "s7",
+  "s9",
+  "s7",
+  "s9",
+  "s7",
+] as const;
+
+export function createObservedReactDomRawRemoveChildFrames(
+  variant: ReactDomRawRemoveChildVariant = "base"
+): SentryStackFrame[] {
+  const functionNames =
+    variant === "with-s9" ? rawFunctionNamesWithS9 : baseRawFunctionNames;
+
+  return functionNames.map((functionName) => ({
+    filename: sanitizedReactDomChunkPath,
+    abs_path: sanitizedReactDomChunkPath,
+    function: functionName,
+    in_app: true,
+  }));
+}

--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -3,6 +3,10 @@ import {
   createLatestReactDomRawFrames,
   createObservedReactDomRawInsertBeforeFrames,
 } from "@/__tests__/fixtures/reactDomRawInsertBeforeFixtures";
+import {
+  createObservedReactDomRawRemoveChildFrames,
+  type ReactDomRawRemoveChildVariant,
+} from "@/__tests__/fixtures/reactDomRawRemoveChildFixtures";
 
 const mockInit = jest.fn();
 const mockReplayIntegration = jest.fn(() => ({ name: "replay" }));
@@ -1285,6 +1289,77 @@ describe("instrumentation-client", () => {
     const result = beforeSend(event);
 
     expect(result).toBeNull();
+  });
+
+  it.each([
+    { variant: "base", transaction: "/waves/:wave" },
+    { variant: "with-s9", transaction: "/:user" },
+  ] satisfies ReadonlyArray<{
+    variant: ReactDomRawRemoveChildVariant;
+    transaction: string;
+  }>)(
+    "drops the production-shaped raw removeChild stack variant $variant on $transaction",
+    ({ variant, transaction }) => {
+      const beforeSend = loadBeforeSend();
+      const event = {
+        event_id: "raw-react-dom-remove-child-event",
+        transaction,
+        exception: {
+          values: [
+            {
+              type: "NotFoundError",
+              value: reactDomRemoveChildMessage,
+              mechanism: {
+                type: "generic",
+                handled: true,
+              },
+              stacktrace: {
+                frames: createObservedReactDomRawRemoveChildFrames(variant),
+              },
+            },
+          ],
+        },
+        tags: {
+          transaction,
+          url: transaction,
+        },
+      };
+
+      const result = beforeSend(event);
+
+      expect(result).toBeNull();
+    }
+  );
+
+  it("keeps the production-shaped raw removeChild stack outside affected routes", () => {
+    const beforeSend = loadBeforeSend();
+    const event = {
+      event_id: "raw-react-dom-remove-child-unobserved-route",
+      transaction: "/about",
+      exception: {
+        values: [
+          {
+            type: "NotFoundError",
+            value: reactDomRemoveChildMessage,
+            mechanism: {
+              type: "generic",
+              handled: true,
+            },
+            stacktrace: {
+              frames: createObservedReactDomRawRemoveChildFrames(),
+            },
+          },
+        ],
+      },
+      tags: {
+        transaction: "/about",
+        url: "/about",
+      },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result).toEqual(event);
   });
 
   it("drops injected WebAssembly CSP unsafe-eval errors", () => {

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -3,6 +3,10 @@ import {
   createObservedReactDomRawInsertBeforeFrames,
 } from "@/__tests__/fixtures/reactDomRawInsertBeforeFixtures";
 import {
+  createObservedReactDomRawRemoveChildFrames,
+  type ReactDomRawRemoveChildVariant,
+} from "@/__tests__/fixtures/reactDomRawRemoveChildFixtures";
+import {
   __testing,
   getLowValueNetworkErrorDecision,
   getLowValueNetworkErrorTargetUrl,
@@ -2568,6 +2572,64 @@ describe("sentry-client-filters", () => {
     ...overrides,
   });
 
+  const createReactDomRawRemoveChildEvent = (
+    options: {
+      exceptionType?: string;
+      exceptionValue?: string;
+      frames?: SentryStackFrame[];
+      transaction?: string;
+      includeAdditionalException?: boolean;
+      includeMechanism?: boolean;
+      mechanismType?: string;
+      mechanismHandled?: boolean;
+      variant?: ReactDomRawRemoveChildVariant;
+    } = {}
+  ): SentryClientEvent => ({
+    transaction: options.transaction ?? "/waves/:wave",
+    exception: {
+      values: [
+        {
+          type: options.exceptionType ?? "NotFoundError",
+          value: options.exceptionValue ?? reactDomRemoveChildMessage,
+          ...(options.includeMechanism === false
+            ? {}
+            : {
+                mechanism: {
+                  type: options.mechanismType ?? "generic",
+                  handled: options.mechanismHandled ?? true,
+                },
+              }),
+          stacktrace: {
+            frames:
+              options.frames ??
+              createObservedReactDomRawRemoveChildFrames(options.variant),
+          },
+        },
+        ...(options.includeAdditionalException
+          ? [
+              {
+                type: "Error",
+                value: "Independent application failure",
+                stacktrace: {
+                  frames: [
+                    {
+                      filename: "app:///components/waves/Wave.tsx",
+                      function: "Wave",
+                      in_app: true,
+                    },
+                  ],
+                },
+              },
+            ]
+          : []),
+      ],
+    },
+    tags: {
+      transaction: options.transaction ?? "/waves/:wave",
+      url: options.transaction ?? "/waves/:wave",
+    },
+  });
+
   it("filters events when a stack frame matches a filename exception", () => {
     // Arrange
     const frames: SentryStackFrame[] = [
@@ -2997,6 +3059,141 @@ describe("sentry-client-filters", () => {
     );
 
     expect(result).toBe(true);
+  });
+
+  it.each(["base", "with-s9"] as const)(
+    "filters the observed 50-frame raw React DOM removeChild stack variant %s",
+    (variant) => {
+      const frames = createObservedReactDomRawRemoveChildFrames(variant);
+      expect(frames).toHaveLength(50);
+
+      const result = shouldFilterReactDomRemoveChildNotFoundError(
+        createReactDomRawRemoveChildEvent({ frames })
+      );
+
+      expect(result).toBe(true);
+    }
+  );
+
+  it.each([
+    {
+      name: "49 frames",
+      getFrames: () => createObservedReactDomRawRemoveChildFrames().slice(1),
+    },
+    {
+      name: "51 frames",
+      getFrames: () => [
+        ...createObservedReactDomRawRemoveChildFrames(),
+        reactDomRawStaticChunkFrame("s7"),
+      ],
+    },
+    {
+      name: "an unknown function",
+      getFrames: () => [
+        reactDomRawStaticChunkFrame("WaveDrop"),
+        ...createObservedReactDomRawRemoveChildFrames().slice(1),
+      ],
+    },
+    {
+      name: "a missing required function",
+      getFrames: () =>
+        createObservedReactDomRawRemoveChildFrames().map((frame) =>
+          frame.function === "lr" ? reactDomRawStaticChunkFrame("li") : frame
+        ),
+    },
+    {
+      name: "a nonterminal s7 function",
+      getFrames: () =>
+        createObservedReactDomRawRemoveChildFrames("with-s9").reverse(),
+    },
+    {
+      name: "multiple chunk files",
+      getFrames: () => [
+        reactDomRawStaticChunkFrame(
+          "lr",
+          "app:///_next/static/chunks/0different-runtime.js"
+        ),
+        ...createObservedReactDomRawRemoveChildFrames().slice(1),
+      ],
+    },
+    {
+      name: "a non-Next chunk",
+      getFrames: () =>
+        createObservedReactDomRawRemoveChildFrames().map((frame) => ({
+          ...frame,
+          filename: "app:///runtime.js",
+          abs_path: "app:///runtime.js",
+        })),
+    },
+    {
+      name: "an application-owned frame",
+      getFrames: () => [
+        {
+          filename: "app:///components/waves/Wave.tsx",
+          abs_path: "app:///components/waves/Wave.tsx",
+          function: "lr",
+          in_app: true,
+        },
+        ...createObservedReactDomRawRemoveChildFrames().slice(1),
+      ],
+    },
+  ])("keeps raw removeChild events with $name", ({ getFrames }) => {
+    const result = shouldFilterReactDomRemoveChildNotFoundError(
+      createReactDomRawRemoveChildEvent({ frames: getFrames() })
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it.each([
+    {
+      name: "a different exception type",
+      options: { exceptionType: "TypeError" },
+    },
+    {
+      name: "a different exception message",
+      options: { exceptionValue: "The requested node was not found." },
+    },
+    {
+      name: "an unrelated route",
+      options: { transaction: "/about" },
+    },
+    {
+      name: "an actual profile pathname",
+      options: { transaction: "/profile-name" },
+    },
+    {
+      name: "a nested profile transaction",
+      options: { transaction: "/:user/subscriptions" },
+    },
+    {
+      name: "a different mechanism",
+      options: {
+        mechanismType: "auto.browser.global_handlers.onerror",
+      },
+    },
+    {
+      name: "an unhandled mechanism",
+      options: { mechanismHandled: false },
+    },
+    {
+      name: "no mechanism",
+      options: { includeMechanism: false },
+    },
+    {
+      name: "an empty stack",
+      options: { frames: [] },
+    },
+    {
+      name: "an additional exception",
+      options: { includeAdditionalException: true },
+    },
+  ])("keeps the observed raw removeChild stack with $name", ({ options }) => {
+    const result = shouldFilterReactDomRemoveChildNotFoundError(
+      createReactDomRawRemoveChildEvent(options)
+    );
+
+    expect(result).toBe(false);
   });
 
   it.each(["/profile-name", "/about", "/:user/", "/:user/subscriptions"])(

--- a/utils/sentry-client-filters/app-frame-utils.ts
+++ b/utils/sentry-client-filters/app-frame-utils.ts
@@ -44,6 +44,16 @@ const reactDomInsertBeforeRawRuntimeFunctions = new Set([
 ]);
 const reactDomInsertBeforeRawRequiredFunctions = ["lo", "li", "lr"];
 const reactDomInsertBeforeRawTerminalFunctions = new Set(["sN", "sR"]);
+const reactDomRemoveChildRawFrameCount = 50;
+const reactDomRemoveChildRawRuntimeFunctions = new Set([
+  "li",
+  "lr",
+  "s7",
+  "s9",
+]);
+const reactDomRemoveChildRawRequiredFunctions = ["li", "lr", "s7"];
+const reactDomRemoveChildRawOptionalFunction = "s9";
+const reactDomRemoveChildRawTerminalFunction = "s7";
 
 function isReactDomRuntimeFrame(frame: SentryStackFrame): boolean {
   const paths = getFramePaths(frame);
@@ -151,6 +161,47 @@ function hasRawReactDomInsertBeforeFrameSignature(
   );
 }
 
+function hasRawReactDomRemoveChildFrameSignature(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  // beforeSend sees this minified stack before Sentry applies source maps.
+  // Keep both cohort-backed function sets exact so minifier drift fails open.
+  if (
+    !Array.isArray(frames) ||
+    frames.length !== reactDomRemoveChildRawFrameCount ||
+    frames.at(-1)?.function?.trim() !== reactDomRemoveChildRawTerminalFunction
+  ) {
+    return false;
+  }
+
+  const functionNames = new Set<string>();
+  for (const frame of frames) {
+    const functionName = frame.function?.trim();
+    if (
+      !functionName ||
+      !reactDomRemoveChildRawRuntimeFunctions.has(functionName)
+    ) {
+      return false;
+    }
+    functionNames.add(functionName);
+  }
+
+  const hasRequiredFunctions = reactDomRemoveChildRawRequiredFunctions.every(
+    (functionName) => functionNames.has(functionName)
+  );
+  const hasObservedFunctionSet =
+    functionNames.size === reactDomRemoveChildRawRequiredFunctions.length ||
+    (functionNames.size ===
+      reactDomRemoveChildRawRequiredFunctions.length + 1 &&
+      functionNames.has(reactDomRemoveChildRawOptionalFunction));
+
+  return (
+    hasRequiredFunctions &&
+    hasObservedFunctionSet &&
+    hasOnlyOneNextStaticChunk(frames)
+  );
+}
+
 function getReactDomNotFoundErrorValue(
   event: SentryClientEvent,
   message: string
@@ -193,6 +244,18 @@ export function hasReactDomInsertBeforeRawNotFoundErrorSignature(
     value?.mechanism?.type === "generic" &&
     value.mechanism.handled === true &&
     hasRawReactDomInsertBeforeFrameSignature(value.stacktrace?.frames)
+  );
+}
+
+export function hasReactDomRemoveChildRawNotFoundErrorSignature(
+  event: SentryClientEvent,
+  message: string
+): boolean {
+  const value = getReactDomNotFoundErrorValue(event, message);
+  return (
+    value?.mechanism?.type === "generic" &&
+    value.mechanism.handled === true &&
+    hasRawReactDomRemoveChildFrameSignature(value.stacktrace?.frames)
   );
 }
 

--- a/utils/sentry-client-filters/react-dom.ts
+++ b/utils/sentry-client-filters/react-dom.ts
@@ -11,6 +11,7 @@ import {
 import {
   hasReactDomInsertBeforeRawNotFoundErrorSignature,
   hasReactDomNotFoundErrorSignature,
+  hasReactDomRemoveChildRawNotFoundErrorSignature,
 } from "./app-frame-utils";
 
 export function shouldFilterReactDomInsertBeforeNotFoundError(
@@ -45,8 +46,14 @@ export function shouldFilterReactDomRemoveChildNotFoundError(
     return false;
   }
 
-  return hasReactDomNotFoundErrorSignature(
-    event,
-    REACT_DOM_REMOVE_CHILD_NOT_FOUND_ERROR_MESSAGE
+  return (
+    hasReactDomNotFoundErrorSignature(
+      event,
+      REACT_DOM_REMOVE_CHILD_NOT_FOUND_ERROR_MESSAGE
+    ) ||
+    hasReactDomRemoveChildRawNotFoundErrorSignature(
+      event,
+      REACT_DOM_REMOVE_CHILD_NOT_FOUND_ERROR_MESSAGE
+    )
   );
 }


### PR DESCRIPTION
<!-- sentry-fix-job:46 issue:7083151951 -->
## Issue

- Sentry: [6529-FRONTEND-2V](https://seize-ff.sentry.io/issues/7083151951/)
- First seen: 2025-12-03T04:46:38.623Z
- Latest occurrence: 2026-08-06T13:28:13.000Z
- Automatic triage confidence: 99%

A small telemetry fix is useful. The current route-scoped removeChild filter is already deployed for Waves, Gradient, The Memes mint, and the exact /:user transaction, but it only recognizes source-mapped React frames. Production beforeSend receives the same failures as a stable 50-frame minified Next.js chunk stack, so the events escape filtering before Sentry later symbolicates them.

## Fix

The original filter missed pre-symbolication raw React DOM stacks; that gap is already fixed. The reviewer flagged an intentional defensive membership check as redundant and overlooked existing boundary tests.

## Changes

- Not reported.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Focused Sentry filter and beforeSend suites passed: 2 suites, 654 tests.
- Changed-file ESLint passed.
- Changed-file TypeScript check passed.
- Whitespace validation passed and the worktree remains clean.
- All 15 current GitHub checks are successful.

## Risk

- Assessed risk: low
- Changed files: 5
- Changed lines: 436
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

The external DOM mutator cannot be conclusively identified. Future minifier or bundler drift intentionally fails open so changed signatures remain reportable.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
