### PR TITLE
Run Knip on every frontend pull request

### DIFF
--- a/.github/workflows/app-pr-ci.yml
+++ b/.github/workflows/app-pr-ci.yml
@@ -31,7 +31,6 @@ jobs:
       playwright_smoke_required: ${{ steps.plan_outputs.outputs.playwright_smoke_required }}
       playwright_critical_shell_required: ${{ steps.plan_outputs.outputs.playwright_critical_shell_required }}
       playwright_museum_required: ${{ steps.plan_outputs.outputs.playwright_museum_required }}
-      deadcode_required: ${{ steps.plan_outputs.outputs.deadcode_required }}
       release_bus_contract_required: ${{ steps.plan_outputs.outputs.release_bus_contract_required }}
       dependency_governance_required: ${{ steps.plan_outputs.outputs.dependency_governance_required }}
       reviewbot_contract_required: ${{ steps.plan_outputs.outputs.reviewbot_contract_required }}
@@ -374,7 +373,7 @@ jobs:
         run: ./bin/6529 install:frozen
 
       - name: Run Knip dead-code check
-        if: matrix.lane == 'quality' && needs.plan.outputs.deadcode_required == 'true'
+        if: matrix.lane == 'quality'
         run: ./bin/6529 run deadcode:knip
 
       - name: Lint package.json versions
@@ -753,7 +752,6 @@ jobs:
           EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           EXPECTED_MERGE_SHA: ${{ github.sha }}
           BUILD_REQUIRED: ${{ needs.plan.outputs.build_required }}
-          DEADCODE_REQUIRED: ${{ needs.plan.outputs.deadcode_required }}
           RELEASE_BUS_CONTRACT_REQUIRED: ${{ needs.plan.outputs.release_bus_contract_required }}
           TEST_TYPECHECK_REQUIRED: ${{ needs.plan.outputs.test_typecheck_required }}
           MUSEUM_BROWSER_REQUIRED: ${{ needs.plan.outputs.playwright_museum_required }}
@@ -763,7 +761,6 @@ jobs:
           [[ "$EXPECTED_MERGE_SHA" =~ ^[a-f0-9]{40}$ ]]
           [[ "$EXPECTED_HEAD_SHA" =~ ^[a-f0-9]{40}$ ]]
           [[ "$BUILD_REQUIRED" =~ ^(true|false)$ ]]
-          [[ "$DEADCODE_REQUIRED" =~ ^(true|false)$ ]]
           [[ "$RELEASE_BUS_CONTRACT_REQUIRED" =~ ^(true|false)$ ]]
           [[ "$TEST_TYPECHECK_REQUIRED" =~ ^(true|false)$ ]]
           [[ "$MUSEUM_BROWSER_REQUIRED" =~ ^(true|false)$ ]]
@@ -815,7 +812,6 @@ jobs:
             --arg policy_bundle_digest "$policy_bundle_digest" \
             --argjson policy_bundle_line_count "$policy_bundle_line_count" \
             --argjson build_required "$BUILD_REQUIRED" \
-            --argjson deadcode_required "$DEADCODE_REQUIRED" \
             --argjson release_bus_contract_required "$RELEASE_BUS_CONTRACT_REQUIRED" \
             --argjson test_typecheck_required "$TEST_TYPECHECK_REQUIRED" \
             --argjson museum_browser_required "$MUSEUM_BROWSER_REQUIRED" \
@@ -830,7 +826,7 @@ jobs:
               merge_sha:$merge_sha,
               head_sha:$head_sha,
               production_build_required:$build_required,
-              dependency_analysis_required:$deadcode_required,
+              dependency_analysis_required:true,
               release_bus_contract_required:$release_bus_contract_required,
               test_typecheck_required:$test_typecheck_required,
               museum_browser_required:$museum_browser_required,
@@ -842,7 +838,7 @@ jobs:
               policy_bundle_line_count:$policy_bundle_line_count,
               required_gates:([
                 "package-manager-discipline",
-                "dependency-analysis-or-plan-not-required",
+                "dependency-analysis",
                 "reviewbot-contract",
                 "generated-agent-files",
                 "release-bus-workflow-contract-or-plan-not-required",

--- a/.github/workflows/release-bus-v2-preflight.yml
+++ b/.github/workflows/release-bus-v2-preflight.yml
@@ -313,12 +313,12 @@ jobs:
             .policy_bundle_contract == "pr-ci-policy-bundle-v1" and
             (.policy_bundle_digest | test("^[a-f0-9]{64}$")) and
             (.policy_bundle_line_count | type == "number" and . >= 1 and . <= 1000 and floor == .) and
-            (.dependency_analysis_required | type == "boolean") and
+            .dependency_analysis_required == true and
             (.release_bus_contract_required | type == "boolean") and
             (.test_typecheck_required | type == "boolean") and
             .required_gates == ([
               "package-manager-discipline",
-              "dependency-analysis-or-plan-not-required",
+              "dependency-analysis",
               "reviewbot-contract",
               "generated-agent-files",
               "release-bus-workflow-contract-or-plan-not-required",

--- a/__tests__/scripts/app-pr-ci-effective-plan.test.ts
+++ b/__tests__/scripts/app-pr-ci-effective-plan.test.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 
 type EffectivePlan = {
   checks: {
-    deadcode: { required: boolean };
     release_bus_contract: { required: boolean };
     test_typecheck: { required: boolean };
     playwright_smoke?: { required: boolean };
@@ -62,11 +61,23 @@ describe("effective App PR CI plan", () => {
   it("preserves risk-selected browser checks for ordinary runtime changes", () => {
     const effective = executePlan(["components/header/AppHeader.tsx"]);
 
-    expect(effective.checks.deadcode.required).toBe(false);
     expect(effective.checks.release_bus_contract.required).toBe(false);
     expect(effective.checks.test_typecheck.required).toBe(false);
     expect(effective.checks.playwright_smoke?.required).toBe(true);
     expect(effective.checks.playwright_critical_shell?.required).toBe(true);
+  });
+
+  it("requires the installed quality lane for every pull request", () => {
+    const rawPlan = plan(["README.md"]);
+    rawPlan.checks.install = {
+      required: false,
+      reason: "No installed checks selected.",
+    };
+
+    const effective = executeRawPlan(rawPlan);
+
+    expect(effective.checks.install.required).toBe(true);
+    expect(effective.checks).not.toHaveProperty("deadcode");
   });
 
   it.each([
@@ -127,13 +138,6 @@ describe("effective App PR CI plan", () => {
     "README.md",
   ])("does not run Museum browser coverage for unrelated change %s", (file) => {
     expect(executePlan([file]).checks.playwright_museum.required).toBe(false);
-  });
-
-  it("requires dead-code analysis for dependency changes or deleted runtime source", () => {
-    expect(executePlan(["package.json"]).checks.deadcode.required).toBe(true);
-    expect(
-      executePlan(["lib/removed-runtime-source.ts"]).checks.deadcode.required
-    ).toBe(true);
   });
 
   it.each([

--- a/__tests__/scripts/release-bus-artifact-compatibility.test.ts
+++ b/__tests__/scripts/release-bus-artifact-compatibility.test.ts
@@ -281,7 +281,7 @@ function createStrictEvidence(root: string, mergeSha: string) {
     policy_bundle_line_count: 1,
     required_gates: [
       "package-manager-discipline",
-      "dependency-analysis-or-plan-not-required",
+      "dependency-analysis",
       "reviewbot-contract",
       "generated-agent-files",
       "release-bus-workflow-contract-or-plan-not-required",

--- a/__tests__/scripts/release-bus-performance-contract.test.ts
+++ b/__tests__/scripts/release-bus-performance-contract.test.ts
@@ -76,6 +76,12 @@ describe("Release Bus frontend performance contract", () => {
     );
     expect(appPrCi).toContain("./bin/6529 run lint:changed");
     expect(appPrCi).toContain("./bin/6529 run typecheck:changed");
+    expect(appPrCi).toContain("./bin/6529 run deadcode:knip");
+    expect(appPrCi).toContain("if: matrix.lane == 'quality'");
+    expect(appPrCi).not.toContain("deadcode_required");
+    expect(appPrCi).toContain("dependency_analysis_required:true");
+    expect(appPrCi).toContain('"dependency-analysis"');
+    expect(appPrCi).not.toContain('"dependency-analysis-or-plan-not-required"');
     expect(appPrCi).toContain("Run related Jest tests");
     expect(appPrCi).toContain("./bin/6529 run build:ci");
     expect(appPrCi).toContain("playwright install --with-deps chromium");

--- a/components/about/AboutLayout.tsx
+++ b/components/about/AboutLayout.tsx
@@ -18,9 +18,6 @@ export const ABOUT_PAGE_HORIZONTAL_PADDING_CLASS_NAME =
 export const ABOUT_PAGE_SURFACE_CLASS_NAME =
   "tw-border-y-0 tw-border-l-0 tw-border-r tw-border-solid tw-border-iron-900 tw-bg-[#0D0D0F]";
 
-export const ABOUT_TEXT_PAGE_CONTAINER_CLASS =
-  "tw-px-5 tw-pb-4 tw-pt-4 tw-text-iron-50 sm:tw-px-6 lg:tw-px-8";
-
 // Reclaims AboutCol's mobile `tw-px-3` gutter for full-bleed feature surfaces.
 // Keep the negative margin and added width paired with that column padding.
 export const ABOUT_MOBILE_COLUMN_GUTTER_BREAKOUT_CLASS =

--- a/pr-reports/3661.md
+++ b/pr-reports/3661.md
@@ -1,0 +1,31 @@
+# PR Report: Run Knip on every frontend pull request
+
+PR: https://github.com/6529-Collections/6529seize-frontend/pull/3661
+Branch: `agent-prxt/knip-ci-update` -> `main`
+Related PRs: None
+
+## Summary
+
+Frontend pull-request CI now runs repository-wide Knip analysis for every PR instead of limiting it to dependency, Knip configuration, and runtime-source deletion changes.
+
+## What Changed
+
+- Made the installed quality lane mandatory for every frontend pull request and removed the obsolete conditional dead-code classification output.
+- Updated exact merge-tree evidence and Release Bus preflight validation to require dependency analysis unconditionally.
+- Removed the unused `ABOUT_TEXT_PAGE_CONTAINER_CLASS` export identified by Knip.
+- Updated focused planner, workflow, and release-evidence contracts for the always-on policy.
+
+## Frontend Impact
+
+- Routes/views: Not affected.
+- Components: Removed one unused About layout export; rendered behavior is unchanged.
+- Generated API/client: Not affected.
+- User-visible behavior: Not affected; this strengthens pull-request dead-code detection.
+
+## Config / Env
+
+None.
+
+## Release Notes
+
+Frontend pull requests now receive consistent repository-wide dead-code validation before merge.

--- a/scripts/app-pr-ci-effective-plan.cjs
+++ b/scripts/app-pr-ci-effective-plan.cjs
@@ -28,7 +28,6 @@ const REQUIRED_BASE_CHECKS = [
   "reviewbot_contract",
   "agent_files_sync",
 ];
-const SOURCE_EXTENSION = /\.(?:cjs|js|jsx|mjs|ts|tsx)$/u;
 const RELEASE_BUS_CONTRACT_PATTERNS = [
   /^\.github\/workflows\//u,
   /^ops\/deployment-bus\//u,
@@ -54,7 +53,7 @@ function isTestFile(file) {
   );
 }
 
-function applyEffectiveAppPrCiPlan(plan, { cwd = process.cwd() } = {}) {
+function applyEffectiveAppPrCiPlan(plan) {
   const baseChecks = plan?.checks;
   const hasValidBaseChecks =
     baseChecks !== null &&
@@ -76,16 +75,6 @@ function applyEffectiveAppPrCiPlan(plan, { cwd = process.cwd() } = {}) {
   const packageGovernance = files.some((file) =>
     PACKAGE_GOVERNANCE_FILES.has(file)
   );
-  // The caller runs this planner from the exact PR merge-tree checkout;
-  // absence therefore identifies a deleted runtime source, not a sparse tree.
-  const deletedRuntimeSource = files.some(
-    (file) =>
-      SOURCE_EXTENSION.test(file) &&
-      !isTestFile(file) &&
-      !fs.existsSync(path.join(cwd, file))
-  );
-  const deadcode =
-    packageGovernance || files.includes("knip.jsonc") || deletedRuntimeSource;
   const testTypecheck =
     packageGovernance ||
     files.some(
@@ -105,16 +94,12 @@ function applyEffectiveAppPrCiPlan(plan, { cwd = process.cwd() } = {}) {
   const checks = {
     ...plan.checks,
     install: check(
-      baseChecks.install.required || playwrightMuseum,
+      true,
       playwrightMuseum
         ? "Museum-owned public pages or their publication contract changed and need the isolated Museum browser lane."
-        : baseChecks.install.reason
-    ),
-    deadcode: check(
-      deadcode,
-      deadcode
-        ? "Dependency policy, Knip configuration, or deleted runtime source needs dead-code analysis."
-        : "No dependency policy, Knip configuration, or deleted runtime source changed."
+        : baseChecks.install.required
+          ? baseChecks.install.reason
+          : "Repository-wide Knip runs for every pull request."
     ),
     release_bus_contract: check(
       releaseBusContract,

--- a/tests/README.md
+++ b/tests/README.md
@@ -148,9 +148,10 @@ App PR CI:
   credentials, deployment credentials, external-model API keys, or durable
   artifact-store write credentials.
 - PR CI uses changed-file lint, typechecking, related Jest contracts, and a
-  production build when the risk plan requires it. Repository-wide Knip,
-  test-helper typechecking, and release-workflow contract suites run only when
-  their owning paths change.
+  production build when the risk plan requires it. Repository-wide Knip runs
+  in the installed quality lane for every pull request; test-helper
+  typechecking and release-workflow contract suites run only when their owning
+  paths change.
 - Selected quality/contracts, production-build, smoke-Playwright, and
   critical-shell-Playwright lanes run in parallel. The lightweight final
   `Installed app checks` job preserves the required branch-protection gate and


### PR DESCRIPTION
## Issue

- App PR CI runs Knip only when the risk planner marks dead-code analysis as required, allowing unused code to reach ordinary pull requests unchecked.

## Fix

- Make the installed quality lane mandatory and run Knip for every pull request.
- Remove the obsolete dead-code classifier and its plan output.
- Require dependency-analysis evidence in the Release Bus preflight contract.

## Changes

- Updated App PR CI, effective-plan logic, Release Bus evidence validation, and focused contracts.
- Removed the unused ABOUT_TEXT_PAGE_CONTAINER_CLASS export.
- Updated CI documentation to reflect universal Knip coverage.

## Validation

- Complete Knip check.
- Focused App PR planner, testing-strategy, policy-bundle, Release Bus performance, and artifact compatibility suites.
- Changed-file quality and typechecking.
- Frontend debt-ratchet gate.

## Risk

- Level: Low
- Why: CI-only policy expansion plus removal of one unused export; application runtime behavior is unchanged.
- Rollback: Revert this PR to restore conditional Knip execution and the prior evidence contract.

## Review Notes

- Confirm that always enabling the installed quality lane is the intended cost tradeoff for universal Knip coverage.