### PR TITLE
Fix live Elastic Beanstalk readiness normalization

### DIFF
--- a/__tests__/scripts/artifact-portability-and-readiness.test.ts
+++ b/__tests__/scripts/artifact-portability-and-readiness.test.ts
@@ -415,6 +415,44 @@ describe("adaptive Elastic Beanstalk readiness", () => {
     });
   });
 
+  it("accepts the normalized AWS adapter shape in the readiness loop", async () => {
+    const clock = makeClock();
+    const execFileImpl = async () => ({
+      stdout: JSON.stringify({
+        Environments: [
+          {
+            Health: "Green",
+            Status: "Ready",
+            VersionLabel: EXPECTED_VERSION,
+          },
+        ],
+      }),
+    });
+    const result = await readiness.waitForElasticBeanstalkReadiness({
+      environmentName: "seizeapp-env-node22",
+      expectedVersion: EXPECTED_VERSION,
+      timeoutSeconds: 30,
+      describeEnvironment: ({ timeoutMs }) =>
+        readiness.describeEnvironmentWithAws({
+          environmentName: "seizeapp-env-node22",
+          timeoutMs,
+          execFileImpl,
+        }),
+      sleep: clock.sleep,
+      now: clock.now,
+      monotonicNow: clock.monotonicNow,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.evidence.attempts).toBe(2);
+    expect(result.evidence.result).toMatchObject({
+      health: "Green",
+      status: "Ready",
+      version_label: EXPECTED_VERSION,
+      consecutive_samples: 2,
+    });
+  });
+
   it("takes an immediate sample and requires two consecutive exact healthy samples", async () => {
     const { result, clock } = await runReadiness([
       snapshot("Green", "Ready", EXPECTED_VERSION),

--- a/ops/scripts/elastic-beanstalk-readiness.cjs
+++ b/ops/scripts/elastic-beanstalk-readiness.cjs
@@ -60,7 +60,10 @@ function normalizeSnapshot(value) {
 
   const health = environment.Health ?? environment.health;
   const status = environment.Status ?? environment.status;
-  const versionLabel = environment.VersionLabel ?? environment.versionLabel;
+  const versionLabel =
+    environment.VersionLabel ??
+    environment.versionLabel ??
+    environment.version_label;
 
   invariant(typeof health === "string", "Elastic Beanstalk health is missing");
   invariant(typeof status === "string", "Elastic Beanstalk status is missing");

--- a/ops/workstreams/museum-release-fast-lane/active-context.md
+++ b/ops/workstreams/museum-release-fast-lane/active-context.md
@@ -394,3 +394,19 @@ publication status.
 - No staging or production environment has been mutated by this six-PR train.
   Final staging, E2E, production, E2E, retained qualification, and developer
   Wave closeout remain required.
+
+## 2026-08-06 live qualification correction
+
+- The six-PR train is now merged through PR #3656 at exact main
+  `ee156caa5b2a9ed2efaee34659f098e916badcb9`.
+- Exact staging deployment and automatic staging E2E passed. Production run
+  31113392584 deployed the exact version; live Elastic Beanstalk and HTTP
+  readbacks are healthy.
+- Final production qualification is blocked by the readiness adapter's
+  double-normalization defect, not by the deployed application. The focused
+  correction and real-adapter regression are the only active hotfix scope.
+- After the hotfix completes its governed release and production E2E, the next
+  workstream is the separately reviewed one-click production operation agreed
+  with the Dev Team. It must use authoritative pre-dispatch drain/acquisition,
+  a bounded cross-repository lane lease and control epoch, an isolated builder
+  without deployment credentials, and a fresh artifact verifier before AWS.

--- a/ops/workstreams/museum-release-fast-lane/run-log.md
+++ b/ops/workstreams/museum-release-fast-lane/run-log.md
@@ -929,3 +929,22 @@ disabled pending the migration proof in the implementation document.
   volume identifier, so cross-platform identity comparison treats only that
   documented zero as unavailable while still requiring the inode match. The
   two corrected suites pass 57/57 with changed-source lint clean.
+
+## 2026-08-06 - Live readiness adapter defect
+
+- PR #3656 merged as `ee156caa5b2a9ed2efaee34659f098e916badcb9`.
+  Staging deployment 31110364640 and automatic staging E2E 31111224279
+  passed. Production run 31113392584 deployed that exact version and live
+  readback reached Green/Ready with three exact `/api/version` responses.
+- The production qualification step then exposed a real adapter-boundary bug:
+  `describeEnvironmentWithAws` returned the normalized `version_label` field,
+  while the outer readiness loop normalized that value again but recognized
+  only AWS `VersionLabel` and camel-case `versionLabel`. Every valid sample was
+  therefore discarded as `Elastic Beanstalk VersionLabel is missing`.
+- The correction makes normalization idempotent by accepting the closed
+  normalized field. A regression test passes the actual AWS adapter output
+  through the readiness loop. The focused suite passes 25/25, and a live
+  read-only reproduction now accepts two consecutive Green/Ready exact-version
+  observations in 7.3 seconds.
+- No additional environment mutation was used to diagnose or prove the fix.
+  Production E2E remains required after this correction is merged and released.


### PR DESCRIPTION
## Outcome

Fix the production Elastic Beanstalk readiness verifier so the normalized AWS adapter output is accepted by the readiness loop. The currently deployed application is already exact and healthy; qualification run 31113392584 exposed this verifier defect under the real AWS adapter boundary.

## Root cause

`describeEnvironmentWithAws` normalizes AWS `VersionLabel` to `version_label`. `observeEnvironment` then calls `normalizeSnapshot` again, but that function recognized only `VersionLabel` and `versionLabel`. Every healthy exact-version sample was therefore discarded as `Elastic Beanstalk VersionLabel is missing` until timeout.

## Correction

- make snapshot normalization idempotent by accepting the closed `version_label` field;
- add a regression that passes the actual normalized AWS adapter result through the readiness loop;
- record the live incident and exact release state in the durable workstream context.

## Evidence

- focused suite: 25/25 passed;
- changed lint passed;
- changed TypeScript passed (1,410 files);
- Jest and Playwright typecheck ratchets passed;
- Prettier, Node syntax, and `codex-diff-check` passed;
- live read-only AWS reproduction: two consecutive Green/Ready observations at exact `ee156caa5b2a9ed2efaee34659f098e916badcb9` accepted in 7.3 seconds;
- live `/api/version`: exact `ee156caa...` returned three times with `stale:false`.

No additional environment mutation was used to diagnose or prove the correction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment readiness checks to recognize version labels returned in alternate formats.
  * Prevented duplicate normalization of readiness data, improving reliability of production qualification checks.

* **Tests**
  * Added integration coverage for AWS readiness responses.
  * Verified successful readiness after two consecutive matching healthy-version checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->