### PR TITLE
fix: The existing draft fully covers Sentry revision 5. The new occurrence has the same exact HEAD signature a

### DIFF
--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -4211,6 +4211,47 @@ describe("instrumentation-client", () => {
     expect(payload).not.toContain("#private");
   });
 
+  it("removes only misleading response body sizes from standalone HEAD spans", () => {
+    const beforeSendSpan = loadBeforeSendSpan();
+    const span = {
+      op: "http.client",
+      description: "HEAD https://media.example.invalid/renditions/video.mp4",
+      start_timestamp: 10,
+      timestamp: 10.25,
+      data: {
+        "http.method": "HEAD",
+        "http.response_content_length": 3_569_517,
+        "http.response.body.size": 3_569_517,
+        "http.response.status_code": 200,
+        "http.response_transfer_size": 512,
+        "http.url": "https://media.example.invalid/renditions/video.mp4",
+      },
+    };
+
+    const result = beforeSendSpan(span);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        op: "http.client",
+        description: "HEAD /renditions/video.mp4",
+        start_timestamp: 10,
+        timestamp: 10.25,
+        data: {
+          "http.method": "HEAD",
+          "http.response.status_code": 200,
+          "http.response_transfer_size": 512,
+          "http.url": "/renditions/video.mp4",
+        },
+      })
+    );
+    expect(span.data).toEqual(
+      expect.objectContaining({
+        "http.response_content_length": 3_569_517,
+        "http.response.body.size": 3_569_517,
+      })
+    );
+  });
+
   it("does not add audit metadata when no spans were filtered", () => {
     const beforeSendTransaction = loadBeforeSendTransaction();
     const event = {

--- a/__tests__/utils/sentry-sanitizer.test.ts
+++ b/__tests__/utils/sentry-sanitizer.test.ts
@@ -422,6 +422,55 @@ describe("sentry-sanitizer", () => {
     expect(payload).not.toContain("#private");
   });
 
+  it.each(["http.method", "http.request.method", "http.request_method"])(
+    "removes misleading HEAD response body sizes for the %s method attribute",
+    (methodKey) => {
+      const input = {
+        op: "http.client",
+        data: {
+          [methodKey]: "HEAD",
+          "http.response_content_length": 3_569_517,
+          "http.response.body.size": 3_569_517,
+          "http.response.status_code": 200,
+          "http.response_transfer_size": 512,
+        },
+      };
+
+      const span = sanitizeSentrySpan(input);
+
+      expect(span.data).toEqual({
+        [methodKey]: "HEAD",
+        "http.response.status_code": 200,
+        "http.response_transfer_size": 512,
+      });
+      expect(input.data).toEqual(
+        expect.objectContaining({
+          "http.response_content_length": 3_569_517,
+          "http.response.body.size": 3_569_517,
+        })
+      );
+    }
+  );
+
+  it.each([
+    ["a GET span", "http.client", "GET", true],
+    ["a POST span", "http.client", "POST", true],
+    ["a non-HTTP client span", "resource.video", "HEAD", true],
+    ["a HEAD span without body-size attributes", "http.client", "HEAD", false],
+  ])("preserves response metadata for %s", (_case, op, method, hasBodySize) => {
+    const data: Record<string, unknown> = {
+      "http.method": method,
+      "http.response.status_code": 200,
+    };
+    if (hasBodySize) {
+      data["http.response_content_length"] = 4_096;
+      data["http.response.body.size"] = 4_096;
+    }
+    const input = { op, data };
+
+    expect(sanitizeSentrySpan(input)).toEqual(input);
+  });
+
   it("keeps automatic span sanitization idempotent across SDK hooks", () => {
     const once = sanitizeSentrySpan({
       op: "http.client",

--- a/utils/sentry-sanitizer.ts
+++ b/utils/sentry-sanitizer.ts
@@ -39,6 +39,15 @@ const HOST_VALUE_KEY_PATTERN = /^(?:http\.host|server\.address|url\.domain)$/i;
 const HOST_ATTRIBUTION_VALUES = new Set(
   `first-party first-party-api first-party-app ${THIRD_PARTY}`.split(" ")
 );
+const HTTP_REQUEST_METHOD_KEYS = [
+  "http.method",
+  "http.request.method",
+  "http.request_method",
+] as const;
+const HEAD_RESPONSE_BODY_SIZE_KEYS = new Set([
+  "http.response_content_length",
+  "http.response.body.size",
+]);
 const OMIT_SANITIZED_VALUE = Symbol("omit-sanitized-value");
 
 const SENSITIVE_KEY_FRAGMENT_PATTERN =
@@ -684,10 +693,14 @@ function parseHttpMethodDescription(
 
 function sanitizeSpanData(
   data: Record<string, unknown>,
-  kind: SentryPathKind
+  kind: SentryPathKind,
+  omitHeadResponseBodySize: boolean
 ): Record<string, unknown> {
   const nextData: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(data)) {
+    if (omitHeadResponseBodySize && HEAD_RESPONSE_BODY_SIZE_KEYS.has(key)) {
+      continue;
+    }
     if (URL_DETAIL_KEY_PATTERN.test(key)) {
       continue;
     }
@@ -705,6 +718,10 @@ function sanitizeSpanData(
   return nextData;
 }
 
+function hasHeadRequestMethod(data: Record<string, unknown>): boolean {
+  return HTTP_REQUEST_METHOD_KEYS.some((key) => data[key] === "HEAD");
+}
+
 export function sanitizeSentrySpan<T extends SanitizableSentrySpan>(
   span: T
 ): T {
@@ -715,7 +732,9 @@ export function sanitizeSentrySpan<T extends SanitizableSentrySpan>(
     next.description = sanitizeSpanDescription(next.description, kind);
   }
   if (next.data) {
-    next.data = sanitizeSpanData(next.data, kind);
+    const omitHeadResponseBodySize =
+      next.op === "http.client" && hasHeadRequestMethod(next.data);
+    next.data = sanitizeSpanData(next.data, kind, omitHeadResponseBodySize);
   }
 
   return next;


### PR DESCRIPTION
<!-- sentry-fix-job:49 issue:7656854977 -->
## Issue

- Sentry: [6529-FRONTEND-F7](https://seize-ff.sentry.io/issues/7656854977/)
- First seen: 2026-08-06T17:42:00.305Z
- Latest occurrence: 2026-08-07T09:28:10.000Z
- Automatic triage confidence: 98%

A narrow telemetry fix is useful. Preserve the successful HEAD request spans, but remove their misleading response-body-size attribute so Sentry does not classify representation metadata as a large transferred payload.

## Fix

Sentry SDK 10.45.0 maps the Content-Length header to response-body-size telemetry for HEAD requests. For HEAD, that header describes the equivalent GET representation even though no response body is transferred.

## Changes

- Not reported.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Focused Jest regression suites passed: 2 suites, 206 tests.
- Changed-file ESLint passed.
- Changed-file TypeScript validation passed.
- Diff whitespace validation passed.
- Live read-only Sentry verification confirmed five occurrences, all from the pre-fix release, with no newer event after revision 5.
- All current GitHub checks pass on the exact PR head; no review threads are present.
- Worktree remains clean and local HEAD matches the remote PR head.

## Risk

- Assessed risk: low
- Changed files: 3
- Changed lines: 113
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

Production effectiveness can only be confirmed after deployment by the trusted release stage. The draft branch is behind current main, so the publisher may need its normal synchronization cycle. No commit, push, PR-state change, deployment, or Sentry mutation was performed.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
