### PR TITLE
Fix isolated production verifier checkout

### DIFF
--- a/.github/workflows/production-artifact-verifier.yml
+++ b/.github/workflows/production-artifact-verifier.yml
@@ -121,7 +121,9 @@ jobs:
           ref: ${{ github.workflow_sha }}
           persist-credentials: false
           path: trusted-verifier
-          sparse-checkout: ops/scripts/verify-production-artifact-selection.cjs
+          sparse-checkout: |
+            ops/scripts/verify-production-artifact-selection.cjs
+            ops/scripts/cli-args.cjs
           sparse-checkout-cone-mode: false
 
       - name: Install pinned Node.js

--- a/__tests__/scripts/production-artifact-verifier.test.ts
+++ b/__tests__/scripts/production-artifact-verifier.test.ts
@@ -191,7 +191,7 @@ describe("isolated production artifact verifier", () => {
     const visitLocalDependencies = (sourcePath: string): void => {
       const sourceCode = fs.readFileSync(sourcePath, "utf8");
       for (const match of sourceCode.matchAll(
-        /require\(["']\.\/([^"']+)["']\)/gu
+        /require\(["']((?:\.{1,2}\/)[^"']+)["']\)/gu
       )) {
         const dependencyPath = path.resolve(path.dirname(sourcePath), match[1]);
         const relativeToScripts = path.relative(

--- a/__tests__/scripts/production-artifact-verifier.test.ts
+++ b/__tests__/scripts/production-artifact-verifier.test.ts
@@ -115,7 +115,14 @@ describe("isolated production artifact verifier", () => {
       };
       jobs: Record<
         string,
-        { permissions: Record<string, string>; "runs-on": string }
+        {
+          permissions: Record<string, string>;
+          "runs-on": string;
+          steps: Array<{
+            name?: string;
+            with?: Record<string, unknown>;
+          }>;
+        }
       >;
     };
     const requiredInputs = ["target_sha", "operation_id"];
@@ -171,6 +178,29 @@ describe("isolated production artifact verifier", () => {
       actions: "read",
       contents: "read",
     });
+    const checkout = verifyJob.steps.find(
+      ({ name }) => name === "Check out immutable verifier helper"
+    );
+    const sparseCheckout = String(checkout?.with?.["sparse-checkout"] ?? "");
+    const verifierSource = fs.readFileSync(
+      path.join(
+        process.cwd(),
+        "ops",
+        "scripts",
+        "verify-production-artifact-selection.cjs"
+      ),
+      "utf8"
+    );
+    const localDependencies = [
+      ...verifierSource.matchAll(/require\(["']\.\/([^"']+)["']\)/gu),
+    ].map((match) => `ops/scripts/${match[1]}`);
+    expect(localDependencies).toEqual(["ops/scripts/cli-args.cjs"]);
+    expect(sparseCheckout).toContain(
+      "ops/scripts/verify-production-artifact-selection.cjs"
+    );
+    for (const dependency of localDependencies) {
+      expect(sparseCheckout).toContain(dependency);
+    }
     expect(source).toContain(
       "actions/runs/${ARTIFACT_RUN_ID}/attempts/${ARTIFACT_RUN_ATTEMPT}"
     );

--- a/__tests__/scripts/production-artifact-verifier.test.ts
+++ b/__tests__/scripts/production-artifact-verifier.test.ts
@@ -193,7 +193,14 @@ describe("isolated production artifact verifier", () => {
       for (const match of sourceCode.matchAll(
         /require\(["']((?:\.{1,2}\/)[^"']+)["']\)/gu
       )) {
-        const dependencyPath = path.resolve(path.dirname(sourcePath), match[1]);
+        const relativeDependency = match[1];
+        if (!relativeDependency) {
+          throw new Error("Verifier dependency match is missing a path.");
+        }
+        const dependencyPath = path.resolve(
+          path.dirname(sourcePath),
+          relativeDependency
+        );
         const relativeToScripts = path.relative(
           scriptsDirectory,
           dependencyPath

--- a/__tests__/scripts/production-artifact-verifier.test.ts
+++ b/__tests__/scripts/production-artifact-verifier.test.ts
@@ -182,23 +182,46 @@ describe("isolated production artifact verifier", () => {
       ({ name }) => name === "Check out immutable verifier helper"
     );
     const sparseCheckout = String(checkout?.with?.["sparse-checkout"] ?? "");
-    const verifierSource = fs.readFileSync(
-      path.join(
-        process.cwd(),
-        "ops",
-        "scripts",
-        "verify-production-artifact-selection.cjs"
-      ),
-      "utf8"
+    const scriptsDirectory = path.join(process.cwd(), "ops", "scripts");
+    const verifierPath = path.join(
+      scriptsDirectory,
+      "verify-production-artifact-selection.cjs"
     );
-    const localDependencies = [
-      ...verifierSource.matchAll(/require\(["']\.\/([^"']+)["']\)/gu),
-    ].map((match) => `ops/scripts/${match[1]}`);
-    expect(localDependencies).toEqual(["ops/scripts/cli-args.cjs"]);
+    const localDependencies = new Set<string>();
+    const visitLocalDependencies = (sourcePath: string): void => {
+      const sourceCode = fs.readFileSync(sourcePath, "utf8");
+      for (const match of sourceCode.matchAll(
+        /require\(["']\.\/([^"']+)["']\)/gu
+      )) {
+        const dependencyPath = path.resolve(path.dirname(sourcePath), match[1]);
+        const relativeToScripts = path.relative(
+          scriptsDirectory,
+          dependencyPath
+        );
+        if (
+          relativeToScripts.startsWith("..") ||
+          path.isAbsolute(relativeToScripts)
+        ) {
+          throw new Error(
+            `Verifier dependency escapes ops/scripts: ${dependencyPath}`
+          );
+        }
+        const repositoryPath = path
+          .relative(process.cwd(), dependencyPath)
+          .split(path.sep)
+          .join("/");
+        if (!localDependencies.has(repositoryPath)) {
+          localDependencies.add(repositoryPath);
+          visitLocalDependencies(dependencyPath);
+        }
+      }
+    };
+    visitLocalDependencies(verifierPath);
+    expect([...localDependencies]).toContain("ops/scripts/cli-args.cjs");
     expect(sparseCheckout).toContain(
       "ops/scripts/verify-production-artifact-selection.cjs"
     );
-    for (const dependency of localDependencies) {
+    for (const dependency of [...localDependencies].sort()) {
       expect(sparseCheckout).toContain(dependency);
     }
     expect(source).toContain(


### PR DESCRIPTION
## Outcome

Restores the isolated production artifact verifier without weakening its trust boundary.

The first one-click production attempt built the exact operation-bound artifact successfully, then failed closed before artifact download because the immutable sparse checkout omitted the verifier's local `cli-args.cjs` dependency.

## Change

- include `ops/scripts/cli-args.cjs` in the immutable verifier checkout
- derive local `require(./...)` dependencies from the verifier source in the workflow contract test and require the sparse checkout to include the complete closure

## Evidence

- focused verifier/controller suites: 2 suites, 10 tests passed
- `lint:changed`: passed
- `typecheck:changed`: passed (1,410 files)
- Prettier and `codex-diff-check`: passed
- isolated sparse-checkout smoke: `validate-inputs` passed with only the two declared files
- failed production verifier: run 31176562035
- failed parent controller: run 31175798509
- no production deployment occurred; live frontend remains on the prior healthy release

## Release plan

After exact-head review and merge, rerun the governed one-click production controller for the staging-qualified frontend SHA and require live version proof plus automatic Production E2E and immutable evidence before closeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production artifact verification by ensuring all required verification scripts and local dependencies are available during checkout.
  * Added safeguards to detect missing or out-of-scope verification dependencies.

* **Tests**
  * Expanded workflow validation to cover optional step details, dependency discovery, and sparse checkout completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->