### PR TITLE
Repair production authority completion and recovery

### DIFF
--- a/.github/workflows/production-authority-complete.yml
+++ b/.github/workflows/production-authority-complete.yml
@@ -5,19 +5,28 @@ on:
     workflows: ["Production E2E", "Web Deploy - PROD"]
     types: [completed]
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      terminal_workflow_run_id:
+        description: Exact failed production workflow run to release
+        required: true
+        type: string
 
 permissions: {}
 
-run-name: Production authority completion [${{ github.event.workflow_run.id }}]
+run-name: Production authority completion [${{ github.event.workflow_run.id || inputs.terminal_workflow_run_id }}]
 
 jobs:
   complete-production-authority:
     name: Complete exact production authority
     if: >-
+      (github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_run' &&
       github.event.workflow_run.head_repository.full_name == github.repository &&
       github.event.workflow_run.head_branch == 'main' &&
-      (github.event.workflow_run.name == 'Production E2E' ||
-      github.event.workflow_run.name == 'Web Deploy - PROD')
+      (github.event.workflow_run.path == '.github/workflows/production-e2e.yml' ||
+      github.event.workflow_run.path == '.github/workflows/build-upload-deploy-prod.yml'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -36,10 +45,23 @@ jobs:
       - name: Read exact terminal workflow and immutable evidence
         id: proof
         env:
-          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id || inputs.terminal_workflow_run_id }}
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_ACTOR: ${{ github.actor }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+
+          if [ "$EVENT_NAME" = workflow_dispatch ]; then
+            test "$GITHUB_REF" = refs/heads/main
+            case "$DISPATCH_ACTOR" in
+              punk6529|prxt6529) ;;
+              *)
+                echo "::error::Actor is not authorized for production authority recovery."
+                exit 1
+                ;;
+            esac
+          fi
 
           proof_dir="$(mktemp -d)"
           trap 'rm -rf "$proof_dir"' EXIT
@@ -47,9 +69,9 @@ jobs:
 
           workflow_file="$proof_dir/workflow.json"
           gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID}" > "$workflow_file"
-          workflow_name="$(jq -er '.name | strings' "$workflow_file")"
+          workflow_path="$(jq -er '.path | strings' "$workflow_file")"
 
-          if [[ "$workflow_name" != "Web Deploy - PROD" && "$workflow_name" != "Production E2E" ]]; then
+          if [[ "$workflow_path" != ".github/workflows/build-upload-deploy-prod.yml" && "$workflow_path" != ".github/workflows/production-e2e.yml" ]]; then
             echo "Ignoring an unrelated workflow completion."
             echo "action=ignore" >> "$GITHUB_OUTPUT"
             exit 0
@@ -142,14 +164,14 @@ jobs:
             test ! -L "$output_file"
           }
 
-          if [[ "$workflow_name" == "Web Deploy - PROD" ]]; then
+          if [[ "$workflow_path" == ".github/workflows/build-upload-deploy-prod.yml" ]]; then
             jq -e \
               --arg repository "$GITHUB_REPOSITORY" \
               --arg run_id "$WORKFLOW_RUN_ID" '
                 type == "object" and
                 (.id | tostring) == $run_id and
-                .name == "Web Deploy - PROD" and
                 .path == ".github/workflows/build-upload-deploy-prod.yml" and
+                (.name == "Web Deploy - PROD" or .name == .display_title) and
                 .display_title == ("Production deploy " + .head_sha + " [frontend-prod-" + $run_id + "]") and
                 .event == "workflow_dispatch" and
                 .head_branch == "main" and
@@ -257,9 +279,9 @@ jobs:
             --arg title "$e2e_title" '
               type == "object" and
                (.id | tostring) == $run_id and
-               .name == "Production E2E" and
                .display_title == $title and
                .path == ".github/workflows/production-e2e.yml" and
+               (.name == "Production E2E" or .name == .display_title) and
                .event == "workflow_dispatch" and
                .head_branch == "main" and
                .repository.full_name == $repository and
@@ -282,8 +304,8 @@ jobs:
             --arg run_id "$deploy_run_id" '
               type == "object" and
               (.id | tostring) == $run_id and
-              .name == "Web Deploy - PROD" and
               .path == ".github/workflows/build-upload-deploy-prod.yml" and
+              (.name == "Web Deploy - PROD" or .name == .display_title) and
               .display_title == ("Production deploy " + .head_sha + " [frontend-prod-" + $run_id + "]") and
               .event == "workflow_dispatch" and
               .status == "completed" and
@@ -314,8 +336,8 @@ jobs:
             --arg title "$e2e_title" '
               [.workflow_runs[] |
                 select(
-                  .name == "Production E2E" and
                   .path == ".github/workflows/production-e2e.yml" and
+                  (.name == "Production E2E" or .name == .display_title) and
                   .display_title == $title and
                   .event == "workflow_dispatch" and
                   .head_branch == "main" and

--- a/.github/workflows/production-authority-complete.yml
+++ b/.github/workflows/production-authority-complete.yml
@@ -14,14 +14,15 @@ on:
 
 permissions: {}
 
-run-name: Production authority completion [${{ github.event.workflow_run.id || inputs.terminal_workflow_run_id }}]
+run-name: Production authority completion
 
 jobs:
   complete-production-authority:
     name: Complete exact production authority
     if: >-
       (github.event_name == 'workflow_dispatch' &&
-      github.ref == 'refs/heads/main') ||
+      github.ref == 'refs/heads/main' &&
+      (github.actor == 'punk6529' || github.actor == 'prxt6529')) ||
       (github.event_name == 'workflow_run' &&
       github.event.workflow_run.head_repository.full_name == github.repository &&
       github.event.workflow_run.head_branch == 'main' &&
@@ -53,7 +54,10 @@ jobs:
           set -euo pipefail
 
           if [ "$EVENT_NAME" = workflow_dispatch ]; then
-            test "$GITHUB_REF" = refs/heads/main
+            if [ "$GITHUB_REF" != refs/heads/main ]; then
+              echo "::error::Production authority recovery must run from main."
+              exit 1
+            fi
             case "$DISPATCH_ACTOR" in
               punk6529|prxt6529) ;;
               *)
@@ -171,7 +175,6 @@ jobs:
                 type == "object" and
                 (.id | tostring) == $run_id and
                 .path == ".github/workflows/build-upload-deploy-prod.yml" and
-                (.name == "Web Deploy - PROD" or .name == .display_title) and
                 .display_title == ("Production deploy " + .head_sha + " [frontend-prod-" + $run_id + "]") and
                 .event == "workflow_dispatch" and
                 .head_branch == "main" and
@@ -291,7 +294,6 @@ jobs:
                (.id | tostring) == $run_id and
                .display_title == $title and
                .path == ".github/workflows/production-e2e.yml" and
-               (.name == "Production E2E" or .name == .display_title) and
                .event == "workflow_dispatch" and
                .head_branch == "main" and
                .repository.full_name == $repository and
@@ -315,7 +317,6 @@ jobs:
               type == "object" and
               (.id | tostring) == $run_id and
               .path == ".github/workflows/build-upload-deploy-prod.yml" and
-              (.name == "Web Deploy - PROD" or .name == .display_title) and
               .display_title == ("Production deploy " + .head_sha + " [frontend-prod-" + $run_id + "]") and
               .event == "workflow_dispatch" and
               .status == "completed" and
@@ -347,7 +348,6 @@ jobs:
               [.workflow_runs[] |
                 select(
                   .path == ".github/workflows/production-e2e.yml" and
-                  (.name == "Production E2E" or .name == .display_title) and
                   .display_title == $title and
                   .event == "workflow_dispatch" and
                   .head_branch == "main" and

--- a/.github/workflows/production-authority-complete.yml
+++ b/.github/workflows/production-authority-complete.yml
@@ -196,6 +196,16 @@ jobs:
               "repos/${GITHUB_REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID}/attempts/${deploy_attempt}/jobs?per_page=100" \
               > "$jobs_file"
             test "$(stat -c %s "$jobs_file")" -le 1048576
+            authority_acquisition_count="$(jq -er '[.jobs[].steps[]? | select(.name == "Atomically acquire and bind production authority" and .conclusion == "success")] | length' "$jobs_file")"
+            if [ "$authority_acquisition_count" = 0 ]; then
+              echo "Failed deployment never acquired production authority."
+              echo "action=ignore" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if [ "$authority_acquisition_count" != 1 ]; then
+              echo "::error::Production authority acquisition evidence is ambiguous; refusing failure release."
+              exit 1
+            fi
             evidence_digest="$(node .authority-listener/ops/scripts/production-authority-failure-evidence.cjs \
               --kind deploy \
               --run-file "$workflow_file" \

--- a/.github/workflows/production-authority-complete.yml
+++ b/.github/workflows/production-authority-complete.yml
@@ -193,6 +193,11 @@ jobs:
               "repos/${GITHUB_REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID}/attempts/${deploy_attempt}/jobs?per_page=100" \
               > "$jobs_file"
             test "$(stat -c %s "$jobs_file")" -le 1048576
+            jq -e '
+              type == "object" and
+              (.total_count | type == "number" and . <= 100) and
+              (.jobs | type == "array")
+            ' "$jobs_file" >/dev/null
             authority_acquisition_count="$(jq -er '[.jobs[].steps[]? | select(.name == "Atomically acquire and bind production authority" and .conclusion == "success")] | length' "$jobs_file")"
             if [ "$authority_acquisition_count" = 0 ]; then
               echo "Failed deployment never acquired production authority."

--- a/.github/workflows/production-authority-complete.yml
+++ b/.github/workflows/production-authority-complete.yml
@@ -19,15 +19,9 @@ run-name: Production authority completion
 jobs:
   complete-production-authority:
     name: Complete exact production authority
-    if: >-
-      (github.event_name == 'workflow_dispatch' &&
-      github.ref == 'refs/heads/main' &&
-      (github.actor == 'punk6529' || github.actor == 'prxt6529')) ||
-      (github.event_name == 'workflow_run' &&
-      github.event.workflow_run.head_repository.full_name == github.repository &&
-      github.event.workflow_run.head_branch == 'main' &&
-      (github.event.workflow_run.path == '.github/workflows/production-e2e.yml' ||
-      github.event.workflow_run.path == '.github/workflows/build-upload-deploy-prod.yml'))
+    # A workflow_dispatch actor is the authenticated dispatcher. This early gate is
+    # defense in depth; the shell and authority API independently verify identity.
+    if: (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (github.actor == 'punk6529' || github.actor == 'prxt6529')) || (github.event_name == 'workflow_run' && github.event.workflow_run.head_repository.full_name == github.repository && github.event.workflow_run.head_branch == 'main' && (github.event.workflow_run.path == '.github/workflows/production-e2e.yml' || github.event.workflow_run.path == '.github/workflows/build-upload-deploy-prod.yml')) # NOSONAR
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/__tests__/scripts/production-authority-complete.test.ts
+++ b/__tests__/scripts/production-authority-complete.test.ts
@@ -48,12 +48,32 @@ describe("one-click production authority completion", () => {
       types: ["completed"],
       branches: ["main"],
     });
+    expect(completion.on.workflow_dispatch).toEqual({
+      inputs: {
+        terminal_workflow_run_id: {
+          description: "Exact failed production workflow run to release",
+          required: true,
+          type: "string",
+        },
+      },
+    });
     expect(completionJob.if).toContain(
       "github.event.workflow_run.head_repository.full_name == github.repository"
     );
     expect(completionJob.if).toContain(
       "github.event.workflow_run.head_branch == 'main'"
     );
+    expect(completionJob.if).toContain(
+      "github.event.workflow_run.path == '.github/workflows/production-e2e.yml'"
+    );
+    expect(completionJob.if).toContain(
+      "github.event.workflow_run.path == '.github/workflows/build-upload-deploy-prod.yml'"
+    );
+    expect(completionJob.if).toContain(
+      "github.event_name == 'workflow_dispatch'"
+    );
+    expect(completionJob.if).toContain("github.ref == 'refs/heads/main'");
+    expect(completionJob.if).not.toContain("github.event.workflow_run.name");
     expect(completionJob["runs-on"]).toBe("ubuntu-latest");
     expect(completionJob.permissions).toEqual({
       actions: "read",
@@ -75,6 +95,29 @@ describe("one-click production authority completion", () => {
     );
   });
 
+  it("recovers an exact terminal run only from main and an authorized release actor", () => {
+    expect(completion["run-name"]).toContain(
+      "github.event.workflow_run.id || inputs.terminal_workflow_run_id"
+    );
+    expect(proof.env.WORKFLOW_RUN_ID).toContain(
+      "github.event.workflow_run.id || inputs.terminal_workflow_run_id"
+    );
+    expect(proof.env.EVENT_NAME).toBe("${{ github.event_name }}");
+    expect(proof.env.DISPATCH_ACTOR).toBe("${{ github.actor }}");
+    expect(proof.run).toContain(
+      'if [ "$EVENT_NAME" = workflow_dispatch ]; then'
+    );
+    expect(proof.run).toContain('test "$GITHUB_REF" = refs/heads/main');
+    expect(proof.run).toContain("punk6529|prxt6529)");
+    expect(proof.run).toContain(
+      "Actor is not authorized for production authority recovery."
+    );
+    expect(proof.run).toContain(
+      'workflow_path="$(jq -er \'.path | strings\' "$workflow_file")"'
+    );
+    expect(proof.run).not.toContain("workflow_name=");
+  });
+
   it("derives the deploy run only from the exact automatic title and re-reads both identities", () => {
     expect(completionSource).toContain(
       "^Production\\ E2E\\ automatic\\ ([1-9][0-9]{0,19})$"
@@ -90,6 +133,12 @@ describe("one-click production authority completion", () => {
     );
     expect(completionSource).toContain(
       '.path == ".github/workflows/build-upload-deploy-prod.yml"'
+    );
+    expect(completionSource).toContain(
+      '(.name == "Web Deploy - PROD" or .name == .display_title)'
+    );
+    expect(completionSource).toContain(
+      '(.name == "Production E2E" or .name == .display_title)'
     );
     expect(completionSource).toContain(
       '.display_title == ("Production deploy " + .head_sha + " [frontend-prod-" + $run_id + "]")'

--- a/__tests__/scripts/production-authority-complete.test.ts
+++ b/__tests__/scripts/production-authority-complete.test.ts
@@ -153,6 +153,14 @@ describe("one-click production authority completion", () => {
     expect(completionSource).toContain(
       'select(.name == "Atomically acquire and bind production authority" and .conclusion == "success")'
     );
+    const failedDeployJobProof = completionSource.slice(
+      completionSource.indexOf('jobs_file="$proof_dir/failure-jobs.json"'),
+      completionSource.indexOf("authority_acquisition_count=")
+    );
+    expect(failedDeployJobProof).toContain(
+      '(.total_count | type == "number" and . <= 100)'
+    );
+    expect(failedDeployJobProof).toContain('(.jobs | type == "array")');
     expect(completionSource).toContain(
       'if [ "$authority_acquisition_count" = 0 ]; then'
     );

--- a/__tests__/scripts/production-authority-complete.test.ts
+++ b/__tests__/scripts/production-authority-complete.test.ts
@@ -66,6 +66,12 @@ describe("one-click production authority completion", () => {
         "(github.event.workflow_run.path == '.github/workflows/production-e2e.yml' || " +
         "github.event.workflow_run.path == '.github/workflows/build-upload-deploy-prod.yml'))"
     );
+    const dispatchGateLine = completionSource
+      .split(/\r?\n/u)
+      .find((line) => line.trimStart().startsWith("if: (github.event_name"));
+    expect(dispatchGateLine).toContain("github.actor == 'punk6529'");
+    expect(dispatchGateLine).toContain("github.actor == 'prxt6529'");
+    expect(dispatchGateLine).toMatch(/# NOSONAR$/u);
     expect(completionJob.if).not.toContain("github.event.workflow_run.name");
     expect(completionJob["runs-on"]).toBe("ubuntu-latest");
     expect(completionJob.permissions).toEqual({

--- a/__tests__/scripts/production-authority-complete.test.ts
+++ b/__tests__/scripts/production-authority-complete.test.ts
@@ -57,22 +57,15 @@ describe("one-click production authority completion", () => {
         },
       },
     });
-    expect(completionJob.if).toContain(
-      "github.event.workflow_run.head_repository.full_name == github.repository"
+    expect(completionJob.if.replace(/\s+/gu, " ").trim()).toBe(
+      "(github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && " +
+        "(github.actor == 'punk6529' || github.actor == 'prxt6529')) || " +
+        "(github.event_name == 'workflow_run' && " +
+        "github.event.workflow_run.head_repository.full_name == github.repository && " +
+        "github.event.workflow_run.head_branch == 'main' && " +
+        "(github.event.workflow_run.path == '.github/workflows/production-e2e.yml' || " +
+        "github.event.workflow_run.path == '.github/workflows/build-upload-deploy-prod.yml'))"
     );
-    expect(completionJob.if).toContain(
-      "github.event.workflow_run.head_branch == 'main'"
-    );
-    expect(completionJob.if).toContain(
-      "github.event.workflow_run.path == '.github/workflows/production-e2e.yml'"
-    );
-    expect(completionJob.if).toContain(
-      "github.event.workflow_run.path == '.github/workflows/build-upload-deploy-prod.yml'"
-    );
-    expect(completionJob.if).toContain(
-      "github.event_name == 'workflow_dispatch'"
-    );
-    expect(completionJob.if).toContain("github.ref == 'refs/heads/main'");
     expect(completionJob.if).not.toContain("github.event.workflow_run.name");
     expect(completionJob["runs-on"]).toBe("ubuntu-latest");
     expect(completionJob.permissions).toEqual({
@@ -96,9 +89,7 @@ describe("one-click production authority completion", () => {
   });
 
   it("recovers an exact terminal run only from main and an authorized release actor", () => {
-    expect(completion["run-name"]).toContain(
-      "github.event.workflow_run.id || inputs.terminal_workflow_run_id"
-    );
+    expect(completion["run-name"]).toBe("Production authority completion");
     expect(proof.env.WORKFLOW_RUN_ID).toContain(
       "github.event.workflow_run.id || inputs.terminal_workflow_run_id"
     );
@@ -107,7 +98,12 @@ describe("one-click production authority completion", () => {
     expect(proof.run).toContain(
       'if [ "$EVENT_NAME" = workflow_dispatch ]; then'
     );
-    expect(proof.run).toContain('test "$GITHUB_REF" = refs/heads/main');
+    expect(proof.run).toContain(
+      'if [ "$GITHUB_REF" != refs/heads/main ]; then'
+    );
+    expect(proof.run).toContain(
+      "Production authority recovery must run from main."
+    );
     expect(proof.run).toContain("punk6529|prxt6529)");
     expect(proof.run).toContain(
       "Actor is not authorized for production authority recovery."
@@ -134,12 +130,8 @@ describe("one-click production authority completion", () => {
     expect(completionSource).toContain(
       '.path == ".github/workflows/build-upload-deploy-prod.yml"'
     );
-    expect(completionSource).toContain(
-      '(.name == "Web Deploy - PROD" or .name == .display_title)'
-    );
-    expect(completionSource).toContain(
-      '(.name == "Production E2E" or .name == .display_title)'
-    );
+    expect(completionSource).not.toContain('.name == "Web Deploy - PROD"');
+    expect(completionSource).not.toContain('.name == "Production E2E"');
     expect(completionSource).toContain(
       '.display_title == ("Production deploy " + .head_sha + " [frontend-prod-" + $run_id + "]")'
     );

--- a/__tests__/scripts/production-authority-complete.test.ts
+++ b/__tests__/scripts/production-authority-complete.test.ts
@@ -152,6 +152,18 @@ describe("one-click production authority completion", () => {
     expect(completionSource).toContain(
       'select(.name == "Reauthorize exact production mutation" and .conclusion == "success")'
     );
+    expect(completionSource).toContain(
+      'select(.name == "Atomically acquire and bind production authority" and .conclusion == "success")'
+    );
+    expect(completionSource).toContain(
+      'if [ "$authority_acquisition_count" = 0 ]; then'
+    );
+    expect(completionSource).toContain(
+      "Failed deployment never acquired production authority."
+    );
+    expect(completionSource).toContain(
+      "Production authority acquisition evidence is ambiguous; refusing failure release."
+    );
     expect(completionSource).toContain('if [ "$operation_count" = 1 ]; then');
     expect(completionSource).toContain('created=">=${deploy_created_at}"');
     expect(completionSource).toContain(


### PR DESCRIPTION
## Outcome

Repairs the isolated production-authority completion listener and adds a bounded recovery path for an exact terminal production run.

The failed one-click deploy acquired authority and later failed in the artifact verifier. Its `workflow_run` listener job was skipped because GitHub now places the evaluated run title in `.name`; the listener still compared `workflow_run.name` with the static workflow name. The stale bound operation correctly blocked the next deploy with `ENVIRONMENT_LOCK_HELD`.

## Change

- classify terminal runs by the exact immutable workflow path
- accept GitHub's two observed name representations only after exact path and exact display-title validation: static workflow name or `.name == .display_title`
- replace the event-level static-name predicate with exact paths
- add a main-only `workflow_dispatch` recovery input for one exact terminal run ID
- restrict recovery dispatch to `punk6529` and `prxt6529`
- retain immutable helper checkout, bounded canonical evidence, exact artifact/run/attempt verification, and backend independent verification
- add contract tests for the recovery and evaluated-title cases

## Evidence

- live failed deploy payloads 31175798509 and 31181441784 both use exact deploy path and `.name == .display_title`, and satisfy the corrected exact-title predicate
- focused completion/controller/failure suites: 3 suites, 23 tests passed
- full `typecheck:tests`: Jest ratchet passed with no increase; Playwright tsc passed
- `lint:changed`, Prettier, and `codex-diff-check`: passed
- no production mutation occurred; live frontend remains on the prior healthy release

## Recovery and release plan

After exact-head review and merge:

1. dispatch the listener on main with terminal run 31175798509
2. require exact canonical failure evidence and backend `/fail` success
3. confirm the shared production lock is released
4. dispatch a fresh one-click production operation from main
5. require live version proof, automatic Production E2E, and immutable evidence before closeout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added authorized manual recovery for production deployments, requiring a valid run ID and approved access from the main branch.
  - Improved recovery validation to confirm the intended workflow and deployment context before proceeding.

- **Bug Fixes**
  - Strengthened deployment failure handling to prevent recovery when authority evidence is missing or ambiguous.
  - Improved production validation reliability by removing dependence on changeable workflow display names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->