### PR TITLE
CI: bind failure evidence to evaluated run names

### DIFF
--- a/__tests__/scripts/production-authority-failure-evidence.test.ts
+++ b/__tests__/scripts/production-authority-failure-evidence.test.ts
@@ -16,17 +16,18 @@ function run(
   actorLogin = "github-actions[bot]",
   triggeringActorLogin = actorLogin
 ) {
+  const evaluatedTitle =
+    kind === "deploy"
+      ? `Production deploy ${headSha} [frontend-prod-123456789]`
+      : "Production E2E automatic 123456789";
   return {
     id: kind === "deploy" ? 123456789 : 987654321,
-    name: kind === "deploy" ? "Web Deploy - PROD" : "Production E2E",
+    name: evaluatedTitle,
     path:
       kind === "deploy"
         ? ".github/workflows/build-upload-deploy-prod.yml"
         : ".github/workflows/production-e2e.yml",
-    display_title:
-      kind === "deploy"
-        ? `Production deploy ${headSha} [frontend-prod-123456789]`
-        : "Production E2E automatic 123456789",
+    display_title: evaluatedTitle,
     event: "workflow_dispatch",
     head_branch: "main",
     head_sha: headSha,
@@ -139,6 +140,32 @@ describe("production terminal failure evidence", () => {
       })
     ).toThrow("DEPLOY_TITLE");
   });
+
+  it.each([
+    ["deploy", "Web Deploy - PROD", "DEPLOY_NAME"],
+    ["e2e", "Production E2E", "E2E_NAME"],
+  ] as const)(
+    "rejects the stale static %s workflow name",
+    (kind, staticName, expectedError) => {
+      const candidate = run(
+        kind,
+        "failure",
+        kind === "e2e" ? FOREIGN_SHA : TARGET_SHA
+      );
+      candidate.name = staticName;
+      expect(() =>
+        evidence.buildFailureEvidence({
+          kind,
+          run: candidate,
+          jobs,
+          runId: kind === "deploy" ? "123456789" : "987654321",
+          attempt: 2,
+          deployRunId: "123456789",
+          targetSha: TARGET_SHA,
+        })
+      ).toThrow(expectedError);
+    }
+  );
 
   it.each(["neutral", "skipped"])(
     "rejects unsupported terminal conclusion %s",

--- a/ops/scripts/production-authority-failure-evidence.cjs
+++ b/ops/scripts/production-authority-failure-evidence.cjs
@@ -97,21 +97,18 @@ function validateRun({
     fail("RUN_TARGET_SHA_MISMATCH");
 
   if (kind === "deploy") {
-    exactString(run.name, "Web Deploy - PROD", "DEPLOY_NAME");
+    const expectedTitle = `Production deploy ${expectedTargetSha} [frontend-prod-${expectedRunId}]`;
+    exactString(run.name, expectedTitle, "DEPLOY_NAME");
     exactString(
       run.path,
       ".github/workflows/build-upload-deploy-prod.yml",
       "DEPLOY_PATH"
     );
-    exactString(
-      run.display_title,
-      `Production deploy ${expectedTargetSha} [frontend-prod-${expectedRunId}]`,
-      "DEPLOY_TITLE"
-    );
+    exactString(run.display_title, expectedTitle, "DEPLOY_TITLE");
   } else if (kind === "e2e") {
-    exactString(run.name, "Production E2E", "E2E_NAME");
-    exactString(run.path, ".github/workflows/production-e2e.yml", "E2E_PATH");
     const expectedTitle = `Production E2E automatic ${expectedDeployRunId}`;
+    exactString(run.name, expectedTitle, "E2E_NAME");
+    exactString(run.path, ".github/workflows/production-e2e.yml", "E2E_PATH");
     exactString(run.display_title, expectedTitle, "E2E_TITLE");
     actionsActor(run.actor, "E2E_ACTOR");
     actionsActor(run.triggering_actor, "E2E_TRIGGERING_ACTOR");


### PR DESCRIPTION
## Outcome

Correct the immutable terminal-failure evidence helper to the live GitHub Actions run-name representation. GitHub currently returns the evaluated operation-bound title in both `name` and `display_title`.

## Change

- deploy evidence now requires both fields to equal `Production deploy <target SHA> [frontend-prod-<run ID>]`
- automatic Production E2E failure evidence now requires both fields to equal `Production E2E automatic <deploy run ID>`
- fixtures match the observed API shape
- regressions reject the stale static workflow names for both paths

No production mutation, runtime application, backend contract, actor gate, path binding, repository binding, run/attempt binding, target binding, or failure conclusion rule changes.

## Evidence

- exact live run `31175798509` reproduces the old `failure-evidence:DEPLOY_NAME` failure
- the corrected helper accepts its exact API run/jobs payload and emits deterministic digest `7c44ad1067c35666c919ca46c428ce31ab2ff3499aa97e5529ddb32b5d441ccd`
- focused completion/controller/failure suites: 25/25
- full Jest/Playwright test typecheck: pass
- changed lint, Prettier, and `codex-diff-check`: pass
- production remains unchanged on `ee156caa5b2a9ed2efaee34659f098e916badcb9`

After merge, rerun only the governed recovery for exact failed controller `31175798509`, then dispatch a fresh controller if and only if the lock release succeeds.