### PR TITLE
CI: verify exact production artifact roots

### DIFF
--- a/.github/workflows/build-upload-deploy-prod.yml
+++ b/.github/workflows/build-upload-deploy-prod.yml
@@ -278,7 +278,7 @@ jobs:
           unzip -Z1 .one-click-production/selection.zip \
             > .one-click-production/selection-members.txt
           node ops/scripts/verify-production-artifact-selection.cjs \
-            validate-archive-members \
+            validate-selection-archive-members \
             --archive-members .one-click-production/selection-members.txt >/dev/null
           unzip -q .one-click-production/selection.zip \
             -d .one-click-production/selection

--- a/.github/workflows/production-e2e-dispatch.yml
+++ b/.github/workflows/production-e2e-dispatch.yml
@@ -64,7 +64,7 @@ jobs:
               --arg title "Production E2E automatic ${DEPLOY_WORKFLOW_RUN_ID}" '
                 [.workflow_runs[] |
                   select(
-                    .name == "Production E2E" and
+                    .name == $title and
                     .path == ".github/workflows/production-e2e.yml" and
                     .display_title == $title and
                     .event == "workflow_dispatch" and

--- a/.github/workflows/production-e2e.yml
+++ b/.github/workflows/production-e2e.yml
@@ -85,14 +85,17 @@ jobs:
             --arg repository "$GITHUB_REPOSITORY" \
             --argjson run_id "$AUTOMATIC_DEPLOY_RUN_ID" '
               .id == $run_id and
-              .name == "Web Deploy - PROD" and
+              .name == ("Production deploy " + .head_sha + " [frontend-prod-" + ($run_id | tostring) + "]") and
+              .display_title == .name and
               .path == ".github/workflows/build-upload-deploy-prod.yml" and
               .event == "workflow_dispatch" and
               .status == "completed" and
               .conclusion == "success" and
               .head_branch == "main" and
               .repository.full_name == $repository and
-              (.head_sha | test("^[a-f0-9]{40}$"))
+              .head_repository.full_name == $repository and
+              (.head_sha | test("^[a-f0-9]{40}$")) and
+              (.run_attempt | type == "number" and . >= 1 and . <= 1000000)
             ' "$response_file" >/dev/null
           echo "deployed-sha=$(jq -r .head_sha "$response_file")" >> "$GITHUB_OUTPUT"
           started_at="$(jq -er .run_started_at "$response_file")"
@@ -102,18 +105,23 @@ jobs:
             > "$runs_file"
           previous_sha="$(jq -r \
             --argjson current_run_id "$AUTOMATIC_DEPLOY_RUN_ID" \
+            --arg repository "$GITHUB_REPOSITORY" \
             --arg started_at "$started_at" '
               [.workflow_runs[] |
                 select(
                   .id != $current_run_id and
-                  .name == "Web Deploy - PROD" and
+                  .name == ("Production deploy " + .head_sha + " [frontend-prod-" + (.id | tostring) + "]") and
+                  .display_title == .name and
                   .path == ".github/workflows/build-upload-deploy-prod.yml" and
                   .event == "workflow_dispatch" and
                   .status == "completed" and
                   .conclusion == "success" and
                   .head_branch == "main" and
+                  .repository.full_name == $repository and
+                  .head_repository.full_name == $repository and
                   .run_started_at < $started_at and
-                  (.head_sha | test("^[a-f0-9]{40}$"))
+                  (.head_sha | test("^[a-f0-9]{40}$")) and
+                  (.run_attempt | type == "number" and . >= 1 and . <= 1000000)
                 )] |
               sort_by(.run_started_at) |
               last |
@@ -501,7 +509,8 @@ jobs:
               --arg repository "$GITHUB_REPOSITORY" \
               --argjson run_id "$AUTOMATIC_DEPLOY_RUN_ID" '
                 .id == $run_id and
-                .name == "Web Deploy - PROD" and
+                .name == ("Production deploy " + .head_sha + " [frontend-prod-" + ($run_id | tostring) + "]") and
+                .display_title == .name and
                 .path == ".github/workflows/build-upload-deploy-prod.yml" and
                 .event == "workflow_dispatch" and
                 .status == "completed" and

--- a/__tests__/scripts/one-click-production-workflow.test.ts
+++ b/__tests__/scripts/one-click-production-workflow.test.ts
@@ -116,9 +116,16 @@ describe("one-click production operation", () => {
     expect(downloadSelection?.run).toMatch(
       /rm -rf \.one-click-production\/selection\s+mkdir -p \.one-click-production\/selection/
     );
+    expect(downloadSelection?.run).toContain(
+      "validate-selection-archive-members"
+    );
+    expect(
+      downloadSelection?.run.indexOf("validate-selection-archive-members")
+    ).toBeLessThan(downloadSelection?.run.indexOf("unzip -q") ?? -1);
     expect(downloadArtifact?.run).toMatch(
       /rm -rf production-artifact\s+mkdir -p production-artifact/
     );
+    expect(downloadArtifact?.run).toContain("validate-archive-members");
     expect(downloadArtifact?.run).toContain(
       "zip-container overhead above the 500 MiB package limit"
     );

--- a/__tests__/scripts/production-artifact-verifier.test.ts
+++ b/__tests__/scripts/production-artifact-verifier.test.ts
@@ -16,6 +16,8 @@ const verifier =
       verifierRunAttempt: number
     ) => string;
     validateArchiveMembers: (memberList: string) => unknown;
+    validateExtractedArtifact: (root: string) => unknown;
+    validateSelectionArchiveMembers: (memberList: string) => unknown;
     validateVerifierInputs: (options: Record<string, unknown>) => unknown;
     verifyChecksums: (root: string, requiredFiles: string[]) => unknown;
     verifyArtifact: (
@@ -275,8 +277,18 @@ describe("isolated production artifact verifier", () => {
     const artifactApiDigest = `sha256:${digest(rawArtifactArchive)}`;
     const artifactRoot = path.join(tempRoot, "artifact");
     const packagePath = path.join(artifactRoot, "target", "package.zip");
+    const staticAssetPath = path.join(
+      artifactRoot,
+      "target",
+      "_next",
+      "static",
+      targetSha,
+      "_buildManifest.js"
+    );
     fs.mkdirSync(path.dirname(packagePath), { recursive: true });
     fs.writeFileSync(packagePath, packageBytes);
+    fs.mkdirSync(path.dirname(staticAssetPath), { recursive: true });
+    fs.writeFileSync(staticAssetPath, "self.__BUILD_MANIFEST = {};\n");
     writeJson(path.join(artifactRoot, "artifact-portability.json"), {
       contract: "artifact-portability-v1",
       digests: { package_sha256: digest(packageBytes) },
@@ -309,6 +321,7 @@ describe("isolated production artifact verifier", () => {
     writeChecksums(artifactRoot, [
       "artifact-portability.json",
       "manifest.json",
+      `target/_next/static/${targetSha}/_buildManifest.js`,
       "target/package.zip",
     ]);
     const archivePath = path.join(tempRoot, "artifact.zip");
@@ -528,6 +541,7 @@ describe("isolated production artifact verifier", () => {
     writeChecksums(artifactRoot, [
       "artifact-portability.json",
       "manifest.json",
+      `target/_next/static/${targetSha}/_buildManifest.js`,
       "target/package.zip",
     ]);
     writeJson(targetAncestryPath, ancestryEvidence(targetSha, 2));
@@ -549,12 +563,46 @@ describe("isolated production artifact verifier", () => {
 
   it("rejects unsafe archive members and non-regular extracted entries", () => {
     expect(() =>
+      verifier.validateSelectionArchiveMembers(
+        ["SHA256SUMS", "selection.json"].join("\n")
+      )
+    ).not.toThrow();
+    for (const member of [
+      "target/package.zip",
+      "target/_next/static/chunks/app.js",
+      "selection/",
+      "unexpected.json",
+    ]) {
+      expect(() =>
+        verifier.validateSelectionArchiveMembers(
+          ["SHA256SUMS", "selection.json", member].join("\n")
+        )
+      ).toThrow("outside the closed artifact root");
+    }
+
+    expect(() =>
       verifier.validateArchiveMembers(
         [
           "SHA256SUMS",
           "artifact-portability.json",
           "manifest.json",
           "target/",
+          "target/package.zip",
+        ].join("\n")
+      )
+    ).not.toThrow();
+
+    expect(() =>
+      verifier.validateArchiveMembers(
+        [
+          "SHA256SUMS",
+          "artifact-portability.json",
+          "manifest.json",
+          "target/",
+          "target/_next/",
+          "target/_next/static/",
+          "target/_next/static/chunks/",
+          "target/_next/static/chunks/app.js",
           "target/package.zip",
         ].join("\n")
       )
@@ -568,6 +616,9 @@ describe("isolated production artifact verifier", () => {
       "C:/manifest.json",
       "\\\\server\\share\\manifest.json",
       "outside/manifest.json",
+      "target/_next/server.js",
+      "target/_next/staticx/app.js",
+      "target/_next/static",
       "./manifest.json",
     ]) {
       expect(() =>
@@ -593,7 +644,37 @@ describe("isolated production artifact verifier", () => {
           "manifest.json",
         ].join("\n")
       )
-    ).toThrow("duplicate archive member");
+    ).toThrow("duplicate archive member path");
+
+    expect(() =>
+      verifier.validateArchiveMembers(
+        [
+          "SHA256SUMS",
+          "artifact-portability.json",
+          "manifest.json",
+          "target/_next/static/chunks/",
+          "target/_next/static/chunks",
+          "target/package.zip",
+        ].join("\n")
+      )
+    ).toThrow("duplicate archive member path");
+
+    const outsideRoot = path.join(tempRoot, "outside-entry");
+    const outsideFiles = [
+      "artifact-portability.json",
+      "manifest.json",
+      "target/_next/server.js",
+      "target/package.zip",
+    ];
+    for (const relativePath of outsideFiles) {
+      const absolutePath = path.join(outsideRoot, ...relativePath.split("/"));
+      fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+      fs.writeFileSync(absolutePath, `${relativePath}\n`);
+    }
+    writeChecksums(outsideRoot, outsideFiles);
+    expect(() => verifier.validateExtractedArtifact(outsideRoot)).toThrow(
+      "outside the closed artifact root: target/_next/server.js"
+    );
 
     const specialRoot = path.join(tempRoot, "special-entry");
     fs.mkdirSync(path.join(specialRoot, "target"), { recursive: true });

--- a/__tests__/scripts/production-e2e-dispatch.test.ts
+++ b/__tests__/scripts/production-e2e-dispatch.test.ts
@@ -48,6 +48,9 @@ describe("automatic production E2E dispatch", () => {
         candidate.name === "Dispatch exact successful deploy to production E2E"
     );
     expect(step.run).toContain("list_exact_runs()");
+    expect(step.run).toContain(".name == $title");
+    expect(step.run).toContain(".display_title == $title");
+    expect(step.run).not.toContain('.name == "Production E2E"');
     expect(step.run).toContain('created=">=${DEPLOY_CREATED_AT}"');
     expect(step.run).toContain('if [ "$existing_count" = 1 ]; then');
     expect(step.run).toContain("|| dispatch_status=$?");
@@ -131,7 +134,10 @@ describe("automatic production E2E dispatch", () => {
     expect(
       e2e.on.workflow_dispatch.inputs.automatic_deploy_run_id.required
     ).toBe(false);
-    expect(resolve.run).toContain('.name == "Web Deploy - PROD"');
+    expect(resolve.run).toContain(
+      '.name == ("Production deploy " + .head_sha + " [frontend-prod-" + ($run_id | tostring) + "]")'
+    );
+    expect(resolve.run).toContain(".display_title == .name");
     expect(resolve.run).toContain(
       '.path == ".github/workflows/build-upload-deploy-prod.yml"'
     );
@@ -139,6 +145,11 @@ describe("automatic production E2E dispatch", () => {
     expect(resolve.run).toContain('.head_branch == "main"');
     expect(resolve.run).toContain("previous_deployed_sha=$previous_sha");
     expect(resolve.run).toContain(".run_started_at < $started_at");
+    expect(resolve.run).toContain(
+      '.name == ("Production deploy " + .head_sha + " [frontend-prod-" + (.id | tostring) + "]")'
+    );
+    expect(resolve.run).not.toContain('.name == "Web Deploy - PROD"');
+    expect(e2eSource).not.toContain('.name == "Web Deploy - PROD"');
     expect(e2eSource).toContain(
       "inputs.expected_sha || steps.automatic-deploy.outputs.deployed-sha"
     );

--- a/ops/docs/developer/production-artifact-verifier.md
+++ b/ops/docs/developer/production-artifact-verifier.md
@@ -44,8 +44,9 @@ artifact endpoints by the supplied IDs, then requires all of the following:
   expected root (including traversal, absolute-path, duplicate, and
   backslash checks); the extracted artifact has no symlinks or special files,
   has exact checksummed regular-file membership, contains the required
-  manifest, portability inventory, and `target/package.zip`, and passes every
-  `SHA256SUMS` entry.
+  manifest, portability inventory, and `target/package.zip`, permits deployment
+  assets only below `target/_next/static/`, and passes every `SHA256SUMS`
+  entry. No other `target/**` or root path is admissible.
 
 The manifest must be `production-prebuild-v2` and bind exactly the builder
 contract fields `schema_version`, `artifact_contract`, `repository`,
@@ -105,8 +106,9 @@ selection_digest           # selection.json content digest, <hex>
 
 The orchestrator must pass these exact outputs to the later fresh deploy job.
 That job must fetch selection metadata by the exact selection artifact ID,
-download the raw archive from the exact artifact endpoint/run, compare its
-bytes to the GitHub API digest, verify `SHA256SUMS` and `selection_digest`,
+download the raw archive from the exact artifact endpoint/run, validate its
+pre-extraction member list against the separate two-file selection contract,
+compare its bytes to the GitHub API digest, verify `SHA256SUMS` and `selection_digest`,
 and verify the target, operation, original artifact run/ID/name, original
 artifact API digest, and production workflow identity before any deploy
 authority is used. The helper supports this with:

--- a/ops/scripts/verify-production-artifact-selection.cjs
+++ b/ops/scripts/verify-production-artifact-selection.cjs
@@ -16,6 +16,7 @@ const ARTIFACT_WORKFLOW_PATH =
 const MAX_PACKAGE_BYTES = 500 * 1024 * 1024;
 const SELECTION_ARTIFACT_NAME_PREFIX = "one-click-production-selection-";
 const SELECTION_CONTRACT = "production-artifact-selection-v1";
+const SELECTION_FILE = "selection.json";
 const SELECTION_SCHEMA_VERSION = 1;
 const VERIFIER_WORKFLOW_PATH =
   ".github/workflows/production-artifact-verifier.yml";
@@ -25,7 +26,13 @@ const EXPECTED_ARTIFACT_FILES = Object.freeze([
   "manifest.json",
   "target/package.zip",
 ]);
-const EXPECTED_ARTIFACT_DIRECTORIES = new Set(["target"]);
+const EXPECTED_ARTIFACT_DIRECTORIES = new Set([
+  "target",
+  "target/_next",
+  "target/_next/static",
+]);
+const EXPECTED_STATIC_ASSET_PREFIX = "target/_next/static/";
+const EXPECTED_SELECTION_FILES = Object.freeze(["SHA256SUMS", SELECTION_FILE]);
 
 const SHA_RE = /^[a-f0-9]{40}$/u;
 const DIGEST_RE = /^sha256:[a-f0-9]{64}$/u;
@@ -289,7 +296,7 @@ function canonicalJson(value) {
   return JSON.stringify(canonicalize(value));
 }
 
-function validateArchiveMemberPath(member) {
+function validateArchiveMemberPath(member, contract) {
   assert(
     typeof member === "string" && member.length > 0,
     "archive member path must be non-empty"
@@ -325,12 +332,16 @@ function validateArchiveMemberPath(member) {
 
   if (isDirectory) {
     assert(
-      EXPECTED_ARTIFACT_DIRECTORIES.has(relativePath),
+      contract.directories.has(relativePath) ||
+        (contract.directoryPrefix !== null &&
+          relativePath.startsWith(contract.directoryPrefix)),
       `archive member directory is outside the closed artifact root: ${member}`
     );
   } else {
     assert(
-      EXPECTED_ARTIFACT_FILES.includes(relativePath),
+      contract.files.includes(relativePath) ||
+        (contract.filePrefix !== null &&
+          relativePath.startsWith(contract.filePrefix)),
       `archive member is outside the closed artifact root: ${member}`
     );
   }
@@ -338,7 +349,7 @@ function validateArchiveMemberPath(member) {
   return { isDirectory, relativePath };
 }
 
-function validateArchiveMembers(memberList) {
+function validateClosedArchiveMembers(memberList, contract) {
   assert(
     typeof memberList === "string" && memberList.length > 0,
     "archive member list is required"
@@ -350,20 +361,43 @@ function validateArchiveMembers(memberList) {
   assert(lines.length > 0, "archive member list is empty");
 
   const seen = new Set();
+  const seenPaths = new Set();
   for (const member of lines) {
-    const normalized = validateArchiveMemberPath(member);
+    const normalized = validateArchiveMemberPath(member, contract);
+    assert(
+      !seenPaths.has(normalized.relativePath),
+      `duplicate archive member path: ${member}`
+    );
+    seenPaths.add(normalized.relativePath);
     const key = `${normalized.isDirectory ? "directory" : "file"}:${normalized.relativePath}`;
-    assert(!seen.has(key), `duplicate archive member: ${member}`);
     seen.add(key);
   }
 
-  for (const requiredFile of EXPECTED_ARTIFACT_FILES) {
+  for (const requiredFile of contract.files) {
     assert(
       seen.has(`file:${requiredFile}`),
       `archive is missing required member: ${requiredFile}`
     );
   }
   return [...seen];
+}
+
+function validateArchiveMembers(memberList) {
+  return validateClosedArchiveMembers(memberList, {
+    directories: EXPECTED_ARTIFACT_DIRECTORIES,
+    directoryPrefix: EXPECTED_STATIC_ASSET_PREFIX,
+    filePrefix: EXPECTED_STATIC_ASSET_PREFIX,
+    files: EXPECTED_ARTIFACT_FILES,
+  });
+}
+
+function validateSelectionArchiveMembers(memberList) {
+  return validateClosedArchiveMembers(memberList, {
+    directories: new Set(),
+    directoryPrefix: null,
+    filePrefix: null,
+    files: EXPECTED_SELECTION_FILES,
+  });
 }
 
 function validateVerifierInputs(options) {
@@ -871,12 +905,14 @@ function validateExtractedArtifact(root) {
     "manifest.json",
     "target/package.zip",
   ]);
-  assertExactRegularFiles(
-    checksums.files,
-    EXPECTED_ARTIFACT_FILES.filter(
-      (relativePath) => relativePath !== "SHA256SUMS"
-    ),
-    "artifact"
+  const unexpectedFiles = checksums.files.filter(
+    (relativePath) =>
+      !EXPECTED_ARTIFACT_FILES.includes(relativePath) &&
+      !relativePath.startsWith(EXPECTED_STATIC_ASSET_PREFIX)
+  );
+  assert(
+    unexpectedFiles.length === 0,
+    `artifact regular-file membership is outside the closed artifact root: ${unexpectedFiles[0]}`
   );
   return checksums;
 }
@@ -1097,7 +1133,7 @@ function verifyArtifact(options) {
   writeJson(options.output, selection);
   writeTextFile(
     options.checksumsOutput,
-    `${sha256File(options.output)}  selection.json\n`
+    `${sha256File(options.output)}  ${SELECTION_FILE}\n`
   );
   return selection;
 }
@@ -1294,15 +1330,15 @@ function verifySelection(options) {
   verifyArchiveDigest(options.archive, artifact);
   const rootPath = path.resolve(options.selectionRoot);
   requireRegularDirectory(rootPath, "selection artifact root");
-  const selectionChecksums = verifyChecksums(rootPath, ["selection.json"]);
+  const selectionChecksums = verifyChecksums(rootPath, [SELECTION_FILE]);
   assertExactRegularFiles(
     selectionChecksums.files,
-    ["selection.json"],
+    [SELECTION_FILE],
     "selection artifact"
   );
 
   const selection = readJson(
-    safeArtifactPath(rootPath, "selection.json"),
+    safeArtifactPath(rootPath, SELECTION_FILE),
     "production artifact selection"
   );
   const selectionRunMetadata = readJson(
@@ -1411,6 +1447,7 @@ function commonVerifierOptions(args) {
 function usage() {
   return `Usage:
   node ops/scripts/verify-production-artifact-selection.cjs validate-archive-members --archive-members <file>
+  node ops/scripts/verify-production-artifact-selection.cjs validate-selection-archive-members --archive-members <file>
   node ops/scripts/verify-production-artifact-selection.cjs validate-extracted-artifact --artifact-root <dir>
   node ops/scripts/verify-production-artifact-selection.cjs validate-inputs --target-sha <sha> --operation-id <id> --artifact-run-id <id> --artifact-run-attempt <n> --artifact-id <id> --artifact-api-digest sha256:<digest> --artifact-name <name> --repository <owner/name>
   node ops/scripts/verify-production-artifact-selection.cjs verify-metadata --target-sha <sha> --operation-id <id> --artifact-run-id <id> --artifact-run-attempt <n> --artifact-id <id> --artifact-api-digest sha256:<digest> --artifact-name <name> --repository <owner/name> --run-metadata <file> --artifact-metadata <file>
@@ -1434,6 +1471,20 @@ function main(argv = process.argv.slice(2)) {
             readTextFile(
               requiredArg(args, "archive-members"),
               "archive member list"
+            )
+          )
+        )}\n`
+      );
+      return;
+    }
+
+    if (command === "validate-selection-archive-members") {
+      process.stdout.write(
+        `${JSON.stringify(
+          validateSelectionArchiveMembers(
+            readTextFile(
+              requiredArg(args, "archive-members"),
+              "selection archive member list"
             )
           )
         )}\n`
@@ -1563,6 +1614,7 @@ module.exports = {
   main,
   validateArchiveMembers,
   validateExtractedArtifact,
+  validateSelectionArchiveMembers,
   validateVerifierInputs,
   verifyArtifact,
   verifyChecksums,


### PR DESCRIPTION
## Outcome

Corrects the fail-closed archive-contract mismatch exposed by production verifier run 31188958948 and closes the next downstream selection-archive mismatch before another production attempt.

## Changes

- admit only required metadata, `target/package.zip`, and checksummed files/directories below `target/_next/static/` in production artifacts
- keep every other root and `target/**` path forbidden before extraction and after extraction
- reject file/directory path collisions as duplicate archive members
- add a separate exact two-file (`SHA256SUMS`, `selection.json`) pre-extraction contract for selection artifacts
- bind the production controller to that selection-specific command
- document both closed archive roots

## Evidence

- failed controller 31188152187 released authority through successful listener 31189033102; no deploy job ran and production did not mutate
- downloaded exact builder artifact 8997939019: 119,484,863 bytes, GitHub SHA-256 `2715fd2b95aadee7bb46fa348b29c2d759438b5a316db8f7d3b57ae6b39bf186`
- all 673 real archive members pass the corrected pre-extraction contract
- exact artifact replay passes through manifest, ancestry, 672 checksums, package and selection generation; selection digest `8328aac43c0fc7f43468ad5b03fae5c77fc37d67a8c63aedaa5b6a0cc4f25c19`
- 8 focused suites / 130 tests pass
- changed lint, changed typecheck, full Jest/Playwright test typecheck, Prettier and codex-diff-check pass

## Safety

The fix does not weaken traversal, absolute-path, backslash, duplicate, symlink, special-file, checksum, digest, ancestry, operation, run, attempt or artifact identity checks. The new prefix is exactly the existing builder/deployer static-asset path.