### PR TITLE
fix: Repaired the Exodus timeout filter so it matches the actual browser event received by Sentry beforeSend.

### DIFF
--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -129,6 +129,26 @@ describe("instrumentation-client", () => {
       in_app: true,
     },
   ];
+  const exodusProviderAccountTimeoutMessage =
+    "JSON-RPC: method call timeout calling 0x1_eth_accounts";
+  const exodusSentryWrapperChunkPath =
+    "app:///_next/static/chunks/44mdj46vrfcef.js";
+  const exodusProviderPath = "app:///ethereum-provider.js";
+  const createExodusProviderTimeoutFrames = (wrapperLine = 7) => [
+    {
+      filename: exodusSentryWrapperChunkPath,
+      function: "n",
+      lineno: wrapperLine,
+      colno: 4853,
+      in_app: true,
+    },
+    {
+      filename: exodusProviderPath,
+      lineno: 1,
+      colno: 2244,
+      in_app: true,
+    },
+  ];
   const expectedWaveAbortErrorValue = "AbortError: The user aborted a request.";
   const poperBlockerNetworkErrorMessage =
     "Network request failed. Please check your connection and try again. (/api/dm-drops/unread)";
@@ -423,6 +443,28 @@ describe("instrumentation-client", () => {
         {
           type: "Error",
           value: browserExtensionWalletRejectionMessage,
+          mechanism: {
+            type: browserUnhandledRejectionMechanismType,
+            handled: false,
+          },
+          stacktrace: { frames },
+        },
+      ],
+    },
+  });
+
+  const createExodusProviderAccountTimeoutEvent = (
+    frames: Array<
+      Record<string, unknown>
+    > = createExodusProviderTimeoutFrames(),
+    value = exodusProviderAccountTimeoutMessage
+  ) => ({
+    ...createUnhandledRejectionEvent(value),
+    exception: {
+      values: [
+        {
+          type: "Error",
+          value,
           mechanism: {
             type: browserUnhandledRejectionMechanismType,
             handled: false,
@@ -2430,6 +2472,47 @@ describe("instrumentation-client", () => {
     const result = beforeSend(
       createBrowserExtensionWalletRejectionEvent(frames)
     );
+
+    expect(result).not.toBeNull();
+  });
+
+  it.each([3, 7])(
+    "drops the exact Exodus provider account timeout without absolute paths and wrapper line %i",
+    (wrapperLine) => {
+      const beforeSend = loadBeforeSend();
+      const event = createExodusProviderAccountTimeoutEvent(
+        createExodusProviderTimeoutFrames(wrapperLine)
+      );
+
+      const result = beforeSend(event);
+
+      expect(result).toBeNull();
+    }
+  );
+
+  it("keeps an Exodus provider account timeout with changed provider coordinates", () => {
+    const beforeSend = loadBeforeSend();
+    const frames = createExodusProviderTimeoutFrames().map((frame, index) =>
+      index === 1 ? { ...frame, colno: 2245 } : frame
+    );
+
+    const result = beforeSend(createExodusProviderAccountTimeoutEvent(frames));
+
+    expect(result).not.toBeNull();
+  });
+
+  it("keeps an Exodus provider account timeout with an app-owned original stack", () => {
+    const beforeSend = loadBeforeSend();
+    const error = new Error(exodusProviderAccountTimeoutMessage);
+    error.stack = [
+      `Error: ${exodusProviderAccountTimeoutMessage}`,
+      `    at n (${exodusSentryWrapperChunkPath}:7:4853)`,
+      "    at connectWallet (app:///services/wallet/connection.ts:10:1)",
+    ].join("\n");
+
+    const result = beforeSend(createExodusProviderAccountTimeoutEvent(), {
+      originalException: error,
+    });
 
     expect(result).not.toBeNull();
   });

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -16,6 +16,7 @@ import {
   shouldFilterChromeMobileIosInjectedGaError,
   shouldFilterCoinbaseWalletLinkWebSocket1006,
   shouldFilterDisconnectedWalletProviderRejection,
+  shouldFilterExodusProviderAccountTimeout,
   shouldFilterGifPickerTenorCategoriesError,
   shouldFilterInstagramPageHideBridgeError,
   shouldFilterInjectedProviderProxyStartsWithError,
@@ -347,6 +348,28 @@ describe("sentry-client-filters", () => {
       function: "a",
       lineno: 1,
       colno: 16591,
+      in_app: true,
+    },
+  ];
+  const exodusProviderAccountTimeoutMessage =
+    "JSON-RPC: method call timeout calling 0x1_eth_accounts";
+  const exodusSentryWrapperChunkPath =
+    "app:///_next/static/chunks/44mdj46vrfcef.js";
+  const exodusProviderPath = "app:///ethereum-provider.js";
+  const createExodusProviderTimeoutFrames = (
+    wrapperLine = 7
+  ): SentryStackFrame[] => [
+    {
+      filename: exodusSentryWrapperChunkPath,
+      function: "n",
+      lineno: wrapperLine,
+      colno: 4853,
+      in_app: true,
+    },
+    {
+      filename: exodusProviderPath,
+      lineno: 1,
+      colno: 2244,
       in_app: true,
     },
   ];
@@ -1192,6 +1215,40 @@ describe("sentry-client-filters", () => {
     mechanismType = "auto.browser.global_handlers.onunhandledrejection",
     handled = false,
     frames = browserExtensionWalletBridgeFrames,
+    additionalException,
+    eventOverrides = {},
+  }: {
+    type?: string | undefined;
+    value?: string | undefined;
+    mechanismType?: string | undefined;
+    handled?: boolean | undefined;
+    frames?: SentryStackFrame[] | undefined;
+    additionalException?: SentryExceptionValue | undefined;
+    eventOverrides?: TestSentryClientEventOverrides | undefined;
+  } = {}): TestSentryClientEvent => ({
+    ...eventOverrides,
+    exception: {
+      values: [
+        {
+          type,
+          value,
+          mechanism: {
+            type: mechanismType,
+            handled,
+          },
+          stacktrace: { frames },
+        },
+        ...(additionalException ? [additionalException] : []),
+      ],
+    },
+  });
+
+  const createExodusProviderAccountTimeoutEvent = ({
+    type = "Error",
+    value = exodusProviderAccountTimeoutMessage,
+    mechanismType = "auto.browser.global_handlers.onunhandledrejection",
+    handled = false,
+    frames = createExodusProviderTimeoutFrames(),
     additionalException,
     eventOverrides = {},
   }: {
@@ -8552,6 +8609,202 @@ describe("sentry-client-filters", () => {
     });
 
     const result = shouldFilterBrowserExtensionWalletRejection(event);
+
+    expect(result).toBe(false);
+  });
+
+  it.each([3, 7])(
+    "filters the exact Exodus provider account timeout without absolute paths and wrapper line %i",
+    (wrapperLine) => {
+      const event = createExodusProviderAccountTimeoutEvent({
+        frames: createExodusProviderTimeoutFrames(wrapperLine),
+      });
+
+      const result = shouldFilterExodusProviderAccountTimeout(event);
+
+      expect(result).toBe(true);
+    }
+  );
+
+  it("filters the exact Exodus provider account timeout with matching absolute paths", () => {
+    const frames = createExodusProviderTimeoutFrames().map((frame) => ({
+      ...frame,
+      abs_path: frame.filename,
+    }));
+    const event = createExodusProviderAccountTimeoutEvent({ frames });
+
+    const result = shouldFilterExodusProviderAccountTimeout(event);
+
+    expect(result).toBe(true);
+  });
+
+  it.each([
+    [
+      "message",
+      createExodusProviderAccountTimeoutEvent({
+        value: "JSON-RPC: method call timed out calling 0x1_eth_accounts",
+      }),
+    ],
+    [
+      "RPC method",
+      createExodusProviderAccountTimeoutEvent({
+        value: "JSON-RPC: method call timeout calling 0x1_eth_requestAccounts",
+      }),
+    ],
+    [
+      "exception type",
+      createExodusProviderAccountTimeoutEvent({ type: "TypeError" }),
+    ],
+    [
+      "capture mechanism",
+      createExodusProviderAccountTimeoutEvent({
+        mechanismType: "auto.browser.global_handlers.onerror",
+      }),
+    ],
+    [
+      "handled state",
+      createExodusProviderAccountTimeoutEvent({ handled: true }),
+    ],
+    [
+      "wrapper line",
+      createExodusProviderAccountTimeoutEvent({
+        frames: createExodusProviderTimeoutFrames(4),
+      }),
+    ],
+    [
+      "wrapper coordinate",
+      createExodusProviderAccountTimeoutEvent({
+        frames: createExodusProviderTimeoutFrames().map((frame, index) =>
+          index === 0 ? { ...frame, colno: 4854 } : frame
+        ),
+      }),
+    ],
+    [
+      "wrapper absolute path",
+      createExodusProviderAccountTimeoutEvent({
+        frames: createExodusProviderTimeoutFrames().map((frame, index) =>
+          index === 0
+            ? { ...frame, abs_path: "app:///_next/static/chunks/other.js" }
+            : frame
+        ),
+      }),
+    ],
+    [
+      "provider path",
+      createExodusProviderAccountTimeoutEvent({
+        frames: createExodusProviderTimeoutFrames().map((frame, index) =>
+          index === 1
+            ? {
+                ...frame,
+                filename: "app:///ethereum-provider-v2.js",
+                abs_path: "app:///ethereum-provider-v2.js",
+              }
+            : frame
+        ),
+      }),
+    ],
+    [
+      "provider absolute path",
+      createExodusProviderAccountTimeoutEvent({
+        frames: createExodusProviderTimeoutFrames().map((frame, index) =>
+          index === 1
+            ? { ...frame, abs_path: "app:///ethereum-provider-v2.js" }
+            : frame
+        ),
+      }),
+    ],
+    [
+      "provider coordinate",
+      createExodusProviderAccountTimeoutEvent({
+        frames: createExodusProviderTimeoutFrames().map((frame, index) =>
+          index === 1 ? { ...frame, colno: 2245 } : frame
+        ),
+      }),
+    ],
+    [
+      "missing frame",
+      createExodusProviderAccountTimeoutEvent({
+        frames: createExodusProviderTimeoutFrames().slice(1),
+      }),
+    ],
+    [
+      "extra frame",
+      createExodusProviderAccountTimeoutEvent({
+        frames: [
+          ...createExodusProviderTimeoutFrames(),
+          {
+            filename: exodusProviderPath,
+            abs_path: exodusProviderPath,
+            lineno: 1,
+            colno: 2244,
+          },
+        ],
+      }),
+    ],
+  ])(
+    "keeps an Exodus provider timeout near miss with changed %s",
+    (_, event) => {
+      const result = shouldFilterExodusProviderAccountTimeout(event);
+
+      expect(result).toBe(false);
+    }
+  );
+
+  it("keeps mixed exceptions containing the Exodus provider timeout", () => {
+    const event = createExodusProviderAccountTimeoutEvent({
+      additionalException: {
+        type: "TypeError",
+        value: "Application wallet state failed.",
+        stacktrace: {
+          frames: [
+            {
+              filename: "app:///services/wallet/connection.ts",
+              function: "connectWallet",
+              in_app: true,
+            },
+          ],
+        },
+      },
+    });
+
+    const result = shouldFilterExodusProviderAccountTimeout(event);
+
+    expect(result).toBe(false);
+  });
+
+  it("keeps Exodus provider timeouts with app-owned original stacks", () => {
+    const event = createExodusProviderAccountTimeoutEvent();
+    const error = new Error(exodusProviderAccountTimeoutMessage);
+    error.stack = [
+      `Error: ${exodusProviderAccountTimeoutMessage}`,
+      `    at n (${exodusSentryWrapperChunkPath}:7:4853)`,
+      "    at connectWallet (app:///services/wallet/connection.ts:10:1)",
+    ].join("\n");
+
+    const result = shouldFilterExodusProviderAccountTimeout(event, {
+      originalException: error,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("keeps Exodus provider timeouts with app-owned serialized stacks", () => {
+    const event = createExodusProviderAccountTimeoutEvent({
+      eventOverrides: {
+        extra: {
+          __serialized__: {
+            message: exodusProviderAccountTimeoutMessage,
+            stack: [
+              `Error: ${exodusProviderAccountTimeoutMessage}`,
+              `    at n (${exodusSentryWrapperChunkPath}:7:4853)`,
+              "    at connectWallet (app:///services/wallet/connection.ts:10:1)",
+            ].join("\n"),
+          },
+        },
+      },
+    });
+
+    const result = shouldFilterExodusProviderAccountTimeout(event);
 
     expect(result).toBe(false);
   });

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -34,6 +34,7 @@ import {
   shouldFilterExpectedWaveRequestReplacementAbort,
   shouldFilterCoinbaseWalletLinkWebSocket1006,
   shouldFilterDisconnectedWalletProviderRejection,
+  shouldFilterExodusProviderAccountTimeout,
   shouldFilterInjectedIosAutoplayNotAllowedError,
   shouldFilterInjectedProviderProxyStartsWithError,
   shouldFilterInjectedWalletCollision,
@@ -177,6 +178,10 @@ function shouldFilterEvent(
   }
 
   if (shouldFilterBrowserExtensionWalletRejection(event, hint)) {
+    return true;
+  }
+
+  if (shouldFilterExodusProviderAccountTimeout(event, hint)) {
     return true;
   }
 

--- a/utils/sentry-client-filters.ts
+++ b/utils/sentry-client-filters.ts
@@ -37,6 +37,7 @@ export {
   shouldFilterBrowserExtensionMessagingConnectionError,
   shouldFilterBrowserExtensionSendMessageError,
   shouldFilterBrowserExtensionWalletRejection,
+  shouldFilterExodusProviderAccountTimeout,
 } from "./sentry-client-filters/extension-messaging";
 export { shouldFilterPoperBlockerOrphanFetchRejection } from "./sentry-client-filters/extension-fetch";
 export { shouldFilterExpectedWaveRequestReplacementAbort } from "./sentry-client-filters/wave-abort";

--- a/utils/sentry-client-filters/extension-messaging.ts
+++ b/utils/sentry-client-filters/extension-messaging.ts
@@ -12,6 +12,7 @@ import {
 import type {
   SentryClientEvent,
   SentryEventHint,
+  SentryExceptionValue,
   SentryStackFrame,
 } from "./types";
 import { hasAppOwnedSourceEvidence } from "./app-frame-utils";
@@ -23,6 +24,12 @@ import {
 
 const browserExtensionWalletRejectionMessage = "User rejected the request.";
 const browserExtensionWalletBridgePath = "app:///content-scripts/bridge.js";
+const exodusProviderAccountTimeoutMessage =
+  "JSON-RPC: method call timeout calling 0x1_eth_accounts";
+const exodusProviderPath = "app:///ethereum-provider.js";
+const exodusSentryWrapperChunkPathPattern =
+  /^app:\/\/\/_next\/static\/chunks\/[a-z0-9._~-]+\.js$/i;
+const exodusSentryWrapperLineNumbers = new Set([3, 7]);
 // Keep the complete pre-symbolication stack exact so extension bundle drift
 // fails open and nearby application failures remain visible.
 const browserExtensionWalletBridgeFrameSignatures = [
@@ -117,6 +124,62 @@ function hasExactBrowserExtensionWalletBridgeFrames(
   });
 }
 
+function isExactExodusSentryWrapperFrame(
+  frame: SentryStackFrame | undefined
+): boolean {
+  if (!frame) {
+    return false;
+  }
+
+  const filename = frame.filename;
+  return (
+    typeof filename === "string" &&
+    (frame.abs_path === undefined || frame.abs_path === filename) &&
+    exodusSentryWrapperChunkPathPattern.test(filename) &&
+    frame.function === "n" &&
+    frame.lineno !== undefined &&
+    exodusSentryWrapperLineNumbers.has(frame.lineno) &&
+    frame.colno === 4853
+  );
+}
+
+function isExactExodusProviderFrame(
+  frame: SentryStackFrame | undefined
+): boolean {
+  return (
+    frame?.filename === exodusProviderPath &&
+    (frame.abs_path === undefined || frame.abs_path === exodusProviderPath) &&
+    frame.lineno === 1 &&
+    frame.colno === 2244
+  );
+}
+
+function hasExactExodusProviderTimeoutFrames(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  return (
+    Array.isArray(frames) &&
+    frames.length === 2 &&
+    isExactExodusSentryWrapperFrame(frames[0]) &&
+    isExactExodusProviderFrame(frames[1])
+  );
+}
+
+function hasExodusProviderTimeoutAppEvidence(
+  event: SentryClientEvent,
+  value: SentryExceptionValue,
+  hint?: SentryEventHint
+): boolean {
+  // beforeSend sees the known Sentry wrapper chunk before source mapping.
+  // The exact two-frame signature accounts for it, while independent hint and
+  // serialized stacks must still fail open when they identify application code.
+  const sourceEvidenceValue: SentryExceptionValue = {
+    ...value,
+    stacktrace: { frames: [] },
+  };
+  return hasAppOwnedSourceEvidence(event, sourceEvidenceValue, hint);
+}
+
 function hasExtensionMessagingConnectionFailureMessage(
   event: SentryClientEvent,
   hint?: SentryEventHint
@@ -173,6 +236,29 @@ export function shouldFilterBrowserExtensionWalletRejection(
   }
 
   return hasExactBrowserExtensionWalletBridgeFrames(value.stacktrace?.frames);
+}
+
+export function shouldFilterExodusProviderAccountTimeout(
+  event: SentryClientEvent,
+  hint?: SentryEventHint
+): boolean {
+  const values = event.exception?.values;
+  if (!Array.isArray(values) || values.length !== 1) {
+    return false;
+  }
+
+  const [value] = values;
+  if (
+    value?.type !== "Error" ||
+    value.value !== exodusProviderAccountTimeoutMessage ||
+    value.mechanism?.type !== browserUnhandledRejectionMechanism ||
+    value.mechanism.handled !== false ||
+    !hasExactExodusProviderTimeoutFrames(value.stacktrace?.frames)
+  ) {
+    return false;
+  }
+
+  return !hasExodusProviderTimeoutAppEvidence(event, value, hint);
 }
 
 export function shouldFilterBrowserExtensionSendMessageError(


### PR DESCRIPTION
<!-- sentry-fix-job:51 issue:7097579604 -->
## Issue

- Sentry: [6529-FRONTEND-3W](https://seize-ff.sentry.io/issues/7097579604/)
- First seen: 2025-12-09T05:46:25.055Z
- Latest occurrence: 2026-08-07T14:37:44.000Z
- Automatic triage confidence: 98%

A narrow repository-owned telemetry filter is useful. The failure comes from an injected Exodus wallet provider, not the application, and the observed signature is specific enough to suppress without hiding nearby wallet or application errors.

## Fix

The draft incorrectly required abs_path on both frames. Sentry Browser 10.45.0 creates frames with filename and coordinates but no abs_path, while Next.js normalization rewrites filename only, making the filter a production no-op.

## Changes

- Made abs_path optional while still rejecting it when present but inconsistent with filename.
- Updated predicate and beforeSend fixtures to cover browser-shaped events without abs_path.
- Added positive matching-path and negative mismatched-path regression coverage.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Focused Jest: 2 suites and 654 tests passed.
- lint:changed passed.
- typecheck:changed passed but found no included files; full production typecheck passed.
- Jest typecheck ratchet passed.
- git diff --check passed.

## Risk

- Assessed risk: low
- Changed files: 5
- Changed lines: 428
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

Future Exodus or Sentry frame drift intentionally remains reportable. No commits, pushes, PR mutations, deployments, or Sentry mutations were performed.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
