### PR TITLE
Normalize one-click selection artifact digest

### DIFF
--- a/.github/workflows/production-artifact-verifier.yml
+++ b/.github/workflows/production-artifact-verifier.yml
@@ -361,7 +361,7 @@ jobs:
       - name: Publish immutable selection identity
         id: selection-result
         env:
-          SELECTION_ARTIFACT_DIGEST: ${{ steps.upload-selection.outputs.artifact-digest }}
+          SELECTION_ARTIFACT_DIGEST: sha256:${{ steps.upload-selection.outputs.artifact-digest }}
           SELECTION_ARTIFACT_ID: ${{ steps.upload-selection.outputs.artifact-id }}
           SELECTION_ARTIFACT_NAME: ${{ steps.verified-selection.outputs.selection_artifact_name }}
           SELECTION_ARTIFACT_RUN_ATTEMPT: ${{ steps.verified-selection.outputs.selection_artifact_run_attempt }}

--- a/__tests__/scripts/production-artifact-verifier.test.ts
+++ b/__tests__/scripts/production-artifact-verifier.test.ts
@@ -245,6 +245,9 @@ describe("isolated production artifact verifier", () => {
     expect(source).toContain("ARTIFACT_WORKFLOW_SHA");
     expect(source).toContain("builder ${{ inputs.artifact_run_id }}");
     expect(source).toContain("sha256sum -c SHA256SUMS");
+    expect(source).toContain(
+      "SELECTION_ARTIFACT_DIGEST: sha256:${{ steps.upload-selection.outputs.artifact-digest }}"
+    );
     expect(source).toContain("unzip -Z1");
     expect(source).toContain("validate-archive-members");
     expect(source).toContain("validate-extracted-artifact");


### PR DESCRIPTION
## Summary

- prefix the upload-artifact v4 raw 64-hex output with the canonical `sha256:` scheme before publishing verifier outputs
- pin the exact normalization in the isolated-verifier workflow contract test

## Exact failure evidence

Fresh controller `31194846549` built exact artifact `9000650448`; isolated verifier `31195650604` passed archive membership, extraction, manifest, all checksums, package bytes, and selection upload, then failed closed at `Publish immutable selection identity`. Live output was raw `2efb...`; the existing validator correctly requires `sha256:<64hex>`. Production did not mutate and completion listener `31195725657` released the failed operation.

## Validation

- 4 suites / 79 tests
- changed lint
- changed typecheck (1,410 files)
- full Jest/Playwright test typecheck
- Prettier
- `codex-diff-check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production artifact verification by recording the selection artifact digest in the expected format.

* **Tests**
  * Added validation to ensure the production verifier captures the selection artifact digest correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->