### PR TITLE
ci: accept GitHub selection artifact metadata shape

### DIFF
--- a/__tests__/scripts/one-click-production-children.test.ts
+++ b/__tests__/scripts/one-click-production-children.test.ts
@@ -627,22 +627,29 @@ describe("one-click production verifier selection artifact metadata", () => {
     });
   });
 
+  it("rejects a present selection artifact attempt that disagrees with the verifier run", () => {
+    const exact = selectionBundle().artifacts[0];
+    expect(() =>
+      validateSelectionArtifactMetadata(
+        selectionInput({
+          metadataBundle: selectionBundle({
+            artifacts: [
+              {
+                ...exact,
+                workflow_run: {
+                  id: Number(VERIFIER_RUN_ID),
+                  run_attempt: VERIFIER_RUN_ATTEMPT + 1,
+                  head_sha: VERIFIER_HEAD_SHA,
+                },
+              },
+            ],
+          }),
+        })
+      )
+    ).toThrow(/workflow run attempt does not match/);
+  });
+
   it.each([
-    {
-      label: "wrong attempt attachment",
-      metadataBundle: selectionBundle({
-        artifacts: [
-          {
-            ...selectionBundle().artifacts[0],
-            workflow_run: {
-              id: Number(VERIFIER_RUN_ID),
-              run_attempt: 3,
-              head_sha: VERIFIER_HEAD_SHA,
-            },
-          },
-        ],
-      }),
-    },
     {
       label: "wrong artifact name",
       metadataBundle: selectionBundle({

--- a/__tests__/scripts/one-click-production-children.test.ts
+++ b/__tests__/scripts/one-click-production-children.test.ts
@@ -243,7 +243,6 @@ function selectionBundle(overrides: Record<string, unknown> = {}) {
         digest: SELECTION_ARTIFACT_DIGEST,
         workflow_run: {
           id: Number(VERIFIER_RUN_ID),
-          run_attempt: VERIFIER_RUN_ATTEMPT,
           head_sha: VERIFIER_HEAD_SHA,
         },
       },
@@ -484,20 +483,23 @@ describe("one-click production child run selection", () => {
     { id: "8002" },
     { api_digest: `sha256:${"0".repeat(64)}` },
     { workflow_sha: FOREIGN_SHA },
-  ])("does not select a verifier bound to a different artifact: %j", (source) => {
-    const stale = verifierRun({ display_title: verifierTitle(source) });
-    expect(
-      selectTrustedWorkflowRun({
-        workflowRunsJson: { workflow_runs: [stale] },
-        repository: EXPECTED_REPOSITORY,
-        workflowPath: VERIFIER_WORKFLOW_PATH,
-        workflowId: VERIFIER_WORKFLOW_ID,
-        operationId: OPERATION_ID,
-        targetSha: TARGET_SHA,
-        sourceArtifact: SOURCE_ARTIFACT,
-      })
-    ).toMatchObject({ result: "absent", reason: "no_exact_identity_match" });
-  });
+  ])(
+    "does not select a verifier bound to a different artifact: %j",
+    (source) => {
+      const stale = verifierRun({ display_title: verifierTitle(source) });
+      expect(
+        selectTrustedWorkflowRun({
+          workflowRunsJson: { workflow_runs: [stale] },
+          repository: EXPECTED_REPOSITORY,
+          workflowPath: VERIFIER_WORKFLOW_PATH,
+          workflowId: VERIFIER_WORKFLOW_ID,
+          operationId: OPERATION_ID,
+          targetSha: TARGET_SHA,
+          sourceArtifact: SOURCE_ARTIFACT,
+        })
+      ).toMatchObject({ result: "absent", reason: "no_exact_identity_match" });
+    }
+  );
 });
 
 describe("one-click production artifact metadata", () => {

--- a/__tests__/scripts/run-one-click-production-children.test.ts
+++ b/__tests__/scripts/run-one-click-production-children.test.ts
@@ -283,7 +283,6 @@ function artifactRecord(
     digest: selection ? SELECTION_ARTIFACT_DIGEST : BUILDER_ARTIFACT_DIGEST,
     workflow_run: {
       id: Number(selection ? VERIFIER_RUN_ID : BUILDER_RUN_ID),
-      run_attempt: selection ? VERIFIER_RUN_ATTEMPT : BUILDER_RUN_ATTEMPT,
       head_sha: selection ? VERIFIER_SHA : LATER_MAIN_SHA,
     },
     ...overrides,

--- a/ops/scripts/one-click-production-children.cjs
+++ b/ops/scripts/one-click-production-children.cjs
@@ -959,6 +959,7 @@ function validateSelectionArtifactRecord(artifacts, request, verifierRun) {
     );
   }
   if (
+    attachment.run_attempt !== undefined &&
     requireRunAttempt(
       attachment.run_attempt,
       "selection artifact workflow run attempt"

--- a/ops/scripts/one-click-production-children.cjs
+++ b/ops/scripts/one-click-production-children.cjs
@@ -958,6 +958,9 @@ function validateSelectionArtifactRecord(artifacts, request, verifierRun) {
       "selection artifact is not attached to the exact verifier run"
     );
   }
+  // GitHub's artifact attachment omits run_attempt. The exact attempt remains
+  // mandatory on the authenticated verifier run, the attempt-suffixed artifact
+  // name, and selection.json; reject an attachment attempt if GitHub adds one.
   if (
     attachment.run_attempt !== undefined &&
     requireRunAttempt(


### PR DESCRIPTION
## Outcome
Accept the production-shaped GitHub Actions artifact attachment returned by the live artifact API.

## Root cause
The parent resolver required `artifact.workflow_run.run_attempt` for verifier selection artifacts. GitHub's artifact API returns the attached run ID and head SHA, but does not return `run_attempt`. The selected verifier run, attempt-suffixed artifact name, and downloaded `selection.json.verifier_run_attempt` already bind the exact attempt.

## Change
- validate an attached run attempt when GitHub supplies one, but do not require the absent field
- make both controller fixtures match GitHub's production artifact response shape
- retain rejection of a supplied mismatched attempt

## Evidence
- live failed parent: 31198321516
- exact successful builder: 31198362313; artifact 9002012819
- exact successful verifier: 31199024181; selection artifact 9002033401
- focused tests: 2 suites / 69 tests
- changed lint and typecheck: pass
- Prettier and codex-diff-check: pass

No application runtime, archive, deploy, Museum page, or UI behavior changes.