### PR TITLE
ci: wire builder identity into production deploy

### DIFF
--- a/.github/workflows/build-upload-deploy-prod.yml
+++ b/.github/workflows/build-upload-deploy-prod.yml
@@ -155,8 +155,8 @@ jobs:
       artifact-api-digest: ${{ steps.children.outputs.artifact_api_digest }}
       artifact-id: ${{ steps.children.outputs.artifact_id }}
       artifact-name: ${{ steps.children.outputs.artifact_name }}
-      artifact-run-attempt: ${{ steps.children.outputs.artifact_run_attempt }}
-      artifact-run-id: ${{ steps.children.outputs.artifact_run_id }}
+      artifact-run-attempt: ${{ steps.children.outputs.builder_run_attempt }}
+      artifact-run-id: ${{ steps.children.outputs.builder_run_id }}
       selection-artifact-api-digest: ${{ steps.children.outputs.selection_artifact_api_digest }}
       selection-artifact-id: ${{ steps.children.outputs.selection_artifact_id }}
       selection-artifact-name: ${{ steps.children.outputs.selection_artifact_name }}

--- a/__tests__/scripts/one-click-production-workflow.test.ts
+++ b/__tests__/scripts/one-click-production-workflow.test.ts
@@ -2,6 +2,11 @@ import fs from "node:fs";
 import path from "node:path";
 import YAML from "yaml";
 
+const { OUTPUT_FIELDS } =
+  require("../../ops/scripts/run-one-click-production-children.cjs") as {
+    OUTPUT_FIELDS: readonly string[];
+  };
+
 const workflow = (name: string) =>
   YAML.parse(
     fs.readFileSync(
@@ -69,6 +74,18 @@ describe("one-click production operation", () => {
     expect(childContract).toContain("production-build-artifact.yml");
     expect(childContract).toContain("production-artifact-verifier.yml");
     expect(childContract).toContain("frontend-prod-${normalizedParentRunId}");
+    expect(resolve.outputs).toMatchObject({
+      "artifact-run-attempt":
+        "${{ steps.children.outputs.builder_run_attempt }}",
+      "artifact-run-id": "${{ steps.children.outputs.builder_run_id }}",
+    });
+    for (const expression of Object.values(resolve.outputs)) {
+      const match = String(expression).match(
+        /^\$\{\{ steps\.children\.outputs\.([a-z0-9_]+) \}\}$/u
+      );
+      expect(match).not.toBeNull();
+      expect(OUTPUT_FIELDS).toContain(match?.[1]);
+    }
     expect(`${serialized}\n${childContract}`).not.toMatch(
       /sort_by\(|created_at|\|\s*last/
     );


### PR DESCRIPTION
## Outcome
Wire the exact builder run ID and attempt emitted by the child controller into the production deploy verifier.

## Root cause
Controller `31200903180` passed authority, builder `31200930098`, verifier `31201663334`, and parent selection resolution. The deploy job then failed closed before AWS because resolver outputs `artifact-run-id` and `artifact-run-attempt` referenced nonexistent child outputs `artifact_run_id` / `artifact_run_attempt`. The controller emits `builder_run_id` / `builder_run_attempt`.

## Change
- map the two deploy-facing artifact run outputs to the real builder output names
- assert those exact mappings
- enumerate every resolver output expression and require its referenced child field to exist in `OUTPUT_FIELDS`

## Evidence
- failed controller: 31200903180
- failure step: Verify immutable production artifact selection
- observed blanks: ARTIFACT_RUN_ID and ARTIFACT_RUN_ATTEMPT
- automatic authority release: 31201769571 SUCCESS
- local: 4 suites / 95 tests; lint, typecheck, Prettier, codex-diff-check pass

No AWS mutation, application runtime, archive, Museum page, or UI behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected production deployment metadata to report the builder workflow’s run ID and attempt number.
  * Improved validation of artifact output mappings to help ensure accurate deployment information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->