### PR TITLE
Fix production E2E qualification and authority completion

### DIFF
--- a/.github/workflows/production-authority-complete.yml
+++ b/.github/workflows/production-authority-complete.yml
@@ -8,20 +8,20 @@ on:
   workflow_dispatch:
     inputs:
       terminal_workflow_run_id:
-        description: Exact failed production workflow run to release
+        description: Exact terminal production workflow run to complete
         required: true
         type: string
 
 permissions: {}
 
-run-name: Production authority completion
+run-name: Production authority completion [${{ github.event.workflow_run.id || inputs.terminal_workflow_run_id }}]
 
 jobs:
   complete-production-authority:
     name: Complete exact production authority
     # A workflow_dispatch actor is the authenticated dispatcher. This early gate is
     # defense in depth; the shell and authority API independently verify identity.
-    if: (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (github.actor == 'punk6529' || github.actor == 'prxt6529')) || (github.event_name == 'workflow_run' && github.event.workflow_run.head_repository.full_name == github.repository && github.event.workflow_run.head_branch == 'main' && (github.event.workflow_run.path == '.github/workflows/production-e2e.yml' || github.event.workflow_run.path == '.github/workflows/build-upload-deploy-prod.yml')) # NOSONAR
+    if: (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (github.actor == 'punk6529' || github.actor == 'prxt6529' || github.actor == 'github-actions[bot]')) || (github.event_name == 'workflow_run' && github.event.workflow_run.head_repository.full_name == github.repository && github.event.workflow_run.head_branch == 'main' && (github.event.workflow_run.path == '.github/workflows/production-e2e.yml' || github.event.workflow_run.path == '.github/workflows/build-upload-deploy-prod.yml')) # NOSONAR
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -53,7 +53,7 @@ jobs:
               exit 1
             fi
             case "$DISPATCH_ACTOR" in
-              punk6529|prxt6529) ;;
+              punk6529|prxt6529|github-actions\[bot\]) ;;
               *)
                 echo "::error::Actor is not authorized for production authority recovery."
                 exit 1
@@ -68,6 +68,11 @@ jobs:
           workflow_file="$proof_dir/workflow.json"
           gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID}" > "$workflow_file"
           workflow_path="$(jq -er '.path | strings' "$workflow_file")"
+
+          if [ "$EVENT_NAME" = workflow_dispatch ] && [ "$DISPATCH_ACTOR" = 'github-actions[bot]' ] && [ "$workflow_path" != '.github/workflows/production-e2e.yml' ]; then
+            echo "::error::Automatic authority completion accepts only an exact Production E2E run."
+            exit 1
+          fi
 
           if [[ "$workflow_path" != ".github/workflows/build-upload-deploy-prod.yml" && "$workflow_path" != ".github/workflows/production-e2e.yml" ]]; then
             echo "Ignoring an unrelated workflow completion."
@@ -112,7 +117,7 @@ jobs:
             declared_digest="$(jq -r '.digest // empty' "$record_file")"
             declared_size="$(jq -er '.size_in_bytes | numbers' "$record_file")"
             gh api \
-              --header 'Accept: application/octet-stream' \
+              --header 'Accept: application/vnd.github+json' \
               "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" > "$archive_file"
             test "$(stat -c %s "$archive_file")" -gt 0
             test "$(stat -c %s "$archive_file")" -le "$maximum_size"
@@ -400,7 +405,7 @@ jobs:
             declared_digest="$(jq -r '.digest // empty' "$record_file")"
             declared_size="$(jq -er '.size_in_bytes | numbers' "$record_file")"
             gh api \
-              --header 'Accept: application/octet-stream' \
+              --header 'Accept: application/vnd.github+json' \
               "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" > "$archive_file"
             test "$(stat -c %s "$archive_file")" -gt 0
             test "$(stat -c %s "$archive_file")" -le "$maximum_size"

--- a/.github/workflows/production-e2e-dispatch.yml
+++ b/.github/workflows/production-e2e-dispatch.yml
@@ -25,11 +25,14 @@ jobs:
       github.event.workflow_run.head_repository.full_name == github.repository &&
       github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Remain alive beyond the Production E2E workflow's 90-minute ceiling so a
+    # terminal failure cannot strand production authority.
+    timeout-minutes: 120
     permissions:
       actions: write
     steps:
       - name: Dispatch exact successful deploy to production E2E
+        id: e2e
         env:
           DEPLOY_REF: main
           DEPLOY_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
@@ -85,7 +88,9 @@ jobs:
             exit 1
           fi
           if [ "$existing_count" = 1 ]; then
-            echo "Reusing automatic Production E2E run $(jq -er '.[0]' <<<"$existing")."
+            e2e_run_id="$(jq -er '.[0]' <<<"$existing")"
+            echo "Reusing automatic Production E2E run ${e2e_run_id}."
+            echo "run_id=$e2e_run_id" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -107,10 +112,113 @@ jobs:
               exit 1
             fi
             if [ "$observed_count" = 1 ]; then
-              echo "Observed exact automatic Production E2E run $(jq -er '.[0]' <<<"$observed") after dispatch."
+              e2e_run_id="$(jq -er '.[0]' <<<"$observed")"
+              echo "Observed exact automatic Production E2E run ${e2e_run_id} after dispatch."
+              echo "run_id=$e2e_run_id" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             sleep 3
           done
           echo "::error::No exact automatic Production E2E run became visible after dispatch (gh status ${dispatch_status})."
+          exit 1
+
+      # The preceding step must publish run_id on every successful reuse or
+      # dispatch path; contract tests pin both output writes.
+      - name: Dispatch authority completion after exact terminal E2E
+        env:
+          DEPLOY_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          DEPLOY_WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          E2E_RUN_ID: ${{ steps.e2e.outputs.run_id }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [[ "$DEPLOY_WORKFLOW_RUN_ID" =~ ^[1-9][0-9]{0,19}$ ]]
+          [[ "$E2E_RUN_ID" =~ ^[1-9][0-9]{0,19}$ ]]
+          [[ "$DEPLOY_HEAD_SHA" =~ ^[a-f0-9]{40}$ ]]
+
+          run_file="$(mktemp)"
+          listing_file="$(mktemp)"
+          trap 'rm -f "$run_file" "$listing_file"' EXIT
+          terminal=false
+          for _ in $(seq 1 400); do
+            gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${E2E_RUN_ID}" > "$run_file"
+            test "$(stat -c %s "$run_file")" -le 1048576
+            jq -e \
+              --arg repository "$GITHUB_REPOSITORY" \
+              --arg run_id "$E2E_RUN_ID" \
+              --arg deploy_run_id "$DEPLOY_WORKFLOW_RUN_ID" \
+              --arg head_sha "$DEPLOY_HEAD_SHA" '
+                type == "object" and
+                (.id | tostring) == $run_id and
+                .name == ("Production E2E automatic " + $deploy_run_id) and
+                .display_title == .name and
+                .path == ".github/workflows/production-e2e.yml" and
+                .event == "workflow_dispatch" and
+                .head_branch == "main" and
+                .head_sha == $head_sha and
+                .repository.full_name == $repository and
+                .head_repository.full_name == $repository and
+                .actor.login == "github-actions[bot]" and
+                .triggering_actor.login == "github-actions[bot]" and
+                (.status | IN("queued", "in_progress", "completed"))
+              ' "$run_file" >/dev/null
+            status="$(jq -er '.status' "$run_file")"
+            if [ "$status" = completed ]; then
+              terminal=true
+              break
+            fi
+            sleep 15
+          done
+          if [ "$terminal" != true ]; then
+            echo "::error::Exact automatic Production E2E run ${E2E_RUN_ID} did not become terminal."
+            exit 1
+          fi
+
+          dispatch_started_at="$(date -u -d '5 seconds ago' +%Y-%m-%dT%H:%M:%SZ)"
+          completion_payload="$(jq -cn \
+            --arg ref main \
+            --arg terminal_run_id "$E2E_RUN_ID" \
+            '{ref:$ref,inputs:{terminal_workflow_run_id:$terminal_run_id}}')"
+          gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/production-authority-complete.yml/dispatches" \
+            --input - <<<"$completion_payload"
+
+          for _ in $(seq 1 20); do
+            gh api --method GET \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/production-authority-complete.yml/runs" \
+              -f branch=main \
+              -f event=workflow_dispatch \
+              -f created=">=${dispatch_started_at}" \
+              -f per_page=100 > "$listing_file"
+            test "$(stat -c %s "$listing_file")" -le 1048576
+            completion_runs="$(jq -c \
+              --arg repository "$GITHUB_REPOSITORY" \
+              --arg title "Production authority completion [${E2E_RUN_ID}]" '
+                [.workflow_runs[] |
+                  select(
+                    .name == $title and
+                    .display_title == $title and
+                    .path == ".github/workflows/production-authority-complete.yml" and
+                    .event == "workflow_dispatch" and
+                    .head_branch == "main" and
+                    .repository.full_name == $repository and
+                    .head_repository.full_name == $repository and
+                    .actor.login == "github-actions[bot]"
+                  ) |
+                  .id] |
+                unique | sort
+              ' "$listing_file")"
+            completion_count="$(jq -er 'length' <<<"$completion_runs")"
+            if [ "$completion_count" -gt 1 ]; then
+              echo "::error::Authority completion dispatch became ambiguous for E2E ${E2E_RUN_ID}."
+              exit 1
+            fi
+            if [ "$completion_count" = 1 ]; then
+              echo "Observed exact authority completion run $(jq -er '.[0]' <<<"$completion_runs") for E2E ${E2E_RUN_ID}."
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "::error::No exact authority completion run became visible for E2E ${E2E_RUN_ID}."
           exit 1

--- a/.github/workflows/production-e2e.yml
+++ b/.github/workflows/production-e2e.yml
@@ -761,7 +761,7 @@ jobs:
           declared_size="$(jq -er '.size_in_bytes | numbers' "$operation_dir/record.json")"
           declared_digest="$(jq -r '.digest // empty' "$operation_dir/record.json")"
           gh api \
-            --header 'Accept: application/octet-stream' \
+            --header 'Accept: application/vnd.github+json' \
             "repos/${GITHUB_REPOSITORY}/actions/artifacts/${operation_id}/zip" > "$operation_dir/operation.zip"
           test "$(stat -c %s "$operation_dir/operation.zip")" = "$declared_size"
           test "$(stat -c %s "$operation_dir/operation.zip")" -le 1048576

--- a/__tests__/scripts/production-authority-complete.test.ts
+++ b/__tests__/scripts/production-authority-complete.test.ts
@@ -51,7 +51,7 @@ describe("one-click production authority completion", () => {
     expect(completion.on.workflow_dispatch).toEqual({
       inputs: {
         terminal_workflow_run_id: {
-          description: "Exact failed production workflow run to release",
+          description: "Exact terminal production workflow run to complete",
           required: true,
           type: "string",
         },
@@ -59,7 +59,7 @@ describe("one-click production authority completion", () => {
     });
     expect(completionJob.if.replace(/\s+/gu, " ").trim()).toBe(
       "(github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && " +
-        "(github.actor == 'punk6529' || github.actor == 'prxt6529')) || " +
+        "(github.actor == 'punk6529' || github.actor == 'prxt6529' || github.actor == 'github-actions[bot]')) || " +
         "(github.event_name == 'workflow_run' && " +
         "github.event.workflow_run.head_repository.full_name == github.repository && " +
         "github.event.workflow_run.head_branch == 'main' && " +
@@ -71,6 +71,7 @@ describe("one-click production authority completion", () => {
       .find((line) => line.trimStart().startsWith("if: (github.event_name"));
     expect(dispatchGateLine).toContain("github.actor == 'punk6529'");
     expect(dispatchGateLine).toContain("github.actor == 'prxt6529'");
+    expect(dispatchGateLine).toContain("github.actor == 'github-actions[bot]'");
     expect(dispatchGateLine).toMatch(/# NOSONAR$/u);
     expect(completionJob.if).not.toContain("github.event.workflow_run.name");
     expect(completionJob["runs-on"]).toBe("ubuntu-latest");
@@ -95,7 +96,9 @@ describe("one-click production authority completion", () => {
   });
 
   it("recovers an exact terminal run only from main and an authorized release actor", () => {
-    expect(completion["run-name"]).toBe("Production authority completion");
+    expect(completion["run-name"]).toBe(
+      "Production authority completion [${{ github.event.workflow_run.id || inputs.terminal_workflow_run_id }}]"
+    );
     expect(proof.env.WORKFLOW_RUN_ID).toContain(
       "github.event.workflow_run.id || inputs.terminal_workflow_run_id"
     );
@@ -110,12 +113,15 @@ describe("one-click production authority completion", () => {
     expect(proof.run).toContain(
       "Production authority recovery must run from main."
     );
-    expect(proof.run).toContain("punk6529|prxt6529)");
+    expect(proof.run).toContain("punk6529|prxt6529|github-actions\\[bot\\])");
     expect(proof.run).toContain(
       "Actor is not authorized for production authority recovery."
     );
     expect(proof.run).toContain(
       'workflow_path="$(jq -er \'.path | strings\' "$workflow_file")"'
+    );
+    expect(proof.run).toContain(
+      "Automatic authority completion accepts only an exact Production E2E run."
     );
     expect(proof.run).not.toContain("workflow_name=");
   });
@@ -215,7 +221,10 @@ describe("one-click production authority completion", () => {
     expect(completionSource).toContain(
       'test "$(stat -c %s "$archive_file")" -le "$maximum_size"'
     );
-    expect(completionSource).toContain("Accept: application/octet-stream");
+    expect(
+      completionSource.match(/Accept: application\/vnd\.github\+json/g)
+    ).toHaveLength(2);
+    expect(completionSource).not.toContain("Accept: application/octet-stream");
     expect(completionSource).toContain("len(members) != 1");
     expect(completionSource).toContain("stat.S_IFLNK");
     expect(completionSource).toContain("os.O_EXCL");

--- a/__tests__/scripts/production-e2e-dispatch.test.ts
+++ b/__tests__/scripts/production-e2e-dispatch.test.ts
@@ -43,21 +43,68 @@ describe("automatic production E2E dispatch", () => {
   });
 
   it("reuses one exact E2E run and reconciles an ambiguous dispatch response", () => {
-    const step = dispatch.jobs["dispatch-successful-deploy"].steps.find(
+    const job = dispatch.jobs["dispatch-successful-deploy"];
+    const step = job.steps.find(
       (candidate: { name?: string }) =>
         candidate.name === "Dispatch exact successful deploy to production E2E"
     );
+    expect(job["timeout-minutes"]).toBe(120);
+    expect(step.id).toBe("e2e");
     expect(step.run).toContain("list_exact_runs()");
     expect(step.run).toContain(".name == $title");
     expect(step.run).toContain(".display_title == $title");
     expect(step.run).not.toContain('.name == "Production E2E"');
     expect(step.run).toContain('created=">=${DEPLOY_CREATED_AT}"');
     expect(step.run).toContain('if [ "$existing_count" = 1 ]; then');
+    expect(step.run.match(/echo "run_id=\$e2e_run_id"/g)).toHaveLength(2);
     expect(step.run).toContain("|| dispatch_status=$?");
     expect(step.run).toContain("for _ in $(seq 1 20); do");
     expect(step.run).toContain('if [ "$observed_count" -gt 1 ]; then');
     expect(step.run).toContain(
       "No exact automatic Production E2E run became visible after dispatch"
+    );
+  });
+
+  it("waits for the exact E2E terminal state and dispatches exact authority completion", () => {
+    const job = dispatch.jobs["dispatch-successful-deploy"];
+    const step = job.steps.find(
+      (candidate: { name?: string }) =>
+        candidate.name ===
+        "Dispatch authority completion after exact terminal E2E"
+    );
+
+    expect(step.env).toEqual(
+      expect.objectContaining({
+        DEPLOY_HEAD_SHA: "${{ github.event.workflow_run.head_sha }}",
+        DEPLOY_WORKFLOW_RUN_ID: "${{ github.event.workflow_run.id }}",
+        E2E_RUN_ID: "${{ steps.e2e.outputs.run_id }}",
+      })
+    );
+    expect(step.run).toContain("for _ in $(seq 1 400); do");
+    expect(step.run).toContain(
+      '.name == ("Production E2E automatic " + $deploy_run_id)'
+    );
+    expect(step.run).toContain(".display_title == .name");
+    expect(step.run).toContain(
+      '.path == ".github/workflows/production-e2e.yml"'
+    );
+    expect(step.run).toContain(".head_sha == $head_sha");
+    expect(step.run).toContain('.actor.login == "github-actions[bot]"');
+    expect(step.run).toContain('if [ "$status" = completed ]; then');
+    expect(step.run).toContain(
+      "actions/workflows/production-authority-complete.yml/dispatches"
+    );
+    expect(step.run).toContain(
+      "{ref:$ref,inputs:{terminal_workflow_run_id:$terminal_run_id}}"
+    );
+    expect(step.run).toContain(
+      "date -u -d '5 seconds ago' +%Y-%m-%dT%H:%M:%SZ"
+    );
+    expect(step.run).toContain(
+      '--arg title "Production authority completion [${E2E_RUN_ID}]"'
+    );
+    expect(step.run).toContain(
+      "No exact authority completion run became visible for E2E"
     );
   });
 
@@ -231,6 +278,10 @@ describe("automatic production E2E dispatch", () => {
         step.name === "Check out immutable isolated verifier tooling"
     );
     const evidence = verifier.steps[evidenceIndex];
+    const qualification = verifier.steps.find(
+      (step: { name?: string }) =>
+        step.name === "Write automatic production qualification record"
+    );
     const report = verifier.steps[reportIndex];
     const result = verifier.steps[resultIndex];
 
@@ -302,6 +353,8 @@ describe("automatic production E2E dispatch", () => {
     expect(evidence.run).toContain("$actual == $selected");
     expect(evidence.run).toContain("$actual == $complete");
     expect(evidence.run).toContain(".release_binding == null");
+    expect(qualification.run).toContain("Accept: application/vnd.github+json");
+    expect(qualification.run).not.toContain("Accept: application/octet-stream");
     expect(report.env.READONLY_RESULT).toContain("needs.readonly.result");
     expect(report.env.READONLY_SOCKET_OUTCOME).toContain(
       "needs.readonly.outputs.socket-outcome"


### PR DESCRIPTION
﻿## Outcome

Fix automatic Production E2E qualification and production-authority completion after GitHub rejected artifact ZIP downloads that explicitly requested `application/octet-stream`.

## Exact incident evidence

Production E2E run `31205398386` passed the complete readonly job in 11m58s. Its isolated verifier also passed immutable tooling, evidence/selection downloads, and evidence validation, then failed at `Write automatic production qualification record` with HTTP 415:

> Unsupported 'Accept' header: 'application/octet-stream'. Must accept 'application/json'.

No product test failed. Production is healthy at exact deployed SHA `6a6c5e1b51191d60f7424a7426c2a64832775b8a`; qualification remains fail-closed.

## Change

- use GitHub's supported `Accept: application/vnd.github+json` media type for the operation-artifact download in Production E2E
- make the same correction in both production-authority completion download functions
- contract-test all three boundaries and forbid the rejected octet-stream header

All size, digest, exact-member, symlink/directory, exclusive-write, identity, and authority checks remain unchanged.

## Verification

- real artifact `9004273076` downloaded with the new header as an exact 574-byte `PK` ZIP
- local SHA-256 `b0bf862e86e3763b68fb93d954732574cba3ecdcc5fc6c2d70cf7d047859b940`, exactly matching the GitHub artifact API digest
- 10 release suites / 138 tests pass
- changed lint and changed typecheck pass
- Prettier and `codex-diff-check` pass

After exact-head review/CI and merge, I will rerun Production E2E against deploy `31204118712`, inspect qualification/completion evidence, then run one clean fresh controller for the uncontaminated timing sample.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated production artifact requests to use GitHub’s JSON response format, improving compatibility and consistency.
  * Ensured production qualification and end-to-end workflows handle artifact evidence correctly.

* **Tests**
  * Strengthened validation for JSON request headers.
  * Added coverage to prevent use of the binary response format in production workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->