### PR TITLE
fix: Repaired the notification Sentry fix and its regression coverage. No commit, push, deployment, PR publica

### DIFF
--- a/__tests__/components/brain/notifications/Notifications.test.tsx
+++ b/__tests__/components/brain/notifications/Notifications.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 
 const mutateAsyncMock = jest.fn();
+const mutateMock = jest.fn();
 const requestAuthMock = jest.fn().mockResolvedValue({ success: true });
 const setActiveProfileProxyMock = jest.fn().mockResolvedValue(undefined);
 const setToastMock = jest.fn();
@@ -16,7 +17,7 @@ jest.mock("@/utils/monitoring/mobileLaunchTiming", () => ({
 }));
 
 jest.mock("@tanstack/react-query", () => ({
-  useMutation: () => ({ mutateAsync: mutateAsyncMock }),
+  useMutation: () => ({ mutate: mutateMock, mutateAsync: mutateAsyncMock }),
 }));
 
 jest.mock("next/navigation", () => ({
@@ -55,9 +56,15 @@ jest.mock("@/components/react-query-wrapper/ReactQueryWrapper", () => {
   };
 });
 
+const mockNotificationsWrapper = jest.fn(
+  (_props: { markNotificationIdsAsRead?: (ids: number[]) => void }) => (
+    <div data-testid="wrapper" />
+  )
+);
 jest.mock("@/components/brain/notifications/NotificationsWrapper", () => ({
   __esModule: true,
-  default: () => <div data-testid="wrapper" />,
+  default: (props: { markNotificationIdsAsRead?: (ids: number[]) => void }) =>
+    mockNotificationsWrapper(props),
 }));
 
 jest.mock("@/components/brain/notifications/NotificationsCauseFilter", () => ({
@@ -148,6 +155,8 @@ describe("Notifications component", () => {
   beforeEach(() => {
     mutateAsyncMock.mockClear();
     mutateAsyncMock.mockResolvedValue(undefined);
+    mutateMock.mockClear();
+    mockNotificationsWrapper.mockClear();
     useNotificationsQueryMock.mockReset();
     setTitleMock.mockClear();
     requestAuthMock.mockClear();
@@ -205,6 +214,17 @@ describe("Notifications component", () => {
     await waitFor(() => {
       expect(mutateAsyncMock).toHaveBeenCalled();
     });
+  });
+
+  it("exposes grouped notification reads through the void mutation API", () => {
+    mockSuccessfulNotificationsQuery();
+    render(<Notifications activeDrop={null} setActiveDrop={jest.fn()} />);
+    const wrapperProps = mockNotificationsWrapper.mock.calls.at(-1)?.[0];
+
+    const result = wrapperProps?.markNotificationIdsAsRead?.([3, 5]);
+
+    expect(result).toBeUndefined();
+    expect(mutateMock).toHaveBeenCalledWith([3, 5]);
   });
 
   it("does not add floating dock clearance on mobile web", async () => {

--- a/__tests__/components/brain/notifications/NotificationsFollowBtn.test.tsx
+++ b/__tests__/components/brain/notifications/NotificationsFollowBtn.test.tsx
@@ -1,45 +1,157 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import NotificationsFollowBtn from '@/components/brain/notifications/NotificationsFollowBtn';
-import { useMutation } from '@tanstack/react-query';
-import { AuthContext } from '@/components/auth/Auth';
-import { ReactQueryWrapperContext } from '@/components/react-query-wrapper/ReactQueryWrapper';
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import NotificationsFollowBtn from "@/components/brain/notifications/NotificationsFollowBtn";
+import { AuthContext } from "@/components/auth/Auth";
+import { ReactQueryWrapperContext } from "@/components/react-query-wrapper/ReactQueryWrapper";
+import { ApiIdentitySubscriptionTargetAction } from "@/generated/models/ApiIdentitySubscriptionTargetAction";
+import type { ApiProfileMin } from "@/generated/models/ApiProfileMin";
+import {
+  commonApiDeleteWithBody,
+  commonApiPost,
+} from "@/services/api/common-api";
 
-jest.mock('@tanstack/react-query');
+jest.mock("@/services/api/common-api", () => ({
+  commonApiDeleteWithBody: jest.fn(),
+  commonApiPost: jest.fn(),
+}));
 
-const followCall = jest.fn();
-const unfollowCall = jest.fn();
-const mutations: any[] = [];
-(useMutation as jest.Mock).mockImplementation((config) => {
-  const fn = jest.fn(async () => { config.onSuccess?.(); });
-  mutations.push({ mutateAsync: fn });
-  return { mutateAsync: fn };
-});
+const commonApiPostMock = commonApiPost as jest.Mock;
+const commonApiDeleteWithBodyMock = commonApiDeleteWithBody as jest.Mock;
 
-const ctxAuth = { requestAuth: jest.fn().mockResolvedValue({ success: true }), setToast: jest.fn() } as any;
-const ctxRQ = { onIdentityFollowChange: jest.fn() } as any;
-
-function renderBtn(profile: any) {
-  mutations.length = 0;
-  return render(
-    <AuthContext.Provider value={ctxAuth}>
-      <ReactQueryWrapperContext.Provider value={ctxRQ}>
-        <NotificationsFollowBtn profile={profile} />
-      </ReactQueryWrapperContext.Provider>
-    </AuthContext.Provider>
-  );
+function createProfile(following: boolean): ApiProfileMin {
+  return {
+    handle: "bob",
+    subscribed_actions: following
+      ? [ApiIdentitySubscriptionTargetAction.DropCreated]
+      : [],
+  } as ApiProfileMin;
 }
 
-it('follows when not currently following', async () => {
-  const user = userEvent.setup();
-  renderBtn({ handle: 'bob', subscribed_actions: [] });
-  await user.click(screen.getByRole('button'));
-  expect(mutations[0].mutateAsync).toHaveBeenCalled();
-});
+describe("NotificationsFollowBtn", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    commonApiPostMock.mockResolvedValue(undefined);
+    commonApiDeleteWithBodyMock.mockResolvedValue(undefined);
+  });
 
-it('unfollows when already following', async () => {
-  const user = userEvent.setup();
-  renderBtn({ handle: 'bob', subscribed_actions: ['x'] });
-  await user.click(screen.getByRole('button'));
-  expect(mutations[1].mutateAsync).toHaveBeenCalled();
+  function setup({
+    following,
+    requestSuccess = true,
+  }: {
+    following: boolean;
+    requestSuccess?: boolean;
+  }) {
+    const requestAuth = jest
+      .fn()
+      .mockResolvedValue({ success: requestSuccess });
+    const setToast = jest.fn();
+    const onIdentityFollowChange = jest.fn();
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AuthContext.Provider value={{ setToast, requestAuth } as any}>
+          <ReactQueryWrapperContext.Provider
+            value={{ onIdentityFollowChange } as any}
+          >
+            <NotificationsFollowBtn profile={createProfile(following)} />
+          </ReactQueryWrapperContext.Provider>
+        </AuthContext.Provider>
+      </QueryClientProvider>
+    );
+
+    return { onIdentityFollowChange, requestAuth, setToast };
+  }
+
+  it("follows when not currently following", async () => {
+    const user = userEvent.setup();
+    const { onIdentityFollowChange, requestAuth } = setup({ following: false });
+
+    await user.click(screen.getByRole("button", { name: "Follow" }));
+
+    expect(requestAuth).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(commonApiPostMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endpoint: "identities/bob/subscriptions",
+        })
+      );
+    });
+    expect(commonApiDeleteWithBodyMock).not.toHaveBeenCalled();
+    expect(onIdentityFollowChange).toHaveBeenCalled();
+  });
+
+  it("unfollows when already following", async () => {
+    const user = userEvent.setup();
+    const { onIdentityFollowChange } = setup({ following: true });
+
+    await user.click(screen.getByRole("button", { name: "Following" }));
+
+    await waitFor(() => {
+      expect(commonApiDeleteWithBodyMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endpoint: "identities/bob/subscriptions",
+        })
+      );
+    });
+    expect(commonApiPostMock).not.toHaveBeenCalled();
+    expect(onIdentityFollowChange).toHaveBeenCalled();
+  });
+
+  it("does not mutate when authentication fails", async () => {
+    const user = userEvent.setup();
+    setup({ following: false, requestSuccess: false });
+    const followButton = screen.getByRole("button", { name: "Follow" });
+
+    await user.click(followButton);
+
+    expect(commonApiPostMock).not.toHaveBeenCalled();
+    expect(commonApiDeleteWithBodyMock).not.toHaveBeenCalled();
+    expect(followButton).not.toBeDisabled();
+  });
+
+  it.each([
+    {
+      action: "follow",
+      following: false,
+      buttonName: "Follow",
+      getRequestMock: () => commonApiPostMock,
+      toastTitle: "Couldn't follow this profile.",
+    },
+    {
+      action: "unfollow",
+      following: true,
+      buttonName: "Following",
+      getRequestMock: () => commonApiDeleteWithBodyMock,
+      toastTitle: "Couldn't unfollow this profile.",
+    },
+  ])(
+    "restores the button and shows a toast after a failed $action",
+    async ({ following, buttonName, getRequestMock, toastTitle }) => {
+      const expectedError = new Error("network unavailable");
+      getRequestMock().mockRejectedValueOnce(expectedError);
+      const user = userEvent.setup();
+      const { setToast } = setup({ following });
+      const followButton = screen.getByRole("button", { name: buttonName });
+
+      await user.click(followButton);
+
+      await waitFor(() => {
+        expect(setToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: "error",
+            title: toastTitle,
+            description: "Please try again.",
+          })
+        );
+      });
+      expect(followButton).not.toBeDisabled();
+    }
+  );
 });

--- a/__tests__/components/brain/notifications/drop-reacted/NotificationDropReactedGroup.test.tsx
+++ b/__tests__/components/brain/notifications/drop-reacted/NotificationDropReactedGroup.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import NotificationDropReactedGroup from "@/components/brain/notifications/drop-reacted/NotificationDropReactedGroup";
 import { ApiNotificationCause } from "@/generated/models/ApiNotificationCause";
@@ -61,7 +62,17 @@ jest.mock(
 
 jest.mock("@/components/brain/notifications/subcomponents/NotificationDrop", () => ({
   __esModule: true,
-  default: () => <div data-testid="drop" />,
+  default: ({
+    onDropContentClick,
+  }: {
+    onDropContentClick?: ((drop: unknown) => void) | undefined;
+  }) => (
+    <button
+      type="button"
+      data-testid="drop"
+      onClick={() => onDropContentClick?.({})}
+    />
+  ),
 }));
 
 jest.mock(
@@ -540,5 +551,56 @@ describe("NotificationDropReactedGroup", () => {
         notificationId: 1,
       })
     );
+  });
+
+  it("marks each unique notification once when the drop is opened", async () => {
+    const user = userEvent.setup();
+    const onMarkAsRead = jest.fn();
+    const onDropContentClick = jest.fn();
+
+    render(
+      <NotificationDropReactedGroup
+        group={{
+          type: "grouped_reactions",
+          id: 3,
+          createdAt: 300,
+          drop: createMockDrop(),
+          notifications: [
+            createNotification({
+              id: 1,
+              createdAt: 100,
+              reaction: ":heart:",
+              handle: "gpebbles",
+              pfp: "alice.png",
+            }),
+            createNotification({
+              id: 2,
+              createdAt: 200,
+              reaction: ":fire:",
+              handle: "prxt0",
+              pfp: "bob.png",
+            }),
+            createNotification({
+              id: 1,
+              createdAt: 300,
+              reaction: ":heart:",
+              handle: "gpebbles",
+              pfp: "alice.png",
+            }),
+          ],
+        }}
+        activeDrop={null}
+        onReply={jest.fn()}
+        onMarkAsRead={onMarkAsRead}
+        onDropContentClick={onDropContentClick}
+      />
+    );
+
+    await user.click(screen.getByTestId("drop"));
+    await user.click(screen.getByTestId("drop"));
+
+    expect(onMarkAsRead).toHaveBeenCalledTimes(1);
+    expect(onMarkAsRead).toHaveBeenCalledWith([1, 2]);
+    expect(onDropContentClick).toHaveBeenCalledTimes(2);
   });
 });

--- a/components/brain/notifications/NotificationItems.tsx
+++ b/components/brain/notifications/NotificationItems.tsx
@@ -20,7 +20,7 @@ interface NotificationItemsProps {
   readonly activeDrop: ActiveDropState | null;
   readonly onReply: (param: DropInteractionParams) => void;
   readonly onDropContentClick?: ((drop: ExtendedDrop) => void) | undefined;
-  readonly onMarkGroupAsRead?: ((ids: number[]) => Promise<void>) | undefined;
+  readonly onMarkGroupAsRead?: ((ids: number[]) => void) | undefined;
 }
 
 const getItemDrops = (item: NotificationDisplayItem): readonly ApiDrop[] => {

--- a/components/brain/notifications/NotificationsFollowBtn.tsx
+++ b/components/brain/notifications/NotificationsFollowBtn.tsx
@@ -126,10 +126,10 @@ const NotificationsFollowBtn: FC<NotificationsFollowBtnProps> = ({
       return;
     }
     if (following) {
-      await unFollowMutation.mutateAsync();
+      unFollowMutation.mutate();
       return;
     }
-    await followMutation.mutateAsync();
+    followMutation.mutate();
   };
 
   return (

--- a/components/brain/notifications/NotificationsWrapper.tsx
+++ b/components/brain/notifications/NotificationsWrapper.tsx
@@ -38,7 +38,7 @@ interface NotificationsWrapperProps {
   readonly loadingOlder: boolean;
   readonly activeDrop: ActiveDropState | null;
   readonly setActiveDrop: (drop: ActiveDropState | null) => void;
-  readonly markNotificationIdsAsRead?: (ids: number[]) => Promise<void>;
+  readonly markNotificationIdsAsRead?: (ids: number[]) => void;
 }
 
 export default function NotificationsWrapper({

--- a/components/brain/notifications/hooks/useNotificationsController.ts
+++ b/components/brain/notifications/hooks/useNotificationsController.ts
@@ -60,7 +60,7 @@ interface UseNotificationsControllerResult {
   readonly pagination: NotificationsPagination;
   readonly contentState: NotificationsContentState;
   readonly handlers: NotificationsHandlers;
-  readonly markNotificationIdsAsRead: (ids: number[]) => Promise<void>;
+  readonly markNotificationIdsAsRead: (ids: number[]) => void;
 }
 
 export const useNotificationsController =
@@ -169,7 +169,7 @@ export const useNotificationsController =
     });
     const rawItems = rawItemsFromQuery ?? items;
 
-    const { mutateAsync: markNotificationIdsAsRead } = useMutation({
+    const { mutate: markNotificationIdsAsRead } = useMutation({
       mutationFn: async (ids: number[]) => {
         await Promise.all(
           ids.map((id) =>

--- a/components/brain/notifications/subcomponents/NotificationsContent.tsx
+++ b/components/brain/notifications/subcomponents/NotificationsContent.tsx
@@ -24,7 +24,7 @@ interface NotificationsContentProps {
   readonly loadingOlder: boolean;
   readonly activeDrop: ActiveDropState | null;
   readonly setActiveDrop: (activeDrop: ActiveDropState | null) => void;
-  readonly markNotificationIdsAsRead?: (ids: number[]) => Promise<void>;
+  readonly markNotificationIdsAsRead?: (ids: number[]) => void;
 }
 
 export default function NotificationsContent({


### PR DESCRIPTION
<!-- sentry-fix-job:53 issue:7084719263 -->
## Issue

- Sentry: [6529-FRONTEND-2Y](https://seize-ff.sentry.io/issues/7084719263/)
- First seen: 2025-12-03T17:37:20.920Z
- Latest occurrence: 2026-08-07T18:20:27.000Z
- Automatic triage confidence: 99%

A small draft fix remains useful. The two newest production occurrences are repository-owned notification actions whose TanStack mutateAsync promises escape UI click handlers as unhandled rejections. The earlier generic follow-button fix is already deployed but did not cover these notification-specific paths.

## Fix

Notification read, follow, and unfollow handlers exposed unused React Query mutateAsync rejections. The initial regression test also used a jsdom unhandledrejection listener that could pass without observing Jest/Node promise rejections.

## Changes

- Kept notification reads and follow/unfollow actions on React Query's void-returning mutate API.
- Aligned grouped-read callback types with their void behavior.
- Removed the unreliable unhandled-rejection listener assertion and retained deterministic toast and restored-button checks.
- Preserved focused coverage for grouped reads, authentication cancellation, successful requests, and failed requests.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Focused Jest: 3 suites and 20 tests passed.
- Changed-file ESLint passed.
- Full no-emit TypeScript check passed.
- React Doctor passed with 100/100 and no issues.
- git diff --check passed.

## Risk

- Assessed risk: low
- Changed files: 8
- Changed lines: 294
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

Underlying connectivity failures can still occur and will continue to show the existing user-facing errors. This heterogeneous Sentry group may also continue receiving unrelated handled or third-party network events.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
