### PR TITLE
fix: Repaired the active regression-test finding while preserving the provider-safe Sentry fix. No commit, pus

### DIFF
--- a/__tests__/components/error/Error.providerless.test.tsx
+++ b/__tests__/components/error/Error.providerless.test.tsx
@@ -1,0 +1,59 @@
+import ErrorComponent from "@/components/error/Error";
+import { render, screen } from "@testing-library/react";
+
+type MockImageProps = React.ComponentPropsWithoutRef<"img"> & {
+  readonly priority?: boolean;
+  readonly unoptimized?: boolean;
+};
+
+jest.mock("next/navigation", () => ({
+  __esModule: true,
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ priority, unoptimized, ...imageProps }: MockImageProps) => {
+    void priority;
+    void unoptimized;
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img {...imageProps} />;
+  },
+}));
+
+jest.mock("react-use", () => ({
+  __esModule: true,
+  useCopyToClipboard: () => [null, jest.fn()],
+}));
+
+jest.mock("framer-motion", () => ({
+  __esModule: true,
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+  motion: { div: "div" },
+}));
+
+describe("ErrorComponent without providers", () => {
+  it("renders through the real optional title context", () => {
+    const resetMock = jest.fn();
+    document.title = "Existing title";
+
+    const { container } = render(<ErrorComponent onReset={resetMock} />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Welcome to the 6529 Page of Doom",
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /try again/i })
+    ).toBeInTheDocument();
+    expect(document.title).toBe("6529 Error");
+    expect(document.head.querySelector("title")).toHaveTextContent(
+      "6529 Error"
+    );
+    expect(container.querySelector("section title")).not.toBeInTheDocument();
+    expect(
+      Array.from(container.querySelectorAll("img"), (image) => image.alt)
+    ).toEqual(["", ""]);
+  });
+});

--- a/__tests__/components/error/Error.test.tsx
+++ b/__tests__/components/error/Error.test.tsx
@@ -5,7 +5,7 @@ import ErrorComponent from "@/components/error/Error";
 const setTitleMock = jest.fn();
 const copyToClipboardMock = jest.fn();
 let mockSearchParams: URLSearchParams;
-let mockTitleContext: { setTitle: typeof setTitleMock } | null;
+let mockTitleContext: { setTitle: typeof setTitleMock };
 
 jest.mock("@/contexts/TitleContext", () => ({
   __esModule: true,
@@ -19,9 +19,9 @@ jest.mock("next/navigation", () => ({
 
 jest.mock("next/image", () => ({
   __esModule: true,
-  default: ({ unoptimized, ...props }: any) => {
+  default: ({ unoptimized, priority, ...props }: any) => {
     // eslint-disable-next-line @next/next/no-img-element
-    return <img {...props} alt="SummerGlasses" />;
+    return <img {...props} />;
   },
 }));
 
@@ -62,24 +62,6 @@ describe("ErrorComponent", () => {
 
     const supportLink = screen.getByRole("link", { name: "support@6529.io" });
     expect(supportLink).toHaveAttribute("href", "mailto:support@6529.io");
-  });
-
-  it("renders the error fallback without a TitleProvider", () => {
-    mockTitleContext = null;
-    const resetMock = jest.fn();
-
-    render(<ErrorComponent onReset={resetMock} />);
-
-    expect(
-      screen.getByRole("heading", {
-        name: "Welcome to the 6529 Page of Doom",
-      })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /try again/i })
-    ).toBeInTheDocument();
-    expect(document.title).toBe("6529 Error");
-    expect(setTitleMock).not.toHaveBeenCalled();
   });
 
   it("reveals a provided stack trace when toggled", () => {

--- a/__tests__/components/error/Error.test.tsx
+++ b/__tests__/components/error/Error.test.tsx
@@ -5,12 +5,11 @@ import ErrorComponent from "@/components/error/Error";
 const setTitleMock = jest.fn();
 const copyToClipboardMock = jest.fn();
 let mockSearchParams: URLSearchParams;
+let mockTitleContext: { setTitle: typeof setTitleMock } | null;
 
 jest.mock("@/contexts/TitleContext", () => ({
   __esModule: true,
-  useTitle: () => ({
-    setTitle: setTitleMock,
-  }),
+  useTitleOptional: () => mockTitleContext,
 }));
 
 jest.mock("next/navigation", () => ({
@@ -46,6 +45,8 @@ describe("ErrorComponent", () => {
     setTitleMock.mockClear();
     copyToClipboardMock.mockClear();
     mockSearchParams = new URLSearchParams();
+    mockTitleContext = { setTitle: setTitleMock };
+    document.title = "Existing title";
   });
 
   afterEach(() => {
@@ -57,9 +58,28 @@ describe("ErrorComponent", () => {
     render(<ErrorComponent />);
 
     expect(setTitleMock).toHaveBeenCalledWith("6529 Error");
+    expect(document.title).toBe("Existing title");
 
     const supportLink = screen.getByRole("link", { name: "support@6529.io" });
     expect(supportLink).toHaveAttribute("href", "mailto:support@6529.io");
+  });
+
+  it("renders the error fallback without a TitleProvider", () => {
+    mockTitleContext = null;
+    const resetMock = jest.fn();
+
+    render(<ErrorComponent onReset={resetMock} />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Welcome to the 6529 Page of Doom",
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /try again/i })
+    ).toBeInTheDocument();
+    expect(document.title).toBe("6529 Error");
+    expect(setTitleMock).not.toHaveBeenCalled();
   });
 
   it("reveals a provided stack trace when toggled", () => {

--- a/__tests__/contexts/TitleContext.test.tsx
+++ b/__tests__/contexts/TitleContext.test.tsx
@@ -62,6 +62,16 @@ describe("TitleContext", () => {
     expect(result.current).toBeNull();
   });
 
+  it("returns the real context from optional access inside TitleProvider", () => {
+    const { result } = renderHook(() => useTitleOptional(), {
+      wrapper: TitleProvider,
+    });
+
+    expect(result.current).toEqual(
+      expect.objectContaining({ setTitle: expect.any(Function) })
+    );
+  });
+
   it("resets the client title when leaving a wave for the meme calendar", async () => {
     const view = render(
       <TitleProvider>

--- a/__tests__/contexts/TitleContext.test.tsx
+++ b/__tests__/contexts/TitleContext.test.tsx
@@ -3,8 +3,9 @@ import {
   TitleProvider,
   useSetWaveData,
   useTitle,
+  useTitleOptional,
 } from "@/contexts/TitleContext";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, renderHook, screen, waitFor } from "@testing-library/react";
 
 let mockPathname = "/waves/wave-1";
 let mockSearchParams = new URLSearchParams("divider=841669");
@@ -47,6 +48,18 @@ describe("TitleContext", () => {
     mockSearchParams = new URLSearchParams("divider=841669");
     mockActiveWaveId = "wave-1";
     document.title = "";
+  });
+
+  it("keeps useTitle strict outside TitleProvider", () => {
+    expect(() => renderHook(() => useTitle())).toThrow(
+      "useTitle must be used within a TitleProvider"
+    );
+  });
+
+  it("allows optional title access outside TitleProvider", () => {
+    const { result } = renderHook(() => useTitleOptional());
+
+    expect(result.current).toBeNull();
   });
 
   it("resets the client title when leaving a wave for the meme calendar", async () => {

--- a/__tests__/i18n/messages.test.ts
+++ b/__tests__/i18n/messages.test.ts
@@ -498,6 +498,12 @@ describe("frontend i18n helpers", () => {
     ).toBe("(1 notification) Waves | Brain");
   });
 
+  it("falls back to the source-locale global error title", () => {
+    for (const locale of SUPPORTED_LOCALES) {
+      expect(t(locale, "errorFallback.pageTitle")).toBe("6529 Error");
+    }
+  });
+
   it("translates the wave drop copy action messages", () => {
     expect(t("en-US", "waves.drop.actions.copyFailed")).toBe("Copy failed");
     expect(t("en-GB", "waves.drop.actions.copyFailed")).toBe("Copy failed");

--- a/components/error/Error.tsx
+++ b/components/error/Error.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Button from "@/components/utils/button/Button";
-import { useTitle } from "@/contexts/TitleContext";
+import { useTitleOptional } from "@/contexts/TitleContext";
 import {
   faChevronDown,
   faChevronUp,
@@ -20,12 +20,15 @@ type ErrorComponentProps = {
   readonly onReset?: (() => void) | undefined;
 };
 
+const ERROR_TITLE = "6529 Error";
+
 export default function ErrorComponent({
   stackTrace,
   digest,
   onReset,
 }: ErrorComponentProps = {}) {
-  const { setTitle } = useTitle();
+  const titleContext = useTitleOptional();
+  const setTitle = titleContext?.setTitle;
   const searchParams = useSearchParams();
   const [isStacktraceExpanded, setIsStacktraceExpanded] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
@@ -33,7 +36,7 @@ export default function ErrorComponent({
   const [, copyToClipboard] = useCopyToClipboard();
 
   useEffect(() => {
-    setTitle("6529 Error");
+    setTitle?.(ERROR_TITLE);
   }, [setTitle]);
 
   const stackTraceFromQuery = useMemo(() => {
@@ -62,6 +65,7 @@ export default function ErrorComponent({
 
   return (
     <section className="tw-flex tw-h-full tw-min-h-screen tw-w-full tw-items-center tw-justify-center">
+      {titleContext ? null : <title>{ERROR_TITLE}</title>}
       <div className="tw-flex tw-flex-col tw-items-center tw-gap-2">
         <Image
           unoptimized

--- a/components/error/Error.tsx
+++ b/components/error/Error.tsx
@@ -2,6 +2,8 @@
 
 import Button from "@/components/utils/button/Button";
 import { useTitleOptional } from "@/contexts/TitleContext";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import {
   faChevronDown,
   faChevronUp,
@@ -20,7 +22,7 @@ type ErrorComponentProps = {
   readonly onReset?: (() => void) | undefined;
 };
 
-const ERROR_TITLE = "6529 Error";
+const ERROR_TITLE = t(DEFAULT_LOCALE, "errorFallback.pageTitle");
 
 export default function ErrorComponent({
   stackTrace,
@@ -71,19 +73,21 @@ export default function ErrorComponent({
           unoptimized
           priority
           loading="eager"
-          width="0"
-          height="0"
-          style={{ height: "auto", width: "100px" }}
+          width={100}
+          height={100}
+          className="tw-h-auto tw-w-[100px]"
           src="/SummerGlasses.svg"
-          alt="SummerGlasses"
+          alt=""
         />
         <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-center tw-gap-2">
           <h3 className="tw-text-2xl tw-font-semibold">
             Welcome to the 6529 Page of Doom
           </h3>
-          <img
+          <Image
             src="/emojis/sgt_grimacing.webp"
-            alt="sgt_grimacing"
+            alt=""
+            width={32}
+            height={32}
             className="tw-h-8 tw-w-8"
           />
         </div>

--- a/contexts/TitleContext.tsx
+++ b/contexts/TitleContext.tsx
@@ -286,6 +286,8 @@ export const useTitle = () => {
   return context;
 };
 
+export const useTitleOptional = () => useContext(TitleContext) ?? null;
+
 // Hook to set page title - use this in page components
 export const useSetTitle = (pageTitle: string) => {
   const { setTitle } = useTitle();

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -400,6 +400,10 @@ const TITLE_CONTEXT_MESSAGES = objectMessages("titleContext", {
   "notifications.other": "({count} notifications) {title}",
 } as const);
 
+const ERROR_FALLBACK_MESSAGES = objectMessages("errorFallback", {
+  pageTitle: "6529 Error",
+} as const);
+
 const WAVE_NAVIGATION_MESSAGES = objectMessages("wave.navigation", {
   waveSections: "Wave sections",
   appSections: "App sections",
@@ -2615,6 +2619,7 @@ export const EN_US_MESSAGES = {
   ...HEADER_SEARCH_MESSAGES,
   ...NEW_VERSION_TOAST_MESSAGES,
   ...NAVIGATION_MESSAGES,
+  ...ERROR_FALLBACK_MESSAGES,
   ...PUBLIC_REVIEW_MESSAGES,
   ...TITLE_CONTEXT_MESSAGES,
   ...WAVE_NAVIGATION_MESSAGES,

--- a/ops/workstreams/i18n-fallbacks/README.md
+++ b/ops/workstreams/i18n-fallbacks/README.md
@@ -1,6 +1,6 @@
 # Frontend I18n Fallback Debt
 
-Status verified against current source on 2026-08-05.
+Status verified against current source on 2026-08-08.
 
 These records remain active because the corresponding surfaces still use the
 source locale, `DEFAULT_LOCALE`, hardcoded English copy, or source-locale
@@ -8,6 +8,7 @@ fallback dictionaries.
 
 | Record                                                              | Current source evidence                                                                                                       |
 | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| [Global error fallback](global-error-fallback.md)                   | The document title is message-backed in `en-US`; the remaining fallback controls and recovery copy still render in English    |
 | [About contents/navigation](about-contents-navigation.md)           | The About route, contents dropdown, Tech reports, and wallet-auth page still resolve with `DEFAULT_LOCALE`                    |
 | [About The Memes](about-memes.md)                                   | `AboutMemes` still resolves `about.memes.*` through `DEFAULT_LOCALE`                                                          |
 | [About minting](about-minting.md)                                   | `AboutMinting` still uses `DEFAULT_LOCALE`, with canonical body copy remaining in source-locale English                       |

--- a/ops/workstreams/i18n-fallbacks/global-error-fallback.md
+++ b/ops/workstreams/i18n-fallbacks/global-error-fallback.md
@@ -1,0 +1,17 @@
+# Global error fallback localization debt
+
+- Route/component: the App Router global error boundary and
+  `components/error/Error.tsx`.
+- Untranslated surface: the error heading and recovery message, retry control,
+  stack-trace show/hide and copy controls, copy status, and digest label.
+- Current fallback: the document title resolves through the `en-US`
+  `errorFallback.pageTitle` message. The remaining copy renders from English
+  literals; the decorative images use empty alternative text.
+- User impact: users in `en-GB`, `fr-FR`, `es-ES`, and `de-DE` contexts see a
+  functional English error page until this provider-independent fallback is
+  fully localized.
+- Owner/follow-up: frontend error-surface localization follow-up.
+- Remediation path: extract the remaining copy into `i18n/messages`, add
+  reviewed translations, choose the supported locale without relying on the
+  replaced root provider tree, verify wrapping and accessible names, then
+  remove this debt record.


### PR DESCRIPTION
<!-- sentry-fix-job:55 issue:7659419148 -->
## Issue

- Sentry: [6529-FRONTEND-F8](https://seize-ff.sentry.io/issues/7659419148/)
- First seen: 2026-08-07T20:21:48.981Z
- Latest occurrence: 2026-08-07T20:21:48.000Z
- Automatic triage confidence: 98%

A narrow repository fix is useful. The global error fallback renders ErrorComponent after Next.js has replaced the root layout, so TitleProvider is unavailable. ErrorComponent then throws while trying to display the original failure, preventing both the fallback UI and its original-error capture effect from completing.

## Fix

The providerless ErrorComponent test mocked the entire TitleContext module, so it bypassed the real hook integration and could not reproduce the exact production failure.

## Changes

- Moved providerless ErrorComponent coverage into a dedicated test using the real TitleContext module.
- Verified useTitleOptional returns null without a provider and the real context inside TitleProvider.
- Kept the mocked ErrorComponent suite for unrelated isolated behavior.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Focused Jest passed: 5 suites, 42 tests.
- lint:changed passed.
- typecheck:changed and the Jest typecheck ratchet passed.
- React Doctor completed at 98/100 with three pre-existing diagnostics.
- git diff --check passed.
- Focused Prettier was infrastructure-blocked by a missing shared Tailwind dependency file in the disposable worktree.

## Risk

- Assessed risk: low
- Changed files: 9
- Changed lines: 155
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

Final-head CI and production recurrence checks remain with the trusted publisher. The original upstream error that activated the global boundary remains unknown; this repair covers the exact secondary failure that masked it.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
