### PR TITLE
fix: No repair edit was needed. The current draft already preserves Set-only and first-party AbortError events

### DIFF
--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -130,6 +130,9 @@ describe("instrumentation-client", () => {
     },
   ];
   const expectedWaveAbortErrorValue = "AbortError: The user aborted a request.";
+  const coinbaseAnalyticsAbortErrorValue = "AbortError: AbortError";
+  const coinbaseAnalyticsIndexedDbGetErrorMessage =
+    "Analytics SDK: Error: IndexedDB:Get:InternalError undefined";
   const poperBlockerNetworkErrorMessage =
     "Network request failed. Please check your connection and try again. (/api/dm-drops/unread)";
   const poperBlockerInjectedFetchFrames = [
@@ -566,6 +569,23 @@ describe("instrumentation-client", () => {
           request_kind: "background_sync",
           trigger: "request_replaced",
         },
+      },
+    ],
+  });
+
+  const createCoinbaseAnalyticsIndexedDBAbortEvent = () => ({
+    ...createUnhandledRejectionEvent(coinbaseAnalyticsAbortErrorValue),
+    timestamp: 1_786_147_714.163,
+    tags: {
+      "DOMException.code": "20",
+      "os.name": "iOS",
+    },
+    breadcrumbs: [
+      {
+        category: "console",
+        level: "error",
+        message: coinbaseAnalyticsIndexedDbGetErrorMessage,
+        timestamp: 1_786_147_714.162,
       },
     ],
   });
@@ -2585,6 +2605,27 @@ describe("instrumentation-client", () => {
     const beforeSend = loadBeforeSend();
     const event = {
       ...createExpectedWaveReplacementAbortEvent(),
+      breadcrumbs: [],
+    };
+
+    const result = beforeSend(event);
+
+    expect(result).not.toBeNull();
+  });
+
+  it("drops the exact Coinbase analytics IndexedDB abort", () => {
+    const beforeSend = loadBeforeSend();
+    const event = createCoinbaseAnalyticsIndexedDBAbortEvent();
+
+    const result = beforeSend(event);
+
+    expect(result).toBeNull();
+  });
+
+  it("keeps the Coinbase-shaped AbortError without the vendor breadcrumb", () => {
+    const beforeSend = loadBeforeSend();
+    const event = {
+      ...createCoinbaseAnalyticsIndexedDBAbortEvent(),
       breadcrumbs: [],
     };
 

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -14,6 +14,7 @@ import {
   shouldFilterBrowserExtensionSendMessageError,
   shouldFilterBrowserExtensionWalletRejection,
   shouldFilterChromeMobileIosInjectedGaError,
+  shouldFilterCoinbaseAnalyticsIndexedDBAbort,
   shouldFilterCoinbaseWalletLinkWebSocket1006,
   shouldFilterDisconnectedWalletProviderRejection,
   shouldFilterGifPickerTenorCategoriesError,
@@ -153,9 +154,27 @@ type ExpectedWaveReplacementAbortOverrides = {
   additionalException?: SentryExceptionValue | undefined;
 };
 
+type CoinbaseAnalyticsIndexedDBAbortOverrides = {
+  exception?: Partial<SentryExceptionValue> | undefined;
+  domExceptionCode?: unknown;
+  includeDomExceptionCode?: boolean | undefined;
+  osName?: unknown;
+  includeOsName?: boolean | undefined;
+  eventTimestamp?: number | undefined;
+  includeEventTimestamp?: boolean | undefined;
+  breadcrumbs?: SentryClientEvent["breadcrumbs"];
+  additionalException?: SentryExceptionValue | undefined;
+};
+
 const expectedWaveAbortErrorValue = "AbortError: The user aborted a request.";
 const expectedWaveAbortEventTimestamp = 1_785_689_742.621;
 const expectedWaveAbortBreadcrumbTimestamp = 1_785_689_742.5;
+const coinbaseAnalyticsAbortEventTimestamp = 1_786_147_714.163;
+const coinbaseAnalyticsBreadcrumbTimestamp = 1_786_147_714.162;
+const coinbaseAnalyticsIndexedDbGetErrorMessage =
+  "Analytics SDK: Error: IndexedDB:Get:InternalError undefined";
+const coinbaseAnalyticsIndexedDbSetErrorMessage =
+  "Analytics SDK: Error: IndexedDB:Set:InternalError undefined";
 
 const createExpectedWaveReplacementAbortEvent = ({
   exception = {},
@@ -194,6 +213,48 @@ const createExpectedWaveReplacementAbortEvent = ({
   tags: includeDomExceptionCode
     ? { "DOMException.code": domExceptionCode }
     : {},
+  breadcrumbs,
+});
+
+const createCoinbaseAnalyticsIndexedDBAbortEvent = ({
+  exception = {},
+  domExceptionCode = "20",
+  includeDomExceptionCode = true,
+  osName = "iOS",
+  includeOsName = true,
+  eventTimestamp = coinbaseAnalyticsAbortEventTimestamp,
+  includeEventTimestamp = true,
+  breadcrumbs = [
+    {
+      category: "console",
+      level: "error",
+      message: coinbaseAnalyticsIndexedDbGetErrorMessage,
+      timestamp: coinbaseAnalyticsBreadcrumbTimestamp,
+    },
+  ],
+  additionalException,
+}: CoinbaseAnalyticsIndexedDBAbortOverrides = {}): TestSentryClientEvent => ({
+  ...(includeEventTimestamp ? { timestamp: eventTimestamp } : {}),
+  exception: {
+    values: [
+      {
+        type: "Error",
+        value: "AbortError: AbortError",
+        mechanism: {
+          type: "auto.browser.global_handlers.onunhandledrejection",
+          handled: false,
+        },
+        ...exception,
+      },
+      ...(additionalException ? [additionalException] : []),
+    ],
+  },
+  tags: {
+    ...(includeDomExceptionCode
+      ? { "DOMException.code": domExceptionCode }
+      : {}),
+    ...(includeOsName ? { "os.name": osName } : {}),
+  },
   breadcrumbs,
 });
 
@@ -10243,6 +10304,194 @@ describe("sentry-client-filters", () => {
     // Assert
     expect(result).toBe(false);
   });
+
+  it.each([
+    ["Get-only", [coinbaseAnalyticsIndexedDbGetErrorMessage]],
+    [
+      "Get-and-Set",
+      [
+        coinbaseAnalyticsIndexedDbGetErrorMessage,
+        coinbaseAnalyticsIndexedDbSetErrorMessage,
+      ],
+    ],
+  ])(
+    "filters the exact Coinbase analytics IndexedDB abort with %s evidence",
+    (_, messages) => {
+      const event = createCoinbaseAnalyticsIndexedDBAbortEvent({
+        breadcrumbs: messages.map((message) => ({
+          category: "console",
+          level: "error",
+          message,
+          timestamp: coinbaseAnalyticsBreadcrumbTimestamp,
+        })),
+      });
+
+      const result = shouldFilterCoinbaseAnalyticsIndexedDBAbort(event);
+
+      expect(result).toBe(true);
+    }
+  );
+
+  it("filters the exact Coinbase analytics abort using the client user agent", () => {
+    const event = {
+      ...createCoinbaseAnalyticsIndexedDBAbortEvent({ includeOsName: false }),
+      request: {
+        headers: {
+          "User-Agent":
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148 Safari/604.1",
+        },
+      },
+    };
+
+    const result = shouldFilterCoinbaseAnalyticsIndexedDBAbort(event);
+
+    expect(result).toBe(true);
+  });
+
+  it("filters the Coinbase analytics abort at the causal time boundary", () => {
+    const event = createCoinbaseAnalyticsIndexedDBAbortEvent({
+      eventTimestamp: coinbaseAnalyticsBreadcrumbTimestamp + 1,
+    });
+
+    const result = shouldFilterCoinbaseAnalyticsIndexedDBAbort(event);
+
+    expect(result).toBe(true);
+  });
+
+  it("keeps the Coinbase-shaped abort when the exact breadcrumb is count-stale", () => {
+    const event = createCoinbaseAnalyticsIndexedDBAbortEvent({
+      breadcrumbs: [
+        {
+          category: "console",
+          level: "error",
+          message: coinbaseAnalyticsIndexedDbGetErrorMessage,
+          timestamp: coinbaseAnalyticsBreadcrumbTimestamp,
+        },
+        ...Array.from({ length: 15 }, (_, index) => ({
+          type: "http",
+          category: "fetch",
+          level: "info",
+          message: `later request ${index}`,
+        })),
+      ],
+    });
+
+    const result = shouldFilterCoinbaseAnalyticsIndexedDBAbort(event);
+
+    expect(result).toBe(false);
+  });
+
+  it.each([
+    [
+      "an altered exception message",
+      { exception: { value: "AbortError: The operation was aborted" } },
+    ],
+    ["a different exception type", { exception: { type: "AbortError" } }],
+    ["a different DOMException code", { domExceptionCode: "19" }],
+    ["a numeric DOMException code", { domExceptionCode: 20 }],
+    ["a missing DOMException code", { includeDomExceptionCode: false }],
+    ["a non-iOS operating system", { osName: "Android" }],
+    ["missing platform evidence", { includeOsName: false }],
+    ["a missing event timestamp", { includeEventTimestamp: false }],
+    [
+      "a stale vendor breadcrumb",
+      { eventTimestamp: coinbaseAnalyticsBreadcrumbTimestamp + 1.001 },
+    ],
+    [
+      "a vendor breadcrumb after the event",
+      { eventTimestamp: coinbaseAnalyticsBreadcrumbTimestamp - 0.001 },
+    ],
+    [
+      "a different mechanism",
+      {
+        exception: {
+          mechanism: {
+            type: "auto.browser.global_handlers.onerror",
+            handled: false,
+          },
+        },
+      },
+    ],
+    [
+      "a handled mechanism",
+      {
+        exception: {
+          mechanism: {
+            type: "auto.browser.global_handlers.onunhandledrejection",
+            handled: true,
+          },
+        },
+      },
+    ],
+    [
+      "an application-owned frame",
+      {
+        exception: {
+          stacktrace: {
+            frames: [{ filename: "app:///services/api/common-api.ts" }],
+          },
+        },
+      },
+    ],
+    [
+      "an altered console message",
+      {
+        breadcrumbs: [
+          {
+            category: "console",
+            level: "error",
+            message: "Analytics SDK: Error: IndexedDB:Get:InternalError",
+            timestamp: coinbaseAnalyticsBreadcrumbTimestamp,
+          },
+        ],
+      },
+    ],
+    [
+      "altered console metadata",
+      {
+        breadcrumbs: [
+          {
+            category: "console",
+            level: "warning",
+            message: coinbaseAnalyticsIndexedDbGetErrorMessage,
+            timestamp: coinbaseAnalyticsBreadcrumbTimestamp,
+          },
+        ],
+      },
+    ],
+    ["a missing vendor breadcrumb", { breadcrumbs: [] }],
+    [
+      "a Set-only vendor breadcrumb",
+      {
+        breadcrumbs: [
+          {
+            category: "console",
+            level: "error",
+            message: coinbaseAnalyticsIndexedDbSetErrorMessage,
+            timestamp: coinbaseAnalyticsBreadcrumbTimestamp,
+          },
+        ],
+      },
+    ],
+    [
+      "an additional exception",
+      {
+        additionalException: {
+          type: "TypeError",
+          value: "A nearby application failure",
+        },
+      },
+    ],
+  ] satisfies Array<[string, CoinbaseAnalyticsIndexedDBAbortOverrides]>)(
+    "keeps the Coinbase analytics abort near miss with %s",
+    (_, overrides) => {
+      const event = createCoinbaseAnalyticsIndexedDBAbortEvent(overrides);
+
+      const result = shouldFilterCoinbaseAnalyticsIndexedDBAbort(event);
+
+      expect(result).toBe(false);
+    }
+  );
 
   it("filters the exact expected Wave background-sync replacement abort", () => {
     const event = createExpectedWaveReplacementAbortEvent();

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -30,6 +30,7 @@ import {
   shouldFilterBrowserExtensionSendMessageError,
   shouldFilterBrowserExtensionWalletRejection,
   shouldFilterChromeMobileIosInjectedGaError,
+  shouldFilterCoinbaseAnalyticsIndexedDBAbort,
   shouldFilterPoperBlockerOrphanFetchRejection,
   shouldFilterExpectedWaveRequestReplacementAbort,
   shouldFilterCoinbaseWalletLinkWebSocket1006,
@@ -181,6 +182,10 @@ function shouldFilterEvent(
   }
 
   if (shouldFilterPoperBlockerOrphanFetchRejection(event, hint)) {
+    return true;
+  }
+
+  if (shouldFilterCoinbaseAnalyticsIndexedDBAbort(event)) {
     return true;
   }
 

--- a/utils/sentry-client-filters.ts
+++ b/utils/sentry-client-filters.ts
@@ -9,6 +9,9 @@ export { LOW_VALUE_NETWORK_ERROR_SAMPLE_RATE } from "./sentry-client-filters/con
 export { redactDropReactionFailureIdentifiers } from "./sentry-client-filters/drop-reaction";
 export { shouldFilterChromeMobileIosInjectedGaError } from "./sentry-client-filters/chrome-ios";
 export {
+  shouldFilterCoinbaseAnalyticsIndexedDBAbort,
+} from "./sentry-client-filters/coinbase-analytics";
+export {
   getLowValueNetworkErrorDecision,
   getLowValueNetworkErrorTargetUrl,
   getNetworkErrorMessageTargetUrl,

--- a/utils/sentry-client-filters/coinbase-analytics.ts
+++ b/utils/sentry-client-filters/coinbase-analytics.ts
@@ -1,0 +1,129 @@
+import { browserUnhandledRejectionMechanism } from "./constants";
+import type {
+  SentryBreadcrumb,
+  SentryClientEvent,
+  SentryExceptionValue,
+} from "./types";
+import {
+  getBreadcrumbValues,
+  getContextString,
+  getRequestHeaderString,
+  getRuntimeUserAgentString,
+  getStringValue,
+  isRecord,
+} from "./value-utils";
+
+const coinbaseAnalyticsAbortErrorValue = "AbortError: AbortError";
+const expectedDomExceptionCode = "20";
+const maximumCausalBreadcrumbDistance = 15;
+const maximumCausalTimeDifferenceSeconds = 1;
+const iosUserAgentPattern = /\b(?:iphone|ipad|ipod)\b/i;
+const coinbaseAnalyticsIndexedDbGetErrorMessage =
+  "Analytics SDK: Error: IndexedDB:Get:InternalError undefined";
+
+function hasNoStackFrames(value: SentryExceptionValue): boolean {
+  const stacktrace: unknown = value.stacktrace;
+  if (stacktrace === undefined) {
+    return true;
+  }
+
+  if (!isRecord(stacktrace)) {
+    return false;
+  }
+
+  const frames = stacktrace["frames"];
+  return Array.isArray(frames) && frames.length === 0;
+}
+
+function isIosOsValue(value: string): boolean {
+  return value === "iOS" || value.startsWith("iOS ");
+}
+
+function hasIosPlatformEvidence(event: SentryClientEvent): boolean {
+  const osValues = [
+    getContextString(event, "os", "name"),
+    getStringValue(event.tags?.["os.name"]),
+    getStringValue(event.tags?.["os"]),
+  ].filter((value): value is string => value !== undefined);
+
+  if (osValues.length > 0) {
+    return osValues.every(isIosOsValue);
+  }
+
+  const userAgent =
+    getRequestHeaderString(event, "user-agent") ??
+    getRuntimeUserAgentString();
+  return userAgent !== undefined && iosUserAgentPattern.test(userAgent);
+}
+
+function isCoinbaseAnalyticsIndexedDbGetErrorBreadcrumb(
+  breadcrumb: SentryBreadcrumb | null | undefined
+): boolean {
+  if (!isRecord(breadcrumb)) {
+    return false;
+  }
+
+  return (
+    breadcrumb.category === "console" &&
+    breadcrumb.level === "error" &&
+    breadcrumb.message === coinbaseAnalyticsIndexedDbGetErrorMessage
+  );
+}
+
+function isWithinCausalTimeWindow(
+  eventTimestamp: number | undefined,
+  breadcrumbTimestamp: number | undefined
+): boolean {
+  if (
+    typeof eventTimestamp !== "number" ||
+    !Number.isFinite(eventTimestamp) ||
+    typeof breadcrumbTimestamp !== "number" ||
+    !Number.isFinite(breadcrumbTimestamp)
+  ) {
+    return false;
+  }
+
+  const timeDifference = eventTimestamp - breadcrumbTimestamp;
+  return (
+    timeDifference >= 0 &&
+    timeDifference <= maximumCausalTimeDifferenceSeconds
+  );
+}
+
+function hasRecentCoinbaseAnalyticsIndexedDbGetErrorBreadcrumb(
+  event: SentryClientEvent
+): boolean {
+  const recentBreadcrumbs = getBreadcrumbValues(event).slice(
+    -maximumCausalBreadcrumbDistance
+  );
+
+  return recentBreadcrumbs.some(
+    (breadcrumb) =>
+      isCoinbaseAnalyticsIndexedDbGetErrorBreadcrumb(breadcrumb) &&
+      isWithinCausalTimeWindow(event.timestamp, breadcrumb.timestamp)
+  );
+}
+
+export function shouldFilterCoinbaseAnalyticsIndexedDBAbort(
+  event: SentryClientEvent
+): boolean {
+  const values = event.exception?.values;
+  if (!Array.isArray(values) || values.length !== 1) {
+    return false;
+  }
+
+  const [value] = values;
+  if (
+    value?.type !== "Error" ||
+    value.value !== coinbaseAnalyticsAbortErrorValue ||
+    value.mechanism?.type !== browserUnhandledRejectionMechanism ||
+    value.mechanism.handled !== false ||
+    event.tags?.["DOMException.code"] !== expectedDomExceptionCode ||
+    !hasNoStackFrames(value) ||
+    !hasIosPlatformEvidence(event)
+  ) {
+    return false;
+  }
+
+  return hasRecentCoinbaseAnalyticsIndexedDbGetErrorBreadcrumb(event);
+}


### PR DESCRIPTION
<!-- sentry-fix-job:56 issue:7082202049 -->
## Issue

- Sentry: [6529-FRONTEND-2S](https://seize-ff.sentry.io/issues/7082202049/)
- First seen: 2025-12-02T20:06:51.099Z
- Latest occurrence: 2026-08-08T00:08:34.000Z
- Automatic triage confidence: 95%

A useful draft fix is available: narrowly filter the Coinbase/Base analytics IndexedDB abort signature. Six of 11 retained events have decisive vendor breadcrumbs; generic AbortError events must remain visible.

## Fix

Coinbase/Base analytics can produce a frame-less iOS unhandled rejection when its IndexedDB Get path fails. The [commit-pinned vendor source](https://github.com/base/account-sdk/blob/5422cca5b008c194c033f309978d39a2c80c3210/packages/account-sdk/src/vendor-js/CCA/ca.js) supports requiring the exact Get breadcrumb; Set failures are caught separately.

## Changes

- No repository files changed.
- Confirmed the matcher requires the exact IndexedDB Get breadcrumb, so Set-only events remain reportable.
- Confirmed the existing negative test preserves an app-owned frame even when the exact vendor Get breadcrumb is present, which is stricter than the suggested boundary test.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Focused Jest: 2 suites and 656 tests passed.
- Changed-file lint passed.
- Changed production TypeScript check passed for 3 files.
- Jest typecheck ratchet passed.
- React Doctor against origin/main scored 100/100 with no issues across 5 changed files.
- git diff --check passed and the worktree remained clean.
- Read-only GitHub inspection showed all reported checks successful on the current draft head.

## Risk

- Assessed risk: low
- Changed files: 5
- Changed lines: 427
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

Only 11 of 54 occurrences are retained. Five events without the exact Get breadcrumb intentionally remain reportable, and this filter does not repair the upstream IndexedDB behavior.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
