### PR TITLE
Keep wave sharing in the overflow menu

### DIFF
--- a/__tests__/components/header/AppHeader.test.tsx
+++ b/__tests__/components/header/AppHeader.test.tsx
@@ -944,7 +944,7 @@ describe("AppHeader", () => {
     expect(screen.getByTestId("wave-picture")).toBeInTheDocument();
   });
 
-  it("shows gallery toggle in eligible wave context and toggles view mode", () => {
+  it("keeps eligible wave sharing in the overflow with the arrow icon", () => {
     const toggleViewMode = jest.fn();
     const wave = {
       id: "w4",
@@ -961,8 +961,18 @@ describe("AppHeader", () => {
       waveInfo: { isRankWave: false, isMemesWave: false, isDm: false },
     });
 
+    expect(
+      screen.queryByRole("button", { name: "Share page" })
+    ).not.toBeInTheDocument();
+
     fireEvent.click(
       screen.getByRole("button", { name: "More header actions" })
+    );
+
+    const shareWave = screen.getByRole("menuitem", { name: "Share wave" });
+    expect(shareWave.querySelector("svg")).toHaveAttribute(
+      "viewBox",
+      "0 0 512 512"
     );
 
     const galleryToggle = screen.getByRole("menuitem", {

--- a/__tests__/components/header/AppHeader.test.tsx
+++ b/__tests__/components/header/AppHeader.test.tsx
@@ -4,6 +4,7 @@ import {
   screen,
   fireEvent,
   waitFor,
+  within,
 } from "@testing-library/react";
 import React from "react";
 import AppHeader from "@/components/header/AppHeader";
@@ -55,6 +56,12 @@ jest.mock("@/components/utils/Spinner", () => ({
 jest.mock("@/components/header/HeaderActionButtons", () => ({
   __esModule: true,
   default: () => <div data-testid="actions" />,
+}));
+jest.mock("@/components/common/icons/ShareArrowIcon", () => ({
+  __esModule: true,
+  default: ({ className }: { readonly className?: string | undefined }) => (
+    <svg data-testid="share-arrow-icon" className={className} />
+  ),
 }));
 jest.mock("@/hooks/useCapacitor", () => ({
   __esModule: true,
@@ -944,7 +951,7 @@ describe("AppHeader", () => {
     expect(screen.getByTestId("wave-picture")).toBeInTheDocument();
   });
 
-  it("keeps eligible wave sharing in the overflow with the arrow icon", () => {
+  it("keeps wave sharing in the overflow and toggles gallery view", () => {
     const toggleViewMode = jest.fn();
     const wave = {
       id: "w4",
@@ -953,6 +960,7 @@ describe("AppHeader", () => {
       contributors_overview: [{ contributor_pfp: "/c1.png" }],
       chat: { scope: { group: { is_direct_message: false } } },
     };
+    useCapacitor.mockReturnValue({ isCapacitor: true });
     setup({
       wave,
       asPath: "/waves/w4",
@@ -970,10 +978,7 @@ describe("AppHeader", () => {
     );
 
     const shareWave = screen.getByRole("menuitem", { name: "Share wave" });
-    expect(shareWave.querySelector("svg")).toHaveAttribute(
-      "viewBox",
-      "0 0 512 512"
-    );
+    expect(within(shareWave).getByTestId("share-arrow-icon")).toBeVisible();
 
     const galleryToggle = screen.getByRole("menuitem", {
       name: "Switch to gallery view",

--- a/components/header/AppHeader.tsx
+++ b/components/header/AppHeader.tsx
@@ -587,6 +587,7 @@ export default function AppHeader() {
   });
   const showPageShareAction =
     isCapacitor &&
+    !isInsideWave &&
     isPageShareSupported({ activeView, pathname, surface: "mobile" });
 
   const isProfilePage = typeof params["user"] === "string";

--- a/components/header/app-header-more-menu-items.tsx
+++ b/components/header/app-header-more-menu-items.tsx
@@ -2,7 +2,6 @@ import {
   ChatBubbleLeftIcon,
   CheckIcon,
   LinkIcon,
-  ShareIcon,
   Squares2X2Icon,
 } from "@heroicons/react/24/outline";
 import type { ReactNode } from "react";
@@ -45,11 +44,7 @@ const getWaveLinkActionIcon = ({
   }
 
   if (waveLinkActionMode === "share") {
-    return direct ? (
-      <ShareArrowIcon className={iconClassName} />
-    ) : (
-      <ShareIcon className={iconClassName} />
-    );
+    return <ShareArrowIcon className={iconClassName} />;
   }
 
   return <LinkIcon className={iconClassName} />;

--- a/ops/docs/navigation/feature-app-header-context.md
+++ b/ops/docs/navigation/feature-app-header-context.md
@@ -64,10 +64,12 @@ In the app layout, the header adapts to route and thread state. It controls:
    - On `/`, network-health heart shortcut appears.
    - In the native app and small-screen web header, `Share page` appears
      immediately before `Search` on pages outside `/`, `/messages*`, and
-     `/notifications*`.
+     `/notifications*`. In the native app, it is also hidden while an active
+     wave is open because that wave keeps its share action in `More`.
    - `Search` is always available.
 7. More actions:
-   - Wave-specific actions can appear in the overflow menu.
+   - Wave-specific actions can appear in the overflow menu. The wave share
+     action uses the arrow-style share icon there.
    - If the only overflow action is the wave link share/copy action, it renders
      as a direct icon button instead of a one-item overflow menu.
 
@@ -96,7 +98,8 @@ In the app layout, the header adapts to route and thread state. It controls:
 - Mobile page share is hidden on `/`, `/messages*`, and `/notifications*`, and
   also while the native app or small-screen web header is showing the Messages
   context from query-state navigation. Waves routes and the Waves query context
-  remain shareable.
+  remain shareable, but the native app hides the general page-share button once
+  a wave is active and uses that wave's `More` menu instead.
 - Rememes formatting applies only when both `contract` and `tokenId` are
   present.
 - Drop Forge title formatting applies only on `craft` and `launch` route
@@ -110,7 +113,8 @@ In the app layout, the header adapts to route and thread state. It controls:
 - If create action is missing, verify you are in waves/messages list context
   and not inside an active thread.
 - If page share is missing on mobile, verify the route is not `/`, under
-  `/messages` or `/notifications`, or rendered in the Messages query view.
+  `/messages` or `/notifications`, rendered in the Messages query view, or an
+  active wave in the native app. Active waves share from `More`.
 - If menu does not open, retry from the same top-left control.
 - If the menu/avatar unread dot looks stale, open account controls and switch
   to the target account, then revisit `/notifications`.

--- a/ops/docs/navigation/feature-share-modal.md
+++ b/ops/docs/navigation/feature-share-modal.md
@@ -31,6 +31,8 @@ profile menu. Mobile web and native apps open page sharing from the app header.
   device connection with a full-width divider inside the connection-actions
   section and stronger section boundaries around the pair.
 - Native app: select the page-share icon in the app header on supported routes.
+  When a wave is active, use its arrow-style share action inside the `More`
+  menu instead of a separate page-share icon.
 
 ## User Journey
 
@@ -81,8 +83,10 @@ mobile web and the native app hide it. Specifically, Share is hidden on:
 - home (`/`) on mobile web and in the native app only
 
 All other pages, including `/waves`, wave detail routes, and the `waves` query
-view, support Share. Desktop web uses the sidebar entry; mobile web and the
-native app use their header entry.
+view, support Share. Desktop web uses the sidebar entry and mobile web uses its
+header entry. In the native app, the general header entry is hidden while a
+wave is active because the wave-specific share action is already available in
+the `More` menu.
 
 ## Connect Device
 

--- a/ops/docs/waves/header/feature-wave-link-share-copy.md
+++ b/ops/docs/waves/header/feature-wave-link-share-copy.md
@@ -35,7 +35,7 @@ Users can:
 2. Use the wave-link action button near other thread header controls. In the
    native app header, the action appears directly when it is the only overflow
    action; when other wave actions are available, it appears inside the
-   overflow menu.
+   overflow menu with the arrow-style share icon.
 
 ## User Journey
 
@@ -55,8 +55,9 @@ Users can:
 - Share-cancel (`AbortError`) does not trigger copy fallback.
 - If share is unsupported, the action starts in copy mode.
 - This control does not change tabs, route, or sidebar open/closed state.
-- The native app's global `Share page` header button is hidden on wave routes,
-  so wave routes keep using this wave-specific share/copy action.
+- The native app's global `Share page` header button is hidden while a wave is
+  active, so the header does not duplicate this wave-specific share/copy
+  action.
 
 ## Failure and Recovery
 

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -3944,6 +3944,7 @@
         "Copy changes to a green Copied state for about 1.5 seconds.",
         "System sharing uses the browser URL at invocation time, including search parameters and the hash; cancellation is silent, while runtime unavailability hides the action and provides accessible feedback without falling back to Copy.",
         "Desktop web supports page sharing on home, while mobile web and the native app hide it there; all three surfaces hide page sharing on Messages, Notifications, and the Messages query view, while Waves and the Waves query view remain shareable.",
+        "When a wave is active in the native app, the general Share page button is hidden and the wave-specific arrow share action remains inside the More menu.",
         "Mobile web and native app sharing use their existing header placement and open the compact Share dialog.",
         "The profile menu contains Profile and Connect Device; connection targets never appear in the Share modal.",
         "Wave-specific link sharing also exists in the wave header.",
@@ -5114,6 +5115,7 @@
       "facts": [
         "Wave link share and copy behavior is documented as a wave header feature.",
         "Use the wave header share/copy affordance when users ask how to send someone a wave link.",
+        "In the native app, an active wave keeps sharing in the More menu with an arrow-style share icon instead of showing a second page-share button.",
         "General route sharing is covered by the shared share modal record."
       ],
       "canonical_path": "/waves",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -3940,6 +3940,7 @@
         "Copy changes to a green Copied state for about 1.5 seconds.",
         "System sharing uses the browser URL at invocation time, including search parameters and the hash; cancellation is silent, while runtime unavailability hides the action and provides accessible feedback without falling back to Copy.",
         "Desktop web supports page sharing on home, while mobile web and the native app hide it there; all three surfaces hide page sharing on Messages, Notifications, and the Messages query view, while Waves and the Waves query view remain shareable.",
+        "When a wave is active in the native app, the general Share page button is hidden and the wave-specific arrow share action remains inside the More menu.",
         "Mobile web and native app sharing use their existing header placement and open the compact Share dialog.",
         "The profile menu contains Profile and Connect Device; connection targets never appear in the Share modal.",
         "Wave-specific link sharing also exists in the wave header.",
@@ -5110,6 +5111,7 @@
       "facts": [
         "Wave link share and copy behavior is documented as a wave header feature.",
         "Use the wave header share/copy affordance when users ask how to send someone a wave link.",
+        "In the native app, an active wave keeps sharing in the More menu with an arrow-style share icon instead of showing a second page-share button.",
         "General route sharing is covered by the shared share modal record."
       ],
       "canonical_path": "/waves",


### PR DESCRIPTION
## Issue

- An active wave in the native app showed the general page-share button beside Search even though wave sharing was already available in the three-dot menu.

## Fix

- Hide the general page-share button while a wave is active and use the arrow-style share icon for the wave action inside the existing overflow menu.

## Changes

- Preserve page sharing on non-wave pages and the Waves list.
- Preserve existing copy fallback and success-state icons.
- Add focused regression coverage and align navigation, Waves, and Help Bot documentation.

## Validation

- Focused AppHeader component suite
- Changed-file lint and type checking
- React Doctor diff scan (100/100)
- Help-index sync, docs-link validation, and diff checks

## Risk

- Level: Low
- Why: The change is limited to native active-wave header visibility and one existing menu icon.
- Rollback: Revert the single commit.

## Review Notes

- Verify generic active waves show only Search plus the three-dot menu, with the arrow icon on the Share wave menu row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated sharing controls for native-app waves: wave sharing is available through the More menu with an arrow-style share action.
  * The general Share page button is hidden while a native-app wave is active, avoiding duplicate sharing options.
  * Page sharing remains available on eligible native and web routes outside active waves.

* **Documentation**
  * Updated navigation, wave-sharing, and help content to reflect the revised sharing behavior and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->