### PR TITLE
fix(museum): bind deployed E2E provenance to catalog source

### DIFF
--- a/.github/workflows/museum-publication-compatibility.yml
+++ b/.github/workflows/museum-publication-compatibility.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       source_commit:
-        description: Exact canonical 6529networkmuseum main commit to validate.
+        description: Exact canonical 6529networkmuseum catalog/control commit to validate.
         required: true
         type: string
   repository_dispatch:
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       source_commit:
-        description: Exact canonical 6529networkmuseum main commit; blank resolves current main.
+        description: Exact canonical 6529networkmuseum catalog/control commit; blank resolves current main.
         required: false
         type: string
       run_full_sweep:
@@ -81,6 +81,7 @@ jobs:
       contents: read
     outputs:
       frontend_commit: ${{ steps.frontend.outputs.frontend_commit }}
+      publication_commit: ${{ steps.adapter.outputs.publication_commit }}
     steps:
       - name: Check out current frontend main
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -115,6 +116,7 @@ jobs:
       - name: Install frozen dependencies
         run: ./bin/6529 install:frozen
       - name: Validate exact source through the strict adapter
+        id: adapter
         env:
           FRONTEND_COMMIT: ${{ steps.frontend.outputs.frontend_commit }}
           MUSEUM_PUBLICATION_COMPATIBILITY_COMMIT: ${{ needs.resolve-canonical-source.outputs.source_commit }}
@@ -132,7 +134,7 @@ jobs:
               --arg contract "museum-publication-compatibility-v1" \
               --arg source_commit "$MUSEUM_PUBLICATION_COMPATIBILITY_COMMIT" \
               --arg error_code "publication_compatibility_runner_failed" \
-              "{contract:\$contract,source_commit:\$source_commit,accepted:false,adapter_status:\"unavailable\",adapter_error_code:\$error_code,publication_commit:null}" \
+              "{contract:\$contract,source_commit:\$source_commit,accepted:false,adapter_status:\"unavailable\",adapter_error_code:\$error_code,publication_commit:null,catalog_id:null,catalog_content_hash:null}" \
               > museum-publication-compatibility-artifacts/strict-adapter.json
           fi
           jq --arg frontend_commit "$FRONTEND_COMMIT" \
@@ -141,6 +143,20 @@ jobs:
             > museum-publication-compatibility-artifacts/strict-adapter.tmp.json
           mv museum-publication-compatibility-artifacts/strict-adapter.tmp.json \
             museum-publication-compatibility-artifacts/strict-adapter.json
+          if [ "$adapter_exit" -eq 0 ]; then
+            jq -e --arg source_commit "$MUSEUM_PUBLICATION_COMPATIBILITY_COMMIT" '
+              .contract == "museum-publication-compatibility-v1" and
+              .source_commit == $source_commit and
+              .accepted == true and
+              .adapter_status == "current" and
+              .adapter_error_code == null and
+              (.publication_commit | test("^[a-f0-9]{40}$")) and
+              .catalog_id == ("6529NM-PUBCAT-" + .publication_commit) and
+              (.catalog_content_hash | test("^0x[a-f0-9]{64}$"))
+            ' museum-publication-compatibility-artifacts/strict-adapter.json >/dev/null
+            publication_commit="$(jq -r .publication_commit museum-publication-compatibility-artifacts/strict-adapter.json)"
+            echo "publication_commit=$publication_commit" >> "$GITHUB_OUTPUT"
+          fi
           exit "$adapter_exit"
       - name: Upload strict-adapter evidence
         if: always()
@@ -193,7 +209,7 @@ jobs:
         id: sweep
         continue-on-error: true
         env:
-          MUSEUM_PUBLICATION_EXPECTED_COMMIT: ${{ needs.resolve-canonical-source.outputs.source_commit }}
+          MUSEUM_PUBLICATION_EXPECTED_COMMIT: ${{ needs.strict-adapter.outputs.publication_commit }}
         run: |
           set -euo pipefail
           ./bin/6529 run e2e:packs -- \

--- a/.github/workflows/production-e2e.yml
+++ b/.github/workflows/production-e2e.yml
@@ -36,6 +36,8 @@ jobs:
       e2e-outcome: ${{ steps.e2e.outcome }}
       evidence-upload-outcome: ${{ steps.evidence-upload.outcome }}
       expected-sha: ${{ inputs.expected_sha || steps.automatic-deploy.outputs.deployed-sha }}
+      museum-provenance-outcome: ${{ steps.museum-provenance-evidence.outcome }}
+      museum-publication-outcome: ${{ steps.museum-publication.outcome }}
       playwright-outcome: ${{ steps.playwright.outcome }}
       selection-outcome: ${{ steps.museum-selection.outcome }}
       selection-upload-outcome: ${{ steps.museum-selection-upload.outcome }}
@@ -313,7 +315,7 @@ jobs:
             echo "Tier: $(jq -r .classification.tier "$selection_file")"
             echo "Activation: $(jq -r .activation.effective_mode "$selection_file")"
             echo "Hold: $(jq -r .activation.hold_state "$selection_file")"
-            echo "Source: $source_commit"
+            echo "Catalog/control commit: $source_commit"
             echo "Packs: $(jq -r '.selected_packs | join(", ") // "none"' "$selection_file")"
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Upload immutable Museum selection evidence
@@ -349,6 +351,34 @@ jobs:
         env:
           SFW_BIN: ${{ steps.socket-firewall.outputs.firewall-path-binary }}
         run: ./bin/6529 install:frozen
+      - name: Resolve immutable Museum publication provenance
+        id: museum-publication
+        if: steps.dependencies.outcome == 'success'
+        env:
+          MUSEUM_CATALOG_COMMIT: ${{ steps.museum-selection.outputs.source_commit }}
+        run: |
+          set -euo pipefail
+          identity_file="$RUNNER_TEMP/museum-publication-identity.json"
+          ./bin/6529 exec tsx scripts/museum-publication-compatibility.ts \
+            --source-commit "$MUSEUM_CATALOG_COMMIT" \
+            > "$identity_file"
+          jq -e --arg catalog_commit "$MUSEUM_CATALOG_COMMIT" '
+            .contract == "museum-publication-compatibility-v1" and
+            .source_commit == $catalog_commit and
+            .accepted == true and
+            .adapter_status == "current" and
+            .adapter_error_code == null and
+            (.publication_commit | test("^[a-f0-9]{40}$")) and
+            .catalog_id == ("6529NM-PUBCAT-" + .publication_commit) and
+            (.catalog_content_hash | test("^0x[a-f0-9]{64}$"))
+          ' "$identity_file" >/dev/null
+          publication_commit="$(jq -r .publication_commit "$identity_file")"
+          echo "file=$identity_file" >> "$GITHUB_OUTPUT"
+          echo "publication_commit=$publication_commit" >> "$GITHUB_OUTPUT"
+          {
+            echo "Catalog/control commit: $MUSEUM_CATALOG_COMMIT"
+            echo "Publication/source commit: $publication_commit"
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Restore Playwright browser
         if: steps.dependencies.outcome == 'success'
         id: playwright-cache
@@ -370,10 +400,10 @@ jobs:
           fi
       - name: Run production-safe read-only packs
         id: e2e
-        if: steps.playwright.outcome == 'success'
+        if: steps.museum-publication.outcome == 'success' && steps.playwright.outcome == 'success'
         continue-on-error: true
         env:
-          MUSEUM_PUBLICATION_EXPECTED_COMMIT: ${{ steps.museum-selection.outputs.source_commit }}
+          MUSEUM_PUBLICATION_EXPECTED_COMMIT: ${{ steps.museum-publication.outputs.publication_commit }}
           MUSEUM_SELECTED_PACKS_JSON: ${{ steps.museum-selection.outputs.selected_packs }}
           RELEASE_BUS_E2E_MANIFEST_ID: ${{ inputs.release_manifest_id }}
           RELEASE_BUS_E2E_MANIFEST_IDENTITY_SHA256: ${{ inputs.release_manifest_identity_sha256 }}
@@ -442,6 +472,37 @@ jobs:
           fi
           echo "MUSEUM_SELECTED_PACKS_JSON=$MUSEUM_SELECTED_PACKS_JSON" >> "$GITHUB_ENV"
           ./bin/6529 run e2e:packs -- "${args[@]}"
+      - name: Stage and validate immutable Museum provenance evidence
+        id: museum-provenance-evidence
+        if: always()
+        env:
+          MUSEUM_CATALOG_COMMIT: ${{ steps.museum-selection.outputs.source_commit }}
+          MUSEUM_PUBLICATION_COMMIT: ${{ steps.museum-publication.outputs.publication_commit }}
+          MUSEUM_PUBLICATION_FILE: ${{ steps.museum-publication.outputs.file }}
+          MUSEUM_PUBLICATION_OUTCOME: ${{ steps.museum-publication.outcome }}
+        run: |
+          set -euo pipefail
+          test "$MUSEUM_PUBLICATION_OUTCOME" = success
+          test -f "$MUSEUM_PUBLICATION_FILE"
+          test ! -L "$MUSEUM_PUBLICATION_FILE"
+          mkdir -p production-e2e-artifacts
+          provenance_file='production-e2e-artifacts/museum-publication-provenance.json'
+          install -m 0644 "$MUSEUM_PUBLICATION_FILE" "$provenance_file"
+          test "$(stat -c %s "$provenance_file")" -le 4096
+          jq -e \
+            --arg catalog_commit "$MUSEUM_CATALOG_COMMIT" \
+            --arg publication_commit "$MUSEUM_PUBLICATION_COMMIT" '
+              .contract == "museum-publication-compatibility-v1" and
+              .source_commit == $catalog_commit and
+              .publication_commit == $publication_commit and
+              .accepted == true and
+              .adapter_status == "current" and
+              .adapter_error_code == null and
+              .catalog_id == ("6529NM-PUBCAT-" + $publication_commit) and
+              (.catalog_content_hash | test("^0x[a-f0-9]{64}$")) and
+              ($catalog_commit | test("^[a-f0-9]{40}$")) and
+              ($publication_commit | test("^[a-f0-9]{40}$"))
+            ' "$provenance_file" >/dev/null
       - name: Upload manifest-bound Playwright evidence
         id: evidence-upload
         if: always()
@@ -453,7 +514,7 @@ jobs:
           if-no-files-found: ignore
       - name: Upload exact automatic authority evidence
         id: authority-evidence-upload
-        if: always() && inputs.automatic_deploy_run_id != '' && steps.e2e.outcome == 'success'
+        if: always() && inputs.automatic_deploy_run_id != '' && steps.e2e.outcome == 'success' && steps.museum-provenance-evidence.outcome == 'success'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: production-authority-evidence-${{ inputs.automatic_deploy_run_id }}
@@ -467,9 +528,13 @@ jobs:
           DEPENDENCIES_OUTCOME: ${{ steps.dependencies.outcome }}
           PLAYWRIGHT_OUTCOME: ${{ steps.playwright.outcome }}
           E2E_OUTCOME: ${{ steps.e2e.outcome }}
+          MUSEUM_PROVENANCE_OUTCOME: ${{ steps.museum-provenance-evidence.outcome }}
+          MUSEUM_PUBLICATION_OUTCOME: ${{ steps.museum-publication.outcome }}
         run: |
           test "$SOCKET_OUTCOME" = success
           test "$DEPENDENCIES_OUTCOME" = success
+          test "$MUSEUM_PUBLICATION_OUTCOME" = success
+          test "$MUSEUM_PROVENANCE_OUTCOME" = success
           test "$PLAYWRIGHT_OUTCOME" = success
           test "$E2E_OUTCOME" = success
 
@@ -609,14 +674,18 @@ jobs:
         run: |
           set -euo pipefail
           evidence_file='isolated-production-e2e-artifacts/evidence.json'
+          provenance_file='isolated-production-e2e-artifacts/museum-publication-provenance.json'
           selection_file='isolated-production-e2e-selection/museum-release-selection.json'
           test -f "$evidence_file"
           test ! -L "$evidence_file"
+          test -f "$provenance_file"
+          test ! -L "$provenance_file"
           test -f "$selection_file"
           test ! -L "$selection_file"
           test "$(find isolated-production-e2e-selection -mindepth 1 | wc -l)" -eq 1
           test "$(stat -c %s "$selection_file")" -le 1048576
           test "$(stat -c %s "$evidence_file")" -le 16777216
+          test "$(stat -c %s "$provenance_file")" -le 4096
           jq -e '
             .contract == "museum-release-selection-v1" and
             .environment == "production" and
@@ -626,6 +695,17 @@ jobs:
             (.selected_packs | unique | length) == (.selected_packs | length) and
             (.selection_digest | test("^[a-f0-9]{64}$"))
           ' "$selection_file" >/dev/null
+          jq -e --slurpfile selection "$selection_file" '
+            .contract == "museum-publication-compatibility-v1" and
+            .source_commit == $selection[0].source_commit and
+            (.source_commit | test("^[a-f0-9]{40}$")) and
+            (.publication_commit | test("^[a-f0-9]{40}$")) and
+            .accepted == true and
+            .adapter_status == "current" and
+            .adapter_error_code == null and
+            .catalog_id == ("6529NM-PUBCAT-" + .publication_commit) and
+            (.catalog_content_hash | test("^0x[a-f0-9]{64}$"))
+          ' "$provenance_file" >/dev/null
           node - "$selection_file" <<'NODE'
           const fs = require("node:fs");
           const path = require("node:path");
@@ -848,6 +928,8 @@ jobs:
           READONLY_DEPENDENCIES_OUTCOME: ${{ needs.readonly.outputs.dependencies-outcome }}
           READONLY_E2E_OUTCOME: ${{ needs.readonly.outputs.e2e-outcome }}
           READONLY_EVIDENCE_UPLOAD_OUTCOME: ${{ needs.readonly.outputs.evidence-upload-outcome }}
+          READONLY_MUSEUM_PROVENANCE_OUTCOME: ${{ needs.readonly.outputs.museum-provenance-outcome }}
+          READONLY_MUSEUM_PUBLICATION_OUTCOME: ${{ needs.readonly.outputs.museum-publication-outcome }}
           READONLY_PLAYWRIGHT_OUTCOME: ${{ needs.readonly.outputs.playwright-outcome }}
           READONLY_RESULT: ${{ needs.readonly.result }}
           READONLY_SELECTION_OUTCOME: ${{ needs.readonly.outputs.selection-outcome }}
@@ -871,6 +953,10 @@ jobs:
               [ "$READONLY_SELECTION_UPLOAD_OUTCOME" != success ]; then
               failure_class=CONTROL_PLANE
               failure_phase=production_e2e_selection
+            elif [ "$READONLY_MUSEUM_PUBLICATION_OUTCOME" != success ] || \
+              [ "$READONLY_MUSEUM_PROVENANCE_OUTCOME" != success ]; then
+              failure_class=CONTROL_PLANE
+              failure_phase=production_e2e_museum_publication
             elif [ "$READONLY_SOCKET_OUTCOME" != success ] || \
               [ "$READONLY_DEPENDENCIES_OUTCOME" != success ] || \
               [ "$READONLY_PLAYWRIGHT_OUTCOME" != success ]; then

--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -476,8 +476,37 @@ jobs:
             echo "Tier: $(jq -r .classification.tier "$selection_file")"
             echo "Activation: $(jq -r .activation.effective_mode "$selection_file")"
             echo "Hold: $(jq -r .activation.hold_state "$selection_file")"
-            echo "Source: $source_commit"
+            echo "Catalog/control commit: $source_commit"
             echo "Packs: $(jq -r '.selected_packs | join(", ") // "none"' "$selection_file")"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Resolve immutable Museum publication provenance
+        id: museum-publication
+        if: steps.dependencies.outcome == 'success'
+        env:
+          MUSEUM_CATALOG_COMMIT: ${{ steps.museum-selection.outputs.source_commit }}
+        run: |
+          set -euo pipefail
+          identity_file="$RUNNER_TEMP/museum-publication-identity.json"
+          ./bin/6529 exec tsx scripts/museum-publication-compatibility.ts \
+            --source-commit "$MUSEUM_CATALOG_COMMIT" \
+            > "$identity_file"
+          jq -e --arg catalog_commit "$MUSEUM_CATALOG_COMMIT" '
+            .contract == "museum-publication-compatibility-v1" and
+            .source_commit == $catalog_commit and
+            .accepted == true and
+            .adapter_status == "current" and
+            .adapter_error_code == null and
+            (.publication_commit | test("^[a-f0-9]{40}$")) and
+            .catalog_id == ("6529NM-PUBCAT-" + .publication_commit) and
+            (.catalog_content_hash | test("^0x[a-f0-9]{64}$"))
+          ' "$identity_file" >/dev/null
+          publication_commit="$(jq -r .publication_commit "$identity_file")"
+          echo "file=$identity_file" >> "$GITHUB_OUTPUT"
+          echo "publication_commit=$publication_commit" >> "$GITHUB_OUTPUT"
+          {
+            echo "Catalog/control commit: $MUSEUM_CATALOG_COMMIT"
+            echo "Publication/source commit: $publication_commit"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Restore Playwright browser
@@ -502,11 +531,11 @@ jobs:
           fi
 
       - name: Run staging packs against staging.6529.io
-        if: steps.dependencies.outcome == 'success' && steps.playwright.outcome == 'success'
+        if: steps.dependencies.outcome == 'success' && steps.museum-publication.outcome == 'success' && steps.playwright.outcome == 'success'
         id: e2e
         continue-on-error: true
         env:
-          MUSEUM_PUBLICATION_EXPECTED_COMMIT: ${{ steps.museum-selection.outputs.source_commit }}
+          MUSEUM_PUBLICATION_EXPECTED_COMMIT: ${{ steps.museum-publication.outputs.publication_commit }}
           MUSEUM_SELECTED_PACKS_JSON: ${{ steps.museum-selection.outputs.selected_packs }}
           RELEASE_BUS_E2E_MANIFEST_ID: ${{ inputs.release_manifest_id }}
           RELEASE_BUS_E2E_MANIFEST_IDENTITY_SHA256: ${{ inputs.release_manifest_identity_sha256 }}
@@ -588,6 +617,22 @@ jobs:
           echo "MUSEUM_SELECTED_PACKS_JSON=$MUSEUM_SELECTED_PACKS_JSON" >> "$GITHUB_ENV"
           ./bin/6529 run e2e:packs -- "${args[@]}"
 
+      - name: Stage immutable Museum provenance with staging evidence
+        id: museum-provenance-evidence
+        if: always()
+        env:
+          MUSEUM_PUBLICATION_FILE: ${{ steps.museum-publication.outputs.file }}
+          MUSEUM_PUBLICATION_OUTCOME: ${{ steps.museum-publication.outcome }}
+        run: |
+          set -euo pipefail
+          test "$MUSEUM_PUBLICATION_OUTCOME" = success
+          test -f "$MUSEUM_PUBLICATION_FILE"
+          test ! -L "$MUSEUM_PUBLICATION_FILE"
+          mkdir -p staging-e2e-artifacts
+          install -m 0644 \
+            "$MUSEUM_PUBLICATION_FILE" \
+            staging-e2e-artifacts/museum-publication-provenance.json
+
       - name: Validate exact manifest-bound E2E evidence
         id: evidence
         if: always() && steps.dependencies.outcome == 'success' && steps.playwright.outcome == 'success'
@@ -596,14 +641,37 @@ jobs:
           EXPECTED_SHA: ${{ inputs.expected_sha }}
           MANIFEST_ID: ${{ inputs.release_manifest_id }}
           MANIFEST_IDENTITY: ${{ inputs.release_manifest_identity_sha256 }}
-          MUSEUM_SOURCE_COMMIT: ${{ steps.museum-selection.outputs.source_commit }}
+          MUSEUM_CATALOG_COMMIT: ${{ steps.museum-selection.outputs.source_commit }}
+          MUSEUM_PROVENANCE_OUTCOME: ${{ steps.museum-provenance-evidence.outcome }}
+          MUSEUM_PUBLICATION_COMMIT: ${{ steps.museum-publication.outputs.publication_commit }}
+          MUSEUM_PUBLICATION_OUTCOME: ${{ steps.museum-publication.outcome }}
           MUSEUM_SELECTION_FILE: ${{ steps.museum-selection.outputs.file }}
           OPERATION_KEY: ${{ inputs.operation_key }}
         run: |
           set -euo pipefail
+          provenance_file='staging-e2e-artifacts/museum-publication-provenance.json'
+          test "$MUSEUM_PUBLICATION_OUTCOME" = success
+          test "$MUSEUM_PROVENANCE_OUTCOME" = success
           test -f staging-e2e-artifacts/evidence.json
+          test -f "$provenance_file"
+          test ! -L "$provenance_file"
+          test "$(stat -c %s "$provenance_file")" -le 4096
+          jq -e \
+            --arg catalog_commit "$MUSEUM_CATALOG_COMMIT" \
+            --arg publication_commit "$MUSEUM_PUBLICATION_COMMIT" '
+              .contract == "museum-publication-compatibility-v1" and
+              .source_commit == $catalog_commit and
+              .publication_commit == $publication_commit and
+              .accepted == true and
+              .adapter_status == "current" and
+              .adapter_error_code == null and
+              .catalog_id == ("6529NM-PUBCAT-" + $publication_commit) and
+              (.catalog_content_hash | test("^0x[a-f0-9]{64}$")) and
+              ($catalog_commit | test("^[a-f0-9]{40}$")) and
+              ($publication_commit | test("^[a-f0-9]{40}$"))
+            ' "$provenance_file" >/dev/null
           test -f "$MUSEUM_SELECTION_FILE"
-          jq -e --arg source_commit "$MUSEUM_SOURCE_COMMIT" '
+          jq -e --arg source_commit "$MUSEUM_CATALOG_COMMIT" '
             .contract == "museum-release-selection-v1" and
             .environment == "staging" and
             .source_commit == $source_commit and
@@ -726,6 +794,8 @@ jobs:
           DEPENDENCIES_OUTCOME: ${{ steps.dependencies.outcome }}
           E2E_OUTCOME: ${{ steps.e2e.outcome }}
           EVIDENCE_OUTCOME: ${{ steps.evidence.outcome }}
+          MUSEUM_PROVENANCE_OUTCOME: ${{ steps.museum-provenance-evidence.outcome }}
+          MUSEUM_PUBLICATION_OUTCOME: ${{ steps.museum-publication.outcome }}
           PLAYWRIGHT_OUTCOME: ${{ steps.playwright.outcome }}
           RELEASE_BUS_API_URL: ${{ vars.RELEASE_BUS_API_URL }}
           RELEASE_BUS_WORKFLOW_AUTH_TOKEN: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
@@ -743,6 +813,11 @@ jobs:
             failure_class=INFRASTRUCTURE
             failure_phase=staging_e2e_setup
             retryable=true
+          elif [ "$MUSEUM_PUBLICATION_OUTCOME" != success ] || \
+            [ "$MUSEUM_PROVENANCE_OUTCOME" != success ]; then
+            status=FAILED
+            failure_class=CONTROL_PLANE
+            failure_phase=staging_e2e_museum_publication
           elif [ "$EVIDENCE_OUTCOME" != success ]; then
             status=FAILED
             failure_class=CONTROL_PLANE
@@ -777,9 +852,13 @@ jobs:
           DEPENDENCIES_OUTCOME: ${{ steps.dependencies.outcome }}
           E2E_OUTCOME: ${{ steps.e2e.outcome }}
           EVIDENCE_OUTCOME: ${{ steps.evidence.outcome }}
+          MUSEUM_PROVENANCE_OUTCOME: ${{ steps.museum-provenance-evidence.outcome }}
+          MUSEUM_PUBLICATION_OUTCOME: ${{ steps.museum-publication.outcome }}
           PLAYWRIGHT_OUTCOME: ${{ steps.playwright.outcome }}
         run: |
           test "$DEPENDENCIES_OUTCOME" = success
+          test "$MUSEUM_PUBLICATION_OUTCOME" = success
+          test "$MUSEUM_PROVENANCE_OUTCOME" = success
           test "$PLAYWRIGHT_OUTCOME" = success
           test "$EVIDENCE_OUTCOME" = success
           test "$E2E_OUTCOME" = success

--- a/__tests__/lib/museum/publication/runtime.test.ts
+++ b/__tests__/lib/museum/publication/runtime.test.ts
@@ -369,41 +369,34 @@ describe("Museum publication runtime source ref", () => {
   });
 
   it("reads the publication node environment without requiring unrelated public endpoints", () => {
-    const previousPublicRuntime = process.env["PUBLIC_RUNTIME"];
-    const previousNodeEnvironment = process.env["NODE_ENV"];
+    const environment: NodeJS.ProcessEnv = {
+      ...process.env,
+      NODE_ENV: "production",
+      PUBLIC_RUNTIME: JSON.stringify({ NODE_ENV: "local" }),
+    };
+    const replacement = jest.replaceProperty(process, "env", environment);
     try {
-      process.env["NODE_ENV"] = "production";
-      process.env["PUBLIC_RUNTIME"] = JSON.stringify({ NODE_ENV: "local" });
       expect(getMuseumPublicationNodeEnvironment()).toBe("local");
 
-      process.env["PUBLIC_RUNTIME"] = "{}";
+      environment["PUBLIC_RUNTIME"] = "{}";
       expect(getMuseumPublicationNodeEnvironment()).toBe("production");
 
-      process.env["PUBLIC_RUNTIME"] = "not-json";
+      environment["PUBLIC_RUNTIME"] = "not-json";
       expect(() => getMuseumPublicationNodeEnvironment()).toThrow(
         "museum_publication_runtime_environment_invalid"
       );
 
-      process.env["PUBLIC_RUNTIME"] = "[]";
+      environment["PUBLIC_RUNTIME"] = "[]";
       expect(() => getMuseumPublicationNodeEnvironment()).toThrow(
         "museum_publication_runtime_environment_invalid"
       );
 
-      process.env["PUBLIC_RUNTIME"] = JSON.stringify({ NODE_ENV: "bogus" });
+      environment["PUBLIC_RUNTIME"] = JSON.stringify({ NODE_ENV: "bogus" });
       expect(() => getMuseumPublicationNodeEnvironment()).toThrow(
         "museum_publication_runtime_environment_invalid"
       );
     } finally {
-      if (previousPublicRuntime === undefined) {
-        delete process.env["PUBLIC_RUNTIME"];
-      } else {
-        process.env["PUBLIC_RUNTIME"] = previousPublicRuntime;
-      }
-      if (previousNodeEnvironment === undefined) {
-        delete process.env["NODE_ENV"];
-      } else {
-        process.env["NODE_ENV"] = previousNodeEnvironment;
-      }
+      replacement.restore();
     }
   });
 });

--- a/__tests__/lib/museum/publication/runtime.test.ts
+++ b/__tests__/lib/museum/publication/runtime.test.ts
@@ -383,6 +383,16 @@ describe("Museum publication runtime source ref", () => {
       expect(() => getMuseumPublicationNodeEnvironment()).toThrow(
         "museum_publication_runtime_environment_invalid"
       );
+
+      process.env["PUBLIC_RUNTIME"] = "[]";
+      expect(() => getMuseumPublicationNodeEnvironment()).toThrow(
+        "museum_publication_runtime_environment_invalid"
+      );
+
+      process.env["PUBLIC_RUNTIME"] = JSON.stringify({ NODE_ENV: "bogus" });
+      expect(() => getMuseumPublicationNodeEnvironment()).toThrow(
+        "museum_publication_runtime_environment_invalid"
+      );
     } finally {
       if (previousPublicRuntime === undefined) {
         delete process.env["PUBLIC_RUNTIME"];

--- a/__tests__/lib/museum/publication/runtime.test.ts
+++ b/__tests__/lib/museum/publication/runtime.test.ts
@@ -8,7 +8,10 @@ import {
   type MuseumPublicationLoadState,
   type MuseumPublicationSource,
 } from "@/lib/museum/publication";
-import { isMuseumLocalFixtureEnvironment } from "@/config/museumPublicationEnv.server";
+import {
+  getMuseumPublicationNodeEnvironment,
+  isMuseumLocalFixtureEnvironment,
+} from "@/config/museumPublicationEnv.server";
 import { createCaseyFixture } from "./fixture";
 
 type CurrentState = Extract<
@@ -363,5 +366,34 @@ describe("Museum publication runtime source ref", () => {
     expect(isMuseumLocalFixtureEnvironment(environment, "production")).toBe(
       false
     );
+  });
+
+  it("reads the publication node environment without requiring unrelated public endpoints", () => {
+    const previousPublicRuntime = process.env["PUBLIC_RUNTIME"];
+    const previousNodeEnvironment = process.env["NODE_ENV"];
+    try {
+      process.env["NODE_ENV"] = "production";
+      process.env["PUBLIC_RUNTIME"] = JSON.stringify({ NODE_ENV: "local" });
+      expect(getMuseumPublicationNodeEnvironment()).toBe("local");
+
+      process.env["PUBLIC_RUNTIME"] = "{}";
+      expect(getMuseumPublicationNodeEnvironment()).toBe("production");
+
+      process.env["PUBLIC_RUNTIME"] = "not-json";
+      expect(() => getMuseumPublicationNodeEnvironment()).toThrow(
+        "museum_publication_runtime_environment_invalid"
+      );
+    } finally {
+      if (previousPublicRuntime === undefined) {
+        delete process.env["PUBLIC_RUNTIME"];
+      } else {
+        process.env["PUBLIC_RUNTIME"] = previousPublicRuntime;
+      }
+      if (previousNodeEnvironment === undefined) {
+        delete process.env["NODE_ENV"];
+      } else {
+        process.env["NODE_ENV"] = previousNodeEnvironment;
+      }
+    }
   });
 });

--- a/__tests__/scripts/museum-publication-compatibility.test.ts
+++ b/__tests__/scripts/museum-publication-compatibility.test.ts
@@ -9,6 +9,9 @@ import {
 } from "@/__tests__/lib/museum/publication/fixture";
 import { GitHubMuseumPublicationSource } from "@/lib/museum/publication/github";
 
+const PUBLICATION_COMMIT = "b".repeat(40);
+const CATALOG_CONTENT_HASH = `0x${"c".repeat(64)}`;
+
 describe("museum publication compatibility", () => {
   it("keeps managed and foreign hold detection bound to the exact bot identity", () => {
     const workflow = fs.readFileSync(
@@ -24,22 +27,39 @@ describe("museum publication compatibility", () => {
     expect(workflow).not.toContain("github-actions[bot)");
   });
 
-  it("accepts an exact source commit only when the strict adapter preserves identity", async () => {
-    const fixture = createCaseyFixture();
-
-    await expect(
-      verifyMuseumPublicationCompatibility({
-        sourceCommit: EXACT_COMMIT,
-        fetch: fixture.fetch,
-      })
-    ).resolves.toEqual({
-      contract: COMPATIBILITY_CONTRACT,
-      source_commit: EXACT_COMMIT,
-      accepted: true,
-      adapter_status: "current",
-      adapter_error_code: null,
-      publication_commit: EXACT_COMMIT,
-    });
+  it("accepts a catalog commit only when it resolves a verified immutable publication commit", async () => {
+    const load = jest
+      .spyOn(GitHubMuseumPublicationSource.prototype, "load")
+      .mockResolvedValueOnce({
+        status: "current",
+        publication: {
+          identity: {
+            commit: PUBLICATION_COMMIT,
+            requestedRef: EXACT_COMMIT,
+            catalogId: `6529NM-PUBCAT-${PUBLICATION_COMMIT}`,
+            catalogContentHash: CATALOG_CONTENT_HASH,
+          },
+        },
+        errorCode: null,
+        failedAt: null,
+        lastValidAcceptedAt: null,
+      } as never);
+    try {
+      await expect(
+        verifyMuseumPublicationCompatibility({ sourceCommit: EXACT_COMMIT })
+      ).resolves.toEqual({
+        contract: COMPATIBILITY_CONTRACT,
+        source_commit: EXACT_COMMIT,
+        accepted: true,
+        adapter_status: "current",
+        adapter_error_code: null,
+        publication_commit: PUBLICATION_COMMIT,
+        catalog_id: `6529NM-PUBCAT-${PUBLICATION_COMMIT}`,
+        catalog_content_hash: CATALOG_CONTENT_HASH,
+      });
+    } finally {
+      load.mockRestore();
+    }
   });
 
   it("fails closed before transport for a non-immutable source reference", async () => {
@@ -57,19 +77,20 @@ describe("museum publication compatibility", () => {
       adapter_status: "invalid",
       adapter_error_code: "publication_invalid_commit",
       publication_commit: null,
+      catalog_id: null,
+      catalog_content_hash: null,
     });
     expect(fixture.calls).toEqual([]);
   });
 
-  it("rejects a current publication whose resolved identity differs", async () => {
-    const resolvedCommit = "b".repeat(40);
+  it("rejects a current publication without a verified catalog identity", async () => {
     const load = jest
       .spyOn(GitHubMuseumPublicationSource.prototype, "load")
       .mockResolvedValueOnce({
         status: "current",
         publication: {
           identity: {
-            commit: resolvedCommit,
+            commit: PUBLICATION_COMMIT,
             requestedRef: EXACT_COMMIT,
           },
         },
@@ -86,7 +107,96 @@ describe("museum publication compatibility", () => {
         accepted: false,
         adapter_status: "current",
         adapter_error_code: "publication_source_identity_mismatch",
-        publication_commit: resolvedCommit,
+        publication_commit: PUBLICATION_COMMIT,
+        catalog_id: null,
+        catalog_content_hash: null,
+      });
+    } finally {
+      load.mockRestore();
+    }
+  });
+
+  it("rejects a catalog ID that is not bound to the publication/source commit", async () => {
+    const load = jest
+      .spyOn(GitHubMuseumPublicationSource.prototype, "load")
+      .mockResolvedValueOnce({
+        status: "current",
+        publication: {
+          identity: {
+            commit: PUBLICATION_COMMIT,
+            requestedRef: EXACT_COMMIT,
+            catalogId: `6529NM-PUBCAT-${EXACT_COMMIT}`,
+            catalogContentHash: CATALOG_CONTENT_HASH,
+          },
+        },
+        errorCode: null,
+        failedAt: null,
+        lastValidAcceptedAt: null,
+      } as never);
+    try {
+      await expect(
+        verifyMuseumPublicationCompatibility({ sourceCommit: EXACT_COMMIT })
+      ).resolves.toMatchObject({
+        accepted: false,
+        adapter_error_code: "publication_source_identity_mismatch",
+      });
+    } finally {
+      load.mockRestore();
+    }
+  });
+
+  it("propagates a catalog content-hash mismatch as an unavailable publication", async () => {
+    const load = jest
+      .spyOn(GitHubMuseumPublicationSource.prototype, "load")
+      .mockResolvedValueOnce({
+        status: "unavailable",
+        publication: null,
+        errorCode: "publication_catalog_content_hash_mismatch",
+        failedAt: "2026-08-10T00:00:00.000Z",
+        lastValidAcceptedAt: null,
+      } as never);
+    try {
+      await expect(
+        verifyMuseumPublicationCompatibility({ sourceCommit: EXACT_COMMIT })
+      ).resolves.toMatchObject({
+        accepted: false,
+        adapter_status: "unavailable",
+        adapter_error_code: "publication_catalog_content_hash_mismatch",
+        publication_commit: null,
+        catalog_id: null,
+        catalog_content_hash: null,
+      });
+    } finally {
+      load.mockRestore();
+    }
+  });
+
+  it("rejects a reversed catalog/control and publication/source identity", async () => {
+    const load = jest
+      .spyOn(GitHubMuseumPublicationSource.prototype, "load")
+      .mockResolvedValueOnce({
+        status: "current",
+        publication: {
+          identity: {
+            commit: EXACT_COMMIT,
+            requestedRef: PUBLICATION_COMMIT,
+            catalogId: `6529NM-PUBCAT-${EXACT_COMMIT}`,
+            catalogContentHash: CATALOG_CONTENT_HASH,
+          },
+        },
+        errorCode: null,
+        failedAt: null,
+        lastValidAcceptedAt: null,
+      } as never);
+    try {
+      await expect(
+        verifyMuseumPublicationCompatibility({ sourceCommit: EXACT_COMMIT })
+      ).resolves.toMatchObject({
+        accepted: false,
+        adapter_error_code: "publication_source_identity_mismatch",
+        publication_commit: EXACT_COMMIT,
+        catalog_id: `6529NM-PUBCAT-${EXACT_COMMIT}`,
+        catalog_content_hash: CATALOG_CONTENT_HASH,
       });
     } finally {
       load.mockRestore();
@@ -113,9 +223,85 @@ describe("museum publication compatibility", () => {
         adapter_status: "unavailable",
         adapter_error_code: "publication_source_unavailable",
         publication_commit: null,
+        catalog_id: null,
+        catalog_content_hash: null,
       });
     } finally {
       load.mockRestore();
     }
+  });
+
+  it("keeps catalog/control and publication/source identities separate in every deployed sweep", () => {
+    const adapter = fs.readFileSync(
+      "scripts/museum-publication-compatibility.ts",
+      "utf8"
+    );
+    const staging = fs.readFileSync(
+      ".github/workflows/staging-e2e.yml",
+      "utf8"
+    );
+    const production = fs.readFileSync(
+      ".github/workflows/production-e2e.yml",
+      "utf8"
+    );
+    const compatibility = fs.readFileSync(
+      ".github/workflows/museum-publication-compatibility.yml",
+      "utf8"
+    );
+
+    for (const workflow of [staging, production]) {
+      expect(workflow).toContain("scripts/museum-publication-compatibility.ts");
+      expect(workflow).toContain(
+        "MUSEUM_CATALOG_COMMIT: ${{ steps.museum-selection.outputs.source_commit }}"
+      );
+      expect(workflow).toContain(
+        "MUSEUM_PUBLICATION_EXPECTED_COMMIT: ${{ steps.museum-publication.outputs.publication_commit }}"
+      );
+      expect(workflow).not.toContain(
+        "MUSEUM_PUBLICATION_EXPECTED_COMMIT: ${{ steps.museum-selection.outputs.source_commit }}"
+      );
+      expect(workflow).toContain("museum-publication-provenance.json");
+      expect(workflow).toContain(
+        "MUSEUM_PUBLICATION_OUTCOME: ${{ steps.museum-publication.outcome }}"
+      );
+      const resolveIndex = workflow.indexOf(
+        "name: Resolve immutable Museum publication provenance"
+      );
+      const e2eIndex = workflow.indexOf("name: Run ", resolveIndex);
+      const provenanceIndex = workflow.indexOf(
+        "immutable Museum provenance",
+        e2eIndex
+      );
+      const uploadIndex = workflow.indexOf(
+        "name: Upload manifest-bound Playwright evidence",
+        provenanceIndex
+      );
+      expect(resolveIndex).toBeGreaterThanOrEqual(0);
+      expect(e2eIndex).toBeGreaterThan(resolveIndex);
+      expect(provenanceIndex).toBeGreaterThan(e2eIndex);
+      expect(uploadIndex).toBeGreaterThan(provenanceIndex);
+    }
+    expect(staging.indexOf("museum-publication-provenance.json")).toBeLessThan(
+      staging.indexOf("name: Validate exact manifest-bound E2E evidence")
+    );
+    expect(production).toContain(
+      "provenance_file='isolated-production-e2e-artifacts/museum-publication-provenance.json'"
+    );
+    expect(production).toContain(
+      ".source_commit == $selection[0].source_commit"
+    );
+    expect(production).not.toContain("MUSEUM_PUBLICATION_TEST_COMMIT");
+    expect(adapter).toContain(
+      "catalogResolver: museumPublicationCatalogResolver"
+    );
+    expect(compatibility).toContain(
+      "publication_commit: ${{ steps.adapter.outputs.publication_commit }}"
+    );
+    expect(compatibility).toContain(
+      "MUSEUM_PUBLICATION_EXPECTED_COMMIT: ${{ needs.strict-adapter.outputs.publication_commit }}"
+    );
+    expect(compatibility).not.toContain(
+      "MUSEUM_PUBLICATION_EXPECTED_COMMIT: ${{ needs.resolve-canonical-source.outputs.source_commit }}"
+    );
   });
 });

--- a/__tests__/scripts/museum-publication-compatibility.test.ts
+++ b/__tests__/scripts/museum-publication-compatibility.test.ts
@@ -1,4 +1,6 @@
 import fs from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
 import {
   COMPATIBILITY_CONTRACT,
   verifyMuseumPublicationCompatibility,
@@ -81,6 +83,52 @@ describe("museum publication compatibility", () => {
       catalog_content_hash: null,
     });
     expect(fixture.calls).toEqual([]);
+  });
+
+  it("exits nonzero and retains the rejected result in output mode", () => {
+    const outputDirectory = fs.mkdtempSync(
+      path.join(process.cwd(), ".tmp-museum-compatibility-")
+    );
+    const outputPath = path.join(outputDirectory, "strict-adapter.json");
+    const environment = { ...process.env, NODE_ENV: "test" };
+    delete environment["PUBLIC_RUNTIME"];
+
+    try {
+      const execution = spawnSync(
+        process.execPath,
+        [
+          require.resolve("tsx/cli"),
+          "scripts/museum-publication-compatibility.ts",
+          "--source-commit",
+          "main",
+          "--output",
+          outputPath,
+        ],
+        {
+          cwd: process.cwd(),
+          encoding: "utf8",
+          env: environment,
+        }
+      );
+      const retainedResult = fs.readFileSync(outputPath, "utf8");
+
+      expect(execution.error).toBeUndefined();
+      expect(execution.status).toBe(1);
+      expect(execution.stderr).toBe("");
+      expect(execution.stdout).toBe(retainedResult);
+      expect(JSON.parse(retainedResult)).toEqual({
+        contract: COMPATIBILITY_CONTRACT,
+        source_commit: "main",
+        accepted: false,
+        adapter_status: "invalid",
+        adapter_error_code: "publication_invalid_commit",
+        publication_commit: null,
+        catalog_id: null,
+        catalog_content_hash: null,
+      });
+    } finally {
+      fs.rmSync(outputDirectory, { recursive: true, force: true });
+    }
   });
 
   it("rejects a current publication without a verified catalog identity", async () => {

--- a/__tests__/scripts/museum-publication-compatibility.test.ts
+++ b/__tests__/scripts/museum-publication-compatibility.test.ts
@@ -90,7 +90,10 @@ describe("museum publication compatibility", () => {
       path.join(process.cwd(), ".tmp-museum-compatibility-")
     );
     const outputPath = path.join(outputDirectory, "strict-adapter.json");
-    const environment = { ...process.env, NODE_ENV: "test" };
+    const environment: NodeJS.ProcessEnv = {
+      ...process.env,
+      NODE_ENV: "test",
+    };
     delete environment["PUBLIC_RUNTIME"];
 
     try {

--- a/__tests__/scripts/museum-publication-compatibility.test.ts
+++ b/__tests__/scripts/museum-publication-compatibility.test.ts
@@ -297,7 +297,10 @@ describe("museum publication compatibility", () => {
       "utf8"
     );
 
-    for (const workflow of [staging, production]) {
+    for (const [workflow, e2eStepName] of [
+      [staging, "name: Run staging packs against staging.6529.io"],
+      [production, "name: Run production-safe read-only packs"],
+    ] as const) {
       expect(workflow).toContain("scripts/museum-publication-compatibility.ts");
       expect(workflow).toContain(
         "MUSEUM_CATALOG_COMMIT: ${{ steps.museum-selection.outputs.source_commit }}"
@@ -315,7 +318,7 @@ describe("museum publication compatibility", () => {
       const resolveIndex = workflow.indexOf(
         "name: Resolve immutable Museum publication provenance"
       );
-      const e2eIndex = workflow.indexOf("name: Run ", resolveIndex);
+      const e2eIndex = workflow.indexOf(e2eStepName, resolveIndex);
       const provenanceIndex = workflow.indexOf(
         "immutable Museum provenance",
         e2eIndex

--- a/__tests__/scripts/release-bus-artifact-compatibility.test.ts
+++ b/__tests__/scripts/release-bus-artifact-compatibility.test.ts
@@ -1068,6 +1068,8 @@ describe("Release Bus artifact rollout compatibility", () => {
         OPERATION_KEY: "rb2:production:e2e:a1",
         PATH: `${mockBin}:${process.env["PATH"]}`,
         READONLY_EVIDENCE_UPLOAD_OUTCOME: "skipped",
+        READONLY_MUSEUM_PROVENANCE_OUTCOME: "success",
+        READONLY_MUSEUM_PUBLICATION_OUTCOME: "success",
         READONLY_RESULT: "failure",
         READONLY_SELECTION_OUTCOME: "success",
         READONLY_SELECTION_UPLOAD_OUTCOME: "success",
@@ -1113,6 +1115,26 @@ describe("Release Bus artifact rollout compatibility", () => {
       expect(JSON.parse(fs.readFileSync(curlPayload, "utf8"))).toMatchObject({
         failure_class: "E2E",
         failure_phase: "production_e2e",
+        retryable: false,
+        status: "FAILED",
+      });
+
+      expect(
+        runShell(report.run!, {
+          cwd: root,
+          env: {
+            ...baseEnv,
+            READONLY_DEPENDENCIES_OUTCOME: "success",
+            READONLY_E2E_OUTCOME: "skipped",
+            READONLY_MUSEUM_PUBLICATION_OUTCOME: "failure",
+            READONLY_PLAYWRIGHT_OUTCOME: "success",
+            READONLY_SOCKET_OUTCOME: "success",
+          },
+        }).status
+      ).toBe(0);
+      expect(JSON.parse(fs.readFileSync(curlPayload, "utf8"))).toMatchObject({
+        failure_class: "CONTROL_PLANE",
+        failure_phase: "production_e2e_museum_publication",
         retryable: false,
         status: "FAILED",
       });

--- a/__tests__/scripts/testing-strategy.test.ts
+++ b/__tests__/scripts/testing-strategy.test.ts
@@ -452,6 +452,10 @@ describe("testing strategy CI plan", () => {
       path.join(process.cwd(), "tests/museum/about-readonly.spec.ts"),
       "utf8"
     );
+    const networkIaSpec = fs.readFileSync(
+      path.join(process.cwd(), "tests/museum/network-ia-readonly.spec.ts"),
+      "utf8"
+    );
 
     expect(workflow).toContain("playwright install --with-deps chromium");
     expect(workflow).toContain("test:e2e:smoke");
@@ -513,6 +517,21 @@ describe("testing strategy CI plan", () => {
     expect(museumSpec).toContain("for (const profile of PROFILE_ROUTES)");
     expect(aboutSpec).toContain("MUSEUM_PUBLICATION_EXPECTED_COMMIT");
     expect(aboutSpec).toContain("museum_publication_expected_commit_not_exact");
+    expect(networkIaSpec).not.toContain("page.screenshot");
+    expect(networkIaSpec).not.toContain("fullPage:");
+    expect(networkIaSpec).toContain("newCDPSession(page)");
+    expect(networkIaSpec).toContain('cdpSession.send("Page.captureScreenshot"');
+    expect(networkIaSpec).toContain("captureBeyondViewport: false");
+    expect(networkIaSpec).toContain("fromSurface: true");
+    expect(networkIaSpec).toContain(
+      "await cdpSession.detach().catch(() => undefined)"
+    );
+    expect(networkIaSpec).toContain(
+      "const EVIDENCE_SCREENSHOT_TIMEOUT_MS = 15_000;"
+    );
+    expect(networkIaSpec).toContain(
+      "Museum viewport evidence capture timed out after"
+    );
     expect(
       fs.existsSync(
         path.join(
@@ -586,6 +605,8 @@ describe("testing strategy CI plan", () => {
     ]);
     expect(museumBrowserRun).toContain("--project=web-desktop-chromium");
     expect(museumBrowserRun).toContain("--project=web-mobile-chromium");
+    expect(museumBrowserRun).not.toContain("--project=web-desktop-firefox");
+    expect(museumBrowserRun).not.toContain("--project=web-desktop-webkit");
     expect(museumBrowserRun).toContain("for shard in 1 2");
     expect(museumBrowserRun).toContain('--shard="${shard}/2"');
     expect(museumBrowserRun).toContain(

--- a/config/museumPublicationEnv.server.ts
+++ b/config/museumPublicationEnv.server.ts
@@ -5,6 +5,13 @@ export interface MuseumPublicationEnvironment {
   readonly MUSEUM_PUBLICATION_LOCAL_FIXTURE_COMMIT?: string;
 }
 
+const MUSEUM_PUBLICATION_NODE_ENVIRONMENTS = new Set([
+  "development",
+  "production",
+  "test",
+  "local",
+]);
+
 export function isMuseumLocalFixtureEnvironment(
   environment: MuseumPublicationEnvironment,
   nodeEnvironment: string | undefined
@@ -39,4 +46,39 @@ export function getMuseumPublicationEnvironment(): MuseumPublicationEnvironment 
       ? {}
       : { MUSEUM_PUBLICATION_LOCAL_FIXTURE_COMMIT: localFixtureCommit }),
   };
+}
+
+export function getMuseumPublicationNodeEnvironment(): string | undefined {
+  if (typeof process === "undefined" || !process.env) {
+    return undefined;
+  }
+  const publicRuntime = process.env["PUBLIC_RUNTIME"];
+  if (publicRuntime !== undefined) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(publicRuntime) as unknown;
+    } catch {
+      throw new Error("museum_publication_runtime_environment_invalid");
+    }
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      throw new Error("museum_publication_runtime_environment_invalid");
+    }
+    const runtimeNodeEnvironment = (parsed as Record<string, unknown>)[
+      "NODE_ENV"
+    ];
+    if (runtimeNodeEnvironment !== undefined) {
+      if (
+        typeof runtimeNodeEnvironment !== "string" ||
+        !MUSEUM_PUBLICATION_NODE_ENVIRONMENTS.has(runtimeNodeEnvironment)
+      ) {
+        throw new Error("museum_publication_runtime_environment_invalid");
+      }
+      return runtimeNodeEnvironment;
+    }
+  }
+  return process.env["NODE_ENV"];
 }

--- a/lib/museum/publication/github.ts
+++ b/lib/museum/publication/github.ts
@@ -40,9 +40,9 @@ import {
   type MuseumPublicationCatalogDocument,
   type MuseumPublicationCatalogResolver,
 } from "./catalog";
-import { getNodeEnv } from "../../../config/env";
 import {
   getMuseumPublicationEnvironment,
+  getMuseumPublicationNodeEnvironment,
   isMuseumLocalFixtureEnvironment,
 } from "../../../config/museumPublicationEnv.server";
 
@@ -166,11 +166,12 @@ export class GitHubMuseumPublicationSource implements MuseumPublicationSource {
     this.localFixtureMediaAssetPaths = new Set(
       options.localFixtureMediaAssetPaths ?? []
     );
-    const isTestEnvironment = getNodeEnv() === "test";
+    const nodeEnvironment = getMuseumPublicationNodeEnvironment();
+    const isTestEnvironment = nodeEnvironment === "test";
     const environment = getMuseumPublicationEnvironment();
     const localFixtureEnvironment =
       isTestEnvironment ||
-      isMuseumLocalFixtureEnvironment(environment, getNodeEnv());
+      isMuseumLocalFixtureEnvironment(environment, nodeEnvironment);
     this.allowUncataloguedTestFixture =
       options.allowUncataloguedTestFixture ?? isTestEnvironment;
 

--- a/scripts/museum-publication-compatibility.ts
+++ b/scripts/museum-publication-compatibility.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
+import { museumPublicationCatalogResolver } from "../lib/museum/publication/catalog";
 import { GitHubMuseumPublicationSource } from "../lib/museum/publication/github";
 import { legacyCaseyPublicationAssembler } from "../lib/museum/publication/legacyCasey";
 import { isExactGitCommit } from "../lib/museum/publication/security";
@@ -14,6 +15,8 @@ interface MuseumPublicationCompatibilityResult {
   readonly adapter_status: "current" | "stale" | "unavailable" | "invalid";
   readonly adapter_error_code: string | null;
   readonly publication_commit: string | null;
+  readonly catalog_id: string | null;
+  readonly catalog_content_hash: string | null;
 }
 
 interface VerifyMuseumPublicationCompatibilityOptions {
@@ -31,13 +34,16 @@ function invalidResult(
     adapter_status: "invalid",
     adapter_error_code: "publication_invalid_commit",
     publication_commit: null,
+    catalog_id: null,
+    catalog_content_hash: null,
   };
 }
 
 /**
  * Binds the strict frontend publication adapter to one immutable canonical
- * Museum source commit. Callers must resolve source main before invoking this
- * function; it deliberately does not accept a branch name or a moving ref.
+ * Museum catalog/control commit. Callers must resolve source main before
+ * invoking this function; the verified catalog supplies the distinct
+ * publication/source commit returned as `publication_commit`.
  */
 export async function verifyMuseumPublicationCompatibility(
   options: VerifyMuseumPublicationCompatibilityOptions
@@ -49,6 +55,7 @@ export async function verifyMuseumPublicationCompatibility(
   const state = await new GitHubMuseumPublicationSource({
     ref: options.sourceCommit,
     assembler: legacyCaseyPublicationAssembler,
+    catalogResolver: museumPublicationCatalogResolver,
     ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
   }).load();
 
@@ -60,12 +67,18 @@ export async function verifyMuseumPublicationCompatibility(
       adapter_status: state.status,
       adapter_error_code: state.errorCode ?? "publication_source_unavailable",
       publication_commit: null,
+      catalog_id: null,
+      catalog_content_hash: null,
     };
   }
 
+  const identity = state.publication.identity;
+  const publicationCommit = identity.commit;
   const identityMatches =
-    state.publication.identity.commit === options.sourceCommit &&
-    state.publication.identity.requestedRef === options.sourceCommit;
+    identity.requestedRef === options.sourceCommit &&
+    isExactGitCommit(publicationCommit) &&
+    identity.catalogId === `6529NM-PUBCAT-${publicationCommit}` &&
+    /^0x[a-f0-9]{64}$/u.test(identity.catalogContentHash ?? "");
   return {
     contract: COMPATIBILITY_CONTRACT,
     source_commit: options.sourceCommit,
@@ -74,7 +87,9 @@ export async function verifyMuseumPublicationCompatibility(
     adapter_error_code: identityMatches
       ? null
       : "publication_source_identity_mismatch",
-    publication_commit: state.publication.identity.commit,
+    publication_commit: publicationCommit,
+    catalog_id: identity.catalogId ?? null,
+    catalog_content_hash: identity.catalogContentHash ?? null,
   };
 }
 

--- a/tests/museum/network-ia-readonly.spec.ts
+++ b/tests/museum/network-ia-readonly.spec.ts
@@ -1,3 +1,5 @@
+import { writeFile } from "node:fs/promises";
+
 import type { Page, TestInfo } from "@playwright/test";
 
 import {
@@ -14,6 +16,7 @@ const SOURCE_COMMIT =
 const EXACT_COMMIT_PATTERN = /^[a-f0-9]{40}$/u;
 const MOBILE_PROJECT = "web-mobile-chromium";
 const MOBILE_VIEWPORT = { width: 390, height: 844 } as const;
+const EVIDENCE_SCREENSHOT_TIMEOUT_MS = 15_000;
 const MUSEUM_WAVE_ID = "5f207393-5418-4a75-8738-e40edb44a94d";
 const MAGNUM_DROP_ID = "002bfa4f-8416-48bf-b35e-38f354e9a9f0";
 const MAGNUM_WAVE_CONTEXT_HREF = `https://6529.io/waves/${MUSEUM_WAVE_ID}?drop=${MAGNUM_DROP_ID}`;
@@ -32,10 +35,35 @@ async function openRoute(page: Page, path: string) {
 }
 
 async function retainScreenshot(page: Page, testInfo: TestInfo, name: string) {
-  await page.screenshot({
-    path: testInfo.outputPath(`${name}.png`),
-    fullPage: testInfo.project.name !== MOBILE_PROJECT,
-  });
+  const cdpSession = await page.context().newCDPSession(page);
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    const capture = await Promise.race([
+      cdpSession.send("Page.captureScreenshot", {
+        captureBeyondViewport: false,
+        format: "png",
+        fromSurface: true,
+      }),
+      new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(
+            new Error(
+              `Museum viewport evidence capture timed out after ${EVIDENCE_SCREENSHOT_TIMEOUT_MS}ms: ${name}`
+            )
+          );
+        }, EVIDENCE_SCREENSHOT_TIMEOUT_MS);
+      }),
+    ]);
+
+    await writeFile(
+      testInfo.outputPath(`${name}.png`),
+      Buffer.from(capture.data, "base64")
+    );
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+    await cdpSession.detach().catch(() => undefined);
+  }
 }
 
 async function expectMuseumNavigation(page: Page, activeLabel: string | null) {
@@ -67,6 +95,10 @@ async function expectNoDeadLinks(page: Page) {
 }
 
 test.describe("Museum public IA rendered contract @surface @readonly", () => {
+  test.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "Retained Museum evidence uses the Chromium CDP in the exact desktop/mobile matrix."
+  );
   test.skip(
     SOURCE_COMMIT === null,
     "Requires the exact WP-1 source commit selected by the publication test harness."

--- a/utils/sentry-client-filters/constants.ts
+++ b/utils/sentry-client-filters/constants.ts
@@ -101,9 +101,9 @@ export const objectCapturedPromiseRejectionMessages = new Set([
   objectCapturedPromiseRejectionMessage,
   objectCapturedPromiseRejectionWithoutStackMessage,
 ]);
-export const braveWalletSelectedAddressEvaluationErrorMessage =
+const braveWalletSelectedAddressEvaluationErrorMessage =
   "undefined is not an object (evaluating 'window.ethereum.selectedAddress = undefined')";
-export const braveWalletEmitEvaluationErrorMessage =
+const braveWalletEmitEvaluationErrorMessage =
   "undefined is not an object (evaluating 'window.ethereum.emit')";
 export const braveWalletPageEvaluationErrorMessages = new Set([
   braveWalletSelectedAddressEvaluationErrorMessage,


### PR DESCRIPTION
## Issue

Automatic staging E2E run 31364585951 compared Museum page provenance with catalog/control commit `343f98fcfe1c231755518a513b5af9fc89ac4bed`. The deployed publication correctly identifies immutable reviewed source commit `81c3353b06725582d7d7d7cc297d06ea19ee61bf`, so the About and institutional-practice packs failed despite correct runtime output.

## Fix

- preserve moving-main catalog/control commit C for Museum pack selection while resolving publication/source commit B through the existing strict catalog adapter
- feed only verified B to `MUSEUM_PUBLICATION_EXPECTED_COMMIT` in staging, production, and compatibility sweeps
- retain and validate `museum-publication-provenance.json` beside E2E evidence, including catalog ID and catalog content hash
- make E2E, authority evidence, structured reporting, isolated evidence validation, and final results fail closed when provenance resolution is absent or invalid
- keep the standalone compatibility adapter independent of unrelated app endpoint configuration without changing publication runtime behavior
- add C/B reversal, catalog ID, catalog content-hash, ordering, artifact, and production-environment regressions

No Museum page, public copy, or media/runtime publication semantics changed.

## Validation

- strict live adapter: C `343f98fc…` resolved B `81c3353b…`, catalog `6529NM-PUBCAT-81c3353b…`, content hash `0x568fb9af…`
- Museum compatibility Jest: 9/9
- Museum runtime Jest: 15/15
- testing-strategy Jest: 59/59
- Release Bus performance/workflow contract Jest: 8/8
- staging Museum About: 2/2 desktop/mobile
- staging Museum institutional-practice + Network IA: 76/76 desktop/mobile
- `lint:changed`: pass
- `typecheck:changed`: pass
- debt ratchet: pass
- `codex-diff-check`: pass

A broader local `check:changed` reached the repository-wide Knip inventory and failed on pre-existing unused-file/export findings; the scoped lint, typecheck, debt, and affected tests above are green, and Ubuntu PR CI remains authoritative for the protected policy bundle whose `O_NOFOLLOW` guard intentionally rejects Windows.

## Risk and review notes

The principal risk is workflow identity wiring. Contract tests assert that C remains the selection/control identity, B is the only browser provenance identity, retained evidence binds both, production has no `MUSEUM_PUBLICATION_TEST_COMMIT`, and success cannot bypass provenance resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added immutable publication provenance validation across staging and production end-to-end workflows.
  * Added catalog identity and content-hash verification to publication compatibility checks.
  * Added publication provenance evidence collection, artifact validation, and reporting.
  * Added runtime environment resolution with validation and fallback behavior.

* **Bug Fixes**
  * Improved failure handling for unavailable or mismatched publications.
  * Ensured workflow success depends on validated publication provenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->