### PR TITLE
feat: auth-bridge page for community app authentication

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -28,6 +28,10 @@ TEST_WORKERS=2 # Suggested: half the number of CPU cores
 # MOBILE APP SCHEME
 MOBILE_APP_SCHEME=
 
+# AUTH BRIDGE — comma-separated exact callback URIs for community app auth
+# Example: NEXT_PUBLIC_AUTH_BRIDGE_ALLOWLIST=https:...ck
+NEXT_PUBLIC_AUTH_BRIDGE_ALLOWLIST=
+
 # 6529 CORE SCHEME
 CORE_SCHEME=core6529
 

--- a/app/auth-bridge/page.client.tsx
+++ b/app/auth-bridge/page.client.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { getAuthJwt } from "@/services/auth/auth.utils";
+
+/**
+ * Auth Bridge Page
+ *
+ * Enables community-built applications (e.g. AR apps on Arweave) to
+ * authenticate 6529.io members with zero friction. If the user is already
+ * logged into 6529.io, this page reads the existing JWT and redirects back
+ * to the requesting app with the token in the URL fragment (#t=...).
+ *
+ * The token is placed in the fragment (not the query string) so it never
+ * hits server logs — it is purely client-side.
+ *
+ * Redirect targets are validated against an allowlist to prevent open
+ * redirect attacks. New community apps can be added to AUTH_BRIDGE_ALLOWLIST.
+ */
+
+// Allowlist of approved redirect targets.
+// To add a new community app, add its origin here.
+const AUTH_BRIDGE_ALLOWLIST: string[] = [
+  "https://arweave.net",
+  // Add more approved community app origins here
+];
+
+function isAllowedRedirect(target: string): boolean {
+  try {
+    const url = new URL(target);
+    return AUTH_BRIDGE_ALLOWLIST.some(
+      (allowed) => url.origin === allowed
+    );
+  } catch {
+    return false;
+  }
+}
+
+export default function AuthBridgePageClient() {
+  const searchParams = useSearchParams();
+  const [status, setStatus] = useState<"loading" | "error" | "done">(
+    "loading"
+  );
+  const [message, setMessage] = useState<string>("");
+
+  useEffect(() => {
+    const redirectTarget = searchParams.get("r");
+
+    if (!redirectTarget) {
+      setStatus("error");
+      setMessage("Missing redirect target.");
+      return;
+    }
+
+    if (!isAllowedRedirect(redirectTarget)) {
+      setStatus("error");
+      setMessage(
+        "This redirect target is not approved. Contact the 6529 team to add your app to the allowlist."
+      );
+      return;
+    }
+
+    const jwt = getAuthJwt();
+
+    if (!jwt) {
+      // Not logged in — redirect to 6529.io home / login
+      setStatus("error");
+      setMessage("You are not logged in. Please sign in to 6529.io first.");
+      // Auto-redirect to home after 3 seconds
+      setTimeout(() => {
+        window.location.href = "/";
+      }, 3000);
+      return;
+    }
+
+    // Redirect back to the requesting app with token in the URL fragment
+    const separator = redirectTarget.includes("#") ? "&" : "#";
+    const redirectUrl = `${redirectTarget}${separator}t=${encodeURIComponent(jwt)}`;
+
+    // Clear the fragment from the address bar after redirect
+    window.location.replace(redirectUrl);
+    setStatus("done");
+  }, [searchParams]);
+
+  if (status === "done") {
+    return (
+      <div className="tw-flex tw-min-h-screen tw-items-center tw-justify-center tw-bg-black">
+        <p className="tw-text-sm tw-text-neutral-400">
+          Redirecting…
+        </p>
+      </div>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <div className="tw-flex tw-min-h-screen tw-items-center tw-justify-center tw-bg-black">
+        <div className="tw-text-center">
+          <p className="tw-text-base tw-text-red-400">{message}</p>
+          <p className="tw-mt-4">
+            <a
+              href="/"
+              className="tw-text-sm tw-font-medium tw-text-emerald-400 hover:tw-underline"
+            >
+              Return to 6529.io
+            </a>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="tw-flex tw-min-h-screen tw-items-center tw-justify-center tw-bg-black">
+      <p className="tw-text-sm tw-text-neutral-400">
+        Authenticating…
+      </p>
+    </div>
+  );
+}

--- a/app/auth-bridge/page.client.tsx
+++ b/app/auth-bridge/page.client.tsx
@@ -20,16 +20,22 @@ import { getAuthJwt } from "@/services/auth/auth.utils";
  * anyone can host arbitrary pages, we match exact redirect URIs (not whole
  * origins) to ensure only approved application endpoints receive the JWT.
  *
- * To add a new community app, add its exact callback URI to
- * AUTH_BRIDGE_ALLOWED_REDIRECT_URIS.
+ * The allowlist is populated from the NEXT_PUBLIC_AUTH_BRIDGE_ALLOWLIST
+ * environment variable — a comma-separated list of exact callback URIs.
+ * This lets the team add/remove community apps without a code change.
+ *
+ * Example .env:
+ *   NEXT_PUBLIC_AUTH_BRIDGE_ALLOWLIST=https://arweave.net/XXXX,https://myapp.com/auth/callback
  */
 
-// Allowlist of approved redirect URIs (exact match, not origin-level).
-// Each entry must be the full callback URL the app will use to receive the token.
-const AUTH_BRIDGE_ALLOWED_REDIRECT_URIS = new Set<string>([
-  // Add approved community app callback URIs here, e.g.:
-  // "https://arweave.net/XXXX-specific-transaction-id",
-]);
+// Parse the allowlist from the public env var at module load time.
+// Comma-separated, trimmed, empty entries skipped.
+const AUTH_BRIDGE_ALLOWED_REDIRECT_URIS = new Set<string>(
+  (process.env.NEXT_PUBLIC_AUTH_BRIDGE_ALLOWLIST ?? "")
+    .split(",")
+    .map((uri) => uri.trim())
+    .filter(Boolean)
+);
 
 function isAllowedRedirect(target: string): boolean {
   try {
@@ -59,6 +65,14 @@ export default function AuthBridgePageClient() {
     if (!redirectTarget) {
       setStatus("error");
       setMessage("Missing redirect target.");
+      return;
+    }
+
+    if (AUTH_BRIDGE_ALLOWED_REDIRECT_URIS.size === 0) {
+      setStatus("error");
+      setMessage(
+        "Auth bridge is not configured. Set NEXT_PUBLIC_AUTH_BRIDGE_ALLOWLIST to enable community app authentication."
+      );
       return;
     }
 

--- a/app/auth-bridge/page.client.tsx
+++ b/app/auth-bridge/page.client.tsx
@@ -15,23 +15,32 @@ import { getAuthJwt } from "@/services/auth/auth.utils";
  * The token is placed in the fragment (not the query string) so it never
  * hits server logs — it is purely client-side.
  *
- * Redirect targets are validated against an allowlist to prevent open
- * redirect attacks. New community apps can be added to AUTH_BRIDGE_ALLOWLIST.
+ * Redirect targets are validated against an exact-URI allowlist to prevent
+ * open redirect attacks. Because Arweave is a public content gateway where
+ * anyone can host arbitrary pages, we match exact redirect URIs (not whole
+ * origins) to ensure only approved application endpoints receive the JWT.
+ *
+ * To add a new community app, add its exact callback URI to
+ * AUTH_BRIDGE_ALLOWED_REDIRECT_URIS.
  */
 
-// Allowlist of approved redirect targets.
-// To add a new community app, add its origin here.
-const AUTH_BRIDGE_ALLOWLIST: string[] = [
-  "https://arweave.net",
-  // Add more approved community app origins here
-];
+// Allowlist of approved redirect URIs (exact match, not origin-level).
+// Each entry must be the full callback URL the app will use to receive the token.
+const AUTH_BRIDGE_ALLOWED_REDIRECT_URIS = new Set<string>([
+  // Add approved community app callback URIs here, e.g.:
+  // "https://arweave.net/XXXX-specific-transaction-id",
+]);
 
 function isAllowedRedirect(target: string): boolean {
   try {
     const url = new URL(target);
-    return AUTH_BRIDGE_ALLOWLIST.some(
-      (allowed) => url.origin === allowed
-    );
+    // Reject if the target has a query string or fragment
+    // (the fragment will be appended by us with the token)
+    if (url.search !== "" || url.hash !== "") {
+      return false;
+    }
+    // Exact URI match only — no origin-level wildcards
+    return AUTH_BRIDGE_ALLOWED_REDIRECT_URIS.has(url.toString());
   } catch {
     return false;
   }
@@ -68,17 +77,15 @@ export default function AuthBridgePageClient() {
       setStatus("error");
       setMessage("You are not logged in. Please sign in to 6529.io first.");
       // Auto-redirect to home after 3 seconds
-      setTimeout(() => {
+      const redirectTimer = window.setTimeout(() => {
         window.location.href = "/";
       }, 3000);
-      return;
+      return () => window.clearTimeout(redirectTimer);
     }
 
     // Redirect back to the requesting app with token in the URL fragment
-    const separator = redirectTarget.includes("#") ? "&" : "#";
-    const redirectUrl = `${redirectTarget}${separator}t=${encodeURIComponent(jwt)}`;
+    const redirectUrl = `${redirectTarget}#t=${encodeURIComponent(jwt)}`;
 
-    // Clear the fragment from the address bar after redirect
     window.location.replace(redirectUrl);
     setStatus("done");
   }, [searchParams]);

--- a/app/auth-bridge/page.tsx
+++ b/app/auth-bridge/page.tsx
@@ -1,0 +1,16 @@
+import { getAppMetadata } from "@/components/providers/metadata";
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import AuthBridgePageClient from "./page.client";
+
+export default function AuthBridgePage() {
+  return (
+    <Suspense fallback={null}>
+      <AuthBridgePageClient />
+    </Suspense>
+  );
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  return getAppMetadata({ title: "Auth Bridge" });
+}

--- a/config/env.schema.ts
+++ b/config/env.schema.ts
@@ -82,6 +82,8 @@ export const publicEnvSchema = z.object({
   DEV_MODE_QUORUM_WAVE_ID: z.string().optional(),
   DEV_MODE_WALLET_ADDRESS: z.string().optional(),
   MOBILE_APP_SCHEME: z.string().optional(),
+  // Comma-separated list of exact callback URIs for the /auth-bridge page
+  NEXT_PUBLIC_AUTH_BRIDGE_ALLOWLIST: z.string().optional(),
   NEXTGEN_CHAIN_ID: z.coerce.number().int().positive().optional(),
   USE_DEV_AUTH: z.string().optional(),
 


### PR DESCRIPTION
## Auth Bridge Page

### What

Adds a new page at `/auth-bridge` that lets community-built applications authenticate 6529.io members with zero friction — no second wallet signature needed.

### How it works

1. Community app (e.g. AR app on Arweave) links to `6529.io/auth-bridge?r=https://arweave.net/XXXX`
2. Page reads the existing JWT from the user's cookie/localStorage via `getAuthJwt()`
3. Redirects back to the app with the token in the URL **fragment** (`#t=JWT`)
4. The receiving app reads the token from the fragment, stores it, and clears the fragment

If the user is already logged into 6529.io, the entire flow is an instant flash — no wallet popup, no extra clicks.

### Security

- **Allowlist-based redirect validation** — only origins in `AUTH_BRIDGE_ALLOWLIST` are accepted (no open redirect attacks)
- Currently allows `https://arweave.net` for community AR apps
- New apps can be added to the allowlist array
- Token in URL **fragment** (`#t=...`), not query string — never hits server logs, purely client-side
- If user not logged in, shows an error message and redirects to 6529.io home

### Why

Enables community projects like the 6529 AR platform (world-anchored AR layer gated by 6529.io identity) and other tools to piggyback on 6529.io's wallet sign-in without building separate auth infrastructure or asking users to sign again.

### Files changed

- `app/auth-bridge/page.tsx` — server component (metadata + Suspense wrapper)
- `app/auth-bridge/page.client.tsx` — client component (reads JWT, validates redirect, redirects with token)

### Usage example

```text
// Community app on Arweave:
// 1. User clicks: https://6529.io/auth-bridge?r=https://arweave.net/my-ar-app
// 2. Instant redirect back: https://arweave.net/my-ar-app#t=eyJhbGci...
// 3. App reads fragment, stores JWT in localStorage, clears fragment
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authentication bridge page for redirecting authenticated users to approved destinations.
  * Added strict validation for redirect targets to help prevent unauthorized redirects.
  * Added clear loading, redirecting, and error states during authentication.
  * Unauthenticated visitors are redirected home after a brief delay.
  * Added configurable approved callback addresses and page metadata for the authentication bridge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->