### PR TITLE
Isolate Network Museum browser CI

### DIFF
--- a/.github/workflows/app-pr-ci.yml
+++ b/.github/workflows/app-pr-ci.yml
@@ -1267,31 +1267,77 @@ jobs:
           fi
 
           shard_pids=()
+          shard_logs=()
+          shard_status_files=()
           for shard in 1 2; do
-            PLAYWRIGHT_SKIP_WEB_SERVER=1 \
-              BASE_ENDPOINT="$museum_base_url" \
-              PLAYWRIGHT_BASE_URL="$museum_base_url" \
-              PLAYWRIGHT_OUTPUT_DIR="test-results/playwright/museum-shard-${shard}" \
-              PLAYWRIGHT_HTML_REPORT_DIR="playwright-report/museum-shard-${shard}" \
-              ./bin/6529 exec playwright test \
-                "${selected_specs[@]}" \
-                --project=web-desktop-chromium \
-                --project=web-mobile-chromium \
-                --shard="${shard}/2" \
-                --workers=1 \
-                > "test-results/app-pr-ci/museum-shard-${shard}.log" 2>&1 &
+            shard_log="test-results/app-pr-ci/museum-shard-${shard}.log"
+            shard_status_file="test-results/app-pr-ci/museum-shard-${shard}.status"
+            (
+              set +e
+              set -o pipefail
+              PLAYWRIGHT_SKIP_WEB_SERVER=1 \
+                BASE_ENDPOINT="$museum_base_url" \
+                PLAYWRIGHT_BASE_URL="$museum_base_url" \
+                PLAYWRIGHT_OUTPUT_DIR="test-results/playwright/museum-shard-${shard}" \
+                PLAYWRIGHT_HTML_REPORT_DIR="playwright-report/museum-shard-${shard}" \
+                timeout --signal=TERM --kill-after=30s 25m \
+                ./bin/6529 exec playwright test \
+                  "${selected_specs[@]}" \
+                  --project=web-desktop-chromium \
+                  --project=web-mobile-chromium \
+                  --shard="${shard}/2" \
+                  --workers=1 \
+                  2>&1 \
+                | sed -u "s/^/[museum shard ${shard}\/2] /" \
+                | tee "$shard_log"
+              shard_exit="${PIPESTATUS[0]}"
+              printf '%s\n' "$shard_exit" > "$shard_status_file"
+              exit "$shard_exit"
+            ) &
             shard_pids+=("$!")
+            shard_logs+=("$shard_log")
+            shard_status_files+=("$shard_status_file")
           done
+
+          monitor_museum_shards() {
+            local elapsed=0
+            while true; do
+              sleep 60
+              elapsed=$((elapsed + 60))
+              local active_shards=()
+              for shard_index in 1 2; do
+                if kill -0 "${shard_pids[$((shard_index - 1))]}" 2>/dev/null; then
+                  active_shards+=("${shard_index}/2")
+                fi
+              done
+              if [ "${#active_shards[@]}" -eq 0 ]; then
+                return
+              fi
+              echo "::notice::Museum shards still running after ${elapsed}s: ${active_shards[*]}"
+            done
+          }
+          monitor_museum_shards &
+          museum_progress_pid="$!"
 
           shard_status=0
           for shard_index in 1 2; do
             if ! wait "${shard_pids[$((shard_index - 1))]}"; then
               shard_status=1
-              cat "test-results/app-pr-ci/museum-shard-${shard_index}.log"
+              shard_exit="$(cat "${shard_status_files[$((shard_index - 1))]}" 2>/dev/null || printf 'unknown')"
+              if [ "$shard_exit" = 124 ]; then
+                echo "::error::Museum shard ${shard_index}/2 exceeded its 25-minute timeout."
+              else
+                echo "::error::Museum shard ${shard_index}/2 failed with exit ${shard_exit}."
+              fi
+              tail -n 80 "${shard_logs[$((shard_index - 1))]}"
             else
-              tail -n 8 "test-results/app-pr-ci/museum-shard-${shard_index}.log"
+              tail -n 8 "${shard_logs[$((shard_index - 1))]}"
             fi
           done
+          if kill -0 "$museum_progress_pid" 2>/dev/null; then
+            kill "$museum_progress_pid" 2>/dev/null || true
+          fi
+          wait "$museum_progress_pid" 2>/dev/null || true
           if [ "$shard_status" -ne 0 ]; then
             cat "$museum_server_log"
           else

--- a/.github/workflows/app-pr-ci.yml
+++ b/.github/workflows/app-pr-ci.yml
@@ -1071,7 +1071,8 @@ jobs:
             jq -r '.selected_packs[]' test-results/app-pr-ci/museum-release-selection.json
           )
           test "${#selected_packs[@]}" -gt 0
-          selected_specs=(tests/museum/network-ia-readonly.spec.ts)
+          museum_gate_spec=tests/museum/network-ia-readonly.spec.ts
+          selected_specs=()
           for selected_pack in "${selected_packs[@]}"; do
             case "$selected_pack" in
               test:e2e:museum-data-architecture) selected_specs+=(tests/museum/data-architecture-readonly.spec.ts) ;;
@@ -1085,22 +1086,23 @@ jobs:
               ;;
             esac
           done
-          for selected_spec in "${selected_specs[@]}"; do
+          for selected_spec in "$museum_gate_spec" "${selected_specs[@]}"; do
             if [ ! -f "$selected_spec" ]; then
               echo "Selected Museum spec is missing: $selected_spec" >&2
               exit 1
             fi
           done
-          # Keep the exhaustive Museum lane as one required check, but split
-          # its fully parallel deterministic test list across isolated
-          # processes. Every test independently verifies the exact source
-          # commit, so Playwright sharding cannot inherit cross-test state.
-          # Both read-only shards share one exact-source server so the visitor
-          # corpus and route modules are assembled once. Reports, traces, and
-          # logs remain isolated per shard.
+          # Keep the exhaustive Museum lane as one required check. Run the
+          # route-heavy IA contract first and serially so cold route assembly
+          # cannot make desktop and mobile contend for the shared dev server.
+          # Split the remaining deterministic list across isolated processes.
+          # Every test independently verifies the exact source commit, so
+          # Playwright sharding cannot inherit cross-test state. Reports,
+          # traces, and logs remain isolated per execution group.
           mkdir -p test-results/app-pr-ci
           PLAYWRIGHT_SKIP_WEB_SERVER=1 \
             ./bin/6529 exec playwright test \
+              "$museum_gate_spec" \
               "${selected_specs[@]}" \
               --project=web-desktop-chromium \
               --project=web-mobile-chromium \
@@ -1108,6 +1110,15 @@ jobs:
               --list \
               --reporter=json \
               > test-results/app-pr-ci/museum-tests-full.json
+          PLAYWRIGHT_SKIP_WEB_SERVER=1 \
+            ./bin/6529 exec playwright test \
+              "$museum_gate_spec" \
+              --project=web-desktop-chromium \
+              --project=web-mobile-chromium \
+              --workers=1 \
+              --list \
+              --reporter=json \
+              > test-results/app-pr-ci/museum-tests-gate.json
           for shard in 1 2; do
             PLAYWRIGHT_SKIP_WEB_SERVER=1 \
               ./bin/6529 exec playwright test \
@@ -1175,12 +1186,13 @@ jobs:
             return entries;
           }
           const full = collect(`${outputDir}/museum-tests-full.json`);
+          const gate = collect(`${outputDir}/museum-tests-gate.json`);
           const shards = [1, 2].map((shard) =>
             collect(`${outputDir}/museum-tests-shard-${shard}.json`)
           );
           const fullKeys = new Set(full.map((entry) => entry.key));
           const assigned = new Set();
-          for (const entries of shards) {
+          for (const entries of [gate, ...shards]) {
             for (const entry of entries) {
               if (!fullKeys.has(entry.key) || assigned.has(entry.key)) {
                 throw new Error(`Museum shard overlap or unexpected test: ${entry.key}`);
@@ -1196,6 +1208,13 @@ jobs:
           const actualProjects = [...new Set(full.map((entry) => entry.project))].sort();
           if (JSON.stringify(actualProjects) !== JSON.stringify(expectedProjects)) {
             throw new Error("Museum shard inventory must cover desktop and mobile Chromium.");
+          }
+          if (
+            gate.some((entry) => entry.file !== "museum/network-ia-readonly.spec.ts") ||
+            JSON.stringify([...new Set(gate.map((entry) => entry.project))].sort()) !==
+              JSON.stringify(expectedProjects)
+          ) {
+            throw new Error("Museum fail-fast gate must cover Network IA on desktop and mobile Chromium.");
           }
           for (const project of expectedProjects) {
             const files = new Set(
@@ -1215,6 +1234,11 @@ jobs:
                 catalog_commit: catalogCommit,
                 contract: "museum-playwright-shard-inventory-v1",
                 full_test_count: full.length,
+                gate: {
+                  id: "network-ia",
+                  test_count: gate.length,
+                  test_keys: gate.map((entry) => entry.key).sort(),
+                },
                 projects: expectedProjects,
                 selection_digest: selection.selection_digest,
                 shards: shards.map((entries, index) => ({
@@ -1266,6 +1290,38 @@ jobs:
             exit 1
           fi
 
+          museum_gate_log="test-results/app-pr-ci/museum-gate.log"
+          set +e
+          PLAYWRIGHT_SKIP_WEB_SERVER=1 \
+            BASE_ENDPOINT="$museum_base_url" \
+            PLAYWRIGHT_BASE_URL="$museum_base_url" \
+            PLAYWRIGHT_OUTPUT_DIR="test-results/playwright/museum-gate" \
+            PLAYWRIGHT_HTML_REPORT_DIR="playwright-report/museum-gate" \
+            timeout --signal=TERM --kill-after=30s 10m \
+            ./bin/6529 exec playwright test \
+              "$museum_gate_spec" \
+              --project=web-desktop-chromium \
+              --project=web-mobile-chromium \
+              --workers=1 \
+              --retries=0 \
+              --max-failures=1 \
+              2>&1 \
+            | sed -u 's/^/[museum gate] /' \
+            | tee "$museum_gate_log"
+          museum_gate_exit="${PIPESTATUS[0]}"
+          set -e
+          if [ "$museum_gate_exit" -ne 0 ]; then
+            if [ "$museum_gate_exit" -eq 124 ]; then
+              echo "::error::Museum Network IA gate exceeded its 10-minute timeout."
+            else
+              echo "::error::Museum Network IA gate failed with exit ${museum_gate_exit}."
+            fi
+            tail -n 120 "$museum_gate_log"
+            cat "$museum_server_log"
+            exit 1
+          fi
+          tail -n 12 "$museum_gate_log"
+
           shard_pids=()
           shard_logs=()
           shard_status_files=()
@@ -1287,6 +1343,8 @@ jobs:
                   --project=web-mobile-chromium \
                   --shard="${shard}/2" \
                   --workers=1 \
+                  --retries=0 \
+                  --max-failures=1 \
                   2>&1 \
                 | sed -u "s/^/[museum shard ${shard}\/2] /" \
                 | tee "$shard_log"

--- a/.github/workflows/app-pr-ci.yml
+++ b/.github/workflows/app-pr-ci.yml
@@ -1267,7 +1267,6 @@ jobs:
           NEXT_DEV_DIST_DIR=".next-playwright-${MUSEUM_PROJECT}" \
             BASE_ENDPOINT="$museum_base_url" \
             PORT="$museum_port" \
-            PORT_SEARCH_LIMIT=0 \
             ./bin/6529 run dev > "$museum_server_log" 2>&1 &
           museum_server_pid="$!"
           cleanup_museum_server() {

--- a/.github/workflows/app-pr-ci.yml
+++ b/.github/workflows/app-pr-ci.yml
@@ -191,11 +191,20 @@ jobs:
             });
           }
           if (plan.checks.playwright_museum.required) {
-            appCheckLanes.push({
-              lane: "playwright-museum",
-              label: "Network Museum",
-              runner: defaultRunner,
-            });
+            appCheckLanes.push(
+              {
+                lane: "playwright-museum-desktop",
+                label: "Network Museum desktop",
+                museum_project: "web-desktop-chromium",
+                runner: defaultRunner,
+              },
+              {
+                lane: "playwright-museum-mobile",
+                label: "Network Museum mobile",
+                museum_project: "web-mobile-chromium",
+                runner: defaultRunner,
+              }
+            );
           }
           write("app_check_matrix", JSON.stringify({ include: appCheckLanes }));
           NODE
@@ -296,7 +305,7 @@ jobs:
           persist-credentials: false
 
       - name: Fetch exact base commit
-        if: matrix.lane == 'quality' || matrix.lane == 'playwright-museum'
+        if: matrix.lane == 'quality' || startsWith(matrix.lane, 'playwright-museum-')
         run: |
           set -euo pipefail
           [[ "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]]
@@ -304,7 +313,7 @@ jobs:
           test "$(git rev-parse "${BASE_SHA}^{commit}")" = "$BASE_SHA"
 
       - name: Stage protected Museum tier policy
-        if: matrix.lane == 'quality' || matrix.lane == 'playwright-museum'
+        if: matrix.lane == 'quality' || startsWith(matrix.lane, 'playwright-museum-')
         run: |
           set -euo pipefail
           control_sha="$(git rev-parse "${BASE_SHA}^{commit}")"
@@ -704,7 +713,7 @@ jobs:
           NODE
 
       - name: Verify Museum surface registry and source-shell corpus
-        if: matrix.lane == 'playwright-museum'
+        if: startsWith(matrix.lane, 'playwright-museum-')
         run: |
           set -euo pipefail
           mkdir -p test-results/app-pr-ci/museum-surface-registry
@@ -725,7 +734,7 @@ jobs:
 
       - name: Restore Next.js build cache
         id: nextjs_build_cache
-        if: matrix.lane == 'build' || matrix.lane == 'playwright-museum'
+        if: matrix.lane == 'build'
         uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ${{ github.workspace }}/.next/cache
@@ -891,7 +900,7 @@ jobs:
 
       - name: Resolve exact Museum publication for Playwright
         id: museum_publication
-        if: matrix.lane == 'playwright-museum'
+        if: startsWith(matrix.lane, 'playwright-museum-')
         env:
           # Exact canonical-C qualification. The runtime resolves the pointer
           # and catalog at C, then assembles only the immutable reviewed B corpus.
@@ -921,7 +930,7 @@ jobs:
 
       - name: Select fail-closed Museum qualification packs
         id: museum-selection
-        if: matrix.lane == 'playwright-museum'
+        if: startsWith(matrix.lane, 'playwright-museum-')
         env:
           GH_TOKEN: ${{ github.token }}
           MUSEUM_RELEASE_TIER_MODE: ${{ vars.MUSEUM_RELEASE_TIER_MODE }}
@@ -1058,14 +1067,22 @@ jobs:
         run: ./bin/6529 run test:e2e:critical-shell
 
       - name: Run Network Museum Playwright packs
-        if: matrix.lane == 'playwright-museum'
+        if: startsWith(matrix.lane, 'playwright-museum-')
         env:
-          NODE_ENV: "production"
+          MUSEUM_PROJECT: ${{ matrix.museum_project }}
+          NODE_ENV: "development"
           PLAYWRIGHT_READONLY: "1"
           MUSEUM_PUBLICATION_EXPECTED_COMMIT: ${{ steps.museum_publication.outputs.source_commit }}
           MUSEUM_PUBLICATION_TEST_COMMIT: ${{ steps.museum_publication.outputs.catalog_commit }}
         run: |
           set -euo pipefail
+          case "$MUSEUM_PROJECT" in
+            web-desktop-chromium|web-mobile-chromium) ;;
+            *)
+              echo "Unexpected Museum project: $MUSEUM_PROJECT" >&2
+              exit 1
+            ;;
+          esac
           mapfile -t selected_packs < <(
             jq -r '.selected_packs[]' test-results/app-pr-ci/museum-release-selection.json
           )
@@ -1091,20 +1108,16 @@ jobs:
               exit 1
             fi
           done
-          # Keep the exhaustive Museum lane as one required check. Run the
-          # route-heavy IA contract first and serially, then run the remaining
-          # desktop/mobile groups concurrently against one production build.
-          # The production server does not compile routes on demand, avoiding
-          # cross-browser Turbopack navigation races while retaining parallel
-          # browser coverage. One Playwright process owns the parallel phase so
-          # --max-failures stops every worker immediately after the first error.
+          # Desktop and mobile are separate matrix jobs. Each job owns its
+          # runner, dev server, and Next.js dist directory, eliminating shared
+          # route-compilation and browser state. Network IA runs first, retries
+          # are disabled, and the first failure stops this job immediately.
           mkdir -p test-results/app-pr-ci
           PLAYWRIGHT_SKIP_WEB_SERVER=1 \
             ./bin/6529 exec playwright test \
               "$museum_gate_spec" \
               "${selected_specs[@]}" \
-              --project=web-desktop-chromium \
-              --project=web-mobile-chromium \
+              --project="$MUSEUM_PROJECT" \
               --workers=1 \
               --list \
               --reporter=json \
@@ -1112,8 +1125,7 @@ jobs:
           PLAYWRIGHT_SKIP_WEB_SERVER=1 \
             ./bin/6529 exec playwright test \
               "$museum_gate_spec" \
-              --project=web-desktop-chromium \
-              --project=web-mobile-chromium \
+              --project="$MUSEUM_PROJECT" \
               --workers=1 \
               --list \
               --reporter=json \
@@ -1121,9 +1133,8 @@ jobs:
           PLAYWRIGHT_SKIP_WEB_SERVER=1 \
             ./bin/6529 exec playwright test \
               "${selected_specs[@]}" \
-              --project=web-desktop-chromium \
-              --project=web-mobile-chromium \
-              --workers=2 \
+              --project="$MUSEUM_PROJECT" \
+              --workers=1 \
               --list \
               --reporter=json \
               > test-results/app-pr-ci/museum-tests-remaining.json
@@ -1133,8 +1144,16 @@ jobs:
           const exactCommit = /^[a-f0-9]{40}$/;
           const catalogCommit = process.env.MUSEUM_PUBLICATION_TEST_COMMIT || "";
           const sourceCommit = process.env.MUSEUM_PUBLICATION_EXPECTED_COMMIT || "";
+          const project = process.env.MUSEUM_PROJECT || "";
+          const allowedProjects = new Set([
+            "web-desktop-chromium",
+            "web-mobile-chromium",
+          ]);
           if (!exactCommit.test(catalogCommit) || !exactCommit.test(sourceCommit)) {
-            throw new Error("Museum shard inventory requires exact catalog and source commits.");
+            throw new Error("Museum execution inventory requires exact catalog and source commits.");
+          }
+          if (!allowedProjects.has(project)) {
+            throw new Error(`Unexpected Museum project in execution inventory: ${project}`);
           }
           const selection = JSON.parse(
             fs.readFileSync(`${outputDir}/museum-release-selection.json`, "utf8")
@@ -1149,7 +1168,7 @@ jobs:
           const expectedSpecs = new Set(["museum/network-ia-readonly.spec.ts"]);
           for (const pack of selection.selected_packs) {
             const spec = packSpecs.get(pack);
-            if (!spec) throw new Error(`Unknown Museum pack in shard inventory: ${pack}`);
+            if (!spec) throw new Error(`Unknown Museum pack in execution inventory: ${pack}`);
             expectedSpecs.add(spec);
           }
           function collect(reportPath) {
@@ -1160,7 +1179,7 @@ jobs:
                 for (const test of spec.tests || []) {
                   if (test.expectedStatus !== "passed") {
                     throw new Error(
-                      `Museum shard inventory contains a non-passing expected test: ${test.projectName}:${spec.id}`
+                      `Museum execution inventory contains a non-passing expected test: ${test.projectName}:${spec.id}`
                     );
                   }
                   entries.push({
@@ -1174,10 +1193,10 @@ jobs:
               for (const child of suite.suites || []) visit(child);
             };
             for (const suite of report.suites || []) visit(suite);
-            if (entries.length === 0) throw new Error("Museum shard inventory is empty.");
+            if (entries.length === 0) throw new Error("Museum execution inventory is empty.");
             const keys = new Set(entries.map((entry) => entry.key));
             if (keys.size !== entries.length) {
-              throw new Error("Museum shard inventory contains duplicate test identities.");
+              throw new Error("Museum execution inventory contains duplicate test identities.");
             }
             return entries;
           }
@@ -1198,47 +1217,41 @@ jobs:
           if (missing.length > 0 || assigned.size !== fullKeys.size) {
             throw new Error(`Museum execution coverage is incomplete: ${missing.join(", ")}`);
           }
-          const expectedProjects = ["web-desktop-chromium", "web-mobile-chromium"];
           const actualProjects = [...new Set(full.map((entry) => entry.project))].sort();
-          if (JSON.stringify(actualProjects) !== JSON.stringify(expectedProjects)) {
-            throw new Error("Museum shard inventory must cover desktop and mobile Chromium.");
+          if (JSON.stringify(actualProjects) !== JSON.stringify([project])) {
+            throw new Error(`Museum execution inventory must cover only ${project}.`);
           }
           if (
             gate.some((entry) => entry.file !== "museum/network-ia-readonly.spec.ts") ||
-            JSON.stringify([...new Set(gate.map((entry) => entry.project))].sort()) !==
-              JSON.stringify(expectedProjects)
+            gate.some((entry) => entry.project !== project)
           ) {
-            throw new Error("Museum fail-fast gate must cover Network IA on desktop and mobile Chromium.");
+            throw new Error(`Museum fail-fast gate must cover Network IA on ${project}.`);
           }
-          for (const project of expectedProjects) {
-            const files = new Set(
-              full.filter((entry) => entry.project === project).map((entry) => entry.file)
-            );
-            if (
-              files.size !== expectedSpecs.size ||
-              [...expectedSpecs].some((file) => !files.has(file))
-            ) {
-              throw new Error(`Museum execution spec coverage is incomplete for ${project}.`);
-            }
+          const files = new Set(full.map((entry) => entry.file));
+          if (
+            files.size !== expectedSpecs.size ||
+            [...expectedSpecs].some((file) => !files.has(file))
+          ) {
+            throw new Error(`Museum execution spec coverage is incomplete for ${project}.`);
           }
           fs.writeFileSync(
             `${outputDir}/museum-execution-inventory.json`,
             `${JSON.stringify(
               {
                 catalog_commit: catalogCommit,
-                contract: "museum-playwright-inventory-v2",
+                contract: "museum-playwright-isolated-project-v3",
                 full_test_count: full.length,
                 gate: {
                   id: "network-ia",
                   test_count: gate.length,
                   test_keys: gate.map((entry) => entry.key).sort(),
                 },
-                projects: expectedProjects,
+                project,
                 selection_digest: selection.selection_digest,
                 remaining: {
                   test_count: remaining.length,
                   test_keys: remaining.map((entry) => entry.key).sort(),
-                  workers: 2,
+                  workers: 1,
                 },
                 source_commit: sourceCommit,
                 specs: [...expectedSpecs].sort(),
@@ -1248,19 +1261,18 @@ jobs:
             )}\n`
           );
           NODE
-          museum_port=3001
+          museum_port=3101
           museum_base_url="http://localhost:${museum_port}"
           museum_server_log="test-results/app-pr-ci/museum-server.log"
-          ./bin/6529 run build:env-schema
-          BASE_ENDPOINT="https://6529.io" \
-            ./bin/6529 run base-build
-          BASE_ENDPOINT="https://6529.io" \
+          NEXT_DEV_DIST_DIR=".next-playwright-${MUSEUM_PROJECT}" \
+            BASE_ENDPOINT="$museum_base_url" \
             PORT="$museum_port" \
-            setsid ./bin/6529 run start:standalone > "$museum_server_log" 2>&1 &
+            PORT_SEARCH_LIMIT=0 \
+            ./bin/6529 run dev > "$museum_server_log" 2>&1 &
           museum_server_pid="$!"
           cleanup_museum_server() {
             if kill -0 "$museum_server_pid" 2>/dev/null; then
-              kill -- "-$museum_server_pid" 2>/dev/null || true
+              kill "$museum_server_pid" 2>/dev/null || true
               wait "$museum_server_pid" 2>/dev/null || true
             fi
           }
@@ -1275,14 +1287,14 @@ jobs:
             fi
             if ! kill -0 "$museum_server_pid" 2>/dev/null; then
               cat "$museum_server_log"
-              echo "Museum production server exited before readiness." >&2
+              echo "Museum server exited before readiness for $MUSEUM_PROJECT." >&2
               exit 1
             fi
             sleep 1
           done
           if [ "$museum_server_ready" != true ]; then
             cat "$museum_server_log"
-            echo "Museum production server did not become ready." >&2
+            echo "Museum server did not become ready for $MUSEUM_PROJECT." >&2
             exit 1
           fi
 
@@ -1296,27 +1308,25 @@ jobs:
             timeout --signal=TERM --kill-after=30s 10m \
             ./bin/6529 exec playwright test \
               "$museum_gate_spec" \
-              --project=web-desktop-chromium \
-              --project=web-mobile-chromium \
+              --project="$MUSEUM_PROJECT" \
               --workers=1 \
               --retries=0 \
               --max-failures=1 \
               2>&1 \
-            | sed -u 's/^/[museum gate] /' \
+            | sed -u "s/^/[museum $MUSEUM_PROJECT gate] /" \
             | tee "$museum_gate_log"
           museum_gate_exit="${PIPESTATUS[0]}"
           set -e
           if [ "$museum_gate_exit" -ne 0 ]; then
             if [ "$museum_gate_exit" -eq 124 ]; then
-              echo "::error::Museum Network IA gate exceeded its 10-minute timeout."
+              echo "::error::Museum $MUSEUM_PROJECT Network IA gate exceeded its 10-minute timeout."
             else
-              echo "::error::Museum Network IA gate failed with exit ${museum_gate_exit}."
+              echo "::error::Museum $MUSEUM_PROJECT Network IA gate failed with exit ${museum_gate_exit}."
             fi
             tail -n 120 "$museum_gate_log"
             cat "$museum_server_log"
-            exit 1
+            exit "$museum_gate_exit"
           fi
-          tail -n 12 "$museum_gate_log"
 
           museum_remaining_log="test-results/app-pr-ci/museum-remaining.log"
           set +e
@@ -1328,29 +1338,27 @@ jobs:
             timeout --signal=TERM --kill-after=30s 15m \
             ./bin/6529 exec playwright test \
               "${selected_specs[@]}" \
-              --project=web-desktop-chromium \
-              --project=web-mobile-chromium \
-              --workers=2 \
+              --project="$MUSEUM_PROJECT" \
+              --workers=1 \
               --retries=0 \
               --max-failures=1 \
               2>&1 \
-            | sed -u 's/^/[museum remaining] /' \
+            | sed -u "s/^/[museum $MUSEUM_PROJECT remaining] /" \
             | tee "$museum_remaining_log"
           museum_remaining_exit="${PIPESTATUS[0]}"
           set -e
           if [ "$museum_remaining_exit" -ne 0 ]; then
             if [ "$museum_remaining_exit" -eq 124 ]; then
-              echo "::error::Remaining Museum coverage exceeded its 15-minute timeout."
+              echo "::error::Museum $MUSEUM_PROJECT remaining coverage exceeded its 15-minute timeout."
             else
-              echo "::error::Remaining Museum coverage failed with exit ${museum_remaining_exit}."
+              echo "::error::Museum $MUSEUM_PROJECT remaining coverage failed with exit ${museum_remaining_exit}."
             fi
             tail -n 120 "$museum_remaining_log"
             cat "$museum_server_log"
-          else
-            tail -n 12 "$museum_remaining_log"
-            tail -n 12 "$museum_server_log"
+            exit "$museum_remaining_exit"
           fi
-          exit "$museum_remaining_exit"
+          tail -n 12 "$museum_remaining_log"
+          tail -n 12 "$museum_server_log"
 
       - name: Upload app check artifacts
         if: always()

--- a/.github/workflows/app-pr-ci.yml
+++ b/.github/workflows/app-pr-ci.yml
@@ -725,7 +725,7 @@ jobs:
 
       - name: Restore Next.js build cache
         id: nextjs_build_cache
-        if: matrix.lane == 'build'
+        if: matrix.lane == 'build' || matrix.lane == 'playwright-museum'
         uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ${{ github.workspace }}/.next/cache
@@ -1060,8 +1060,7 @@ jobs:
       - name: Run Network Museum Playwright packs
         if: matrix.lane == 'playwright-museum'
         env:
-          NEXT_DEV_DIST_DIR: ".next-playwright-museum"
-          NODE_ENV: "development"
+          NODE_ENV: "production"
           PLAYWRIGHT_READONLY: "1"
           MUSEUM_PUBLICATION_EXPECTED_COMMIT: ${{ steps.museum_publication.outputs.source_commit }}
           MUSEUM_PUBLICATION_TEST_COMMIT: ${{ steps.museum_publication.outputs.catalog_commit }}
@@ -1093,12 +1092,12 @@ jobs:
             fi
           done
           # Keep the exhaustive Museum lane as one required check. Run the
-          # route-heavy IA contract first and serially so cold route assembly
-          # cannot make desktop and mobile contend for the shared dev server.
-          # Split the remaining deterministic list across isolated processes.
-          # Every test independently verifies the exact source commit, so
-          # Playwright sharding cannot inherit cross-test state. Reports,
-          # traces, and logs remain isolated per execution group.
+          # route-heavy IA contract first and serially, then run the remaining
+          # desktop/mobile groups concurrently against one production build.
+          # The production server does not compile routes on demand, avoiding
+          # cross-browser Turbopack navigation races while retaining parallel
+          # browser coverage. One Playwright process owns the parallel phase so
+          # --max-failures stops every worker immediately after the first error.
           mkdir -p test-results/app-pr-ci
           PLAYWRIGHT_SKIP_WEB_SERVER=1 \
             ./bin/6529 exec playwright test \
@@ -1119,18 +1118,15 @@ jobs:
               --list \
               --reporter=json \
               > test-results/app-pr-ci/museum-tests-gate.json
-          for shard in 1 2; do
-            PLAYWRIGHT_SKIP_WEB_SERVER=1 \
-              ./bin/6529 exec playwright test \
-                "${selected_specs[@]}" \
-                --project=web-desktop-chromium \
-                --project=web-mobile-chromium \
-                --workers=1 \
-                --list \
-                --shard="${shard}/2" \
-                --reporter=json \
-                > "test-results/app-pr-ci/museum-tests-shard-${shard}.json"
-          done
+          PLAYWRIGHT_SKIP_WEB_SERVER=1 \
+            ./bin/6529 exec playwright test \
+              "${selected_specs[@]}" \
+              --project=web-desktop-chromium \
+              --project=web-mobile-chromium \
+              --workers=2 \
+              --list \
+              --reporter=json \
+              > test-results/app-pr-ci/museum-tests-remaining.json
           node <<'NODE'
           const fs = require("node:fs");
           const outputDir = "test-results/app-pr-ci";
@@ -1187,22 +1183,20 @@ jobs:
           }
           const full = collect(`${outputDir}/museum-tests-full.json`);
           const gate = collect(`${outputDir}/museum-tests-gate.json`);
-          const shards = [1, 2].map((shard) =>
-            collect(`${outputDir}/museum-tests-shard-${shard}.json`)
-          );
+          const remaining = collect(`${outputDir}/museum-tests-remaining.json`);
           const fullKeys = new Set(full.map((entry) => entry.key));
           const assigned = new Set();
-          for (const entries of [gate, ...shards]) {
+          for (const entries of [gate, remaining]) {
             for (const entry of entries) {
               if (!fullKeys.has(entry.key) || assigned.has(entry.key)) {
-                throw new Error(`Museum shard overlap or unexpected test: ${entry.key}`);
+                throw new Error(`Museum execution overlap or unexpected test: ${entry.key}`);
               }
               assigned.add(entry.key);
             }
           }
           const missing = [...fullKeys].filter((key) => !assigned.has(key));
           if (missing.length > 0 || assigned.size !== fullKeys.size) {
-            throw new Error(`Museum shard coverage is incomplete: ${missing.join(", ")}`);
+            throw new Error(`Museum execution coverage is incomplete: ${missing.join(", ")}`);
           }
           const expectedProjects = ["web-desktop-chromium", "web-mobile-chromium"];
           const actualProjects = [...new Set(full.map((entry) => entry.project))].sort();
@@ -1224,15 +1218,15 @@ jobs:
               files.size !== expectedSpecs.size ||
               [...expectedSpecs].some((file) => !files.has(file))
             ) {
-              throw new Error(`Museum shard spec coverage is incomplete for ${project}.`);
+              throw new Error(`Museum execution spec coverage is incomplete for ${project}.`);
             }
           }
           fs.writeFileSync(
-            `${outputDir}/museum-shard-inventory.json`,
+            `${outputDir}/museum-execution-inventory.json`,
             `${JSON.stringify(
               {
                 catalog_commit: catalogCommit,
-                contract: "museum-playwright-shard-inventory-v1",
+                contract: "museum-playwright-inventory-v2",
                 full_test_count: full.length,
                 gate: {
                   id: "network-ia",
@@ -1241,11 +1235,11 @@ jobs:
                 },
                 projects: expectedProjects,
                 selection_digest: selection.selection_digest,
-                shards: shards.map((entries, index) => ({
-                  id: `${index + 1}/2`,
-                  test_count: entries.length,
-                  test_keys: entries.map((entry) => entry.key).sort(),
-                })),
+                remaining: {
+                  test_count: remaining.length,
+                  test_keys: remaining.map((entry) => entry.key).sort(),
+                  workers: 2,
+                },
                 source_commit: sourceCommit,
                 specs: [...expectedSpecs].sort(),
               },
@@ -1254,17 +1248,19 @@ jobs:
             )}\n`
           );
           NODE
-          museum_port=3101
+          museum_port=3001
           museum_base_url="http://localhost:${museum_port}"
           museum_server_log="test-results/app-pr-ci/museum-server.log"
-          NEXT_DEV_DIST_DIR=".next-playwright-museum-shared" \
-            BASE_ENDPOINT="$museum_base_url" \
+          ./bin/6529 run build:env-schema
+          BASE_ENDPOINT="https://6529.io" \
+            ./bin/6529 run base-build
+          BASE_ENDPOINT="https://6529.io" \
             PORT="$museum_port" \
-            ./bin/6529 run dev > "$museum_server_log" 2>&1 &
+            setsid ./bin/6529 run start:standalone > "$museum_server_log" 2>&1 &
           museum_server_pid="$!"
           cleanup_museum_server() {
             if kill -0 "$museum_server_pid" 2>/dev/null; then
-              kill "$museum_server_pid" 2>/dev/null || true
+              kill -- "-$museum_server_pid" 2>/dev/null || true
               wait "$museum_server_pid" 2>/dev/null || true
             fi
           }
@@ -1279,14 +1275,14 @@ jobs:
             fi
             if ! kill -0 "$museum_server_pid" 2>/dev/null; then
               cat "$museum_server_log"
-              echo "Museum shard server exited before readiness." >&2
+              echo "Museum production server exited before readiness." >&2
               exit 1
             fi
             sleep 1
           done
           if [ "$museum_server_ready" != true ]; then
             cat "$museum_server_log"
-            echo "Museum shard server did not become ready." >&2
+            echo "Museum production server did not become ready." >&2
             exit 1
           fi
 
@@ -1322,86 +1318,39 @@ jobs:
           fi
           tail -n 12 "$museum_gate_log"
 
-          shard_pids=()
-          shard_logs=()
-          shard_status_files=()
-          for shard in 1 2; do
-            shard_log="test-results/app-pr-ci/museum-shard-${shard}.log"
-            shard_status_file="test-results/app-pr-ci/museum-shard-${shard}.status"
-            (
-              set +e
-              set -o pipefail
-              PLAYWRIGHT_SKIP_WEB_SERVER=1 \
-                BASE_ENDPOINT="$museum_base_url" \
-                PLAYWRIGHT_BASE_URL="$museum_base_url" \
-                PLAYWRIGHT_OUTPUT_DIR="test-results/playwright/museum-shard-${shard}" \
-                PLAYWRIGHT_HTML_REPORT_DIR="playwright-report/museum-shard-${shard}" \
-                timeout --signal=TERM --kill-after=30s 25m \
-                ./bin/6529 exec playwright test \
-                  "${selected_specs[@]}" \
-                  --project=web-desktop-chromium \
-                  --project=web-mobile-chromium \
-                  --shard="${shard}/2" \
-                  --workers=1 \
-                  --retries=0 \
-                  --max-failures=1 \
-                  2>&1 \
-                | sed -u "s/^/[museum shard ${shard}\/2] /" \
-                | tee "$shard_log"
-              shard_exit="${PIPESTATUS[0]}"
-              printf '%s\n' "$shard_exit" > "$shard_status_file"
-              exit "$shard_exit"
-            ) &
-            shard_pids+=("$!")
-            shard_logs+=("$shard_log")
-            shard_status_files+=("$shard_status_file")
-          done
-
-          monitor_museum_shards() {
-            local elapsed=0
-            while true; do
-              sleep 60
-              elapsed=$((elapsed + 60))
-              local active_shards=()
-              for shard_index in 1 2; do
-                if kill -0 "${shard_pids[$((shard_index - 1))]}" 2>/dev/null; then
-                  active_shards+=("${shard_index}/2")
-                fi
-              done
-              if [ "${#active_shards[@]}" -eq 0 ]; then
-                return
-              fi
-              echo "::notice::Museum shards still running after ${elapsed}s: ${active_shards[*]}"
-            done
-          }
-          monitor_museum_shards &
-          museum_progress_pid="$!"
-
-          shard_status=0
-          for shard_index in 1 2; do
-            if ! wait "${shard_pids[$((shard_index - 1))]}"; then
-              shard_status=1
-              shard_exit="$(cat "${shard_status_files[$((shard_index - 1))]}" 2>/dev/null || printf 'unknown')"
-              if [ "$shard_exit" = 124 ]; then
-                echo "::error::Museum shard ${shard_index}/2 exceeded its 25-minute timeout."
-              else
-                echo "::error::Museum shard ${shard_index}/2 failed with exit ${shard_exit}."
-              fi
-              tail -n 80 "${shard_logs[$((shard_index - 1))]}"
+          museum_remaining_log="test-results/app-pr-ci/museum-remaining.log"
+          set +e
+          PLAYWRIGHT_SKIP_WEB_SERVER=1 \
+            BASE_ENDPOINT="$museum_base_url" \
+            PLAYWRIGHT_BASE_URL="$museum_base_url" \
+            PLAYWRIGHT_OUTPUT_DIR="test-results/playwright/museum-remaining" \
+            PLAYWRIGHT_HTML_REPORT_DIR="playwright-report/museum-remaining" \
+            timeout --signal=TERM --kill-after=30s 15m \
+            ./bin/6529 exec playwright test \
+              "${selected_specs[@]}" \
+              --project=web-desktop-chromium \
+              --project=web-mobile-chromium \
+              --workers=2 \
+              --retries=0 \
+              --max-failures=1 \
+              2>&1 \
+            | sed -u 's/^/[museum remaining] /' \
+            | tee "$museum_remaining_log"
+          museum_remaining_exit="${PIPESTATUS[0]}"
+          set -e
+          if [ "$museum_remaining_exit" -ne 0 ]; then
+            if [ "$museum_remaining_exit" -eq 124 ]; then
+              echo "::error::Remaining Museum coverage exceeded its 15-minute timeout."
             else
-              tail -n 8 "${shard_logs[$((shard_index - 1))]}"
+              echo "::error::Remaining Museum coverage failed with exit ${museum_remaining_exit}."
             fi
-          done
-          if kill -0 "$museum_progress_pid" 2>/dev/null; then
-            kill "$museum_progress_pid" 2>/dev/null || true
-          fi
-          wait "$museum_progress_pid" 2>/dev/null || true
-          if [ "$shard_status" -ne 0 ]; then
+            tail -n 120 "$museum_remaining_log"
             cat "$museum_server_log"
           else
+            tail -n 12 "$museum_remaining_log"
             tail -n 12 "$museum_server_log"
           fi
-          exit "$shard_status"
+          exit "$museum_remaining_exit"
 
       - name: Upload app check artifacts
         if: always()

--- a/__tests__/scripts/release-bus-performance-contract.test.ts
+++ b/__tests__/scripts/release-bus-performance-contract.test.ts
@@ -95,7 +95,9 @@ describe("Release Bus frontend performance contract", () => {
     expect(appPrCi).toContain("tests/museum/inside-system-readonly.spec.ts");
     expect(appPrCi).toContain("tests/museum/rights-readonly.spec.ts");
     expect(appPrCi).not.toContain("./bin/6529 run test:e2e:museum-");
-    expect(appPrCi).toContain("matrix.lane == 'playwright-museum'");
+    expect(appPrCi).toContain(
+      "startsWith(matrix.lane, 'playwright-museum-')"
+    );
     expect(appPrCi).toContain("Restore Playwright browser");
     if (appPrCi.includes("exact-merge-tree-pr-ci-v1")) {
       expect(appPrCi).toContain(

--- a/__tests__/scripts/testing-strategy.test.ts
+++ b/__tests__/scripts/testing-strategy.test.ts
@@ -586,7 +586,7 @@ describe("testing strategy CI plan", () => {
         }),
         expect.objectContaining({
           name: "Run Network Museum Playwright packs",
-          if: "matrix.lane == 'playwright-museum'",
+          if: "startsWith(matrix.lane, 'playwright-museum-')",
         }),
       ])
     );
@@ -604,12 +604,19 @@ describe("testing strategy CI plan", () => {
       "tests/museum/inside-system-readonly.spec.ts",
       "tests/museum/rights-readonly.spec.ts",
     ]);
-    expect(museumBrowserRun).toContain("--project=web-desktop-chromium");
-    expect(museumBrowserRun).toContain("--project=web-mobile-chromium");
+    expect(workflow).toContain('lane: "playwright-museum-desktop"');
+    expect(workflow).toContain('label: "Network Museum desktop"');
+    expect(workflow).toContain('museum_project: "web-desktop-chromium"');
+    expect(workflow).toContain('lane: "playwright-museum-mobile"');
+    expect(workflow).toContain('label: "Network Museum mobile"');
+    expect(workflow).toContain('museum_project: "web-mobile-chromium"');
+    expect(museumBrowserRun).toContain('--project="$MUSEUM_PROJECT"');
+    expect(museumBrowserRun).not.toContain("--project=web-desktop-chromium");
+    expect(museumBrowserRun).not.toContain("--project=web-mobile-chromium");
     expect(museumBrowserRun).not.toContain("--project=web-desktop-firefox");
     expect(museumBrowserRun).not.toContain("--project=web-desktop-webkit");
     expect(museumBrowserRun).toContain(
-      'contract: "museum-playwright-inventory-v2"'
+      'contract: "museum-playwright-isolated-project-v3"'
     );
     expect(museumBrowserRun).toContain(
       "Museum execution overlap or unexpected test"
@@ -621,10 +628,10 @@ describe("testing strategy CI plan", () => {
       "Museum execution spec coverage is incomplete"
     );
     expect(museumBrowserRun).toContain(
-      "Museum shard inventory must cover desktop and mobile Chromium"
+      "Museum execution inventory must cover only ${project}"
     );
     expect(museumBrowserRun).toContain(
-      "Museum fail-fast gate must cover Network IA on desktop and mobile Chromium"
+      "Museum fail-fast gate must cover Network IA on ${project}"
     );
     expect(museumBrowserRun).toContain(
       'PLAYWRIGHT_OUTPUT_DIR="test-results/playwright/museum-gate"'
@@ -635,7 +642,7 @@ describe("testing strategy CI plan", () => {
     expect(museumBrowserRun).toContain("--retries=0");
     expect(museumBrowserRun).toContain("--max-failures=1");
     expect(museumBrowserRun).toContain(
-      "Museum Network IA gate exceeded its 10-minute timeout."
+      "Museum $MUSEUM_PROJECT Network IA gate exceeded its 10-minute timeout."
     );
     expect(museumBrowserRun).toContain(
       'PLAYWRIGHT_OUTPUT_DIR="test-results/playwright/museum-remaining"'
@@ -643,38 +650,37 @@ describe("testing strategy CI plan", () => {
     expect(museumBrowserRun).toContain(
       'PLAYWRIGHT_HTML_REPORT_DIR="playwright-report/museum-remaining"'
     );
-    expect(museumBrowserRun).toContain("./bin/6529 run build:env-schema");
-    expect(museumBrowserRun).toContain("./bin/6529 run base-build");
     expect(museumBrowserRun).toContain(
-      "setsid ./bin/6529 run start:standalone"
+      'NEXT_DEV_DIST_DIR=".next-playwright-${MUSEUM_PROJECT}"'
     );
-    expect(museumBrowserRun).toContain(
-      'museum_base_url="http://localhost:${museum_port}"'
-    );
+    expect(museumBrowserRun).toContain("./bin/6529 run dev");
     expect(museumBrowserRun).toContain("PLAYWRIGHT_SKIP_WEB_SERVER=1");
     expect(museumBrowserRun).toContain("trap cleanup_museum_server EXIT");
-    expect(museumBrowserRun).toContain('kill -- "-$museum_server_pid"');
     expect(museumBrowserRun).toContain(
-      'echo "Museum production server did not become ready."'
+      'echo "Museum server did not become ready for $MUSEUM_PROJECT."'
     );
     expect(museumBrowserRun).toContain(
       "timeout --signal=TERM --kill-after=30s 15m"
     );
     expect(museumBrowserRun).toContain(
-      "| sed -u 's/^/[museum remaining] /'"
+      '| sed -u "s/^/[museum $MUSEUM_PROJECT remaining] /"'
     );
     expect(museumBrowserRun).toContain('| tee "$museum_remaining_log"');
     expect(museumBrowserRun).toContain(
-      "Remaining Museum coverage exceeded its 15-minute timeout."
+      "Museum $MUSEUM_PROJECT remaining coverage exceeded its 15-minute timeout."
     );
     expect(museumBrowserRun).toContain(
-      "Remaining Museum coverage failed with exit ${museum_remaining_exit}."
+      "Museum $MUSEUM_PROJECT remaining coverage failed with exit ${museum_remaining_exit}."
     );
     expect(museumBrowserRun).toContain(
       'tail -n 120 "$museum_remaining_log"'
     );
     expect(museumBrowserRun).toContain("--workers=1");
-    expect(museumBrowserRun).toContain("--workers=2");
+    expect(museumBrowserRun).not.toContain("--workers=2");
+    expect(museumBrowserRun).not.toContain("wait -n");
+    expect(museumBrowserRun).not.toContain("setsid");
+    expect(museumBrowserRun).not.toContain("./bin/6529 run base-build");
+    expect(museumBrowserRun).not.toContain("start:standalone");
     expect(parsed.jobs["installed-checks"]).toMatchObject({
       name: "Installed app checks",
       needs: ["plan", "app-checks"],

--- a/__tests__/scripts/testing-strategy.test.ts
+++ b/__tests__/scripts/testing-strategy.test.ts
@@ -654,6 +654,7 @@ describe("testing strategy CI plan", () => {
       'NEXT_DEV_DIST_DIR=".next-playwright-${MUSEUM_PROJECT}"'
     );
     expect(museumBrowserRun).toContain("./bin/6529 run dev");
+    expect(museumBrowserRun).not.toContain("PORT_SEARCH_LIMIT=0");
     expect(museumBrowserRun).toContain("PLAYWRIGHT_SKIP_WEB_SERVER=1");
     expect(museumBrowserRun).toContain("trap cleanup_museum_server EXIT");
     expect(museumBrowserRun).toContain(

--- a/__tests__/scripts/testing-strategy.test.ts
+++ b/__tests__/scripts/testing-strategy.test.ts
@@ -608,17 +608,17 @@ describe("testing strategy CI plan", () => {
     expect(museumBrowserRun).toContain("--project=web-mobile-chromium");
     expect(museumBrowserRun).not.toContain("--project=web-desktop-firefox");
     expect(museumBrowserRun).not.toContain("--project=web-desktop-webkit");
-    expect(museumBrowserRun).toContain("for shard in 1 2");
-    expect(museumBrowserRun).toContain('--shard="${shard}/2"');
     expect(museumBrowserRun).toContain(
-      'contract: "museum-playwright-shard-inventory-v1"'
+      'contract: "museum-playwright-inventory-v2"'
     );
     expect(museumBrowserRun).toContain(
-      "Museum shard overlap or unexpected test"
+      "Museum execution overlap or unexpected test"
     );
-    expect(museumBrowserRun).toContain("Museum shard coverage is incomplete");
     expect(museumBrowserRun).toContain(
-      "Museum shard spec coverage is incomplete"
+      "Museum execution coverage is incomplete"
+    );
+    expect(museumBrowserRun).toContain(
+      "Museum execution spec coverage is incomplete"
     );
     expect(museumBrowserRun).toContain(
       "Museum shard inventory must cover desktop and mobile Chromium"
@@ -638,39 +638,43 @@ describe("testing strategy CI plan", () => {
       "Museum Network IA gate exceeded its 10-minute timeout."
     );
     expect(museumBrowserRun).toContain(
-      'PLAYWRIGHT_OUTPUT_DIR="test-results/playwright/museum-shard-${shard}"'
+      'PLAYWRIGHT_OUTPUT_DIR="test-results/playwright/museum-remaining"'
     );
     expect(museumBrowserRun).toContain(
-      'PLAYWRIGHT_HTML_REPORT_DIR="playwright-report/museum-shard-${shard}"'
+      'PLAYWRIGHT_HTML_REPORT_DIR="playwright-report/museum-remaining"'
     );
+    expect(museumBrowserRun).toContain("./bin/6529 run build:env-schema");
+    expect(museumBrowserRun).toContain("./bin/6529 run base-build");
     expect(museumBrowserRun).toContain(
-      'NEXT_DEV_DIST_DIR=".next-playwright-museum-shared"'
+      "setsid ./bin/6529 run start:standalone"
     );
     expect(museumBrowserRun).toContain(
       'museum_base_url="http://localhost:${museum_port}"'
     );
     expect(museumBrowserRun).toContain("PLAYWRIGHT_SKIP_WEB_SERVER=1");
     expect(museumBrowserRun).toContain("trap cleanup_museum_server EXIT");
+    expect(museumBrowserRun).toContain('kill -- "-$museum_server_pid"');
     expect(museumBrowserRun).toContain(
-      'echo "Museum shard server did not become ready."'
+      'echo "Museum production server did not become ready."'
     );
     expect(museumBrowserRun).toContain(
-      "timeout --signal=TERM --kill-after=30s 25m"
+      "timeout --signal=TERM --kill-after=30s 15m"
     );
     expect(museumBrowserRun).toContain(
-      '| sed -u "s/^/[museum shard ${shard}\\/2] /"'
+      "| sed -u 's/^/[museum remaining] /'"
     );
-    expect(museumBrowserRun).toContain('| tee "$shard_log"');
+    expect(museumBrowserRun).toContain('| tee "$museum_remaining_log"');
     expect(museumBrowserRun).toContain(
-      "Museum shards still running after ${elapsed}s"
-    );
-    expect(museumBrowserRun).toContain(
-      "Museum shard ${shard_index}/2 exceeded its 25-minute timeout."
+      "Remaining Museum coverage exceeded its 15-minute timeout."
     );
     expect(museumBrowserRun).toContain(
-      'tail -n 80 "${shard_logs[$((shard_index - 1))]}"'
+      "Remaining Museum coverage failed with exit ${museum_remaining_exit}."
+    );
+    expect(museumBrowserRun).toContain(
+      'tail -n 120 "$museum_remaining_log"'
     );
     expect(museumBrowserRun).toContain("--workers=1");
+    expect(museumBrowserRun).toContain("--workers=2");
     expect(parsed.jobs["installed-checks"]).toMatchObject({
       name: "Installed app checks",
       needs: ["plan", "app-checks"],

--- a/__tests__/scripts/testing-strategy.test.ts
+++ b/__tests__/scripts/testing-strategy.test.ts
@@ -640,7 +640,20 @@ describe("testing strategy CI plan", () => {
       'echo "Museum shard server did not become ready."'
     );
     expect(museumBrowserRun).toContain(
-      'cat "test-results/app-pr-ci/museum-shard-${shard_index}.log"'
+      "timeout --signal=TERM --kill-after=30s 25m"
+    );
+    expect(museumBrowserRun).toContain(
+      '| sed -u "s/^/[museum shard ${shard}\\/2] /"'
+    );
+    expect(museumBrowserRun).toContain('| tee "$shard_log"');
+    expect(museumBrowserRun).toContain(
+      "Museum shards still running after ${elapsed}s"
+    );
+    expect(museumBrowserRun).toContain(
+      "Museum shard ${shard_index}/2 exceeded its 25-minute timeout."
+    );
+    expect(museumBrowserRun).toContain(
+      'tail -n 80 "${shard_logs[$((shard_index - 1))]}"'
     );
     expect(museumBrowserRun).toContain("--workers=1");
     expect(parsed.jobs["installed-checks"]).toMatchObject({

--- a/__tests__/scripts/testing-strategy.test.ts
+++ b/__tests__/scripts/testing-strategy.test.ts
@@ -501,8 +501,9 @@ describe("testing strategy CI plan", () => {
     );
     expect(workflow).toContain('case "$selected_pack"');
     expect(workflow).toContain(
-      "selected_specs=(tests/museum/network-ia-readonly.spec.ts)"
+      "museum_gate_spec=tests/museum/network-ia-readonly.spec.ts"
     );
+    expect(workflow).toContain("selected_specs=()");
     expect(workflow).toContain('[ ! -f "$selected_spec" ]');
     expect(workflow).toContain("./bin/6529 exec playwright test");
     expect(workflow).not.toContain('./bin/6529 run "$selected_pack"');
@@ -621,6 +622,20 @@ describe("testing strategy CI plan", () => {
     );
     expect(museumBrowserRun).toContain(
       "Museum shard inventory must cover desktop and mobile Chromium"
+    );
+    expect(museumBrowserRun).toContain(
+      "Museum fail-fast gate must cover Network IA on desktop and mobile Chromium"
+    );
+    expect(museumBrowserRun).toContain(
+      'PLAYWRIGHT_OUTPUT_DIR="test-results/playwright/museum-gate"'
+    );
+    expect(museumBrowserRun).toContain(
+      "timeout --signal=TERM --kill-after=30s 10m"
+    );
+    expect(museumBrowserRun).toContain("--retries=0");
+    expect(museumBrowserRun).toContain("--max-failures=1");
+    expect(museumBrowserRun).toContain(
+      "Museum Network IA gate exceeded its 10-minute timeout."
     );
     expect(museumBrowserRun).toContain(
       'PLAYWRIGHT_OUTPUT_DIR="test-results/playwright/museum-shard-${shard}"'


### PR DESCRIPTION
## Summary

- run Network Museum desktop and mobile coverage as separate GitHub matrix jobs
- give each browser project its own runner, development server, and Next.js dist directory
- run Network IA first with retries disabled and stop on the first failure
- preserve exact publication selection and per-project execution inventory checks

## Why

The shared development server allowed desktop and mobile route activity to interfere. The attempted production-server replacement was invalid because the Museum publication test commit is intentionally rejected in production. Separate matrix jobs remove both failure modes while allowing desktop and mobile coverage to run in parallel.

## Validation

- focused testing-strategy contract suite
- extracted workflow shell syntax
- changed-workflow security validation