### PR TITLE
Lead the Conflict accession with a viewable photograph

### DIFF
--- a/__tests__/components/museum/MuseumAcquisitionRecordPage.test.tsx
+++ b/__tests__/components/museum/MuseumAcquisitionRecordPage.test.tsx
@@ -414,17 +414,17 @@ describe("MuseumAcquisitionRecordPage exhibition presentation", () => {
     expect(
       Boolean(
         worksSection !== null &&
-          (worksSection.compareDocumentPosition(curatorialHeading) &
-            Node.DOCUMENT_POSITION_FOLLOWING) !==
-            0
+        (worksSection.compareDocumentPosition(curatorialHeading) &
+          Node.DOCUMENT_POSITION_FOLLOWING) !==
+          0
       )
     ).toBe(true);
     expect(
       Boolean(
         recordSection !== null &&
-          (curatorialHeading.compareDocumentPosition(recordSection) &
-            Node.DOCUMENT_POSITION_FOLLOWING) !==
-            0
+        (curatorialHeading.compareDocumentPosition(recordSection) &
+          Node.DOCUMENT_POSITION_FOLLOWING) !==
+          0
       )
     ).toBe(true);
   });
@@ -454,7 +454,8 @@ describe("MuseumAcquisitionRecordPage exhibition presentation", () => {
   it("renders Conflict at Its Edges as a visual Wave-selected acquisition", () => {
     const workTitle = "Conflict at Its Edges";
     const artistName = "M. Artist";
-    const lifecycle = "Selected by Museum Wave; accession processing in progress";
+    const lifecycle =
+      "Selected by Museum Wave; accession processing in progress";
     const workId = "6529NM-W-0024";
     const presentation = presentationMedia();
 
@@ -511,6 +512,85 @@ describe("MuseumAcquisitionRecordPage exhibition presentation", () => {
     expect(document.body.textContent).not.toContain(
       "selected_by_museum_wave_acquisition_review_in_progress"
     );
+  });
+
+  it("leads an exhibition with an immediately viewable work while preserving the accession order", () => {
+    const gated = presentationMedia();
+    const immediatelyViewable: MuseumExternalProposalPresentationMedia = {
+      ...presentationMedia(),
+      id: "media-wave-proposal-viewable",
+      mediaUrl: "https://museum.test/conflict/border.jpg",
+      sourceByteSize: 800_000,
+      altText: "A patrol moves through a desert border landscape.",
+      source: {
+        ...presentationMedia().source,
+        partId: 2,
+        mediaRecordPath: "records/entities/media-wave-proposal-viewable.json",
+      },
+    };
+    const gatedWorkId = "6529NM-W-0028";
+    const viewableWorkId = "6529NM-W-0024";
+
+    render(
+      <MuseumAcquisitionRecordPage
+        acquisition={acquisition(
+          "acquisition-wave-selection",
+          "conflict-at-its-edges",
+          "Conflict at Its Edges",
+          "selected_by_museum_wave_acquisition_review_in_progress",
+          gatedWorkId,
+          { workIds: [gatedWorkId, viewableWorkId] }
+        )}
+        publication={publication(
+          [artist("artist-m", "M. Artist")],
+          [
+            {
+              ...work(
+                gatedWorkId,
+                "Palmyra, Syria",
+                "artist-m",
+                "selected_by_museum_wave_acquisition_review_in_progress",
+                metadata(
+                  "media-palmyra",
+                  gatedWorkId,
+                  "? artist / Magnum Photos.",
+                  gated.altText
+                )
+              ),
+              presentationMedia: [gated],
+            },
+            {
+              ...work(
+                viewableWorkId,
+                "Patrolling the border",
+                "artist-m",
+                "selected_by_museum_wave_acquisition_review_in_progress",
+                metadata(
+                  "media-border",
+                  viewableWorkId,
+                  "? artist / Magnum Photos.",
+                  immediatelyViewable.altText
+                )
+              ),
+              presentationMedia: [immediatelyViewable],
+            },
+          ]
+        )}
+        view={null}
+        sourceCommit={"b".repeat(40)}
+      />
+    );
+
+    const figures = document.querySelectorAll("#acquisition-works figure");
+    expect(figures).toHaveLength(2);
+    expect(figures[0]).toHaveTextContent("Patrolling the border");
+    expect(figures[1]).toHaveTextContent("Palmyra, Syria");
+    expect(
+      screen.getByRole("img", { name: immediatelyViewable.altText })
+    ).toHaveAttribute("src", immediatelyViewable.mediaUrl);
+    expect(
+      screen.getByRole("button", { name: "View image ? loads 16.5 MB" })
+    ).toBeInTheDocument();
   });
 
   it("fails closed when selected program media has no reviewed derivatives", () => {

--- a/__tests__/components/museum/MuseumAcquisitionRecordPage.test.tsx
+++ b/__tests__/components/museum/MuseumAcquisitionRecordPage.test.tsx
@@ -553,7 +553,7 @@ describe("MuseumAcquisitionRecordPage exhibition presentation", () => {
                 metadata(
                   "media-palmyra",
                   gatedWorkId,
-                  "? artist / Magnum Photos.",
+                  "© artist / Magnum Photos.",
                   gated.altText
                 )
               ),
@@ -568,7 +568,7 @@ describe("MuseumAcquisitionRecordPage exhibition presentation", () => {
                 metadata(
                   "media-border",
                   viewableWorkId,
-                  "? artist / Magnum Photos.",
+                  "© artist / Magnum Photos.",
                   immediatelyViewable.altText
                 )
               ),
@@ -589,7 +589,7 @@ describe("MuseumAcquisitionRecordPage exhibition presentation", () => {
       screen.getByRole("img", { name: immediatelyViewable.altText })
     ).toHaveAttribute("src", immediatelyViewable.mediaUrl);
     expect(
-      screen.getByRole("button", { name: "View image ? loads 16.5 MB" })
+      screen.getByRole("button", { name: "View image · loads 16.5 MB" })
     ).toBeInTheDocument();
   });
 

--- a/components/museum/MuseumAcquisitionRecordPage.tsx
+++ b/components/museum/MuseumAcquisitionRecordPage.tsx
@@ -1,4 +1,5 @@
 import { MuseumRelatedEntities } from "./MuseumRelatedEntities";
+import { MUSEUM_PROPOSAL_INTENT_VIEW_BYTES } from "./MuseumProposalImage";
 import type { AcquisitionWorkCard } from "./acquisition/MuseumAcquisitionExhibition";
 import { MuseumAcquisitionRecordDocuments } from "./acquisition/MuseumAcquisitionRecordDocuments";
 import { MuseumAcquisitionRecordHeader } from "./acquisition/MuseumAcquisitionRecordHeader";
@@ -137,6 +138,26 @@ function acquisitionWorkCards(
   return records;
 }
 
+function exhibitionWorkCards(
+  cards: readonly AcquisitionWorkCard[]
+): readonly AcquisitionWorkCard[] {
+  if (cards.length < 2) return cards;
+  const firstImmediatelyViewableIndex = cards.findIndex(
+    (card) =>
+      card.media !== undefined ||
+      (card.presentationMedia !== undefined &&
+        (card.presentationMedia.sourceByteSize === undefined ||
+          card.presentationMedia.sourceByteSize <
+            MUSEUM_PROPOSAL_INTENT_VIEW_BYTES))
+  );
+  if (firstImmediatelyViewableIndex <= 0) return cards;
+  return [
+    cards[firstImmediatelyViewableIndex] as AcquisitionWorkCard,
+    ...cards.slice(0, firstImmediatelyViewableIndex),
+    ...cards.slice(firstImmediatelyViewableIndex + 1),
+  ];
+}
+
 function acquisitionPublicWorkCard(
   publication: MuseumPublication,
   workId: string,
@@ -246,6 +267,7 @@ export function MuseumAcquisitionRecordPage({
   );
   const workHrefs = museumWorkHrefIndex(publication, view);
   const workCards = acquisitionWorkCards(publication, acquisition, view);
+  const displayedWorkCards = exhibitionWorkCards(workCards);
   const coveredPresentationIds = new Set(
     workCards.flatMap((work) =>
       work.presentationMedia === undefined ? [] : [work.presentationMedia.id]
@@ -283,7 +305,7 @@ export function MuseumAcquisitionRecordPage({
         workCount={workCards.length}
       />
       <MuseumAcquisitionRecordWorkSection
-        workCards={workCards}
+        workCards={displayedWorkCards}
         additionalPresentationMedia={additionalPresentationMedia}
         artFirst={artFirst}
       />

--- a/components/museum/MuseumAcquisitionRecordPage.tsx
+++ b/components/museum/MuseumAcquisitionRecordPage.tsx
@@ -142,14 +142,14 @@ function exhibitionWorkCards(
   cards: readonly AcquisitionWorkCard[]
 ): readonly AcquisitionWorkCard[] {
   if (cards.length < 2) return cards;
-  const firstImmediatelyViewableIndex = cards.findIndex(
-    (card) =>
-      card.media !== undefined ||
-      (card.presentationMedia !== undefined &&
-        (card.presentationMedia.sourceByteSize === undefined ||
-          card.presentationMedia.sourceByteSize <
-            MUSEUM_PROPOSAL_INTENT_VIEW_BYTES))
-  );
+  const firstImmediatelyViewableIndex = cards.findIndex((card) => {
+    if (card.media !== undefined) return true;
+    const sourceByteSize = card.presentationMedia?.sourceByteSize;
+    return (
+      typeof sourceByteSize === "number" &&
+      sourceByteSize < MUSEUM_PROPOSAL_INTENT_VIEW_BYTES
+    );
+  });
   if (firstImmediatelyViewableIndex <= 0) return cards;
   return [
     cards[firstImmediatelyViewableIndex] as AcquisitionWorkCard,

--- a/ops/workstreams/museum-exhibition-presentation/run-log.md
+++ b/ops/workstreams/museum-exhibition-presentation/run-log.md
@@ -143,3 +143,12 @@
   media. The help corpus now describes the reviewed Keys and Gates surrogates
   and the exact Conflict accession-processing status, removing the obsolete
   text-only and acquisition-review statements.
+- Staging qualification of frontend main `9354f35f8ed1e5932a1a32bad0ae6f564b2c5b3e`
+  passed, but retained mobile accession evidence showed that the canonical first
+  Conflict work is the 16.9 MB Palmyra master. Its intentional load control left
+  the opening gallery field without an immediately visible photograph. The
+  downstream accession projection now leads the public exhibition sequence with
+  the first reviewed, immediately viewable work and otherwise preserves canonical
+  order. Palmyra remains in the accession and retains its explicit high-resolution
+  control. Focused component and browser contracts require both properties before
+  the corrected release can advance.

--- a/tests/museum/network-ia-readonly.spec.ts
+++ b/tests/museum/network-ia-readonly.spec.ts
@@ -342,6 +342,11 @@ test.describe("Museum public IA rendered contract @surface @readonly", () => {
       "museum-acquisition-conflict-at-its-edges"
     );
     await page.locator("#acquisition-works-title").scrollIntoViewIfNeeded();
+    await expect(
+      page.locator("#acquisition-works figure").first()
+    ).toContainText(
+      "Patrolling the border between the Negev Desert and Jordan"
+    );
     await expect
       .poll(() =>
         page


### PR DESCRIPTION
## Outcome

Corrects a staging visual-review finding in the downstream accession experience for **Conflict at Its Edges**.

- leads the public works sequence with the first reviewed image that is immediately viewable;
- keeps every other work in canonical accession order;
- retains **Palmyra, Syria** in the accession with its explicit 16.9 MB high-resolution load control;
- adds a component contract and a real-browser Museum contract for the sequence.

The canonical five-work inventory and accession record are unchanged. This is the public-catalogue projection of the accession package, not a separate presentation record.

## Evidence

The prior exact staging release and automatic E2E passed, but the retained 390px Conflict gallery image opened on an empty black field because Palmyra's large master correctly requires visitor intent. Production was held. This PR makes the photograph itself lead the exhibition and preserves Palmyra's technical control.

Local whitespace validation passed. The fresh hosted Museum desktop/mobile lanes are authoritative for exact-catalog rendering and pixels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved acquisition galleries so the first immediately viewable work appears first when multiple works are available.
  - Preserved image controls for works requiring high-resolution or gated media loading.
- **Bug Fixes**
  - Ensured galleries display an immediately visible photograph on initial load.
  - Added coverage confirming the correct description appears for the first work in the gallery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->