### PR TITLE
Fix subwave creation admin-group inheritance

### DIFF
--- a/__tests__/components/brain/mobile/BrainMobileTabs.test.tsx
+++ b/__tests__/components/brain/mobile/BrainMobileTabs.test.tsx
@@ -83,7 +83,18 @@ const { useAuth } = require("@/components/auth/Auth");
 const createWave = () =>
   ({
     id: "1",
-    wave: { authenticated_user_eligible_for_admin: false },
+    parent_wave: null,
+    chat: { scope: { group: { is_direct_message: false } } },
+    wave: {
+      authenticated_user_eligible_for_admin: false,
+      admin_group: {
+        group: {
+          id: "parent-admin-group",
+          name: "Parent admins",
+          is_hidden: false,
+        },
+      },
+    },
   }) as any;
 
 describe("BrainMobileTabs", () => {
@@ -153,7 +164,7 @@ describe("BrainMobileTabs", () => {
     expect(screen.queryByRole("button", { name: /^chat$/i })).toBeNull();
   });
 
-  it("keeps the create curation action outside the scrollable tabs", () => {
+  it("keeps the mobile create menu outside the scrollable tabs", async () => {
     const wave = createWave();
     wave.wave.authenticated_user_eligible_for_admin = true;
 
@@ -170,14 +181,23 @@ describe("BrainMobileTabs", () => {
     );
 
     const createButton = screen.getByRole("button", {
-      name: /create curation/i,
+      name: /open create menu/i,
     });
-    const scrollableTabs = createButton.parentElement?.querySelector(
-      ".tw-overflow-x-auto"
-    );
+    const scrollableTabs = createButton
+      .closest("nav")
+      ?.querySelector(".tw-overflow-x-auto");
 
     expect(scrollableTabs).toBeInTheDocument();
     expect(scrollableTabs).not.toContainElement(createButton);
+    expect(createButton).toHaveClass("tw-size-11");
+
+    await userEvent.click(createButton);
+    expect(
+      screen.getByRole("menuitem", { name: "New curation" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "New subwave" })
+    ).toBeInTheDocument();
   });
 
   it("shows unread indicators and handles message/notification clicks", async () => {

--- a/__tests__/components/brain/my-stream/tabs/MyStreamWaveCreateActionsMenu.test.tsx
+++ b/__tests__/components/brain/my-stream/tabs/MyStreamWaveCreateActionsMenu.test.tsx
@@ -55,26 +55,34 @@ const createWave = ({
   parentWave = null,
   adminGroupId = "parent-admin-group",
   includeAdminGroup = true,
+  includeWaveConfig = true,
 }: {
   readonly eligible?: boolean;
   readonly parentWave?: object | null;
   readonly adminGroupId?: string | null;
   readonly includeAdminGroup?: boolean;
+  readonly includeWaveConfig?: boolean;
 } = {}) =>
   ({
     id: "parent-wave",
     parent_wave: parentWave,
     chat: { scope: { group: { is_direct_message: false } } },
-    wave: {
-      authenticated_user_eligible_for_admin: eligible,
-      admin_group: includeAdminGroup
-        ? {
-            group: adminGroupId
-              ? { id: adminGroupId, name: "Parent admins", is_hidden: false }
-              : null,
-          }
-        : null,
-    },
+    wave: includeWaveConfig
+      ? {
+          authenticated_user_eligible_for_admin: eligible,
+          admin_group: includeAdminGroup
+            ? {
+                group: adminGroupId
+                  ? {
+                      id: adminGroupId,
+                      name: "Parent admins",
+                      is_hidden: false,
+                    }
+                  : null,
+              }
+            : null,
+        }
+      : undefined,
   }) as any;
 
 describe("MyStreamWaveCreateActionsMenu", () => {
@@ -139,6 +147,17 @@ describe("MyStreamWaveCreateActionsMenu", () => {
     const { container } = render(
       <MyStreamWaveCreateActionsMenu
         wave={createWave({ eligible: false })}
+        onCreated={jest.fn()}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders no create control without a wave config payload", () => {
+    const { container } = render(
+      <MyStreamWaveCreateActionsMenu
+        wave={createWave({ includeWaveConfig: false })}
         onCreated={jest.fn()}
       />
     );

--- a/__tests__/components/brain/my-stream/tabs/MyStreamWaveCreateActionsMenu.test.tsx
+++ b/__tests__/components/brain/my-stream/tabs/MyStreamWaveCreateActionsMenu.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import MyStreamWaveCreateActionsMenu from "@/components/brain/my-stream/tabs/MyStreamWaveCreateActionsMenu";
+import { useAuth } from "@/components/auth/Auth";
+
+const createWaveModalMock = jest.fn();
+
+jest.mock("@/components/auth/Auth", () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock("@/components/compact-menu", () => ({
+  CompactMenu: (props: any) => (
+    <div>
+      <button
+        className={props.triggerClassName}
+        aria-label={props["aria-label"]}
+      >
+        {props.trigger}
+      </button>
+      {props.items.map((item: any) => (
+        <button key={item.id} onClick={item.onSelect}>
+          {item.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+jest.mock("@/components/brain/my-stream/MyStreamActionTooltip", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock(
+  "@/components/brain/my-stream/tabs/MyStreamWaveCurationCreateDialog",
+  () => ({
+    __esModule: true,
+    default: () => <div data-testid="curation-dialog" />,
+  })
+);
+
+jest.mock("@/components/waves/create-wave/CreateWaveModal", () => ({
+  __esModule: true,
+  default: (props: any) => {
+    createWaveModalMock(props);
+    return props.isOpen ? <div data-testid="subwave-modal" /> : null;
+  },
+}));
+
+const mockedUseAuth = useAuth as jest.Mock;
+
+const createWave = ({
+  eligible = true,
+  parentWave = null,
+  adminGroupId = "parent-admin-group",
+}: {
+  readonly eligible?: boolean;
+  readonly parentWave?: object | null;
+  readonly adminGroupId?: string | null;
+} = {}) =>
+  ({
+    id: "parent-wave",
+    parent_wave: parentWave,
+    chat: { scope: { group: { is_direct_message: false } } },
+    wave: {
+      authenticated_user_eligible_for_admin: eligible,
+      admin_group: {
+        group: adminGroupId
+          ? { id: adminGroupId, name: "Parent admins", is_hidden: false }
+          : null,
+      },
+    },
+  }) as any;
+
+describe("MyStreamWaveCreateActionsMenu", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseAuth.mockReturnValue({
+      connectedProfile: { handle: "alice" },
+      activeProfileProxy: null,
+    });
+  });
+
+  it("offers both create actions to an eligible root-wave admin", async () => {
+    render(
+      <MyStreamWaveCreateActionsMenu
+        wave={createWave()}
+        onCreated={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Open create menu" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "New curation" })
+    ).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "New subwave" }));
+
+    expect(screen.getByTestId("subwave-modal")).toBeInTheDocument();
+    expect(createWaveModalMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        parentWaveId: "parent-wave",
+        parentAdminGroupId: "parent-admin-group",
+      })
+    );
+  });
+
+  it.each([
+    ["an active proxy", { activeProfileProxy: { id: "proxy" } }, createWave()],
+    ["a nested wave", {}, createWave({ parentWave: { id: "root" } })],
+    ["no reusable admin group", {}, createWave({ adminGroupId: null })],
+  ])("hides subwave creation for %s", (_label, authOverride, wave) => {
+    mockedUseAuth.mockReturnValue({
+      connectedProfile: { handle: "alice" },
+      activeProfileProxy: null,
+      ...authOverride,
+    });
+
+    render(<MyStreamWaveCreateActionsMenu wave={wave} onCreated={jest.fn()} />);
+
+    expect(screen.queryByRole("button", { name: "New subwave" })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "New curation" })
+    ).toBeInTheDocument();
+  });
+
+  it("renders no create control without admin eligibility", () => {
+    const { container } = render(
+      <MyStreamWaveCreateActionsMenu
+        wave={createWave({ eligible: false })}
+        onCreated={jest.fn()}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("uses a 44px touch target in the mobile tab row", () => {
+    render(
+      <MyStreamWaveCreateActionsMenu
+        wave={createWave()}
+        variant="mobile"
+        onCreated={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Open create menu" })
+    ).toHaveClass("tw-size-11");
+  });
+});

--- a/__tests__/components/brain/my-stream/tabs/MyStreamWaveCreateActionsMenu.test.tsx
+++ b/__tests__/components/brain/my-stream/tabs/MyStreamWaveCreateActionsMenu.test.tsx
@@ -54,10 +54,12 @@ const createWave = ({
   eligible = true,
   parentWave = null,
   adminGroupId = "parent-admin-group",
+  includeAdminGroup = true,
 }: {
   readonly eligible?: boolean;
   readonly parentWave?: object | null;
   readonly adminGroupId?: string | null;
+  readonly includeAdminGroup?: boolean;
 } = {}) =>
   ({
     id: "parent-wave",
@@ -65,11 +67,13 @@ const createWave = ({
     chat: { scope: { group: { is_direct_message: false } } },
     wave: {
       authenticated_user_eligible_for_admin: eligible,
-      admin_group: {
-        group: adminGroupId
-          ? { id: adminGroupId, name: "Parent admins", is_hidden: false }
-          : null,
-      },
+      admin_group: includeAdminGroup
+        ? {
+            group: adminGroupId
+              ? { id: adminGroupId, name: "Parent admins", is_hidden: false }
+              : null,
+          }
+        : null,
     },
   }) as any;
 
@@ -111,6 +115,11 @@ describe("MyStreamWaveCreateActionsMenu", () => {
     ["an active proxy", { activeProfileProxy: { id: "proxy" } }, createWave()],
     ["a nested wave", {}, createWave({ parentWave: { id: "root" } })],
     ["no reusable admin group", {}, createWave({ adminGroupId: null })],
+    [
+      "no admin-group payload",
+      {},
+      createWave({ includeAdminGroup: false }),
+    ],
   ])("hides subwave creation for %s", (_label, authOverride, wave) => {
     mockedUseAuth.mockReturnValue({
       connectedProfile: { handle: "alice" },

--- a/__tests__/components/waves/create-wave/CreateWave.test.tsx
+++ b/__tests__/components/waves/create-wave/CreateWave.test.tsx
@@ -55,6 +55,13 @@ jest.mock("@/components/waves/create-wave/hooks/useWaveConfig", () => ({
   useWaveConfig: jest.fn(),
 }));
 
+jest.mock("@/services/api/common-api", () => ({
+  commonApiFetch: jest.fn().mockResolvedValue({
+    id: "parent-admin-group",
+    name: "Parent admins",
+  }),
+}));
+
 jest.mock("@/components/waves/create-wave/services/waveApiService", () => ({
   useAddWaveMutation: jest.fn(),
 }));
@@ -69,6 +76,9 @@ jest.mock("@/components/waves/create-wave/services/waveMediaService", () => ({
 }));
 
 jest.mock("@/components/waves/create-wave/services/waveGroupService", () => ({
+  ...jest.requireActual(
+    "@/components/waves/create-wave/services/waveGroupService"
+  ),
   getAdminGroupId: jest.fn(),
 }));
 
@@ -143,7 +153,10 @@ jest.mock(
 import { useWaveConfig } from "@/components/waves/create-wave/hooks/useWaveConfig";
 import { multiPartUpload } from "@/components/waves/create-wave/services/multiPartUpload";
 import { useAddWaveMutation } from "@/components/waves/create-wave/services/waveApiService";
-import { getAdminGroupId } from "@/components/waves/create-wave/services/waveGroupService";
+import {
+  getAdminGroupId,
+  WaveAdminGroupError,
+} from "@/components/waves/create-wave/services/waveGroupService";
 import { generateDropPart } from "@/components/waves/create-wave/services/waveMediaService";
 import { getCreateNewWaveBody } from "@/helpers/waves/create-wave.helpers";
 import { useGroupMutations } from "@/hooks/groups/useGroupMutations";
@@ -331,10 +344,12 @@ describe("CreateWave", () => {
 
   type RenderCreateWaveOptions = {
     readonly parentWaveId?: string | null | undefined;
+    readonly parentAdminGroupId?: string | null | undefined;
   };
 
   const createWaveElement = ({
     parentWaveId,
+    parentAdminGroupId,
   }: RenderCreateWaveOptions = {}) => (
     <AuthContext.Provider value={mockAuthContext}>
       <ReactQueryWrapperContext.Provider value={mockQueryContext}>
@@ -342,6 +357,7 @@ describe("CreateWave", () => {
           profile={mockProfile}
           onBack={onBack}
           parentWaveId={parentWaveId}
+          parentAdminGroupId={parentAdminGroupId}
         />
       </ReactQueryWrapperContext.Provider>
     </AuthContext.Provider>
@@ -360,11 +376,15 @@ describe("CreateWave", () => {
   });
 
   it("uses subwave title when creating under a parent wave", () => {
-    renderCreateWave({ parentWaveId: "parent-wave" });
+    renderCreateWave({
+      parentWaveId: "parent-wave",
+      parentAdminGroupId: "parent-admin-group",
+    });
 
     expect(screen.getByTestId("create-wave-flow-title")).toHaveTextContent(
       'Create subwave "Test Wave"'
     );
+    expect(mockedUseWaveConfig).toHaveBeenCalledWith();
   });
 
   it("calls onBack when back button is clicked", () => {
@@ -499,16 +519,71 @@ describe("CreateWave", () => {
       };
       mockedUseWaveConfig.mockReturnValue(configOnDescriptionStep);
 
-      renderCreateWave({ parentWaveId: "parent-wave" });
+      renderCreateWave({
+        parentWaveId: "parent-wave",
+        parentAdminGroupId: "parent-admin-group",
+      });
 
       fireEvent.click(screen.getByRole("button", { name: /complete/i }));
 
       await waitFor(() => {
+        expect(mockedGetAdminGroupId).toHaveBeenCalledWith(
+          expect.objectContaining({ adminGroupId: "admin-group-id" })
+        );
         expect(mockedGetCreateNewWaveBody).toHaveBeenCalledWith(
           expect.objectContaining({
             parentWaveId: "parent-wave",
           })
         );
+      });
+    });
+
+    it("uses the parent admin group when a subwave draft has no selection", async () => {
+      mockedUseWaveConfig.mockReturnValue({
+        ...mockWaveConfig,
+        step: CreateWaveStep.DESCRIPTION,
+        config: {
+          ...mockWaveConfig.config,
+          groups: {
+            ...mockWaveConfig.config.groups,
+            admin: null,
+          },
+        },
+      });
+
+      renderCreateWave({
+        parentWaveId: "parent-wave",
+        parentAdminGroupId: "parent-admin-group",
+      });
+      fireEvent.click(screen.getByRole("button", { name: /complete/i }));
+
+      await waitFor(() => {
+        expect(mockedGetAdminGroupId).toHaveBeenCalledWith(
+          expect.objectContaining({ adminGroupId: "parent-admin-group" })
+        );
+      });
+    });
+
+    it("ignores a second submit while authentication is pending", async () => {
+      let resolveAuth: ((value: { success: boolean }) => void) | undefined;
+      mockAuthContext.requestAuth.mockReturnValue(
+        new Promise((resolve) => {
+          resolveAuth = resolve;
+        })
+      );
+      mockedUseWaveConfig.mockReturnValue({
+        ...mockWaveConfig,
+        step: CreateWaveStep.DESCRIPTION,
+      });
+      renderCreateWave();
+
+      const completeButton = screen.getByRole("button", { name: /complete/i });
+      fireEvent.click(completeButton);
+      fireEvent.click(completeButton);
+
+      expect(mockAuthContext.requestAuth).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        resolveAuth?.({ success: false });
       });
     });
 
@@ -676,7 +751,15 @@ describe("CreateWave", () => {
     });
 
     it("shows error when admin group retrieval fails", async () => {
-      mockedGetAdminGroupId.mockResolvedValue(null);
+      mockedGetAdminGroupId.mockImplementation(async ({ onError }) => {
+        onError(
+          new WaveAdminGroupError({
+            reason: "publish-personal-group",
+            cause: "Something went wrong...",
+          })
+        );
+        return null;
+      });
 
       const configOnDescriptionStep = {
         ...mockWaveConfig,
@@ -692,6 +775,12 @@ describe("CreateWave", () => {
       await waitFor(() => {
         expect(mockedGetAdminGroupId).toHaveBeenCalled();
         expect(mockAddWaveMutation.mutateAsync).not.toHaveBeenCalled();
+        expect(mockAuthContext.setToast).toHaveBeenCalledWith({
+          type: "error",
+          title: "Couldn't make the admin group visible.",
+          description: "Choose an existing admin group, or try again later.",
+          details: "The group service did not complete the request.",
+        });
       });
     });
 

--- a/__tests__/components/waves/create-wave/hooks/useSubwaveWaveConfig.test.ts
+++ b/__tests__/components/waves/create-wave/hooks/useSubwaveWaveConfig.test.ts
@@ -1,0 +1,83 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { useSubwaveWaveConfig } from "@/components/waves/create-wave/hooks/useSubwaveWaveConfig";
+import { useWaveConfig } from "@/components/waves/create-wave/hooks/useWaveConfig";
+import { commonApiFetch } from "@/services/api/common-api";
+
+jest.mock("@/components/waves/create-wave/hooks/useWaveConfig", () => ({
+  useWaveConfig: jest.fn(),
+}));
+
+jest.mock("@/services/api/common-api", () => ({
+  commonApiFetch: jest.fn(),
+}));
+
+const mockedUseWaveConfig = useWaveConfig as jest.Mock;
+const mockedCommonApiFetch = commonApiFetch as jest.Mock;
+
+const createWaveConfigController = (adminGroupId: string | null = null) => ({
+  config: {
+    overview: { type: "CHAT" },
+    groups: {
+      admin: adminGroupId,
+      canView: null,
+      canDrop: null,
+      canVote: null,
+      canChat: null,
+    },
+  },
+  groupsCache: {},
+  setOverview: jest.fn(),
+});
+
+describe("useSubwaveWaveConfig", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseWaveConfig.mockReturnValue(createWaveConfigController());
+    mockedCommonApiFetch.mockResolvedValue({
+      id: "parent-admin-group",
+      name: "Parent admins",
+    });
+  });
+
+  it("uses the parent admin group and loads its display details", async () => {
+    const { result } = renderHook(() =>
+      useSubwaveWaveConfig({ parentAdminGroupId: "parent-admin-group" })
+    );
+
+    expect(result.current.config.groups.admin).toBe("parent-admin-group");
+    expect(mockedCommonApiFetch).toHaveBeenCalledWith({
+      endpoint: "groups/parent-admin-group",
+      signal: expect.any(AbortSignal),
+    });
+    await waitFor(() => {
+      expect(result.current.groupsCache["parent-admin-group"]).toMatchObject({
+        id: "parent-admin-group",
+        name: "Parent admins",
+      });
+    });
+  });
+
+  it("keeps a different admin group selected by the creator", () => {
+    mockedUseWaveConfig.mockReturnValue(
+      createWaveConfigController("different-admin-group")
+    );
+
+    const { result } = renderHook(() =>
+      useSubwaveWaveConfig({ parentAdminGroupId: "parent-admin-group" })
+    );
+
+    expect(result.current.config.groups.admin).toBe("different-admin-group");
+  });
+
+  it("leaves top-level wave configuration unchanged", () => {
+    const controller = createWaveConfigController();
+    mockedUseWaveConfig.mockReturnValue(controller);
+
+    const { result } = renderHook(() =>
+      useSubwaveWaveConfig({ parentAdminGroupId: null })
+    );
+
+    expect(result.current.config).toBe(controller.config);
+    expect(mockedCommonApiFetch).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/waves/create-wave/services/waveGroupService.test.ts
+++ b/__tests__/components/waves/create-wave/services/waveGroupService.test.ts
@@ -1,51 +1,100 @@
-import { getAdminGroupId } from '@/components/waves/create-wave/services/waveGroupService';
-import { commonApiPost } from '@/services/api/common-api';
+import {
+  getAdminGroupId,
+  WaveAdminGroupError,
+} from "@/components/waves/create-wave/services/waveGroupService";
+import { commonApiPost } from "@/services/api/common-api";
 
-jest.mock('@/services/api/common-api', () => ({
+jest.mock("@/services/api/common-api", () => ({
   commonApiPost: jest.fn(),
 }));
 
 const mockedCommonApiPost = commonApiPost as jest.Mock;
 
-describe('waveGroupService', () => {
+describe("waveGroupService", () => {
   beforeEach(() => {
     mockedCommonApiPost.mockReset();
   });
 
-  it('returns existing admin group id if provided', async () => {
+  it("returns existing admin group id if provided", async () => {
     const result = await getAdminGroupId({
-      adminGroupId: '123',
-      primaryWallet: '0x1',
-      handle: 'alice',
+      adminGroupId: "123",
+      primaryWallet: "0x1",
+      handle: "alice",
       onError: jest.fn(),
     });
-    expect(result).toBe('123');
+    expect(result).toBe("123");
     expect(mockedCommonApiPost).not.toHaveBeenCalled();
   });
 
-  it('returns null and calls onError when no primary wallet', async () => {
+  it("returns an actionable error when no primary wallet is available", async () => {
     const onError = jest.fn();
     const result = await getAdminGroupId({
       adminGroupId: null,
       primaryWallet: null,
-      handle: 'alice',
+      handle: "alice",
       onError,
     });
     expect(result).toBeNull();
-    expect(onError).toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(expect.any(WaveAdminGroupError));
+    expect(onError.mock.calls[0]?.[0]).toMatchObject({
+      reason: "missing-primary-wallet",
+    });
   });
 
-  it('creates group when no admin group id', async () => {
+  it("creates and publishes a personal group when no admin group id exists", async () => {
     mockedCommonApiPost
-      .mockResolvedValueOnce({ id: 'new' }) // create group
+      .mockResolvedValueOnce({ id: "new" }) // create group
       .mockResolvedValueOnce({}); // set visible
     const result = await getAdminGroupId({
       adminGroupId: null,
-      primaryWallet: '0x1',
-      handle: 'alice',
+      primaryWallet: "0x1",
+      handle: "alice",
       onError: jest.fn(),
     });
-    expect(result).toBe('new');
+    expect(result).toBe("new");
     expect(mockedCommonApiPost).toHaveBeenCalledTimes(2);
+    expect(mockedCommonApiPost).toHaveBeenNthCalledWith(2, {
+      endpoint: "groups/new/visible",
+      body: { visible: true, old_version_id: null },
+      signal: undefined,
+    });
+  });
+
+  it("reports whether personal-group creation failed", async () => {
+    mockedCommonApiPost.mockRejectedValueOnce("create failed");
+    const onError = jest.fn();
+
+    const result = await getAdminGroupId({
+      adminGroupId: null,
+      primaryWallet: "0x1",
+      handle: "alice",
+      onError,
+    });
+
+    expect(result).toBeNull();
+    expect(onError.mock.calls[0]?.[0]).toMatchObject({
+      reason: "create-personal-group",
+      cause: "create failed",
+    });
+  });
+
+  it("reports whether personal-group publication failed", async () => {
+    mockedCommonApiPost
+      .mockResolvedValueOnce({ id: "new" })
+      .mockRejectedValueOnce("publish failed");
+    const onError = jest.fn();
+
+    const result = await getAdminGroupId({
+      adminGroupId: null,
+      primaryWallet: "0x1",
+      handle: "alice",
+      onError,
+    });
+
+    expect(result).toBeNull();
+    expect(onError.mock.calls[0]?.[0]).toMatchObject({
+      reason: "publish-personal-group",
+      cause: "publish failed",
+    });
   });
 });

--- a/components/brain/mobile/BrainMobileTabs.tsx
+++ b/components/brain/mobile/BrainMobileTabs.tsx
@@ -1,19 +1,19 @@
 "use client";
 
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useRef } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { BrainView } from "./brainMobileViews";
 import type { ApiWave } from "@/generated/models/ApiWave";
 import MyStreamWaveTabsLeaderboard from "../my-stream/MyStreamWaveTabsLeaderboard";
 import { useLayout } from "../my-stream/layout/LayoutContext";
 import { useWave } from "@/hooks/useWave";
-import { ArrowLeftIcon, PlusIcon } from "@heroicons/react/24/solid";
+import { ArrowLeftIcon } from "@heroicons/react/24/solid";
 import { useUnreadIndicator } from "@/hooks/useUnreadIndicator";
 import { useUnreadNotifications } from "@/hooks/useUnreadNotifications";
 import { useAuth } from "@/components/auth/Auth";
 import { getWaveHomeRoute } from "../../../helpers/navigation.helpers";
 import { useWaveCurations } from "@/hooks/waves/useWaveCurations";
-import MyStreamWaveCurationCreateDialog from "../my-stream/tabs/MyStreamWaveCurationCreateDialog";
+import MyStreamWaveCreateActionsMenu from "../my-stream/tabs/MyStreamWaveCreateActionsMenu";
 import { useBrowserLocale } from "@/hooks/useBrowserLocale";
 import { t } from "@/i18n/messages";
 
@@ -110,7 +110,6 @@ const BrainMobileTabs: React.FC<BrainMobileTabsProps> = ({
   const { connectedProfile, isAuthenticated } = useAuth();
   const hasValidNotificationAuth = isAuthenticated === true;
   const hasAuthenticatedProfile = Boolean(connectedProfile?.handle);
-  const [isCreateCurationOpen, setIsCreateCurationOpen] = useState(false);
   const shouldShowCurationTabs = Boolean(isApp && waveActive && wave?.id);
   const activeCurationId = shouldShowCurationTabs
     ? searchParams.get("curation")
@@ -305,16 +304,13 @@ const BrainMobileTabs: React.FC<BrainMobileTabsProps> = ({
         </span>
       </button>
     ) : null;
-  const createCurationButton =
-    isApp && canManageCurations ? (
-      <button
-        type="button"
-        onClick={() => setIsCreateCurationOpen(true)}
-        className="tw-inline-flex tw-size-9 tw-flex-shrink-0 tw-items-center tw-justify-center tw-self-center tw-rounded-lg tw-border-0 tw-bg-iron-900/80 tw-text-iron-200 tw-ring-1 tw-ring-inset tw-ring-white/10 tw-transition tw-duration-150 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-300 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-black desktop-hover:hover:tw-bg-iron-800 desktop-hover:hover:tw-text-white motion-reduce:tw-transition-none"
-        aria-label="Create curation"
-      >
-        <PlusIcon className="tw-size-4 tw-flex-shrink-0" />
-      </button>
+  const createActionsMenu =
+    isApp && wave && canManageCurations ? (
+      <MyStreamWaveCreateActionsMenu
+        wave={wave}
+        variant="mobile"
+        onCreated={onCurationClick}
+      />
     ) : null;
 
   return (
@@ -349,7 +345,7 @@ const BrainMobileTabs: React.FC<BrainMobileTabsProps> = ({
               </span>
             ))}
           </output>
-          {createCurationButton}
+          {createActionsMenu}
         </div>
       ) : (
         <div className="tw-flex tw-min-h-12 tw-w-full tw-min-w-0 tw-items-stretch tw-gap-1.5 tw-px-0.5">
@@ -561,19 +557,8 @@ const BrainMobileTabs: React.FC<BrainMobileTabsProps> = ({
               </button>
             )}
           </div>
-          {createCurationButton}
+          {createActionsMenu}
         </div>
-      )}
-      {wave && isCreateCurationOpen && (
-        <MyStreamWaveCurationCreateDialog
-          wave={wave}
-          isOpen={isCreateCurationOpen}
-          onClose={() => setIsCreateCurationOpen(false)}
-          onSaved={(curation) => {
-            onCurationClick(curation.id);
-            setIsCreateCurationOpen(false);
-          }}
-        />
       )}
     </nav>
   );

--- a/components/brain/my-stream/tabs/MyStreamWaveCreateActionsMenu.tsx
+++ b/components/brain/my-stream/tabs/MyStreamWaveCreateActionsMenu.tsx
@@ -76,10 +76,10 @@ export default function MyStreamWaveCreateActionsMenu({
     <>
       <span
         className="tw-inline-flex tw-flex-shrink-0 tw-self-center"
-        data-tooltip-id={isMobile ? undefined : createActionsTooltipId}
-        data-tooltip-content={
-          isMobile ? undefined : t(locale, "waves.create.actions.create")
-        }
+        {...(!isMobile && {
+          "data-tooltip-id": createActionsTooltipId,
+          "data-tooltip-content": t(locale, "waves.create.actions.create"),
+        })}
       >
         <CompactMenu
           className="tailwind-scope tw-flex tw-flex-shrink-0"

--- a/components/brain/my-stream/tabs/MyStreamWaveCreateActionsMenu.tsx
+++ b/components/brain/my-stream/tabs/MyStreamWaveCreateActionsMenu.tsx
@@ -27,19 +27,21 @@ export default function MyStreamWaveCreateActionsMenu({
   const [isCreateCurationOpen, setIsCreateCurationOpen] = useState(false);
   const [isCreateSubwaveOpen, setIsCreateSubwaveOpen] = useState(false);
   const isDirectMessage = wave.chat?.scope?.group?.is_direct_message ?? false;
-  const parentAdminGroup = wave.wave.admin_group as
+  const waveConfig = wave.wave as typeof wave.wave | null | undefined;
+  const parentAdminGroup = waveConfig?.admin_group as
     | typeof wave.wave.admin_group
-    | null;
+    | null
+    | undefined;
   const parentAdminGroupId = parentAdminGroup?.group?.id ?? null;
   const canCreateCuration =
-    wave.wave?.authenticated_user_eligible_for_admin === true;
+    waveConfig?.authenticated_user_eligible_for_admin === true;
   const canCreateSubwave =
     Boolean(connectedProfile) &&
     !activeProfileProxy &&
     !isDirectMessage &&
     !wave.parent_wave &&
     Boolean(parentAdminGroupId) &&
-    wave.wave?.authenticated_user_eligible_for_admin === true;
+    waveConfig?.authenticated_user_eligible_for_admin === true;
 
   const menuItems = useMemo<CompactMenuItem[]>(
     () => [

--- a/components/brain/my-stream/tabs/MyStreamWaveCreateActionsMenu.tsx
+++ b/components/brain/my-stream/tabs/MyStreamWaveCreateActionsMenu.tsx
@@ -6,22 +6,28 @@ import { CompactMenu, type CompactMenuItem } from "@/components/compact-menu";
 import { useAuth } from "@/components/auth/Auth";
 import CreateWaveModal from "@/components/waves/create-wave/CreateWaveModal";
 import type { ApiWave } from "@/generated/models/ApiWave";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import { t } from "@/i18n/messages";
 import MyStreamActionTooltip from "../MyStreamActionTooltip";
 import MyStreamWaveCurationCreateDialog from "./MyStreamWaveCurationCreateDialog";
 
 interface MyStreamWaveCreateActionsMenuProps {
   readonly wave: ApiWave;
   readonly onCreated: (curationId: string) => void;
+  readonly variant?: "desktop" | "mobile" | undefined;
 }
 
 export default function MyStreamWaveCreateActionsMenu({
   wave,
   onCreated,
+  variant = "desktop",
 }: MyStreamWaveCreateActionsMenuProps) {
   const { connectedProfile, activeProfileProxy } = useAuth();
+  const locale = useBrowserLocale();
   const [isCreateCurationOpen, setIsCreateCurationOpen] = useState(false);
   const [isCreateSubwaveOpen, setIsCreateSubwaveOpen] = useState(false);
   const isDirectMessage = wave.chat?.scope?.group?.is_direct_message ?? false;
+  const parentAdminGroupId = wave.wave.admin_group.group?.id ?? null;
   const canCreateCuration =
     wave.wave?.authenticated_user_eligible_for_admin === true;
   const canCreateSubwave =
@@ -29,6 +35,7 @@ export default function MyStreamWaveCreateActionsMenu({
     !activeProfileProxy &&
     !isDirectMessage &&
     !wave.parent_wave &&
+    Boolean(parentAdminGroupId) &&
     wave.wave?.authenticated_user_eligible_for_admin === true;
 
   const menuItems = useMemo<CompactMenuItem[]>(
@@ -37,7 +44,7 @@ export default function MyStreamWaveCreateActionsMenu({
         ? [
             {
               id: "create-curation",
-              label: "New curation",
+              label: t(locale, "waves.create.actions.newCuration"),
               onSelect: () => setIsCreateCurationOpen(true),
             },
           ]
@@ -46,13 +53,13 @@ export default function MyStreamWaveCreateActionsMenu({
         ? [
             {
               id: "create-subwave",
-              label: "New subwave",
+              label: t(locale, "waves.create.actions.newSubwave"),
               onSelect: () => setIsCreateSubwaveOpen(true),
             },
           ]
         : []),
     ],
-    [canCreateCuration, canCreateSubwave]
+    [canCreateCuration, canCreateSubwave, locale]
   );
 
   if (menuItems.length === 0) {
@@ -60,27 +67,31 @@ export default function MyStreamWaveCreateActionsMenu({
   }
 
   const createActionsTooltipId = `my-stream-create-actions-${wave.id}`;
-  const buttonClassName =
-    "tw-flex tw-h-8 tw-w-8 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900 tw-transition tw-duration-150 hover:tw-border-iron-500 hover:tw-bg-iron-800 hover:tw-text-white tw-text-iron-200";
+  const isMobile = variant === "mobile";
+  const buttonClassName = isMobile
+    ? "tw-flex tw-size-11 tw-items-center tw-justify-center tw-rounded-lg tw-border-0 tw-bg-iron-900/80 tw-text-iron-200 tw-ring-1 tw-ring-inset tw-ring-white/10 tw-transition tw-duration-150 desktop-hover:hover:tw-bg-iron-800 desktop-hover:hover:tw-text-white focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-300 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-black motion-reduce:tw-transition-none"
+    : "tw-flex tw-h-8 tw-w-8 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900 tw-text-iron-200 tw-transition tw-duration-150 hover:tw-border-iron-500 hover:tw-bg-iron-800 hover:tw-text-white";
 
   return (
     <>
       <span
-        className="tw-inline-flex"
-        data-tooltip-id={createActionsTooltipId}
-        data-tooltip-content="Create"
+        className="tw-inline-flex tw-flex-shrink-0 tw-self-center"
+        data-tooltip-id={isMobile ? undefined : createActionsTooltipId}
+        data-tooltip-content={
+          isMobile ? undefined : t(locale, "waves.create.actions.create")
+        }
       >
         <CompactMenu
           className="tailwind-scope tw-flex tw-flex-shrink-0"
           trigger={<PlusIcon className="tw-h-4 tw-w-4 tw-flex-shrink-0" />}
           triggerClassName={buttonClassName}
           unstyledTrigger
-          aria-label="Open create menu"
+          aria-label={t(locale, "waves.create.actions.openCreateMenu")}
           items={menuItems}
           menuWidthClassName="tw-w-52"
           unstyledMenu
           menuClassName="tailwind-scope tw-z-50 tw-mt-3 tw-rounded-lg tw-bg-iron-950 tw-py-0 tw-shadow-2xl tw-ring-1 tw-ring-iron-700/80 focus:tw-outline-none"
-          header="CREATE"
+          header={t(locale, "waves.create.actions.createMenuHeader")}
           headerClassName="tw-px-3 tw-pb-2 tw-pt-2 tw-text-xs tw-font-medium tw-uppercase tw-leading-4 tw-tracking-widest tw-text-iron-400"
           itemsWrapperClassName="tw-p-2"
           itemClassName="tw-flex tw-w-full tw-items-center tw-rounded-lg tw-border-0 tw-bg-transparent tw-px-3 tw-py-2 tw-text-left tw-text-sm tw-font-medium tw-leading-6 tw-transition tw-duration-150 tw-ease-out"
@@ -89,7 +100,7 @@ export default function MyStreamWaveCreateActionsMenu({
           unstyledItems
         />
       </span>
-      <MyStreamActionTooltip id={createActionsTooltipId} />
+      {!isMobile && <MyStreamActionTooltip id={createActionsTooltipId} />}
 
       {isCreateCurationOpen && (
         <MyStreamWaveCurationCreateDialog
@@ -106,6 +117,7 @@ export default function MyStreamWaveCreateActionsMenu({
           onClose={() => setIsCreateSubwaveOpen(false)}
           profile={connectedProfile}
           parentWaveId={wave.id}
+          parentAdminGroupId={parentAdminGroupId}
         />
       )}
     </>

--- a/components/brain/my-stream/tabs/MyStreamWaveCreateActionsMenu.tsx
+++ b/components/brain/my-stream/tabs/MyStreamWaveCreateActionsMenu.tsx
@@ -27,7 +27,10 @@ export default function MyStreamWaveCreateActionsMenu({
   const [isCreateCurationOpen, setIsCreateCurationOpen] = useState(false);
   const [isCreateSubwaveOpen, setIsCreateSubwaveOpen] = useState(false);
   const isDirectMessage = wave.chat?.scope?.group?.is_direct_message ?? false;
-  const parentAdminGroupId = wave.wave.admin_group.group?.id ?? null;
+  const parentAdminGroup = wave.wave.admin_group as
+    | typeof wave.wave.admin_group
+    | null;
+  const parentAdminGroupId = parentAdminGroup?.group?.id ?? null;
   const canCreateCuration =
     wave.wave?.authenticated_user_eligible_for_admin === true;
   const canCreateSubwave =

--- a/components/brain/my-stream/tabs/MyStreamWaveCurationCreateDialog.tsx
+++ b/components/brain/my-stream/tabs/MyStreamWaveCurationCreateDialog.tsx
@@ -699,7 +699,7 @@ export default function MyStreamWaveCurationCreateDialog({
       tabletModal={true}
       tall={true}
       maxWidthClass="md:tw-max-w-lg"
-      headerClassName="tw-mb-0 tw-border-b tw-border-solid tw-border-x-0 tw-border-t-0 tw-border-white/[0.06] tw-pb-4 tw-pt-6"
+      headerClassName="tw-mb-0 tw-border-b tw-border-solid tw-border-x-0 tw-border-t-0 tw-border-white/[0.06] tw-py-4"
     >
       <div className="tw-flex tw-min-h-0 tw-flex-1 tw-flex-col">
         <div className="tw-min-h-0 tw-flex-1 tw-overflow-y-auto tw-scrollbar-thin tw-scrollbar-track-iron-800 tw-scrollbar-thumb-iron-500 desktop-hover:hover:tw-scrollbar-thumb-iron-300">

--- a/components/waves/create-wave/CreateWave.tsx
+++ b/components/waves/create-wave/CreateWave.tsx
@@ -15,7 +15,7 @@ import type { CreateWaveDraft } from "@/helpers/waves/create-wave-draft.helpers"
 import { useCreateWaveDrafts } from "./hooks/useCreateWaveDrafts";
 import { useCreateWaveSubmission } from "./hooks/useCreateWaveSubmission";
 import useKeyboardFocusScroll from "./hooks/useKeyboardFocusScroll";
-import { useWaveConfig } from "./hooks/useWaveConfig";
+import { useSubwaveWaveConfig } from "./hooks/useSubwaveWaveConfig";
 import CreateWaveDraftsSection from "./overview/CreateWaveDraftsSection";
 
 export default function CreateWave({
@@ -23,13 +23,17 @@ export default function CreateWave({
   onBack,
   onSuccess,
   parentWaveId,
+  parentAdminGroupId,
 }: {
   readonly profile: ApiIdentity;
   readonly onBack: () => void;
   readonly onSuccess?: (() => void) | undefined;
   readonly parentWaveId?: string | null | undefined;
+  readonly parentAdminGroupId?: string | null | undefined;
 }) {
-  const waveConfig = useWaveConfig();
+  const waveConfig = useSubwaveWaveConfig({
+    parentAdminGroupId,
+  });
   const {
     config,
     step,
@@ -122,6 +126,7 @@ export default function CreateWave({
       onSuccess?.();
     },
     parentWaveId,
+    parentAdminGroupId,
   });
 
   const setStep = (

--- a/components/waves/create-wave/CreateWaveModal.tsx
+++ b/components/waves/create-wave/CreateWaveModal.tsx
@@ -12,6 +12,7 @@ interface CreateWaveModalProps {
   readonly onClose: () => void;
   readonly profile: ApiIdentity;
   readonly parentWaveId?: string | null | undefined;
+  readonly parentAdminGroupId?: string | null | undefined;
 }
 
 const subscribeToClientMount = () => () => {};
@@ -23,6 +24,7 @@ export default function CreateWaveModal({
   onClose,
   profile,
   parentWaveId,
+  parentAdminGroupId,
 }: CreateWaveModalProps) {
   const mounted = useSyncExternalStore(
     subscribeToClientMount,
@@ -76,6 +78,7 @@ export default function CreateWaveModal({
                 onBack={onClose}
                 onSuccess={onClose}
                 parentWaveId={parentWaveId}
+                parentAdminGroupId={parentAdminGroupId}
               />
             </div>
           </motion.div>

--- a/components/waves/create-wave/groups/CreateWaveGroup.tsx
+++ b/components/waves/create-wave/groups/CreateWaveGroup.tsx
@@ -68,7 +68,9 @@ export default function CreateWaveGroup({
     isNotChatWave &&
     groupType === CreateWaveGroupConfigType.CAN_CHAT &&
     !chatEnabled;
-  const defaultLabel = CREATE_WAVE_NONE_GROUP_LABELS[groupType];
+  const defaultLabel = selectedGroupId
+    ? "Selected group"
+    : CREATE_WAVE_NONE_GROUP_LABELS[groupType];
   const groupLabel = CREATE_WAVE_SELECT_GROUP_LABELS[waveType][groupType];
   const suggestedName = buildInlineGroupName({ waveName, groupLabel });
 

--- a/components/waves/create-wave/groups/CreateWaveGroup.tsx
+++ b/components/waves/create-wave/groups/CreateWaveGroup.tsx
@@ -9,6 +9,8 @@ import {
 import type { ApiCreateGroup } from "@/generated/models/ApiCreateGroup";
 import type { ApiGroupFull } from "@/generated/models/ApiGroupFull";
 import { ApiWaveType } from "@/generated/models/ApiWaveType";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import { t } from "@/i18n/messages";
 import CreateWaveToggle from "../utils/CreateWaveToggle";
 import { buildInlineGroupName } from "./createWaveInlineGroupBuilder";
 import CreateWaveGroupInlinePanel from "./CreateWaveGroupInlinePanel";
@@ -40,6 +42,7 @@ export default function CreateWaveGroup({
   readonly groups: WaveGroupsConfig;
   readonly setDropsAdminCanDelete: (adminCanDeleteDrops: boolean) => void;
 }) {
+  const locale = useBrowserLocale();
   const getSelectedGroupId = () => {
     switch (groupType) {
       case CreateWaveGroupConfigType.ADMIN:
@@ -69,7 +72,7 @@ export default function CreateWaveGroup({
     groupType === CreateWaveGroupConfigType.CAN_CHAT &&
     !chatEnabled;
   const defaultLabel = selectedGroupId
-    ? "Selected group"
+    ? t(locale, "waves.create.groups.selectedGroup")
     : CREATE_WAVE_NONE_GROUP_LABELS[groupType];
   const groupLabel = CREATE_WAVE_SELECT_GROUP_LABELS[waveType][groupType];
   const suggestedName = buildInlineGroupName({ waveName, groupLabel });

--- a/components/waves/create-wave/hooks/useCreateWaveSubmission.ts
+++ b/components/waves/create-wave/hooks/useCreateWaveSubmission.ts
@@ -1,4 +1,4 @@
-import { useContext, useState, type RefObject } from "react";
+import { useContext, useRef, useState, type RefObject } from "react";
 import { AuthContext } from "@/components/auth/Auth";
 import { ReactQueryWrapperContext } from "@/components/react-query-wrapper/ReactQueryWrapper";
 import { getWaveRoute } from "@/helpers/navigation.helpers";
@@ -13,37 +13,101 @@ import type { ApiGroupFull } from "@/generated/models/ApiGroupFull";
 import type { CreateWaveConfig } from "@/types/waves.types";
 import { useRouter } from "next/navigation";
 import { hasPendingInlineImageUploadDrop } from "@/helpers/waves/inline-image-upload.helpers";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import type { SupportedLocale } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import type { CreateWaveDescriptionHandles } from "../description/CreateWaveDescription";
 import { getCreateWaveDropRequest } from "../services/createWaveDropRequest";
 import { multiPartUpload } from "../services/multiPartUpload";
 import { useAddWaveMutation } from "../services/waveApiService";
-import { getAdminGroupId } from "../services/waveGroupService";
+import {
+  getAdminGroupId,
+  WaveAdminGroupError,
+} from "../services/waveGroupService";
 
 interface UseCreateWaveSubmissionParams {
   readonly config: CreateWaveConfig;
   readonly descriptionRef: RefObject<CreateWaveDescriptionHandles | null>;
   readonly onSuccess?: (() => void) | undefined;
   readonly parentWaveId?: string | null | undefined;
+  readonly parentAdminGroupId?: string | null | undefined;
 }
+
+const getAdminGroupErrorToast = (error: unknown, locale: SupportedLocale) => {
+  if (!(error instanceof WaveAdminGroupError)) {
+    return {
+      type: "error" as const,
+      title: t(locale, "waves.create.groups.error.createAdmin.title"),
+      description: t(
+        locale,
+        "waves.create.groups.error.createAdmin.description"
+      ),
+      details: getToastErrorDetails(
+        error,
+        t(locale, "waves.create.groups.error.fallbackDetails")
+      ),
+    };
+  }
+
+  if (error.reason === "missing-primary-wallet") {
+    return {
+      type: "error" as const,
+      title: t(locale, "waves.create.groups.error.missingWallet.title"),
+      description: t(
+        locale,
+        "waves.create.groups.error.missingWallet.description"
+      ),
+    };
+  }
+
+  const isPublishFailure = error.reason === "publish-personal-group";
+
+  return {
+    type: "error" as const,
+    title: t(
+      locale,
+      isPublishFailure
+        ? "waves.create.groups.error.publishAdmin.title"
+        : "waves.create.groups.error.createAdmin.title"
+    ),
+    description: t(
+      locale,
+      isPublishFailure
+        ? "waves.create.groups.error.publishAdmin.description"
+        : "waves.create.groups.error.createAdmin.description"
+    ),
+    details: getToastErrorDetails(
+      error.cause,
+      t(locale, "waves.create.groups.error.fallbackDetails")
+    ),
+  };
+};
 
 export function useCreateWaveSubmission({
   config,
   descriptionRef,
   onSuccess,
   parentWaveId,
+  parentAdminGroupId,
 }: UseCreateWaveSubmissionParams) {
   const router = useRouter();
   const { isApp } = useDeviceInfo();
+  const locale = useBrowserLocale();
   const { requestAuth, setToast, connectedProfile } = useContext(AuthContext);
   const { waitAndInvalidateDrops, onWaveCreated, onGroupCreate } = useContext(
     ReactQueryWrapperContext
   );
   const [submitting, setSubmitting] = useState(false);
+  const submissionInProgressRef = useRef(false);
   const [showDropError, setShowDropError] = useState(false);
   const { submit: submitInlineGroup } = useGroupMutations({
     requestAuth,
     onGroupCreate,
   });
+  const finishSubmitting = () => {
+    submissionInProgressRef.current = false;
+    setSubmitting(false);
+  };
 
   const addWaveMutation = useAddWaveMutation({
     onSuccess: async (response, variables) => {
@@ -89,7 +153,7 @@ export function useCreateWaveSubmission({
       });
     },
     onSettled: () => {
-      setSubmitting(false);
+      finishSubmitting();
     },
   });
 
@@ -128,19 +192,24 @@ export function useCreateWaveSubmission({
   };
 
   const onComplete = async (): Promise<void> => {
+    if (submissionInProgressRef.current) {
+      return;
+    }
+
+    submissionInProgressRef.current = true;
     setSubmitting(true);
     let mutationStarted = false;
 
     try {
       const { success } = await requestAuth();
       if (!success) {
-        setSubmitting(false);
+        finishSubmitting();
         return;
       }
 
       const drop = descriptionRef.current?.getDropSnapshot() ?? null;
       if (drop === null || drop.parts.length === 0) {
-        setSubmitting(false);
+        finishSubmitting();
         setShowDropError(true);
         return;
       }
@@ -150,25 +219,20 @@ export function useCreateWaveSubmission({
           message: "Wait for image uploads to finish.",
           type: "error",
         });
-        setSubmitting(false);
+        finishSubmitting();
         return;
       }
 
       const adminGroupId = await getAdminGroupId({
-        adminGroupId: config.groups.admin,
+        adminGroupId: config.groups.admin ?? parentAdminGroupId ?? null,
         primaryWallet: connectedProfile?.primary_wallet,
         handle: connectedProfile?.handle ?? undefined,
         onError: (error) => {
-          setToast({
-            type: "error",
-            title: "Couldn't get the admin group.",
-            description: "Please check the group setup and try again.",
-            details: getToastErrorDetails(error, "Could not get admin group."),
-          });
+          setToast(getAdminGroupErrorToast(error, locale));
         },
       });
       if (!adminGroupId) {
-        setSubmitting(false);
+        finishSubmitting();
         return;
       }
 
@@ -209,7 +273,7 @@ export function useCreateWaveSubmission({
           description: "Please try again.",
           details: getToastErrorDetails(error, "Could not create wave."),
         });
-        setSubmitting(false);
+        finishSubmitting();
       }
     }
   };

--- a/components/waves/create-wave/hooks/useSubwaveWaveConfig.ts
+++ b/components/waves/create-wave/hooks/useSubwaveWaveConfig.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ApiGroupFull } from "@/generated/models/ApiGroupFull";
+import { commonApiFetch } from "@/services/api/common-api";
+import type { CreateWaveConfig } from "@/types/waves.types";
+import { useWaveConfig } from "./useWaveConfig";
+
+export function useSubwaveWaveConfig({
+  parentAdminGroupId,
+}: {
+  readonly parentAdminGroupId?: string | null | undefined;
+}) {
+  const waveConfig = useWaveConfig();
+  const [parentAdminGroup, setParentAdminGroup] = useState<ApiGroupFull | null>(
+    null
+  );
+
+  useEffect(() => {
+    if (!parentAdminGroupId) {
+      return;
+    }
+
+    const abortController = new AbortController();
+    void commonApiFetch<ApiGroupFull>({
+      endpoint: `groups/${parentAdminGroupId}`,
+      signal: abortController.signal,
+    })
+      .then(setParentAdminGroup)
+      .catch(() => {
+        // Submission can safely use the inherited ID without the optional
+        // display details supplied by this request.
+      });
+
+    return () => abortController.abort();
+  }, [parentAdminGroupId]);
+
+  const config: CreateWaveConfig = parentAdminGroupId
+    ? {
+        ...waveConfig.config,
+        groups: {
+          ...waveConfig.config.groups,
+          admin: waveConfig.config.groups.admin ?? parentAdminGroupId,
+        },
+      }
+    : waveConfig.config;
+  const groupsCache =
+    parentAdminGroupId && parentAdminGroup?.id === parentAdminGroupId
+      ? {
+          ...waveConfig.groupsCache,
+          [parentAdminGroup.id]: parentAdminGroup,
+        }
+      : waveConfig.groupsCache;
+
+  return {
+    ...waveConfig,
+    config,
+    groupsCache,
+  };
+}

--- a/components/waves/create-wave/services/waveGroupService.ts
+++ b/components/waves/create-wave/services/waveGroupService.ts
@@ -1,10 +1,30 @@
 import type { ApiCreateGroup } from "@/generated/models/ApiCreateGroup";
 import { ApiGroupFilterDirection } from "@/generated/models/ApiGroupFilterDirection";
 import { ApiGroupTdhInclusionStrategy } from "@/generated/models/ApiGroupTdhInclusionStrategy";
-import {
-  createGroup,
-  publishGroup,
-} from "@/services/groups/groupMutations";
+import { createGroup, publishGroup } from "@/services/groups/groupMutations";
+
+type WaveAdminGroupErrorReason =
+  | "missing-primary-wallet"
+  | "create-personal-group"
+  | "publish-personal-group";
+
+export class WaveAdminGroupError extends Error {
+  readonly reason: WaveAdminGroupErrorReason;
+  override readonly cause: unknown;
+
+  constructor({
+    reason,
+    cause,
+  }: {
+    readonly reason: WaveAdminGroupErrorReason;
+    readonly cause?: unknown;
+  }) {
+    super(reason);
+    this.name = "WaveAdminGroupError";
+    this.reason = reason;
+    this.cause = cause;
+  }
+}
 
 /**
  * Creates a group that only includes the specified wallet
@@ -21,49 +41,65 @@ const createOnlyMeGroup = async ({
   readonly handle: string | undefined;
   readonly onError: (error: unknown) => void;
 }): Promise<string | null> => {
-  try {
-    const groupConfig: ApiCreateGroup = {
-      name: `Only ${handle ?? "Me"}`,
-      group: {
-        tdh: {
-          min: null,
-          max: null,
-          inclusion_strategy: ApiGroupTdhInclusionStrategy.Tdh,
-        },
-        rep: {
-          min: null,
-          max: null,
-          direction: ApiGroupFilterDirection.Received,
-          user_identity: null,
-          category: null,
-        },
-        cic: {
-          min: null,
-          max: null,
-          direction: ApiGroupFilterDirection.Received,
-          user_identity: null,
-        },
-        level: { min: null, max: null },
-        owns_nfts: [],
-        identity_addresses: [primaryWallet],
-        excluded_identity_addresses: null,
+  const groupConfig: ApiCreateGroup = {
+    name: `Only ${handle ?? "Me"}`,
+    group: {
+      tdh: {
+        min: null,
+        max: null,
+        inclusion_strategy: ApiGroupTdhInclusionStrategy.Tdh,
       },
-    };
+      rep: {
+        min: null,
+        max: null,
+        direction: ApiGroupFilterDirection.Received,
+        user_identity: null,
+        category: null,
+      },
+      cic: {
+        min: null,
+        max: null,
+        direction: ApiGroupFilterDirection.Received,
+        user_identity: null,
+      },
+      level: { min: null, max: null },
+      owns_nfts: [],
+      identity_addresses: [primaryWallet],
+      excluded_identity_addresses: null,
+    },
+  };
 
-    const group = await createGroup({
+  let group: Awaited<ReturnType<typeof createGroup>>;
+  try {
+    group = await createGroup({
       payload: groupConfig,
     });
+  } catch (error) {
+    onError(
+      new WaveAdminGroupError({
+        reason: "create-personal-group",
+        cause: error,
+      })
+    );
+    return null;
+  }
 
+  try {
     await publishGroup({
       id: group.id,
       oldVersionId: null,
     });
-
-    return group.id;
   } catch (error) {
-    onError(error);
+    onError(
+      new WaveAdminGroupError({
+        reason: "publish-personal-group",
+        cause: error,
+      })
+    );
     return null;
   }
+
+  return group.id;
 };
 
 /**
@@ -90,7 +126,7 @@ export const getAdminGroupId = async ({
   }
 
   if (!primaryWallet) {
-    onError("You need to have a primary wallet to create a wave");
+    onError(new WaveAdminGroupError({ reason: "missing-primary-wallet" }));
     return null;
   }
 

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -975,6 +975,7 @@ const WAVE_NOTIFICATION_SETTINGS_MESSAGES = namespaceMessages(
 const WAVE_CREATE_GROUPS_MESSAGES = objectMessages("waves.create.groups", {
   accessHelper:
     "The {viewGroupName} group controls who can access this wave. Your followers who can view the wave may be notified when it is created.",
+  selectedGroup: "Selected group",
   limitedAccessTitle: "Warning: Limited Access",
   limitedAccessDescription:
     'This wave is configured with restricted access. It can only be viewed by members of the "{viewGroupName}" group and managed by members of the "{adminGroupName}" group. If you are not in a group that can view it, you will not be able to access this wave.',

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -982,12 +982,27 @@ const WAVE_CREATE_GROUPS_MESSAGES = objectMessages("waves.create.groups", {
     "Add identities one by one to build this access group.",
   "inlineIdentities.creatorExcludedWarning":
     "Warning: You are not included in this group. If it controls who can view the wave, you may not be able to access the wave after creating it.",
+  "error.missingWallet.title": "Add a primary wallet first.",
+  "error.missingWallet.description":
+    "A primary wallet is required to create this wave's admin group.",
+  "error.createAdmin.title": "Couldn't create the admin group.",
+  "error.createAdmin.description":
+    "Choose an existing admin group, or try again.",
+  "error.publishAdmin.title": "Couldn't make the admin group visible.",
+  "error.publishAdmin.description":
+    "Choose an existing admin group, or try again later.",
+  "error.fallbackDetails": "The group service did not complete the request.",
 } as const);
 
 const WAVE_CREATE_ACTIONS_MESSAGES = objectMessages("waves.create.actions", {
   cancel: "Cancel",
   complete: "Complete",
+  create: "Create",
+  createMenuHeader: "Create",
   next: "Next",
+  newCuration: "New curation",
+  newSubwave: "New subwave",
+  openCreateMenu: "Open create menu",
   previous: "Previous",
   save: "Save",
 } as const);

--- a/ops/docs/waves/chat/feature-content-tabs.md
+++ b/ops/docs/waves/chat/feature-content-tabs.md
@@ -22,8 +22,8 @@ restores it whenever that wave is opened again and the tab is still available.
 - Open a wave from waves lists, profile wave links, or a shared wave URL.
 - Open a direct message thread with a selected wave.
 - Select a tab from the wave tab strip.
-- Eligible wave admins can use the tab-row `+` menu to create a curation or,
-  on root non-direct-message waves, create a subwave.
+- Eligible wave admins can use the tab-row `+` menu on web and in the app to
+  create a curation or, on root non-direct-message waves, create a subwave.
 
 ## User Journey
 
@@ -46,6 +46,9 @@ restores it whenever that wave is opened again and the tab is still available.
    when present, and media interactions stay disabled in the row.
 8. If the active tab is no longer valid when entering a new wave, the active tab
    resets to that wave’s first available tab.
+9. Eligible admins can open the `+` menu and select `New subwave`. The new
+   subwave starts with the parent wave's admin group, which can still be changed
+   in the `Groups` step before submission.
 
 ## Common Scenarios
 
@@ -67,6 +70,9 @@ restores it whenever that wave is opened again and the tab is still available.
 - Eligible readers can use `View results` on an open unanswered poll to inspect
   counts and percentages before voting, then return to `Vote` while the poll is
   still open.
+- On mobile, the fixed `+` control stays outside the horizontally scrolling tab
+  list so both `New curation` and `New subwave` remain reachable on narrow
+  screens.
 
 ## Edge Cases
 
@@ -88,6 +94,9 @@ restores it whenever that wave is opened again and the tab is still available.
   includes video, audio, or HTML media.
 - If `preview_image` is missing or invalid, the row still shows the drop by using
   its standard media source and keeping interaction disabled.
+- `New subwave` is unavailable in direct messages, inside an existing subwave,
+  while using a profile proxy, when the parent has no reusable admin group, or
+  when the signed-in profile is not eligible to administer the parent.
 
 ## Failure and Recovery
 
@@ -105,13 +114,17 @@ restores it whenever that wave is opened again and the tab is still available.
   (title, author, and vote score) and can open the drop.
 - If metadata parsing for `preview_image` fails, `My Votes` entries continue to render
   with the row’s media source and remain navigable to the drop detail.
+- If the inherited admin group cannot be loaded for display, submission still
+  keeps its known group ID; the Groups step may temporarily label it as
+  `Selected group`.
 
 ## Limitations / Notes
 
 - Tab selection is UI state and is not encoded in wave URLs.
 - Available tabs depend on wave type, curation settings, voting state, and
   first-decision status.
-- In app-specific surfaces, tab presentation can differ from the web layout.
+- The app and web layouts present the tab row differently, but eligible root
+  wave admins receive the same curation and subwave create actions.
 
 ## Related Pages
 

--- a/ops/docs/waves/create/feature-groups-step.md
+++ b/ops/docs/waves/create/feature-groups-step.md
@@ -40,7 +40,8 @@ This step is user-reachable for `Chat`, `Rank`, and `Approve`.
   - `Allow admins to delete posts` toggle sets admin delete permission
 - Defaults:
   - `Anyone` for view/drop/vote/chat
-  - `Only me` for admin
+  - `Only me` for admin when creating a top-level wave
+  - the parent wave's admin group when creating a subwave
   - `Allow admins to delete posts` is enabled by default
 
 ## Group Picker Behavior
@@ -77,9 +78,12 @@ This step is user-reachable for `Chat`, `Rank`, and `Approve`.
 - If search shows no matches, clear or change search text and retry.
 - No group selection is required to leave `Groups` and continue.
 - If no explicit admin group is selected, submit tries to create and publish a
-  personal admin group (`Only {handle}` / `Only Me`).
-- If admin-group creation fails (for example missing primary wallet), submit
-  stops on create-wave; fix prerequisites and retry.
+  personal admin group (`Only {handle}` / `Only Me`) for a top-level wave.
+- A subwave reuses its parent wave's admin group instead of creating another
+  personal group when no different group is selected.
+- If a top-level personal admin group cannot be created or made visible, submit
+  stops and identifies the failed stage. Add a primary wallet when requested,
+  choose an existing admin group, or retry later.
 
 ## Limitations / Notes
 

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -2113,6 +2113,31 @@
       ]
     },
     {
+      "id": "waves.subwaves.create",
+      "kind": "workflow",
+      "title": "Create a subwave",
+      "aliases": [
+        "create subwave",
+        "new subwave",
+        "make a subwave",
+        "subwave plus button",
+        "mobile subwave"
+      ],
+      "keywords": ["waves", "subwaves", "create", "admin", "mobile", "plus"],
+      "facts": [
+        "Eligible admins can open the + menu in a root wave's tab row and select New subwave on web or in the app.",
+        "New subwave is hidden in direct messages, inside an existing subwave, while using a profile proxy, when the parent has no reusable admin group, or when the profile cannot administer the parent.",
+        "A new subwave starts with the parent wave's admin group, and the creator can choose a different existing admin group in the Groups step before submitting."
+      ],
+      "canonical_path": "/waves",
+      "related_paths": ["/waves"],
+      "tags": ["waves", "subwaves", "create", "admin", "mobile"],
+      "source_refs": [
+        "ops/docs/waves/chat/feature-content-tabs.md",
+        "ops/docs/waves/create/feature-groups-step.md"
+      ]
+    },
+    {
       "id": "waves.create.entrypoint.sidebar",
       "kind": "ui_affordance",
       "title": "Create a wave from the Waves panel",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -2109,6 +2109,31 @@
       ]
     },
     {
+      "id": "waves.subwaves.create",
+      "kind": "workflow",
+      "title": "Create a subwave",
+      "aliases": [
+        "create subwave",
+        "new subwave",
+        "make a subwave",
+        "subwave plus button",
+        "mobile subwave"
+      ],
+      "keywords": ["waves", "subwaves", "create", "admin", "mobile", "plus"],
+      "facts": [
+        "Eligible admins can open the + menu in a root wave's tab row and select New subwave on web or in the app.",
+        "New subwave is hidden in direct messages, inside an existing subwave, while using a profile proxy, when the parent has no reusable admin group, or when the profile cannot administer the parent.",
+        "A new subwave starts with the parent wave's admin group, and the creator can choose a different existing admin group in the Groups step before submitting."
+      ],
+      "canonical_path": "/waves",
+      "related_paths": ["/waves"],
+      "tags": ["waves", "subwaves", "create", "admin", "mobile"],
+      "source_refs": [
+        "ops/docs/waves/chat/feature-content-tabs.md",
+        "ops/docs/waves/create/feature-groups-step.md"
+      ]
+    },
+    {
       "id": "waves.create.entrypoint.sidebar",
       "kind": "ui_affordance",
       "title": "Create a wave from the Waves panel",


### PR DESCRIPTION
## Issue

Eligible wave admins could not reliably create subwaves:

- mobile Brain navigation exposed only **New curation**, so **New subwave** was effectively hidden
- the subwave form forgot the parent wave's admin group and tried to create/publish a new personal group
- the captured staging request failed at `POST /api/groups/{id}/visible` with HTTP 500 after group creation

## Fix

Reuse the parent wave's existing admin group when opening and submitting a subwave. The parent group remains selectable and can still be intentionally changed.

## Notable changes

- reuse the existing create-actions menu on mobile with a 44px accessible trigger
- pass the parent admin group through modal, form state, and submission
- load parent-group details for display without blocking submission if that lookup fails
- prevent duplicate submits and distinguish missing-wallet, group-creation, and group-publication failures
- add localized copy, product docs, and Help Bot guidance

## Validation

- `./bin/6529 run check:changed`
- focused Jest: 6 suites / 106 tests
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff` (98/100; three pre-existing warnings in touched legacy components)
- `./bin/6529 run help-index:sync`
- docs link validation
- `git diff --check`

## Risk

Low-to-moderate and scoped to wave creation. Top-level wave behavior retains its existing personal-group fallback; only subwaves receive the parent admin-group fallback. Tests cover permission gating, mobile placement, inheritance, override, service failures, and duplicate submission.

## Review notes

Please focus on the parent admin-group authority boundary and the mobile eligibility gate. Post-fix authenticated staging QA is pending restoration of the staging access credential; the pre-fix request/response failure was captured against staging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a mobile create menu for eligible users to start curations and subwaves.
  - Subwaves can inherit their parent wave’s admin group, with optional alternate selection.
  - Added localized labels and clearer admin-group creation and selection errors.
  - Prevented duplicate submissions and improved recovery from creation failures.

- **Documentation**
  - Updated guidance covering subwave eligibility, creation controls, inherited admin groups, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->