### PR TITLE
Stabilize NextGen server fetches

### DIFF
--- a/__tests__/app/nextgen/nextgen-api.test.ts
+++ b/__tests__/app/nextgen/nextgen-api.test.ts
@@ -5,16 +5,54 @@ import {
 import { commonApiFetch } from "@/services/api/common-api";
 
 jest.mock("@/services/api/common-api", () => ({ commonApiFetch: jest.fn() }));
+jest.mock("@/services/auth/auth.utils", () => ({
+  getAuthJwt: jest.fn(() => null),
+  getStagingAuth: jest.fn(() => null),
+}));
 
 const mockedCommonApiFetch = commonApiFetch as jest.Mock;
+const actualCommonApiFetch = jest.requireActual<
+  typeof import("@/services/api/common-api")
+>("@/services/api/common-api").commonApiFetch;
+const fetchMock = global.fetch as jest.Mock;
 const request = {
   endpoint: "nextgen/featured",
   headers: { "x-test": "1" },
 };
 
+function createApiError(status: number): Error & { status: number } {
+  return Object.assign(new Error(`API request failed with ${status}`), {
+    name: "ApiError",
+    status,
+  });
+}
+
+async function createActualStructuredError(status: number): Promise<unknown> {
+  fetchMock.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: "Not Found",
+    headers: new Headers(),
+    text: async () => JSON.stringify({ error: "missing" }),
+  });
+
+  try {
+    await actualCommonApiFetch({
+      endpoint: "nextgen/contract-check",
+      errorMode: "structured",
+      includeWalletAuth: false,
+    });
+  } catch (error) {
+    return error;
+  }
+
+  throw new Error("Expected commonApiFetch to reject");
+}
+
 describe("NextGen API requests", () => {
   beforeEach(() => {
     mockedCommonApiFetch.mockReset();
+    fetchMock.mockReset();
   });
 
   it("uses structured API errors", async () => {
@@ -29,8 +67,8 @@ describe("NextGen API requests", () => {
 
   it("retries transient server errors", async () => {
     mockedCommonApiFetch
-      .mockRejectedValueOnce({ status: 503 })
-      .mockRejectedValueOnce({ response: { status: 502 } })
+      .mockRejectedValueOnce(createApiError(503))
+      .mockRejectedValueOnce(createApiError(502))
       .mockResolvedValueOnce({ id: 1 });
 
     await expect(fetchNextGenApi(request)).resolves.toEqual({ id: 1 });
@@ -39,7 +77,9 @@ describe("NextGen API requests", () => {
 
   it("retries network failures", async () => {
     mockedCommonApiFetch
-      .mockRejectedValueOnce(new Error("Network request failed"))
+      .mockRejectedValueOnce(
+        new Error("Network request failed. Please try again.")
+      )
       .mockResolvedValueOnce({ id: 1 });
 
     await expect(fetchNextGenApi(request)).resolves.toEqual({ id: 1 });
@@ -47,14 +87,15 @@ describe("NextGen API requests", () => {
   });
 
   it("returns null for a real 404 without retrying", async () => {
-    mockedCommonApiFetch.mockRejectedValue({ status: 404 });
+    const error = await createActualStructuredError(404);
+    mockedCommonApiFetch.mockRejectedValue(error);
 
     await expect(fetchNextGenApiOrNull(request)).resolves.toBeNull();
     expect(mockedCommonApiFetch).toHaveBeenCalledTimes(1);
   });
 
   it("does not turn persistent server errors into missing data", async () => {
-    const error = { status: 503 };
+    const error = createApiError(503);
     mockedCommonApiFetch.mockRejectedValue(error);
 
     await expect(fetchNextGenApiOrNull(request)).rejects.toBe(error);
@@ -62,10 +103,18 @@ describe("NextGen API requests", () => {
   });
 
   it("does not retry non-404 client errors", async () => {
-    const error = { status: 400 };
+    const error = createApiError(400);
     mockedCommonApiFetch.mockRejectedValue(error);
 
     await expect(fetchNextGenApiOrNull(request)).rejects.toBe(error);
+    expect(mockedCommonApiFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry unknown errors", async () => {
+    const error = new Error("Failed to parse response as JSON");
+    mockedCommonApiFetch.mockRejectedValue(error);
+
+    await expect(fetchNextGenApi(request)).rejects.toBe(error);
     expect(mockedCommonApiFetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/app/nextgen/nextgen-api.test.ts
+++ b/__tests__/app/nextgen/nextgen-api.test.ts
@@ -1,0 +1,71 @@
+import {
+  fetchNextGenApi,
+  fetchNextGenApiOrNull,
+} from "@/app/nextgen/nextgen-api";
+import { commonApiFetch } from "@/services/api/common-api";
+
+jest.mock("@/services/api/common-api", () => ({ commonApiFetch: jest.fn() }));
+
+const mockedCommonApiFetch = commonApiFetch as jest.Mock;
+const request = {
+  endpoint: "nextgen/featured",
+  headers: { "x-test": "1" },
+};
+
+describe("NextGen API requests", () => {
+  beforeEach(() => {
+    mockedCommonApiFetch.mockReset();
+  });
+
+  it("uses structured API errors", async () => {
+    mockedCommonApiFetch.mockResolvedValue({ id: 1 });
+
+    await expect(fetchNextGenApi(request)).resolves.toEqual({ id: 1 });
+    expect(mockedCommonApiFetch).toHaveBeenCalledWith({
+      ...request,
+      errorMode: "structured",
+    });
+  });
+
+  it("retries transient server errors", async () => {
+    mockedCommonApiFetch
+      .mockRejectedValueOnce({ status: 503 })
+      .mockRejectedValueOnce({ response: { status: 502 } })
+      .mockResolvedValueOnce({ id: 1 });
+
+    await expect(fetchNextGenApi(request)).resolves.toEqual({ id: 1 });
+    expect(mockedCommonApiFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries network failures", async () => {
+    mockedCommonApiFetch
+      .mockRejectedValueOnce(new Error("Network request failed"))
+      .mockResolvedValueOnce({ id: 1 });
+
+    await expect(fetchNextGenApi(request)).resolves.toEqual({ id: 1 });
+    expect(mockedCommonApiFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null for a real 404 without retrying", async () => {
+    mockedCommonApiFetch.mockRejectedValue({ status: 404 });
+
+    await expect(fetchNextGenApiOrNull(request)).resolves.toBeNull();
+    expect(mockedCommonApiFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not turn persistent server errors into missing data", async () => {
+    const error = { status: 503 };
+    mockedCommonApiFetch.mockRejectedValue(error);
+
+    await expect(fetchNextGenApiOrNull(request)).rejects.toBe(error);
+    expect(mockedCommonApiFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry non-404 client errors", async () => {
+    const error = { status: 400 };
+    mockedCommonApiFetch.mockRejectedValue(error);
+
+    await expect(fetchNextGenApiOrNull(request)).rejects.toBe(error);
+    expect(mockedCommonApiFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/app/nextgen/page.test.tsx
+++ b/__tests__/app/nextgen/page.test.tsx
@@ -119,6 +119,7 @@ describe("NextGen page component", () => {
       expect(mockedFetch).toHaveBeenCalledWith({
         endpoint: "nextgen/featured",
         headers: { "x-mock": "1" },
+        errorMode: "structured",
       })
     );
 

--- a/__tests__/app/nextgenMetadataPages.test.tsx
+++ b/__tests__/app/nextgenMetadataPages.test.tsx
@@ -308,7 +308,14 @@ describe("NextGen metadata", () => {
   });
 
   it("falls back to a branded NextGen token card when token data is missing", async () => {
-    (commonApiFetch as jest.Mock).mockRejectedValue(new Error("missing"));
+    const headers = new Headers();
+    const notFoundError = Object.assign(new Error("missing"), {
+      name: "ApiError",
+      status: 404,
+      headers,
+      response: { status: 404, headers },
+    });
+    (commonApiFetch as jest.Mock).mockRejectedValue(notFoundError);
 
     const metadata = await generateNextGenTokenMetadata({
       params: Promise.resolve({ token: "999" }),

--- a/app/nextgen/[[...view]]/page.tsx
+++ b/app/nextgen/[[...view]]/page.tsx
@@ -7,18 +7,18 @@ import type { NextGenCollection } from "@/entities/INextgen";
 import { getAppCommonHeaders } from "@/helpers/server.app.helpers";
 import JsonLdScript from "@/lib/structured-data/json-ld";
 import { buildNextgenLandingPageJsonLd } from "@/lib/structured-data/nextgen";
-import { commonApiFetch } from "@/services/api/common-api";
 import type { Metadata } from "next";
 import { getNextgenTitle } from "../title-utils";
+import { fetchNextGenApi } from "../nextgen-api";
 import NextGenPageClient from "./NextGenPageClient";
 import { getNextGenView } from "./view-utils";
 
 async function fetchFeaturedNextGenCollection(
   headers: Record<string, string>
 ): Promise<NextGenCollection> {
-  return await commonApiFetch<NextGenCollection>({
+  return await fetchNextGenApi<NextGenCollection>({
     endpoint: `nextgen/featured`,
-    headers: headers,
+    headers,
   });
 }
 

--- a/app/nextgen/collection/[collection]/page-utils.ts
+++ b/app/nextgen/collection/[collection]/page-utils.ts
@@ -5,10 +5,10 @@ import {
 } from "@/components/providers/metadata";
 import type { NextGenCollection } from "@/entities/INextgen";
 import { isEmptyObject } from "@/helpers/Helpers";
-import { commonApiFetch } from "@/services/api/common-api";
 import { NextgenCollectionView } from "@/types/enums";
 import type { Metadata } from "next";
 import { getNextgenTitle } from "../../title-utils";
+import { fetchNextGenApiOrNull } from "../../nextgen-api";
 
 const COLLECTION_VIEW_PATH_SEGMENT_INDEX = 3;
 
@@ -17,10 +17,10 @@ export async function fetchCollection(
   headers: Record<string, string>
 ): Promise<NextGenCollection | null> {
   const parsedId = encodeURIComponent(id.replaceAll(/-/g, " "));
-  const collection = await commonApiFetch<NextGenCollection>({
+  const collection = await fetchNextGenApiOrNull<NextGenCollection>({
     endpoint: `nextgen/collections/${parsedId}`,
-    headers: headers,
-  }).catch(() => null);
+    headers,
+  });
   return collection === null || isEmptyObject(collection) ? null : collection;
 }
 

--- a/app/nextgen/nextgen-api.ts
+++ b/app/nextgen/nextgen-api.ts
@@ -3,11 +3,8 @@ import { commonApiFetch } from "@/services/api/common-api";
 const NEXTGEN_API_MAX_ATTEMPTS = 3;
 const NEXTGEN_API_INITIAL_RETRY_DELAY_MS = 250;
 
-type ApiStatusError = {
+type ApiStatusError = Error & {
   readonly status?: unknown;
-  readonly response?: {
-    readonly status?: unknown;
-  };
 };
 
 interface NextGenApiRequest {
@@ -16,17 +13,29 @@ interface NextGenApiRequest {
 }
 
 function getApiErrorStatus(error: unknown): number | null {
-  if (typeof error !== "object" || error === null) {
+  if (!(error instanceof Error) || error.name !== "ApiError") {
     return null;
   }
 
   const statusError = error as ApiStatusError;
-  const status = statusError.status ?? statusError.response?.status;
+  const status = statusError.status;
   return typeof status === "number" && Number.isInteger(status) ? status : null;
 }
 
 function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "AbortError";
+}
+
+function isNetworkError(error: unknown): boolean {
+  if (error instanceof TypeError) {
+    return true;
+  }
+
+  return (
+    error instanceof Error &&
+    (error.message.startsWith("Network request failed.") ||
+      error.message.startsWith("Network error:"))
+  );
 }
 
 function isRetryableError(error: unknown): boolean {
@@ -35,7 +44,7 @@ function isRetryableError(error: unknown): boolean {
   }
 
   const status = getApiErrorStatus(error);
-  return status === null || status === 429 || status >= 500;
+  return isNetworkError(error) || status === 429 || (status ?? 0) >= 500;
 }
 
 function wait(delayMs: number): Promise<void> {

--- a/app/nextgen/nextgen-api.ts
+++ b/app/nextgen/nextgen-api.ts
@@ -1,0 +1,80 @@
+import { commonApiFetch } from "@/services/api/common-api";
+
+const NEXTGEN_API_MAX_ATTEMPTS = 3;
+const NEXTGEN_API_INITIAL_RETRY_DELAY_MS = 250;
+
+type ApiStatusError = {
+  readonly status?: unknown;
+  readonly response?: {
+    readonly status?: unknown;
+  };
+};
+
+interface NextGenApiRequest {
+  readonly endpoint: string;
+  readonly headers: Record<string, string>;
+}
+
+function getApiErrorStatus(error: unknown): number | null {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+
+  const statusError = error as ApiStatusError;
+  const status = statusError.status ?? statusError.response?.status;
+  return typeof status === "number" && Number.isInteger(status) ? status : null;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+function isRetryableError(error: unknown): boolean {
+  if (isAbortError(error)) {
+    return false;
+  }
+
+  const status = getApiErrorStatus(error);
+  return status === null || status === 429 || status >= 500;
+}
+
+function wait(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+export async function fetchNextGenApi<T>({
+  endpoint,
+  headers,
+}: NextGenApiRequest): Promise<T> {
+  async function execute(attempt: number, retryDelayMs: number): Promise<T> {
+    try {
+      return await commonApiFetch<T>({
+        endpoint,
+        headers,
+        errorMode: "structured",
+      });
+    } catch (error) {
+      if (attempt >= NEXTGEN_API_MAX_ATTEMPTS || !isRetryableError(error)) {
+        throw error;
+      }
+
+      await wait(retryDelayMs);
+      return execute(attempt + 1, retryDelayMs * 2);
+    }
+  }
+
+  return execute(1, NEXTGEN_API_INITIAL_RETRY_DELAY_MS);
+}
+
+export async function fetchNextGenApiOrNull<T>(
+  request: NextGenApiRequest
+): Promise<T | null> {
+  try {
+    return await fetchNextGenApi<T>(request);
+  } catch (error) {
+    if (getApiErrorStatus(error) === 404) {
+      return null;
+    }
+    throw error;
+  }
+}

--- a/app/nextgen/token/[token]/[[...view]]/page-utils.ts
+++ b/app/nextgen/token/[token]/[[...view]]/page-utils.ts
@@ -4,11 +4,9 @@ import type {
   NextGenTrait,
 } from "@/entities/INextgen";
 import { isEmptyObject } from "@/helpers/Helpers";
+import { commonApiFetch } from "@/services/api/common-api";
 import { NextgenCollectionView } from "@/types/enums";
-import {
-  fetchNextGenApi,
-  fetchNextGenApiOrNull,
-} from "../../../nextgen-api";
+import { fetchNextGenApiOrNull } from "../../../nextgen-api";
 
 interface TokenData {
   tokenId: number;
@@ -32,7 +30,7 @@ export async function fetchTokenData(
   let collectionId: number;
 
   if (token && !token.pending) {
-    traits = await fetchNextGenApi<NextGenTrait[]>({
+    traits = await commonApiFetch<NextGenTrait[]>({
       endpoint: `nextgen/tokens/${token.id}/traits`,
       headers,
     }).catch(() => []);

--- a/app/nextgen/token/[token]/[[...view]]/page-utils.ts
+++ b/app/nextgen/token/[token]/[[...view]]/page-utils.ts
@@ -4,8 +4,11 @@ import type {
   NextGenTrait,
 } from "@/entities/INextgen";
 import { isEmptyObject } from "@/helpers/Helpers";
-import { commonApiFetch } from "@/services/api/common-api";
 import { NextgenCollectionView } from "@/types/enums";
+import {
+  fetchNextGenApi,
+  fetchNextGenApiOrNull,
+} from "../../../nextgen-api";
 
 interface TokenData {
   tokenId: number;
@@ -19,24 +22,19 @@ export async function fetchTokenData(
   tokenId: string,
   headers: Record<string, string>
 ): Promise<TokenData | null> {
-  let token: NextGenToken | null;
-  try {
-    token = await commonApiFetch<NextGenToken>({
-      endpoint: `nextgen/tokens/${tokenId}`,
-      headers: headers,
-    });
-  } catch {
-    token = null;
-  }
+  let token = await fetchNextGenApiOrNull<NextGenToken>({
+    endpoint: `nextgen/tokens/${tokenId}`,
+    headers,
+  });
 
   let traits: NextGenTrait[] = [];
   let tokenCount = 0;
   let collectionId: number;
 
   if (token && !token.pending) {
-    traits = await commonApiFetch<NextGenTrait[]>({
+    traits = await fetchNextGenApi<NextGenTrait[]>({
       endpoint: `nextgen/tokens/${token.id}/traits`,
-      headers: headers,
+      headers,
     }).catch(() => []);
     tokenCount = traits[0]?.token_count ?? 0;
     collectionId = token.collection_id;
@@ -45,10 +43,10 @@ export async function fetchTokenData(
     collectionId = Math.round(Number(tokenId) / 10000000000);
   }
 
-  const collection = await commonApiFetch<NextGenCollection>({
+  const collection = await fetchNextGenApiOrNull<NextGenCollection>({
     endpoint: `nextgen/collections/${collectionId}`,
-    headers: headers,
-  }).catch(() => null);
+    headers,
+  });
 
   if (!collection || isEmptyObject(collection)) {
     return null;


### PR DESCRIPTION
## Summary

- add a NextGen-scoped API helper that uses existing structured errors
- retry network, rate-limit, and server failures with two bounded backoff attempts
- return missing data only for genuine 404 responses while preserving persistent upstream errors
- apply the helper to featured collection, collection detail, and token route server fetches

## Root cause

NextGen server-rendered routes either failed immediately on transient upstream errors or converted every rejected collection request into `null`, making temporary API failures appear as page-not-found responses.

## Impact

Brief upstream failures can recover during the server render, real missing resources still render 404 pages, and persistent failures remain visible through the route error boundary. Shared `common-api` behavior is unchanged.

## Validation

- focused NextGen Jest suites passed
- changed production TypeScript check passed
- added unit coverage for transient retries, network failures, genuine 404s, persistent 5xx responses, and non-retryable 4xx responses