### PR TITLE
Fix iPad health icon alignment

### DIFF
--- a/__tests__/components/header/AppHeader.test.tsx
+++ b/__tests__/components/header/AppHeader.test.tsx
@@ -279,6 +279,17 @@ describe("AppHeader", () => {
     expect(healthLink.parentElement).toHaveClass("tw-flex", "tw-items-center");
   });
 
+  it("keeps network health hidden at tablet widths outside Capacitor", () => {
+    useCapacitor.mockReturnValue({ isCapacitor: false });
+    setup({ address: null, asPath: "/" });
+
+    expect(
+      screen.getByRole("link", {
+        name: "Open network health dashboard",
+      })
+    ).toHaveClass("md:tw-hidden");
+  });
+
   it("opens the account menu immediately when only one profile is connected", () => {
     const seizeSwitchConnectedAccount = jest.fn();
     setup({

--- a/__tests__/components/header/AppHeader.test.tsx
+++ b/__tests__/components/header/AppHeader.test.tsx
@@ -266,6 +266,19 @@ describe("AppHeader", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps network health in the native header action row at tablet widths", () => {
+    setup({ address: null, asPath: "/" });
+
+    const healthLink = screen.getByRole("link", {
+      name: "Open network health dashboard",
+    });
+    const search = screen.getByTestId("search");
+
+    expect(healthLink).not.toHaveClass("md:tw-hidden");
+    expect(healthLink.parentElement).toBe(search.parentElement);
+    expect(healthLink.parentElement).toHaveClass("tw-flex", "tw-items-center");
+  });
+
   it("opens the account menu immediately when only one profile is connected", () => {
     const seizeSwitchConnectedAccount = jest.fn();
     setup({

--- a/__tests__/components/header/AppHeader.test.tsx
+++ b/__tests__/components/header/AppHeader.test.tsx
@@ -275,7 +275,7 @@ describe("AppHeader", () => {
     const search = screen.getByTestId("search");
 
     expect(healthLink).not.toHaveClass("md:tw-hidden");
-    expect(healthLink.parentElement).toBe(search.parentElement);
+    expect(healthLink.parentElement).toContainElement(search);
     expect(healthLink.parentElement).toHaveClass("tw-flex", "tw-items-center");
   });
 

--- a/__tests__/components/home/hero/HeroHeader.test.tsx
+++ b/__tests__/components/home/hero/HeroHeader.test.tsx
@@ -30,4 +30,14 @@ describe("HeroHeader", () => {
 
     expect(healthLink).toHaveAttribute("href", "/network/health");
   });
+
+  it("hides the fixed health link inside the native app shell", () => {
+    render(<HeroHeader />);
+
+    expect(
+      screen.getByRole("link", {
+        name: "Open network health dashboard",
+      })
+    ).toHaveClass("[.capacitor-native_&]:tw-hidden");
+  });
 });

--- a/components/header/AppHeader.tsx
+++ b/components/header/AppHeader.tsx
@@ -661,7 +661,7 @@ export default function AppHeader() {
         </div>
         <div className="tw-flex tw-flex-shrink-0 tw-items-center tw-justify-end tw-gap-x-0.5">
           <HeaderDropActionButton action={headerDropAction} />
-          {isHomeRoute && <NetworkHealthCTA className="md:tw-hidden" />}
+          {isHomeRoute && <NetworkHealthCTA />}
           <div className="tw-flex-shrink-0">
             <HeaderActionButtons />
           </div>

--- a/components/header/AppHeader.tsx
+++ b/components/header/AppHeader.tsx
@@ -661,7 +661,11 @@ export default function AppHeader() {
         </div>
         <div className="tw-flex tw-flex-shrink-0 tw-items-center tw-justify-end tw-gap-x-0.5">
           <HeaderDropActionButton action={headerDropAction} />
-          {isHomeRoute && <NetworkHealthCTA />}
+          {isHomeRoute && (
+            <NetworkHealthCTA
+              className={isCapacitor ? undefined : "md:tw-hidden"}
+            />
+          )}
           <div className="tw-flex-shrink-0">
             <HeaderActionButtons />
           </div>

--- a/components/home/hero/HeroHeader.tsx
+++ b/components/home/hero/HeroHeader.tsx
@@ -10,7 +10,7 @@ export default function HeroHeader() {
         href="/network/health"
         aria-label="Open network health dashboard"
         title="Network health"
-        className="tw-bg-red/8 desktop-hover:hover:tw-bg-red/18 tw-group tw-fixed tw-right-4 tw-top-4 tw-z-40 tw-hidden tw-h-10 tw-w-10 tw-items-center tw-justify-center tw-rounded-full tw-border tw-border-solid tw-border-red/35 tw-text-red/85 tw-no-underline tw-shadow-[0_0_12px_rgba(249,112,102,0.16)] tw-backdrop-blur-sm tw-transition-all tw-duration-300 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-red/40 active:tw-scale-95 desktop-hover:hover:tw-border-red/55 desktop-hover:hover:tw-text-red desktop-hover:hover:tw-shadow-[0_0_22px_rgba(249,112,102,0.26)] md:tw-inline-flex md:tw-right-6 md:tw-top-5"
+        className="tw-bg-red/8 desktop-hover:hover:tw-bg-red/18 tw-group tw-fixed tw-right-4 tw-top-4 tw-z-40 tw-hidden tw-h-10 tw-w-10 tw-items-center tw-justify-center tw-rounded-full tw-border tw-border-solid tw-border-red/35 tw-text-red/85 tw-no-underline tw-shadow-[0_0_12px_rgba(249,112,102,0.16)] tw-backdrop-blur-sm tw-transition-all tw-duration-300 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-red/40 active:tw-scale-95 desktop-hover:hover:tw-border-red/55 desktop-hover:hover:tw-text-red desktop-hover:hover:tw-shadow-[0_0_22px_rgba(249,112,102,0.26)] md:tw-inline-flex md:tw-right-6 md:tw-top-5 [.capacitor-native_&]:tw-hidden"
       >
         <span className="tw-relative tw-inline-flex tw-items-center tw-justify-center">
           <HeartIcon


### PR DESCRIPTION
## Summary

- keep the network health action inside the native app header at tablet widths
- hide the desktop hero's fixed health action inside Capacitor shells
- cover the native header grouping and shell-specific visibility rules

## Root cause

The viewport-only `md` breakpoint treated iPads like desktop browsers. It hid the health action in the native header and displayed the hero's fixed top-right version instead, leaving it vertically separated from search.

## User impact

The health and search actions now remain aligned in the same header row across iPhone and iPad, while the website retains its existing responsive behavior.

## Validation

- focused AppHeader and HeroHeader component tests
- React Doctor diff review (100/100, no issues)
- whitespace validation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visibility of the Network Health link in the header at tablet and larger screen sizes.
  * Ensured the link remains hidden in the native app experience where appropriate.
* **Tests**
  * Added coverage for responsive header placement and native-app visibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->