### PR TITLE
Fix staging NextGen chain fallback

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -140,7 +140,7 @@ jobs:
       WS_ENDPOINT: ${{ vars.STAGING_WS_ENDPOINT || 'wss://ws.staging.6529.io' }}
       ALLOWLIST_API_ENDPOINT: ${{ vars.STAGING_ALLOWLIST_API_ENDPOINT || 'https://allowlist-api.staging.6529.io' }}
       BASE_ENDPOINT: https://staging.6529.io
-      NEXTGEN_CHAIN_ID: "1"
+      NEXTGEN_CHAIN_ID: ${{ vars.STAGING_NEXTGEN_CHAIN_ID || '1' }}
       ASSETS_FROM_S3: "false"
 
     steps:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -140,7 +140,7 @@ jobs:
       WS_ENDPOINT: ${{ vars.STAGING_WS_ENDPOINT || 'wss://ws.staging.6529.io' }}
       ALLOWLIST_API_ENDPOINT: ${{ vars.STAGING_ALLOWLIST_API_ENDPOINT || 'https://allowlist-api.staging.6529.io' }}
       BASE_ENDPOINT: https://staging.6529.io
-      NEXTGEN_CHAIN_ID: ${{ vars.STAGING_NEXTGEN_CHAIN_ID || '11155111' }}
+      NEXTGEN_CHAIN_ID: "1"
       ASSETS_FROM_S3: "false"
 
     steps:

--- a/.github/workflows/release-bus-v2-preflight.yml
+++ b/.github/workflows/release-bus-v2-preflight.yml
@@ -512,6 +512,7 @@ jobs:
           STAGING_API_ENDPOINT: ${{ vars.STAGING_API_ENDPOINT || 'https://api.staging.6529.io' }}
           STAGING_WS_ENDPOINT: ${{ vars.STAGING_WS_ENDPOINT || 'wss://ws.staging.6529.io' }}
           STAGING_ALLOWLIST_API_ENDPOINT: ${{ vars.STAGING_ALLOWLIST_API_ENDPOINT || 'https://allowlist-api.staging.6529.io' }}
+          STAGING_NEXTGEN_CHAIN_ID: ${{ vars.STAGING_NEXTGEN_CHAIN_ID || '1' }}
           TRAIN_ID: ${{ inputs.release_train_id }}
         run: |
           set -euo pipefail
@@ -533,7 +534,7 @@ jobs:
               export WS_ENDPOINT="$STAGING_WS_ENDPOINT"
               export ALLOWLIST_API_ENDPOINT="$STAGING_ALLOWLIST_API_ENDPOINT"
               export BASE_ENDPOINT=https://staging.6529.io
-              export NEXTGEN_CHAIN_ID=1
+              export NEXTGEN_CHAIN_ID="$STAGING_NEXTGEN_CHAIN_ID"
               export ASSETS_FROM_S3=false
               unset ANNOUNCED_VERSION_ENDPOINT
             fi

--- a/.github/workflows/release-bus-v2-preflight.yml
+++ b/.github/workflows/release-bus-v2-preflight.yml
@@ -512,7 +512,6 @@ jobs:
           STAGING_API_ENDPOINT: ${{ vars.STAGING_API_ENDPOINT || 'https://api.staging.6529.io' }}
           STAGING_WS_ENDPOINT: ${{ vars.STAGING_WS_ENDPOINT || 'wss://ws.staging.6529.io' }}
           STAGING_ALLOWLIST_API_ENDPOINT: ${{ vars.STAGING_ALLOWLIST_API_ENDPOINT || 'https://allowlist-api.staging.6529.io' }}
-          STAGING_NEXTGEN_CHAIN_ID: ${{ vars.STAGING_NEXTGEN_CHAIN_ID || '11155111' }}
           TRAIN_ID: ${{ inputs.release_train_id }}
         run: |
           set -euo pipefail
@@ -534,7 +533,7 @@ jobs:
               export WS_ENDPOINT="$STAGING_WS_ENDPOINT"
               export ALLOWLIST_API_ENDPOINT="$STAGING_ALLOWLIST_API_ENDPOINT"
               export BASE_ENDPOINT=https://staging.6529.io
-              export NEXTGEN_CHAIN_ID="$STAGING_NEXTGEN_CHAIN_ID"
+              export NEXTGEN_CHAIN_ID=1
               export ASSETS_FROM_S3=false
               unset ANNOUNCED_VERSION_ENDPOINT
             fi

--- a/__tests__/scripts/deploy-staging-artifact.test.ts
+++ b/__tests__/scripts/deploy-staging-artifact.test.ts
@@ -86,7 +86,9 @@ describe("manual staging immutable artifact deployment", () => {
 
     expect(build.needs).toBe("manual-deployment-guard");
     expect(build.permissions).toEqual({ contents: "read" });
+    expect(build.env.NEXTGEN_CHAIN_ID).toBe("1");
     expect(buildSource).not.toContain("secrets.");
+    expect(buildSource).not.toContain("STAGING_NEXTGEN_CHAIN_ID");
     expect(buildStep.run).toContain("./bin/6529 run base-build");
     expect(buildStep.run).not.toContain("./bin/6529 run build\n");
     expect(buildStep.run).toContain('artifact_contract:"manual-staging-v1"');

--- a/__tests__/scripts/deploy-staging-artifact.test.ts
+++ b/__tests__/scripts/deploy-staging-artifact.test.ts
@@ -86,9 +86,11 @@ describe("manual staging immutable artifact deployment", () => {
 
     expect(build.needs).toBe("manual-deployment-guard");
     expect(build.permissions).toEqual({ contents: "read" });
-    expect(build.env.NEXTGEN_CHAIN_ID).toBe("1");
+    expect(build.env.NEXTGEN_CHAIN_ID).toBe(
+      "${{ vars.STAGING_NEXTGEN_CHAIN_ID || '1' }}"
+    );
     expect(buildSource).not.toContain("secrets.");
-    expect(buildSource).not.toContain("STAGING_NEXTGEN_CHAIN_ID");
+    expect(buildSource).not.toContain("11155111");
     expect(buildStep.run).toContain("./bin/6529 run base-build");
     expect(buildStep.run).not.toContain("./bin/6529 run build\n");
     expect(buildStep.run).toContain('artifact_contract:"manual-staging-v1"');

--- a/__tests__/scripts/public-review-artifact-workflows.test.ts
+++ b/__tests__/scripts/public-review-artifact-workflows.test.ts
@@ -30,7 +30,7 @@ const sourceCleanGuard =
   "git status --porcelain=v1 --untracked-files=all -- public/review-data content/public-reviews config/public-reviews";
 
 describe("public-review artifact workflow contract", () => {
-  it("bakes mainnet NextGen contracts into every staging artifact", () => {
+  it("uses the configured staging NextGen chain with a mainnet fallback", () => {
     expect(stagingWorkflow).toContain(
       "NEXTGEN_CHAIN_ID: ${{ vars.STAGING_NEXTGEN_CHAIN_ID || '1' }}"
     );
@@ -41,6 +41,9 @@ describe("public-review artifact workflow contract", () => {
     expect(releaseBusPreflight).toContain(
       'export NEXTGEN_CHAIN_ID="$STAGING_NEXTGEN_CHAIN_ID"'
     );
+    expect(
+      releaseBusPreflight.match(/export NEXTGEN_CHAIN_ID=1/g)
+    ).toHaveLength(1);
     expect(releaseBusPreflight).not.toContain("11155111");
   });
 

--- a/__tests__/scripts/public-review-artifact-workflows.test.ts
+++ b/__tests__/scripts/public-review-artifact-workflows.test.ts
@@ -30,6 +30,15 @@ const sourceCleanGuard =
   "git status --porcelain=v1 --untracked-files=all -- public/review-data content/public-reviews config/public-reviews";
 
 describe("public-review artifact workflow contract", () => {
+  it("bakes mainnet NextGen contracts into every staging artifact", () => {
+    expect(stagingWorkflow).toContain('NEXTGEN_CHAIN_ID: "1"');
+    expect(stagingWorkflow).not.toContain("STAGING_NEXTGEN_CHAIN_ID");
+    expect(
+      releaseBusPreflight.match(/export NEXTGEN_CHAIN_ID=1/g)
+    ).toHaveLength(2);
+    expect(releaseBusPreflight).not.toContain("STAGING_NEXTGEN_CHAIN_ID");
+  });
+
   it("bakes the environment-specific mobile app scheme", () => {
     expect(stagingWorkflow).toContain(
       "MOBILE_APP_SCHEME: mobileStaging6529"

--- a/__tests__/scripts/public-review-artifact-workflows.test.ts
+++ b/__tests__/scripts/public-review-artifact-workflows.test.ts
@@ -31,12 +31,17 @@ const sourceCleanGuard =
 
 describe("public-review artifact workflow contract", () => {
   it("bakes mainnet NextGen contracts into every staging artifact", () => {
-    expect(stagingWorkflow).toContain('NEXTGEN_CHAIN_ID: "1"');
-    expect(stagingWorkflow).not.toContain("STAGING_NEXTGEN_CHAIN_ID");
-    expect(
-      releaseBusPreflight.match(/export NEXTGEN_CHAIN_ID=1/g)
-    ).toHaveLength(2);
-    expect(releaseBusPreflight).not.toContain("STAGING_NEXTGEN_CHAIN_ID");
+    expect(stagingWorkflow).toContain(
+      "NEXTGEN_CHAIN_ID: ${{ vars.STAGING_NEXTGEN_CHAIN_ID || '1' }}"
+    );
+    expect(stagingWorkflow).not.toContain("11155111");
+    expect(releaseBusPreflight).toContain(
+      "STAGING_NEXTGEN_CHAIN_ID: ${{ vars.STAGING_NEXTGEN_CHAIN_ID || '1' }}"
+    );
+    expect(releaseBusPreflight).toContain(
+      'export NEXTGEN_CHAIN_ID="$STAGING_NEXTGEN_CHAIN_ID"'
+    );
+    expect(releaseBusPreflight).not.toContain("11155111");
   });
 
   it("bakes the environment-specific mobile app scheme", () => {


### PR DESCRIPTION
## Issue

- Staging artifact builds defaulted NextGen to Sepolia when the optional repository variable was absent, while the staging NextGen data uses mainnet collections.

## Fix

- Change the default `STAGING_NEXTGEN_CHAIN_ID` fallback from Sepolia (`11155111`) to mainnet (`1`) while preserving repository-variable overrides.

## Changes

- Update both the manual staging artifact workflow and Release Bus preflight workflow.
- Add workflow contract assertions covering the mainnet fallback.

## Validation

- Focused workflow contract tests passed for the manual staging artifact and shared artifact-profile paths.
- `git diff --check` passed.

## Risk

- Level: Low
- Why: The change only affects the default when `STAGING_NEXTGEN_CHAIN_ID` is not configured.
- Rollback: Restore the previous fallback value.

## Review Notes

- Confirm staging should continue to allow an explicit repository-variable override while defaulting NextGen to mainnet.