### PR TITLE
Fix native dock behavior on tablets and landscape

### DIFF
--- a/__tests__/components/navigation/BottomNavigation.test.tsx
+++ b/__tests__/components/navigation/BottomNavigation.test.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "@/components/auth/Auth";
 import { useLayout } from "@/components/brain/my-stream/layout/LayoutContext";
 import { useSeizeConnectContext } from "@/components/auth/SeizeConnectContext";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { useWave } from "@/hooks/useWave";
 import { useWaveData } from "@/hooks/useWaveData";
 import {
@@ -29,6 +30,7 @@ jest.mock("@/hooks/useDeviceInfo", () => ({
   __esModule: true,
   default: jest.fn(),
 }));
+jest.mock("@/hooks/useMediaQuery", () => ({ useMediaQuery: jest.fn() }));
 jest.mock("@/hooks/useWaveData", () => ({ useWaveData: jest.fn() }));
 jest.mock("@/hooks/useWave", () => ({ useWave: jest.fn() }));
 jest.mock("next/navigation", () => ({
@@ -41,6 +43,7 @@ const registerRef = jest.fn();
 (useAuth as jest.Mock).mockReturnValue({ connectedProfile: null });
 (useSeizeConnectContext as jest.Mock).mockReturnValue({ address: undefined });
 (useDeviceInfo as jest.Mock).mockReturnValue({ isApp: false });
+(useMediaQuery as jest.Mock).mockReturnValue(false);
 (useWaveData as jest.Mock).mockReturnValue({ data: null });
 (useWave as jest.Mock).mockReturnValue({ isDm: false });
 
@@ -144,6 +147,7 @@ beforeEach(() => {
     address: undefined,
   });
   (useDeviceInfo as jest.Mock).mockReturnValue({ isApp: false });
+  (useMediaQuery as jest.Mock).mockReturnValue(false);
   (useWaveData as jest.Mock).mockReturnValue({ data: null });
   (useWave as jest.Mock).mockReturnValue({ isDm: false });
   (usePathname as jest.Mock).mockReturnValue("/");
@@ -268,6 +272,29 @@ describe("BottomNavigation", () => {
         return props.variant === "floating" && props.compact === false;
       })
     ).toBe(true);
+  });
+
+  it("widens the expanded and compact dock by ten percent on tablets", async () => {
+    (useMediaQuery as jest.Mock).mockReturnValue(true);
+    Object.defineProperty(globalThis, "scrollY", {
+      configurable: true,
+      value: 0,
+      writable: true,
+    });
+
+    const { container } = render(<BottomNavigation />);
+    const dock = container.querySelector<HTMLElement>(
+      `[${MOBILE_BOTTOM_NAV_DOCK_ATTRIBUTE}="true"]`
+    );
+
+    expect(dock?.style.width).toBe("44rem");
+
+    act(() => {
+      globalThis.scrollY = 24;
+      fireEvent.scroll(globalThis);
+    });
+
+    await waitFor(() => expect(dock?.style.width).toBe("38.5rem"));
   });
 
   it("keeps one active pill mounted while moving it between active items", () => {

--- a/__tests__/components/navigation/BottomNavigation.test.tsx
+++ b/__tests__/components/navigation/BottomNavigation.test.tsx
@@ -232,6 +232,7 @@ describe("BottomNavigation", () => {
   });
 
   it("renders a stable nav fallback when search params suspend", () => {
+    (useMediaQuery as jest.Mock).mockReturnValue(true);
     const pendingSearchParams = new Promise<URLSearchParams>(() => {
       // Keep the promise pending so Suspense stays on the fallback.
     });
@@ -249,6 +250,14 @@ describe("BottomNavigation", () => {
     expect(
       container.querySelector(`[${MOBILE_BOTTOM_NAV_ROOT_ATTRIBUTE}="true"]`)
     ).toBeInTheDocument();
+    const fallbackDock = container.querySelector<HTMLElement>(
+      `[${MOBILE_BOTTOM_NAV_DOCK_ATTRIBUTE}="true"]`
+    );
+    expect(fallbackDock?.style.width).toBe("calc(100vw - 2rem)");
+    expect(fallbackDock?.style.maxWidth).toBe("44rem");
+    expect(useMediaQuery).toHaveBeenCalledWith(
+      "(min-width: 744px) and (min-height: 600px)"
+    );
     expect(NavItem).not.toHaveBeenCalled();
   });
 
@@ -287,14 +296,27 @@ describe("BottomNavigation", () => {
       `[${MOBILE_BOTTOM_NAV_DOCK_ATTRIBUTE}="true"]`
     );
 
-    expect(dock?.style.width).toBe("44rem");
+    expect(dock?.style.width).toBe("calc(100vw - 2rem)");
+    expect(dock?.style.maxWidth).toBe("44rem");
 
     act(() => {
       globalThis.scrollY = 24;
-      fireEvent.scroll(globalThis);
+      fireEvent.scroll(window);
     });
 
-    await waitFor(() => expect(dock?.style.width).toBe("38.5rem"));
+    await waitFor(() => expect(dock?.style.maxWidth).toBe("38.5rem"));
+  });
+
+  it("keeps the phone dock on class-based sizing", () => {
+    (useMediaQuery as jest.Mock).mockReturnValue(false);
+
+    const { container } = render(<BottomNavigation />);
+    const dock = container.querySelector<HTMLElement>(
+      `[${MOBILE_BOTTOM_NAV_DOCK_ATTRIBUTE}="true"]`
+    );
+
+    expect(dock?.style.width).toBe("");
+    expect(dock?.style.maxWidth).toBe("");
   });
 
   it("keeps one active pill mounted while moving it between active items", () => {

--- a/__tests__/components/utils/NewVersionToast.test.tsx
+++ b/__tests__/components/utils/NewVersionToast.test.tsx
@@ -357,6 +357,11 @@ describe("NewVersionToast", () => {
     const { container } = render(<NewVersionToast />);
     const toastLayer = container.firstChild as HTMLElement;
 
+    expect(toastLayer).toHaveClass(
+      "tw-left-1/2",
+      "tw-right-auto",
+      "-tw-translate-x-1/2"
+    );
     expect(
       toastLayer.style.getPropertyValue(
         NEW_VERSION_TOAST_MOBILE_BOTTOM_PROPERTY
@@ -407,11 +412,8 @@ describe("NewVersionToast", () => {
       "-tw-translate-x-1/2",
       "tw-w-[min(calc(100vw-2rem),23.25rem)]"
     );
-    expect(toastLayer).not.toHaveClass(
-      "sm:tw-bottom-7",
-      "sm:tw-right-7",
-      "sm:tw-scale-100"
-    );
+    expect(toastLayer).not.toHaveClass("sm:tw-bottom-7", "sm:tw-right-7");
+    expect(toastLayer).toHaveClass("sm:tw-scale-100");
     await waitFor(() =>
       expect(
         toastLayer.style.getPropertyValue(

--- a/__tests__/components/utils/NewVersionToast.test.tsx
+++ b/__tests__/components/utils/NewVersionToast.test.tsx
@@ -352,7 +352,7 @@ describe("NewVersionToast", () => {
       isAppleMobile: true,
       isMobileDevice: true,
     });
-    setMobileDockViewport(true);
+    setMobileDockViewport(false);
 
     const { container } = render(<NewVersionToast />);
     const toastLayer = container.firstChild as HTMLElement;
@@ -380,6 +380,45 @@ describe("NewVersionToast", () => {
     expect(
       toastLayer.style.getPropertyValue(NEW_VERSION_TOAST_MOBILE_SCALE_PROPERTY)
     ).toBe("1");
+  });
+
+  it("centers the wide native-app toast above the measured dock", async () => {
+    mockedUseIsVersionStale.mockReturnValue(true);
+    mockedUseDeviceInfo.mockReturnValue({
+      hasTouchScreen: true,
+      isApp: true,
+      isAppleMobile: true,
+      isMobileDevice: false,
+    });
+    setMobileDockViewport(false);
+    const dockRoot = createDockRoot();
+    createMeasuredDock({
+      height: 64,
+      parentElement: dockRoot,
+      top: 816,
+    });
+
+    const { container } = render(<NewVersionToast />);
+    const toastLayer = container.firstChild as HTMLElement;
+
+    expect(toastLayer).toHaveClass(
+      "tw-left-1/2",
+      "tw-right-auto",
+      "-tw-translate-x-1/2",
+      "tw-w-[min(calc(100vw-2rem),23.25rem)]"
+    );
+    expect(toastLayer).not.toHaveClass(
+      "sm:tw-bottom-7",
+      "sm:tw-right-7",
+      "sm:tw-scale-100"
+    );
+    await waitFor(() =>
+      expect(
+        toastLayer.style.getPropertyValue(
+          NEW_VERSION_TOAST_MOBILE_BOTTOM_PROPERTY
+        )
+      ).toBe("88px")
+    );
   });
 
   it("does not watch body mutations when mobile web has no dock root", async () => {

--- a/__tests__/hooks/useNativeKeyboard.test.ts
+++ b/__tests__/hooks/useNativeKeyboard.test.ts
@@ -272,6 +272,153 @@ describe("useNativeKeyboard", () => {
     }
   });
 
+  it("does not mistake portrait-to-landscape rotation for a keyboard", async () => {
+    const originalInnerHeight = globalThis.innerHeight;
+    const originalInnerWidth = globalThis.innerWidth;
+    const originalVisualViewport = globalThis.visualViewport;
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+    const originalCancelAnimationFrame = window.cancelAnimationFrame;
+    let visualViewportHeight = 900;
+    let visualViewportWidth = 420;
+    const visualViewport = new EventTarget();
+    Object.defineProperties(visualViewport, {
+      height: { get: () => visualViewportHeight },
+      offsetTop: { value: 0 },
+      width: { get: () => visualViewportWidth },
+    });
+    Object.defineProperty(globalThis, "innerHeight", {
+      configurable: true,
+      value: 900,
+    });
+    Object.defineProperty(globalThis, "innerWidth", {
+      configurable: true,
+      value: 420,
+    });
+    Object.defineProperty(globalThis, "visualViewport", {
+      configurable: true,
+      value: visualViewport,
+    });
+    window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    };
+    window.cancelAnimationFrame = jest.fn();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    try {
+      const { result } = await renderNativeKeyboardHook();
+
+      visualViewportHeight = 420;
+      visualViewportWidth = 900;
+      Object.defineProperty(globalThis, "innerHeight", {
+        configurable: true,
+        value: 420,
+      });
+      Object.defineProperty(globalThis, "innerWidth", {
+        configurable: true,
+        value: 900,
+      });
+
+      act(() => {
+        globalThis.dispatchEvent(new Event("orientationchange"));
+        visualViewport.dispatchEvent(new Event("resize"));
+      });
+
+      expect(result.current.isVisible).toBe(false);
+      expect(result.current.keyboardHeight).toBe(0);
+      expect(result.current.phase).toBe("hidden");
+      expect(document.documentElement.dataset.nativeKeyboardVisible).toBe(
+        undefined
+      );
+    } finally {
+      input.remove();
+      Object.defineProperty(globalThis, "innerHeight", {
+        configurable: true,
+        value: originalInnerHeight,
+      });
+      Object.defineProperty(globalThis, "innerWidth", {
+        configurable: true,
+        value: originalInnerWidth,
+      });
+      Object.defineProperty(globalThis, "visualViewport", {
+        configurable: true,
+        value: originalVisualViewport,
+      });
+      window.requestAnimationFrame = originalRequestAnimationFrame;
+      window.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
+  });
+
+  it("keeps viewport keyboard fallback for a focused field", async () => {
+    const originalInnerHeight = globalThis.innerHeight;
+    const originalInnerWidth = globalThis.innerWidth;
+    const originalVisualViewport = globalThis.visualViewport;
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+    const originalCancelAnimationFrame = window.cancelAnimationFrame;
+    let visualViewportHeight = 900;
+    const visualViewportWidth = 420;
+    const visualViewport = new EventTarget();
+    Object.defineProperties(visualViewport, {
+      height: { get: () => visualViewportHeight },
+      offsetTop: { value: 0 },
+      width: { get: () => visualViewportWidth },
+    });
+    Object.defineProperty(globalThis, "innerHeight", {
+      configurable: true,
+      value: 900,
+    });
+    Object.defineProperty(globalThis, "innerWidth", {
+      configurable: true,
+      value: 420,
+    });
+    Object.defineProperty(globalThis, "visualViewport", {
+      configurable: true,
+      value: visualViewport,
+    });
+    window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    };
+    window.cancelAnimationFrame = jest.fn();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    try {
+      const { result } = await renderNativeKeyboardHook();
+      visualViewportHeight = 620;
+
+      act(() => {
+        visualViewport.dispatchEvent(new Event("resize"));
+      });
+
+      expect(result.current.isVisible).toBe(true);
+      expect(result.current.keyboardHeight).toBe(280);
+      expect(result.current.phase).toBe("showing");
+      expect(document.documentElement.dataset.nativeKeyboardVisible).toBe(
+        "true"
+      );
+    } finally {
+      input.remove();
+      Object.defineProperty(globalThis, "innerHeight", {
+        configurable: true,
+        value: originalInnerHeight,
+      });
+      Object.defineProperty(globalThis, "innerWidth", {
+        configurable: true,
+        value: originalInnerWidth,
+      });
+      Object.defineProperty(globalThis, "visualViewport", {
+        configurable: true,
+        value: originalVisualViewport,
+      });
+      window.requestAnimationFrame = originalRequestAnimationFrame;
+      window.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
+  });
+
   it("publishes the complete closed layout on will-hide", async () => {
     const { result } = await renderNativeKeyboardHook();
 

--- a/__tests__/hooks/useNativeKeyboard.test.ts
+++ b/__tests__/hooks/useNativeKeyboard.test.ts
@@ -329,7 +329,7 @@ describe("useNativeKeyboard", () => {
       expect(result.current.isVisible).toBe(false);
       expect(result.current.keyboardHeight).toBe(0);
       expect(result.current.phase).toBe("hidden");
-      expect(document.documentElement.dataset.nativeKeyboardVisible).toBe(
+      expect(document.documentElement.dataset["nativeKeyboardVisible"]).toBe(
         undefined
       );
     } finally {
@@ -358,7 +358,7 @@ describe("useNativeKeyboard", () => {
     const originalRequestAnimationFrame = window.requestAnimationFrame;
     const originalCancelAnimationFrame = window.cancelAnimationFrame;
     let visualViewportHeight = 900;
-    const visualViewportWidth = 420;
+    let visualViewportWidth = 420;
     const visualViewport = new EventTarget();
     Object.defineProperties(visualViewport, {
       height: { get: () => visualViewportHeight },
@@ -389,6 +389,7 @@ describe("useNativeKeyboard", () => {
     try {
       const { result } = await renderNativeKeyboardHook();
       visualViewportHeight = 620;
+      visualViewportWidth = 450;
 
       act(() => {
         visualViewport.dispatchEvent(new Event("resize"));
@@ -397,7 +398,7 @@ describe("useNativeKeyboard", () => {
       expect(result.current.isVisible).toBe(true);
       expect(result.current.keyboardHeight).toBe(280);
       expect(result.current.phase).toBe("showing");
-      expect(document.documentElement.dataset.nativeKeyboardVisible).toBe(
+      expect(document.documentElement.dataset["nativeKeyboardVisible"]).toBe(
         "true"
       );
     } finally {

--- a/components/navigation/BottomNavigation.tsx
+++ b/components/navigation/BottomNavigation.tsx
@@ -102,8 +102,9 @@ interface BottomNavigationProps {
 const COMPACT_SCROLL_DELTA_PX = 10;
 const EXPANDED_TOP_THRESHOLD_PX = 12;
 const TABLET_DOCK_QUERY = "(min-width: 744px) and (min-height: 600px)";
-const TABLET_DOCK_COMPACT_WIDTH = "38.5rem";
-const TABLET_DOCK_EXPANDED_WIDTH = "44rem";
+const TABLET_DOCK_VIEWPORT_WIDTH = "calc(100vw - 2rem)";
+const TABLET_DOCK_COMPACT_MAX_WIDTH = "38.5rem";
+const TABLET_DOCK_EXPANDED_MAX_WIDTH = "44rem";
 
 const getHiddenStyle = (hidden: boolean) =>
   hidden
@@ -339,7 +340,10 @@ const getDockStyle = ({
 }): React.CSSProperties | undefined =>
   isTabletViewport
     ? {
-        width: compact ? TABLET_DOCK_COMPACT_WIDTH : TABLET_DOCK_EXPANDED_WIDTH,
+        width: TABLET_DOCK_VIEWPORT_WIDTH,
+        maxWidth: compact
+          ? TABLET_DOCK_COMPACT_MAX_WIDTH
+          : TABLET_DOCK_EXPANDED_MAX_WIDTH,
       }
     : undefined;
 

--- a/components/navigation/BottomNavigation.tsx
+++ b/components/navigation/BottomNavigation.tsx
@@ -20,6 +20,7 @@ import {
 import useDeviceInfo from "@/hooks/useDeviceInfo";
 import { useWave } from "@/hooks/useWave";
 import { useWaveData } from "@/hooks/useWaveData";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { DEFAULT_LOCALE } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
 import { useAuth } from "../auth/Auth";
@@ -100,6 +101,9 @@ interface BottomNavigationProps {
 
 const COMPACT_SCROLL_DELTA_PX = 10;
 const EXPANDED_TOP_THRESHOLD_PX = 12;
+const TABLET_DOCK_QUERY = "(min-width: 744px) and (min-height: 600px)";
+const TABLET_DOCK_COMPACT_WIDTH = "38.5rem";
+const TABLET_DOCK_EXPANDED_WIDTH = "44rem";
 
 const getHiddenStyle = (hidden: boolean) =>
   hidden
@@ -326,6 +330,19 @@ const getDockClassName = (compact: boolean) =>
       : "tw-h-[64px] tw-w-[min(calc(100vw-2.25rem),38rem)] tw-rounded-[2rem] sm:tw-h-[66px] sm:tw-w-[min(calc(100vw-4rem),40rem)]"
   }`;
 
+const getDockStyle = ({
+  compact,
+  isTabletViewport,
+}: {
+  readonly compact: boolean;
+  readonly isTabletViewport: boolean;
+}): React.CSSProperties | undefined =>
+  isTabletViewport
+    ? {
+        width: compact ? TABLET_DOCK_COMPACT_WIDTH : TABLET_DOCK_EXPANDED_WIDTH,
+      }
+    : undefined;
+
 const floatingNavInnerClassName = "tw-relative tw-h-full";
 
 const getFloatingNavListClassName = (compact: boolean) =>
@@ -384,18 +401,23 @@ const getFloatingActivePillLeft = ({
 
 const BottomNavigationFallback: React.FC<BottomNavigationProps> = ({
   hidden = false,
-}) => (
-  <nav aria-hidden="true" className={getNavClassName({ hidden })}>
-    <div
-      {...{ [MOBILE_BOTTOM_NAV_DOCK_ATTRIBUTE]: "true" }}
-      className={getDockClassName(false)}
-    >
-      <div className={floatingNavInnerClassName}>
-        <ul className={getFloatingNavListClassName(false)} />
+}) => {
+  const isTabletViewport = useMediaQuery(TABLET_DOCK_QUERY);
+
+  return (
+    <nav aria-hidden="true" className={getNavClassName({ hidden })}>
+      <div
+        {...{ [MOBILE_BOTTOM_NAV_DOCK_ATTRIBUTE]: "true" }}
+        className={getDockClassName(false)}
+        style={getDockStyle({ compact: false, isTabletViewport })}
+      >
+        <div className={floatingNavInnerClassName}>
+          <ul className={getFloatingNavListClassName(false)} />
+        </div>
       </div>
-    </div>
-  </nav>
-);
+    </nav>
+  );
+};
 
 interface BottomNavigationResolvedContentProps extends BottomNavigationProps {
   readonly pathname: string;
@@ -412,6 +434,7 @@ const BottomNavigationResolvedContent: React.FC<
 }) => {
   const { registerRef } = useLayout();
   const { isApp } = useDeviceInfo();
+  const isTabletViewport = useMediaQuery(TABLET_DOCK_QUERY);
   const { connectedProfile } = useAuth();
   const { address } = useSeizeConnectContext();
   // react-doctor-disable-next-line react-doctor/nextjs-no-use-search-params-without-suspense
@@ -495,6 +518,7 @@ const BottomNavigationResolvedContent: React.FC<
       <div
         {...{ [MOBILE_BOTTOM_NAV_DOCK_ATTRIBUTE]: "true" }}
         className={getDockClassName(compact)}
+        style={getDockStyle({ compact, isTabletViewport })}
       >
         <div className={floatingNavInnerClassName}>
           <div

--- a/components/utils/NewVersionToast.tsx
+++ b/components/utils/NewVersionToast.tsx
@@ -94,7 +94,7 @@ const NewVersionToast = (): JSX.Element | null => {
 
   const refreshActionLabel = t(locale, "newVersionToast.refreshAction");
   const positionClassName = usesNativeDockPosition
-    ? "tw-bottom-[var(--new-version-toast-mobile-bottom,1rem)] tw-left-1/2 tw-right-auto tw-w-[min(calc(100vw-2rem),23.25rem)] -tw-translate-x-1/2"
+    ? "tw-bottom-[var(--new-version-toast-mobile-bottom,1rem)] tw-left-1/2 tw-right-auto tw-w-[min(calc(100vw-2rem),23.25rem)] -tw-translate-x-1/2 sm:tw-scale-100"
     : "tw-bottom-[var(--new-version-toast-mobile-bottom,1rem)] tw-left-4 tw-right-4 tw-w-auto sm:tw-bottom-7 sm:tw-left-auto sm:tw-right-7 sm:tw-scale-100";
 
   return (

--- a/components/utils/NewVersionToast.tsx
+++ b/components/utils/NewVersionToast.tsx
@@ -73,11 +73,13 @@ const NewVersionToast = (): JSX.Element | null => {
   const shouldTrackMobileDock = useMediaQuery(
     NEW_VERSION_TOAST_MOBILE_DOCK_QUERY
   );
+  const usesNativeDockPosition = isApp;
   const fallbackBottom = isApp
     ? NEW_VERSION_TOAST_APP_FALLBACK_BOTTOM
     : NEW_VERSION_TOAST_WEB_FALLBACK_BOTTOM;
   const toastLayerRef = useMeasuredMobileBottomNavDockBottom({
-    enabled: isVersionStale && shouldTrackMobileDock,
+    enabled:
+      isVersionStale && (usesNativeDockPosition || shouldTrackMobileDock),
     fallbackBottom,
     measurementWindowMs: MOBILE_BOTTOM_NAV_DOCK_MEASUREMENT_WINDOW_MS,
     resetOnDisabled: false,
@@ -91,12 +93,15 @@ const NewVersionToast = (): JSX.Element | null => {
   }
 
   const refreshActionLabel = t(locale, "newVersionToast.refreshAction");
+  const positionClassName = usesNativeDockPosition
+    ? "tw-bottom-[var(--new-version-toast-mobile-bottom,1rem)] tw-left-1/2 tw-right-auto tw-w-[min(calc(100vw-2rem),23.25rem)] -tw-translate-x-1/2"
+    : "tw-bottom-[var(--new-version-toast-mobile-bottom,1rem)] tw-left-4 tw-right-4 tw-w-auto sm:tw-bottom-7 sm:tw-left-auto sm:tw-right-7 sm:tw-scale-100";
 
   return (
     <div
       ref={toastLayerRef}
       style={getNewVersionToastStyle(fallbackBottom)}
-      className="tailwind-scope tw-pointer-events-none tw-fixed tw-bottom-[var(--new-version-toast-mobile-bottom,1rem)] tw-left-4 tw-right-4 tw-z-[1000] tw-w-auto tw-origin-bottom tw-scale-[var(--new-version-toast-mobile-scale,1)] tw-transform-gpu tw-will-change-[bottom,transform] sm:tw-bottom-7 sm:tw-left-auto sm:tw-right-7 sm:tw-scale-100"
+      className={`tailwind-scope tw-pointer-events-none tw-fixed tw-z-[1000] tw-origin-bottom tw-scale-[var(--new-version-toast-mobile-scale,1)] tw-transform-gpu tw-will-change-[bottom,transform] ${positionClassName}`}
     >
       <button
         type="button"

--- a/hooks/useNativeKeyboard.ts
+++ b/hooks/useNativeKeyboard.ts
@@ -46,6 +46,7 @@ const KEYBOARD_EVENT_LAYOUT_TRANSITION_MS = 250;
 const REDUCED_MOTION_MEDIA_QUERY = "(prefers-reduced-motion: reduce)";
 const VIEWPORT_KEYBOARD_HEIGHT_TOLERANCE_PX = 8;
 const VIEWPORT_KEYBOARD_CLOSED_TOLERANCE_PX = 24;
+const VIEWPORT_ORIENTATION_WIDTH_THRESHOLD_PX = 96;
 const FOCUSOUT_KEYBOARD_HIDE_FALLBACK_MS = 180;
 const NATIVE_KEYBOARD_HIDE_FALLBACK_MS = 500;
 
@@ -384,7 +385,7 @@ function syncKeyboardVisibilityFromViewport(): void {
       keyboardClosedViewportWidth > 0 &&
       viewportWidth > 0 &&
       Math.abs(viewportWidth - keyboardClosedViewportWidth) >
-        VIEWPORT_KEYBOARD_CLOSED_TOLERANCE_PX;
+        VIEWPORT_ORIENTATION_WIDTH_THRESHOLD_PX;
     const hasKeyboardEvidence =
       nativeKeyboardLifecycleActive || hasEditableFocus();
 

--- a/hooks/useNativeKeyboard.ts
+++ b/hooks/useNativeKeyboard.ts
@@ -35,6 +35,7 @@ let listenerSetupToken = 0;
 let browserFallbackTeardown: (() => void) | null = null;
 let hiddenFallbackTimeout: ReturnType<typeof setTimeout> | null = null;
 let keyboardClosedViewportHeight = 0;
+let keyboardClosedViewportWidth = 0;
 let keyboardClosedLayoutViewportHeight = 0;
 let nativeKeyboardLifecycleActive = false;
 
@@ -217,6 +218,30 @@ function getLayoutViewportHeight(): number {
     : 0;
 }
 
+function getViewportWidth(): number {
+  const visualViewportWidth = globalThis.visualViewport?.width;
+  if (
+    typeof visualViewportWidth === "number" &&
+    Number.isFinite(visualViewportWidth) &&
+    visualViewportWidth > 0
+  ) {
+    return visualViewportWidth;
+  }
+
+  const windowWidth = typeof window !== "undefined" ? window.innerWidth : 0;
+  if (
+    typeof windowWidth === "number" &&
+    Number.isFinite(windowWidth) &&
+    windowWidth > 0
+  ) {
+    return windowWidth;
+  }
+
+  return typeof document !== "undefined"
+    ? document.documentElement.clientWidth
+    : 0;
+}
+
 function getLayoutViewportShrinkHeight(): number {
   const layoutViewportHeight = getLayoutViewportHeight();
   if (keyboardClosedLayoutViewportHeight <= 0 || layoutViewportHeight <= 0) {
@@ -245,6 +270,11 @@ function rememberKeyboardClosedViewportHeight(): number {
   const viewportHeight = getViewportHeight();
   if (viewportHeight > 0) {
     keyboardClosedViewportHeight = viewportHeight;
+  }
+
+  const viewportWidth = getViewportWidth();
+  if (viewportWidth > 0) {
+    keyboardClosedViewportWidth = viewportWidth;
   }
 
   const layoutViewportHeight = getLayoutViewportHeight();
@@ -349,6 +379,24 @@ function syncKeyboardVisibilityFromViewport(): void {
 
   const viewportKeyboardHeight = getViewportKeyboardHeight();
   if (viewportKeyboardHeight > VIEWPORT_KEYBOARD_HEIGHT_TOLERANCE_PX) {
+    const viewportWidth = getViewportWidth();
+    const viewportWidthChanged =
+      keyboardClosedViewportWidth > 0 &&
+      viewportWidth > 0 &&
+      Math.abs(viewportWidth - keyboardClosedViewportWidth) >
+        VIEWPORT_KEYBOARD_CLOSED_TOLERANCE_PX;
+    const hasKeyboardEvidence =
+      nativeKeyboardLifecycleActive || hasEditableFocus();
+
+    // Rotation changes both viewport axes and can otherwise look exactly like
+    // a keyboard opening when the portrait height is used as the baseline.
+    // Viewport-only fallback detection also needs editable focus; native
+    // lifecycle events remain authoritative when focus is in transition.
+    if (viewportWidthChanged || !hasKeyboardEvidence) {
+      markKeyboardHiddenFromFallback();
+      return;
+    }
+
     clearHiddenFallbackTimeout();
     setKeyboardState({
       isVisible: true,
@@ -674,6 +722,7 @@ export function __resetNativeKeyboardForTests(): void {
   listenerSetupPromise = null;
   listenerSetupToken = 0;
   keyboardClosedViewportHeight = 0;
+  keyboardClosedViewportWidth = 0;
   keyboardClosedLayoutViewportHeight = 0;
   nativeKeyboardLifecycleActive = false;
   resetKeyboardLayoutVariables();

--- a/ops/docs/navigation/feature-android-keyboard-layout.md
+++ b/ops/docs/navigation/feature-android-keyboard-layout.md
@@ -54,6 +54,8 @@ blank space.
   safe-area and navigation spacing return.
 - When reduced motion is enabled, keyboard-driven layout changes use no added
   transition duration.
+- Portrait-to-landscape and landscape-to-portrait viewport changes reset the
+  closed-keyboard geometry instead of being treated as keyboard visibility.
 - If keyboard listeners are unavailable or fail, layout stays in non-keyboard
   state.
 - This behavior does not apply to desktop web or small-screen web sidebar layout.
@@ -61,7 +63,8 @@ blank space.
 ## Failure and Recovery
 
 - If bottom navigation appears stuck hidden, close the keyboard first
-  (`Done`/back key or blur input).
+  (`Done`/back key or blur input). Rotation without an open keyboard should
+  leave the navigation visible.
 - If spacing looks stale after keyboard close, change route once and return.
 - If stale spacing persists, refresh the current route.
 

--- a/ops/docs/navigation/feature-mobile-bottom-navigation.md
+++ b/ops/docs/navigation/feature-mobile-bottom-navigation.md
@@ -69,8 +69,15 @@ Profile access stays in the app drawer/account surfaces.
   has unread items.
 - On non-stream routes (for example `/network`, `/the-memes`),
   layout reserves bottom space so content is not hidden behind the bar.
+- Tablet-sized app viewports use wider expanded and compact dock widths so the
+  seven destinations remain balanced against the available canvas. Phone
+  sizing is unchanged.
+- Rotating a phone or tablet between portrait and landscape keeps the dock
+  available when no other hide condition is active.
 - While the mobile keyboard is open, the bar stays mounted but slides out of
   view and is non-interactive.
+- The new-version refresh prompt is centered directly above the dock in the
+  native app and follows the dock as it expands or compacts.
 - While a single drop is open (`?drop=...`) or an inline drop edit is active,
   the bar is not rendered.
 
@@ -82,6 +89,8 @@ Profile access stays in the app drawer/account surfaces.
 - If `Waves` or `Messages` keeps reopening a stale thread, tap that tab from an
   active thread once to reset to section root, then retry.
 - If the bar is hidden, dismiss keyboard and close drop/edit overlays first.
+- Rotation by itself should not hide the bar; if it remains hidden after
+  rotating, return to portrait once and rotate again.
 - If content appears clipped under the bar, return to a section root route once
   to reapply bottom reserve spacing.
 - If unread dots look stale, reopen the section after unread state refresh.

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -4040,7 +4040,9 @@
       "facts": [
         "Mobile layouts use bottom navigation for Discovery, Waves, Messages, Home, Network, Collections, and Notifications.",
         "The mobile bottom navigation surface is separate from the desktop and app sidebar IA.",
-        "Mobile keyboard and viewport behavior can affect how navigation and composer controls fit on screen."
+        "Tablet-sized app viewports use a wider dock while phone sizing stays unchanged.",
+        "Rotating a phone or tablet keeps bottom navigation visible unless a route, edit state, open drop, or real software keyboard hides it.",
+        "In the native app, the new-version refresh prompt stays centered directly above the dock and follows its expanded or compact position."
       ],
       "canonical_path": "/waves",
       "related_paths": [

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -4036,7 +4036,9 @@
       "facts": [
         "Mobile layouts use bottom navigation for Discovery, Waves, Messages, Home, Network, Collections, and Notifications.",
         "The mobile bottom navigation surface is separate from the desktop and app sidebar IA.",
-        "Mobile keyboard and viewport behavior can affect how navigation and composer controls fit on screen."
+        "Tablet-sized app viewports use a wider dock while phone sizing stays unchanged.",
+        "Rotating a phone or tablet keeps bottom navigation visible unless a route, edit state, open drop, or real software keyboard hides it.",
+        "In the native app, the new-version refresh prompt stays centered directly above the dock and follows its expanded or compact position."
       ],
       "canonical_path": "/waves",
       "related_paths": [


### PR DESCRIPTION
## Issue

- The floating dock looks undersized on iPad.
- The native new-version prompt uses desktop placement at wider viewports and overlaps the dock.
- Rotation can be mistaken for a software-keyboard resize, hiding the dock in landscape on iPhone and iPad.

## Fix

- Increase expanded and compact tablet dock widths by exactly 10%, while leaving phone sizing unchanged.
- Keep the native new-version prompt horizontally centered above the measured dock at every native viewport width.
- Make viewport keyboard fallback orientation-aware and require real keyboard evidence before hiding the dock.

## Changes

- Add focused coverage for tablet dock widths, native toast positioning, rotation, and focused-field keyboard fallback.
- Update navigation and keyboard behavior documentation plus generated help content.

## Validation

- Focused Jest tests pass for the dock, toast, and native keyboard hook.
- Changed-file checks and production TypeScript checks pass.
- React Doctor reports 100/100 with no issues.

## Risk

Medium-low. The keyboard fallback is shared native layout logic, but native keyboard lifecycle events remain authoritative and focused regression tests cover both rotation and a genuine viewport keyboard resize.

## Rollback

Revert this PR.

## Review Notes

- The tablet breakpoint requires at least 744px width and 600px height, so iPhone landscape keeps existing phone dock sizing.
- Web toast behavior remains unchanged; the centered behavior is native-app-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tablet bottom navigation now adapts its width for compact and expanded layouts.
  * Native-app update prompts use centered, width-constrained positioning on larger screens.
  * Improved keyboard and orientation handling helps keep navigation visible during device rotation.

* **Bug Fixes**
  * Prevented orientation changes from being incorrectly detected as keyboard activity.
  * Improved recovery when navigation becomes hidden after rotating a device.

* **Documentation**
  * Updated mobile navigation guidance for tablet sizing, rotation behavior, keyboard recovery, and native-app prompt placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->