### PR TITLE
Fix Museum art media, project cards, and mobile reading

### DIFF
--- a/__tests__/app/museum/network/catalogOnlyMediaRoutes.test.ts
+++ b/__tests__/app/museum/network/catalogOnlyMediaRoutes.test.ts
@@ -35,6 +35,16 @@ describe("typed Museum routes keep media catalog-only", () => {
     expect(typedBranch).toContain("publicWorkItem(work, publication)");
   });
 
+  it("presents governed accession media on permanent Collection cards", () => {
+    const source = routeSource("app/museum/network/collection/page.tsx");
+    const workProjection = bracedBlock(source, "function publicWorkItem(");
+
+    expect(workProjection).toContain("work.presentationMedia?.[0]");
+    expect(workProjection).toContain('kind: "proposal"');
+    expect(workProjection).toContain("requireIntentForLargeSource: false");
+    expect(workProjection).toContain("presentationMedia.credit.creditLine");
+  });
+
   it("derives the Collection history from active holdings and acquisitions", () => {
     const source = routeSource("app/museum/network/collection/page.tsx");
 

--- a/__tests__/components/museum/acquisition/MuseumAcquisitionLanding.test.tsx
+++ b/__tests__/components/museum/acquisition/MuseumAcquisitionLanding.test.tsx
@@ -296,13 +296,14 @@ describe("Museum acquisitions landing", () => {
 
     render(<MuseumAcquisitionLandingPage records={records} />);
 
-    const disclosures = screen.getAllByRole("button", {
-      name: "View image · loads 16.9 MB",
-    });
-    expect(disclosures).toHaveLength(2);
-    for (const disclosure of disclosures) {
-      expect(disclosure.closest("a")).toBeNull();
-    }
+    expect(
+      screen.queryByRole("button", {
+        name: /View image/,
+      })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getAllByRole("img", { name: "Palmyra by Lorenzo Meloni" })
+    ).toHaveLength(2);
     for (const link of screen.getAllByRole("link", {
       name: "Conflict at Its Edges",
     })) {

--- a/__tests__/components/museum/landing/MuseumLandingMediaCard.test.tsx
+++ b/__tests__/components/museum/landing/MuseumLandingMediaCard.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { MuseumLandingMediaCard } from "@/components/museum/landing/MuseumLandingMediaCard";
+
+describe("MuseumLandingMediaCard", () => {
+  it("shows an accession presentation image immediately on a Collection card", () => {
+    render(
+      <MuseumLandingMediaCard
+        title="Palmyra, Syria"
+        subtitle="Lorenzo Meloni"
+        media={{
+          kind: "proposal",
+          src: "https://museum.test/palmyra.jpg",
+          width: 2400,
+          height: 1600,
+          alt: "Palmyra by Lorenzo Meloni",
+          sourceByteSize: 16_900_000,
+          creditLine: "© Lorenzo Meloni/Magnum Photos 2022.",
+          requireIntentForLargeSource: false,
+        }}
+      />
+    );
+
+    expect(
+      screen.getByRole("img", { name: "Palmyra by Lorenzo Meloni" })
+    ).toHaveAttribute("src", "https://museum.test/palmyra.jpg");
+    expect(
+      screen.queryByRole("button", { name: /loads 16\.9 MB/u })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("© Lorenzo Meloni/Magnum Photos 2022.")
+    ).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/museum/research/MuseumResearchProjectCard.test.tsx
+++ b/__tests__/components/museum/research/MuseumResearchProjectCard.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { MuseumResearchProjectCard } from "@/components/museum/research/MuseumResearchProjectCard";
+
+describe("MuseumResearchProjectCard", () => {
+  it("shows accession-reviewed presentation media without bogus empty metadata", () => {
+    render(
+      <MuseumResearchProjectCard
+        project={{
+          id: "6529NM-PRJ-0006",
+          href: "/museum/network/projects/magnum-photos-75",
+          title: "Magnum Photos 75",
+          artistNames: [],
+          workCount: 5,
+          presentationMedia: {
+            id: "magnum-75-127",
+            kind: "external_proposal_presentation",
+            mediaUrl: "https://example.com/magnum-75-127.jpg",
+            mediaMimeType: "image/jpeg",
+            sourceByteSize: 16_900_000,
+            width: 1600,
+            height: 1067,
+            altText: "David Seymour's 1952 photograph of the Negev border.",
+            source: {
+              kind: "signed_wave_storm",
+              waveId: "wave-id",
+              dropId: "drop-id",
+              partId: 1,
+              serial: 1,
+              publicationRecordId: "publication-id",
+              contextEntityId: "6529NM-CA-2026-003",
+              sourcePath: "records/media/reference.json",
+              mediaRecordPath: "records/media/reference.json",
+              sourceCommit: "a5b64f7",
+            },
+            credit: {
+              creditLine: "© David Seymour/Magnum Photos 2022",
+              sourcePath: "records/media/reference.json",
+            },
+            rights: {
+              status: "presentation_only",
+              licenseLabel: "All Rights Reserved",
+              licenseUrl: null,
+            },
+            download: "not_permitted",
+            preservation: "not_retained",
+            affordances: ["view", "thumbnail", "hero", "alt"],
+          },
+        }}
+      />
+    );
+
+    expect(
+      screen.getByRole("img", {
+        name: "David Seymour's 1952 photograph of the Negev border.",
+      })
+    ).toBeInTheDocument();
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+    expect(screen.queryByText(/loads 16\.9 MB/i)).not.toBeInTheDocument();
+  });
+});

--- a/app/museum/network/acquisition-programs/[slug]/page.tsx
+++ b/app/museum/network/acquisition-programs/[slug]/page.tsx
@@ -10,6 +10,7 @@ import {
 import { MuseumPublicationUnavailable } from "@/components/museum/MuseumPublicationUnavailable";
 import { MuseumPublicMediaFigure } from "@/components/museum/MuseumPublicMediaFigure";
 import { MuseumProgramImage } from "@/components/museum/MuseumProgramImage";
+import { MuseumProposalImage } from "@/components/museum/MuseumProposalImage";
 import {
   AcquisitionWorkFigure,
   type AcquisitionWorkCard,
@@ -360,6 +361,48 @@ export default async function MuseumAcquisitionProgramPage({
                     work={card}
                     eager={index === 0}
                   />
+                );
+              }
+              const presentation = work.presentationMedia?.[0];
+              if (presentation !== undefined) {
+                const artist = publication.artists.find(
+                  (candidate) => candidate.id === work.artistId
+                );
+                return (
+                  <figure key={work.id} className="tw-m-0 tw-min-w-0">
+                    <div className="tw-aspect-square tw-overflow-hidden tw-bg-black">
+                      <MuseumProposalImage
+                        src={presentation.mediaUrl}
+                        width={presentation.width}
+                        height={presentation.height}
+                        alt={presentation.altText.trim() || work.title}
+                        sourceByteSize={presentation.sourceByteSize}
+                        requireIntentForLargeSource={false}
+                        eager={index === 0}
+                        className="tw-h-full tw-w-full tw-object-contain"
+                      />
+                    </div>
+                    <figcaption className="tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-iron-800 tw-py-4">
+                      <Link
+                        href={museumWorkHref(work.id)}
+                        className="hover:tw-text-primary-200 tw-inline-flex tw-min-h-11 tw-items-center tw-text-base tw-font-semibold tw-text-iron-50 tw-no-underline focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
+                      >
+                        {work.title}
+                      </Link>
+                      {artist === undefined ? null : (
+                        <span className="tw-mt-1 tw-block tw-text-sm tw-text-iron-400">
+                          {artist.preferredName}
+                        </span>
+                      )}
+                      <span className="tw-mt-2 tw-block tw-text-sm tw-leading-6 tw-text-iron-300">
+                        {status}
+                      </span>
+                      <span className="tw-mt-2 tw-block tw-text-xs tw-leading-5 tw-text-iron-500">
+                        {presentation.credit.creditLine} ·{" "}
+                        {presentation.rights.licenseLabel}
+                      </span>
+                    </figcaption>
+                  </figure>
                 );
               }
               return (

--- a/app/museum/network/artists/[slug]/page.tsx
+++ b/app/museum/network/artists/[slug]/page.tsx
@@ -82,7 +82,8 @@ function TypedArtistPage({
   const projects = publication.projects.filter(
     (project) =>
       project.artistId === artist.id ||
-      project.artistIds?.includes(artist.id) === true
+      project.artistIds?.includes(artist.id) === true ||
+      works.some((work) => work.projectId === project.id)
   );
   const relationshipLabel = (work: (typeof works)[number]): string => {
     if (isMuseumPermanentCollectionWork(work)) {

--- a/app/museum/network/collection/page.tsx
+++ b/app/museum/network/collection/page.tsx
@@ -90,7 +90,7 @@ function publicWorkItem(
         src: presentationMedia.mediaUrl,
         width: presentationMedia.width,
         height: presentationMedia.height,
-        alt: presentationMedia.altText,
+        alt: presentationMedia.altText.trim() || work.title,
         sourceByteSize: presentationMedia.sourceByteSize,
         creditLine: presentationMedia.credit.creditLine,
         requireIntentForLargeSource: false,

--- a/app/museum/network/collection/page.tsx
+++ b/app/museum/network/collection/page.tsx
@@ -27,6 +27,7 @@ import type {
   MuseumPublication,
   MuseumPublicWork,
 } from "@/lib/museum/publication/types";
+import { buildMuseumSignedWaveStormDropUrl } from "@/lib/museum/publication/types";
 import { selectMuseumStillMedia } from "@/lib/museum/publication/mediaSelection";
 
 export const metadata: Metadata = {
@@ -76,6 +77,35 @@ function publicWorkItem(
         alt: media.altText ?? work.title,
         creditLine: media.credit.creditLine,
       },
+    };
+  } else if (work.presentationMedia?.[0] !== undefined) {
+    const presentationMedia = work.presentationMedia[0];
+    const sourceHref = buildMuseumSignedWaveStormDropUrl(
+      presentationMedia.source.waveId,
+      presentationMedia.source.dropId
+    );
+    presentation = {
+      media: {
+        kind: "proposal" as const,
+        src: presentationMedia.mediaUrl,
+        width: presentationMedia.width,
+        height: presentationMedia.height,
+        alt: presentationMedia.altText,
+        sourceByteSize: presentationMedia.sourceByteSize,
+        creditLine: presentationMedia.credit.creditLine,
+        requireIntentForLargeSource: false,
+        ...(sourceHref === null ||
+        !presentationMedia.affordances.includes("open_upstream_presentation")
+          ? {}
+          : {
+              sourceHref,
+              sourceLabel: t(
+                DEFAULT_LOCALE,
+                "museum.network.acquisitions.openPresentation"
+              ),
+            }),
+      },
+      ...(mediaMetadata === undefined ? {} : { metadata: mediaMetadata }),
     };
   } else if (mediaMetadata !== undefined) {
     presentation = { metadata: mediaMetadata };

--- a/app/museum/network/projects/[slug]/page.tsx
+++ b/app/museum/network/projects/[slug]/page.tsx
@@ -357,10 +357,12 @@ function TypedProjectPage({
   readonly view: MuseumView | null;
 }) {
   const works = museumProjectWorks(publication, project);
+  const workArtistIds = new Set(works.map((work) => work.artistId));
   const artists = publication.artists.filter(
     (artist) =>
       project.artistIds?.includes(artist.id) === true ||
-      artist.id === project.artistId
+      artist.id === project.artistId ||
+      workArtistIds.has(artist.id)
   );
   const organizations =
     publication.organizations?.filter(

--- a/app/museum/network/projects/page.tsx
+++ b/app/museum/network/projects/page.tsx
@@ -51,15 +51,23 @@ function buildProjectCards(
         .filter((artwork) => project.artworkIds.includes(artwork.id))
         .map((artwork) => selectMuseumStillMedia(artwork.media))
         .find((candidate) => candidate !== undefined);
+    const presentationMedia = works
+      .flatMap((work) => work.presentationMedia ?? [])
+      .at(0);
     return {
       id: project.id,
       href: museumProjectHref(project.slug),
       title: project.title,
       artistNames: projectArtists(publication, project),
-      platform: project.platform,
-      releaseYear: project.releaseYear,
+      ...(project.platform.trim().length === 0
+        ? {}
+        : { platform: project.platform }),
+      ...(project.releaseYear > 0 ? { releaseYear: project.releaseYear } : {}),
       workCount: Math.max(works.length, declaredWorkCount),
       ...(media === undefined ? {} : { media }),
+      ...(media === undefined && presentationMedia !== undefined
+        ? { presentationMedia }
+        : {}),
     };
   });
 }

--- a/components/museum/MuseumMarkdown.tsx
+++ b/components/museum/MuseumMarkdown.tsx
@@ -377,15 +377,23 @@ function MuseumMarkdownLink({
 
 function MuseumMarkdownTable({ children }: { readonly children?: ReactNode }) {
   return (
-    <div
-      aria-label={t(DEFAULT_LOCALE, "museum.network.markdown.scrollableTable")}
-      className="tw-max-w-full tw-overflow-x-auto focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
-      role="region"
-      tabIndex={0}
-    >
-      <table className="tw-w-full tw-min-w-[44rem] tw-border-collapse tw-text-left tw-text-sm tw-leading-6 tw-text-iron-200">
-        {children}
-      </table>
+    <div>
+      <p className="tw-m-0 tw-mb-2 tw-text-xs tw-leading-5 tw-text-iron-500 sm:tw-hidden">
+        {t(DEFAULT_LOCALE, "museum.network.markdown.scrollTableHint")}
+      </p>
+      <div
+        aria-label={t(
+          DEFAULT_LOCALE,
+          "museum.network.markdown.scrollableTable"
+        )}
+        className="tw-max-w-full tw-overflow-x-auto focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
+        role="region"
+        tabIndex={0}
+      >
+        <table className="tw-w-full tw-min-w-[44rem] tw-border-collapse tw-text-left tw-text-sm tw-leading-6 tw-text-iron-200">
+          {children}
+        </table>
+      </div>
     </div>
   );
 }
@@ -496,7 +504,7 @@ export function MuseumMarkdown({
   workHrefs = EMPTY_WORK_HREFS,
 }: MuseumMarkdownProps) {
   return (
-    <div className={`tw-space-y-4 ${className}`}>
+    <div className={`tw-space-y-4 tw-text-base ${className}`}>
       <ReactMarkdown
         components={
           documentHeadings ? documentHeadingComponents : baseComponents

--- a/components/museum/MuseumObjectPage.tsx
+++ b/components/museum/MuseumObjectPage.tsx
@@ -124,10 +124,15 @@ function hasMagnumInstitutionalDisplayRights(work: MuseumPublicWork): boolean {
     return false;
   }
 
-  return [...work.media, ...(work.mediaMetadata ?? [])].some(
-    (media) =>
-      media.credit.licenseLabel === "All Rights Reserved" &&
-      media.credit.sourcePath.trim().length > 0
+  return (
+    [...work.media, ...(work.mediaMetadata ?? [])].some(
+      (media) =>
+        media.credit.licenseLabel === "All Rights Reserved" &&
+        media.credit.sourcePath.trim().length > 0
+    ) ||
+    (work.presentationMedia ?? []).some(
+      (media) => media.credit.sourcePath.trim().length > 0
+    )
   );
 }
 
@@ -154,6 +159,7 @@ function MuseumCanonicalWorkMedia({
               <MuseumProgramImage
                 media={publicWorkMedia(stillMedia)}
                 sizes="(min-width: 640px) 50vw, 100vw"
+                className="tw-block tw-h-auto tw-w-full tw-object-contain"
               />
             </div>
             <figcaption className="tw-mt-3 tw-text-sm tw-leading-6 tw-text-iron-400">

--- a/components/museum/acquisition/MuseumAcquisitionLanding.tsx
+++ b/components/museum/acquisition/MuseumAcquisitionLanding.tsx
@@ -393,6 +393,7 @@ function MuseumAcquisitionMediaFrame({
       width={media.width}
       height={media.height}
       sourceByteSize={media.sourceByteSize}
+      requireIntentForLargeSource={false}
       eager={eager}
       className={imageClassName}
     />

--- a/components/museum/acquisition/MuseumAcquisitionProgramsLanding.tsx
+++ b/components/museum/acquisition/MuseumAcquisitionProgramsLanding.tsx
@@ -56,7 +56,7 @@ function programDescription(program: MuseumAcquisitionProgram): string {
   if (program.id === "AP-GIFT-01") {
     return "A standing route for considered gifts, with each gift recorded as its own curated acquisition.";
   }
-  if (program.id === "6529NM-AP-01") {
+  if (program.slug === "keys-and-gates") {
     return "A focused photographic acquisition program. Its selected works remain unminted while the acquisition proceeds.";
   }
   return t(

--- a/components/museum/landing/MuseumLandingMediaCard.tsx
+++ b/components/museum/landing/MuseumLandingMediaCard.tsx
@@ -27,6 +27,7 @@ export type MuseumLandingMedia =
       readonly sourceHref?: string;
       readonly sourceLabel?: string;
       readonly creditLine?: string;
+      readonly requireIntentForLargeSource?: boolean;
     }
   | {
       readonly kind: "program";
@@ -63,6 +64,7 @@ function MediaFrame({
         width={media.width}
         height={media.height}
         sourceByteSize={media.sourceByteSize}
+        requireIntentForLargeSource={media.requireIntentForLargeSource ?? true}
         {...(media.sourceHref === undefined || media.sourceLabel === undefined
           ? {}
           : {

--- a/components/museum/research/MuseumResearchProjectCard.tsx
+++ b/components/museum/research/MuseumResearchProjectCard.tsx
@@ -1,7 +1,11 @@
 import Link from "next/link";
 import { DEFAULT_LOCALE } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
-import type { MuseumMedia } from "@/lib/museum/publication/types";
+import type {
+  MuseumExternalProposalPresentationMedia,
+  MuseumMedia,
+} from "@/lib/museum/publication/types";
+import { MuseumProposalImage } from "../MuseumProposalImage";
 import { MuseumPublicMediaFigure } from "../MuseumPublicMediaFigure";
 
 export interface MuseumResearchProjectCardData {
@@ -9,10 +13,11 @@ export interface MuseumResearchProjectCardData {
   readonly href: string;
   readonly title: string;
   readonly artistNames: readonly string[];
-  readonly platform: string;
-  readonly releaseYear: number;
+  readonly platform?: string;
+  readonly releaseYear?: number;
   readonly workCount: number;
   readonly media?: MuseumMedia;
+  readonly presentationMedia?: MuseumExternalProposalPresentationMedia;
 }
 
 export function MuseumResearchProjectCard({
@@ -33,9 +38,23 @@ export function MuseumResearchProjectCard({
           sizes="(min-width: 1280px) 30vw, (min-width: 768px) 45vw, 100vw"
         />
       )}
+      {project.media !== undefined ||
+      project.presentationMedia === undefined ? null : (
+        <div className="tw-relative tw-aspect-square tw-w-full tw-overflow-hidden tw-bg-black">
+          <MuseumProposalImage
+            src={project.presentationMedia.mediaUrl}
+            width={project.presentationMedia.width}
+            height={project.presentationMedia.height}
+            alt={project.presentationMedia.altText.trim() || project.title}
+            sourceByteSize={project.presentationMedia.sourceByteSize}
+            requireIntentForLargeSource={false}
+            className="tw-h-full tw-w-full tw-object-contain"
+          />
+        </div>
+      )}
       <div
         className={
-          project.media === undefined
+          project.media === undefined && project.presentationMedia === undefined
             ? "tw-flex tw-flex-1 tw-flex-col"
             : "tw-mt-5"
         }
@@ -51,23 +70,32 @@ export function MuseumResearchProjectCard({
             {project.title}
           </Link>
         </h3>
-        <p className="tw-m-0 tw-mt-2 tw-text-sm tw-text-iron-300">
-          {project.artistNames.join(", ")}
-        </p>
-        <dl className="tw-m-0 tw-mt-4 tw-grid tw-grid-cols-2 tw-gap-x-4 tw-gap-y-2 tw-text-xs tw-text-iron-500">
-          <div>
-            <dt className="tw-sr-only">
-              {t(DEFAULT_LOCALE, "museum.network.projects.platform")}
-            </dt>
-            <dd className="tw-m-0">{project.platform}</dd>
-          </div>
-          <div>
-            <dt className="tw-sr-only">
-              {t(DEFAULT_LOCALE, "museum.network.projects.releaseYear")}
-            </dt>
-            <dd className="tw-m-0 tw-text-right">{project.releaseYear}</dd>
-          </div>
-        </dl>
+        {project.artistNames.length === 0 ? null : (
+          <p className="tw-m-0 tw-mt-2 tw-text-sm tw-text-iron-300">
+            {project.artistNames.join(", ")}
+          </p>
+        )}
+        {project.platform === undefined &&
+        project.releaseYear === undefined ? null : (
+          <dl className="tw-m-0 tw-mt-4 tw-grid tw-grid-cols-2 tw-gap-x-4 tw-gap-y-2 tw-text-xs tw-text-iron-500">
+            {project.platform === undefined ? null : (
+              <div>
+                <dt className="tw-sr-only">
+                  {t(DEFAULT_LOCALE, "museum.network.projects.platform")}
+                </dt>
+                <dd className="tw-m-0">{project.platform}</dd>
+              </div>
+            )}
+            {project.releaseYear === undefined ? null : (
+              <div>
+                <dt className="tw-sr-only">
+                  {t(DEFAULT_LOCALE, "museum.network.projects.releaseYear")}
+                </dt>
+                <dd className="tw-m-0 tw-text-right">{project.releaseYear}</dd>
+              </div>
+            )}
+          </dl>
+        )}
         <p className="tw-m-0 tw-mt-2 tw-text-xs tw-text-iron-500">
           {t(
             DEFAULT_LOCALE,

--- a/i18n/messages/museum.en-US.json
+++ b/i18n/messages/museum.en-US.json
@@ -235,6 +235,7 @@
   "museum.network.programs.selectedWorksCount": "{count} selected works",
   "museum.network.markdown.mediaOmitted": "Media omitted from the record view{suffix}.",
   "museum.network.markdown.scrollableTable": "Scrollable research table",
+  "museum.network.markdown.scrollTableHint": "Scroll horizontally to read the complete table.",
   "museum.network.objects.title": "Museum object record",
   "museum.network.objects.description": "Artwork, interpretation, collection status, rights, and technical documentation.",
   "museum.network.objects.back": "Back to programs",

--- a/tests/museum/network-ia-readonly.spec.ts
+++ b/tests/museum/network-ia-readonly.spec.ts
@@ -180,17 +180,19 @@ test.describe("Museum public IA rendered contract @surface @readonly", () => {
         card.getByText(/does not currently include an image/iu)
       ).toHaveCount(0);
     }
-    await page
-      .getByRole("link", {
-        name: "Patrolling the border between the Negev Desert and Jordan",
-        exact: true,
-      })
-      .scrollIntoViewIfNeeded();
+    const firstMagnumCollectionCard = page
+      .locator('[data-testid="museum-landing-media-card"]')
+      .filter({
+        has: page.getByRole("link", {
+          name: "Patrolling the border between the Negev Desert and Jordan",
+          exact: true,
+        }),
+      });
+    await firstMagnumCollectionCard.scrollIntoViewIfNeeded();
     await expect
       .poll(() =>
-        page
-          .locator('[data-testid="museum-landing-media-card"] img')
-          .nth(7)
+        firstMagnumCollectionCard
+          .locator("img")
           .evaluate(
             (image) =>
               image instanceof HTMLImageElement &&
@@ -200,6 +202,30 @@ test.describe("Museum public IA rendered contract @surface @readonly", () => {
       )
       .toBe(true);
     await retainScreenshot(page, testInfo, "museum-network-collection");
+    await expectNoHorizontalOverflow(page);
+
+    await openRoute(page, "/museum/network/projects");
+    const magnumProjectCard = page.locator("article").filter({
+      has: page.getByRole("link", { name: "Magnum Photos 75", exact: true }),
+    });
+    await expect(magnumProjectCard.locator("img")).toHaveCount(1);
+    await expect(magnumProjectCard.getByText("0", { exact: true })).toHaveCount(
+      0
+    );
+    await magnumProjectCard.scrollIntoViewIfNeeded();
+    await expect
+      .poll(() =>
+        magnumProjectCard
+          .locator("img")
+          .evaluate(
+            (image) =>
+              image instanceof HTMLImageElement &&
+              image.complete &&
+              image.naturalWidth > 0
+          )
+      )
+      .toBe(true);
+    await retainScreenshot(page, testInfo, "museum-network-projects");
     await expectNoHorizontalOverflow(page);
 
     await openRoute(page, "/museum/network/artists");

--- a/tests/museum/network-ia-readonly.spec.ts
+++ b/tests/museum/network-ia-readonly.spec.ts
@@ -165,6 +165,42 @@ test.describe("Museum public IA rendered contract @surface @readonly", () => {
           /^\/museum\/network\/works\/6529NM-W-\d{4}$/u.test(href)
       )
     ).toBe(true);
+    for (const title of [
+      "Patrolling the border between the Negev Desert and Jordan",
+      "Government soldiers in a church, Suchitoto, El Salvador",
+      "Demonstration, Western Wall, Jerusalem",
+      "Tripoli, Libya",
+      "Palmyra, Syria",
+    ]) {
+      const card = page
+        .locator('[data-testid="museum-landing-media-card"]')
+        .filter({ has: page.getByRole("link", { name: title, exact: true }) });
+      await expect(card.locator("img")).toHaveCount(1);
+      await expect(
+        card.getByText(/does not currently include an image/iu)
+      ).toHaveCount(0);
+    }
+    await page
+      .getByRole("link", {
+        name: "Patrolling the border between the Negev Desert and Jordan",
+        exact: true,
+      })
+      .scrollIntoViewIfNeeded();
+    await expect
+      .poll(() =>
+        page
+          .locator('[data-testid="museum-landing-media-card"] img')
+          .nth(7)
+          .evaluate(
+            (image) =>
+              image instanceof HTMLImageElement &&
+              image.complete &&
+              image.naturalWidth > 0
+          )
+      )
+      .toBe(true);
+    await retainScreenshot(page, testInfo, "museum-network-collection");
+    await expectNoHorizontalOverflow(page);
 
     await openRoute(page, "/museum/network/artists");
     const artistHrefs = await page


### PR DESCRIPTION
## Outcome\n\nRepairs the first-click Museum presentation defects found on production.\n\n- renders all five accessioned Magnum photographs in the permanent Collection\n- renders Magnum Photos 75 with representative artwork on Projects\n- renders all five Magnum works in Gift Acquisitions\n- links Magnum Photos 75 to its five photographers and reciprocally from artist pages\n- suppresses absent project platform/year instead of publishing blank fields and year 0\n- restores the specific selected/unminted Keys and Gates program description\n- keeps reviewed acquisition artwork visible on acquisition indexes\n- establishes a 16px Museum manuscript floor on mobile\n- adds a visible mobile cue for horizontally scrollable research tables\n- makes canonical work media responsive and restores Magnum display-rights wording\n- adds rendered browser regressions for the Collection and Projects surfaces\n\n## Validation\n\n- focused Museum Jest: 10 tests pass\n- lint:changed: pass\n- typecheck:changed: pass (1,635-file ratchet)\n- codex-diff-check: pass\n\nStaging and production qualification will follow the exact merged head.