### PR TITLE
test(museum): align staging contract with tiered presentation

### DIFF
--- a/ops/workstreams/museum-full-site-correction/active-context.md
+++ b/ops/workstreams/museum-full-site-correction/active-context.md
@@ -6,8 +6,8 @@
   `d438a57eb58d3abaf4d7fc549441c9a5af253190`; staging deploy `31681902527`
   and automatic staging E2E `31682667244` passed, including the complete
   668-route crawl and decoded Casey, Magnum, and Keys and Gates media checks.
-- Follow-up PR #3735 is open at signed exact head
-  `17e6fb8e2fdfbc30318fa6b16656775d3627b917`.
+- Follow-up PR #3735 merged as exact frontend main
+  `3bf97fb98a330e9fd42bcef40b0ffaec1d415aaf`.
 - Canonical Museum source is merged at
   `a5b64f7eb586a5a07024b56a0604d8b8ae0ea574`; post-merge run
   `31657649972` passed all six Museum, portable, catalog, and public-publication
@@ -51,7 +51,8 @@ AI-training permission.
 
 ## Next work
 
-1. Resolve every valid PR #3735 review or CI finding.
-2. Merge the exact approved head.
-3. Compose and qualify staging, then deploy and qualify production.
+1. Merge the test-only correction for the four stale tiering/card-count
+   assertions found by automatic staging E2E.
+2. Recompose and qualify staging on the resulting exact main.
+3. Deploy and qualify production.
 4. Audit every public Museum route live at desktop and 390px mobile widths.

--- a/ops/workstreams/museum-full-site-correction/run-log.md
+++ b/ops/workstreams/museum-full-site-correction/run-log.md
@@ -155,3 +155,20 @@ comes first; acquisition and accession follow.` before the next hosted lane
   Local qualification passed 78 focused/regression tests, changed lint,
   changed typecheck, formatting, and the Windows-safe diff check. Hosted
   exact-head review and CI are in progress.
+- PR #3735 passed its final exact-head review and CI gates and merged as
+  frontend main `3bf97fb98a330e9fd42bcef40b0ffaec1d415aaf`.
+- Staging composition `025db98989f8b2150323d860a9c9f22e98005900`
+  deployed successfully in run `31689338698`. Independent qualification
+  passed all 651 current Museum routes, all 12 permanent Collection images,
+  all five Magnum images, all 16 Keys and Gates images, and 12 retained
+  desktop/mobile overflow and visual checks.
+- Automatic staging E2E run `31690074532` passed 16 of 17 packs. The sole
+  failing pack exposed four stale assertions: two expected long manuscripts
+  to remain permanently expanded and two counted every contextual Work link
+  as a unique artwork card. The runtime, route crawl, media paint, layout, and
+  public copy all passed.
+- Updated the institutional-practice browser contract to open semantic
+  disclosure ancestors before checking tiered manuscript content and to count
+  artwork figures rather than unrelated contextual links. The exact failing
+  pack now passes 70/70 against staging across desktop and mobile. Changed
+  lint, changed typecheck, formatting, and the Windows-safe diff check pass.

--- a/tests/museum/institutional-practice-readonly.spec.ts
+++ b/tests/museum/institutional-practice-readonly.spec.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 
 import {
   expect,
@@ -29,6 +29,19 @@ const CASEY_WORK_HREFS = Array.from(
 const LOCAL_SHELL_ALLOWED_CONSOLE_ERROR_PATTERNS = [
   /^Analytics SDK: TypeError: Failed to fetch(?:\n|$)/,
 ];
+
+async function revealTieredContent(target: Locator): Promise<void> {
+  await target.evaluate((element) => {
+    let ancestor = element.parentElement;
+
+    while (ancestor) {
+      if (ancestor instanceof HTMLDetailsElement) {
+        ancestor.open = true;
+      }
+      ancestor = ancestor.parentElement;
+    }
+  });
+}
 
 if (
   REQUIRED_SOURCE_COMMIT !== null &&
@@ -351,11 +364,12 @@ test.describe("Museum institutional-practice publication @surface @large @readon
     page,
   }) => {
     await expectStudyRoute(page, EDITORIAL_ROUTE, REQUIRED_SOURCE_COMMIT);
-    await expect(
-      page.getByText("3.3 Forms demonstrated in the comparative study", {
-        exact: true,
-      })
-    ).toBeVisible();
+    const demonstratedForms = page.getByText(
+      "3.3 Forms demonstrated in the comparative study",
+      { exact: true }
+    );
+    await revealTieredContent(demonstratedForms);
+    await expect(demonstratedForms).toBeVisible();
     await expect(page.locator(`a[href="${STUDY_PATH}"]`).first()).toBeVisible();
   });
 
@@ -372,9 +386,6 @@ test.describe("Museum institutional-practice publication @surface @large @readon
   }) => {
     await expectStudyRoute(page, CASEY_ARTIST_ROUTE, REQUIRED_SOURCE_COMMIT);
     await expect(page.locator("body")).not.toContainText(/Standfirst/iu);
-    await expect(
-      page.locator('main a[href^="/museum/network/works/"]')
-    ).toHaveCount(7);
     await expect(page.locator("main figure img")).toHaveCount(7);
     for (const href of CASEY_WORK_HREFS) {
       await expect(
@@ -400,7 +411,9 @@ test.describe("Museum institutional-practice publication @surface @large @readon
     await expect(page.locator("body")).not.toContainText(
       /shared source, chronology, and factual-boundary matrix/iu
     );
-    await expect(page.locator("main table").first()).toBeVisible();
+    const sourceTable = page.locator("main table").first();
+    await revealTieredContent(sourceTable);
+    await expect(sourceTable).toBeVisible();
   });
 
   test("publishes Keys and Gates as an art-led program", async ({ page }) => {
@@ -421,10 +434,12 @@ test.describe("Museum institutional-practice publication @surface @large @readon
         exact: true,
       })
     ).toHaveCount(16);
-    await expect(
-      page.locator('main a[href^="/museum/network/works/"]')
-    ).toHaveCount(16);
     await expect(page.locator("main figure img")).toHaveCount(16);
+    await expect(
+      page.locator(
+        'main figure:has(img):has(a[href^="/museum/network/works/"])'
+      )
+    ).toHaveCount(16);
   });
 
   test("publishes each Keys and Gates selection as a complete work page", async ({


### PR DESCRIPTION
## Outcome\n\nCorrects the sole failing automatic staging E2E pack after Museum PR #3735. This is a test-contract and release-ledger change only; it does not change runtime UI, copy, routes, media, CSS, or application behavior.\n\n## Corrections\n\n- Open semantic disclosure ancestors before asserting tiered manuscript content.\n- Count unique artwork figures instead of every contextual link to a Work route.\n- Record exact staging qualification and failure diagnosis in the durable ledger.\n\n## Exact validation\n\n- Institutional-practice staging pack: 70/70 passed across desktop and mobile.\n- Changed lint: passed.\n- Changed typecheck: passed (1,635 files).\n- Prettier and Windows-safe diff check: passed.\n- Independent staging product qualification remains green: 651 routes, all Casey/Magnum/Keys and Gates media, and 12 desktop/mobile visual checks.\n