### PR TITLE
Fix notification reaction hover clipping

### DIFF
--- a/__tests__/components/brain/notifications/NotificationItems.test.tsx
+++ b/__tests__/components/brain/notifications/NotificationItems.test.tsx
@@ -47,6 +47,7 @@ describe("NotificationItems", () => {
     const firstRow = container.querySelector("#feed-item-1") as HTMLElement;
     expect(firstRow.style.contentVisibility).toBe("auto");
     expect(firstRow.style.containIntrinsicSize).toBe("auto 400px");
+    expect(firstRow.style.overflowClipMargin).toBe("4px");
     const firstCall = NotificationItem.mock.calls.at(0);
     const secondCall = NotificationItem.mock.calls.at(1);
     expect(firstCall?.[0]).toEqual(

--- a/__tests__/components/common/OverlappingAvatars.test.tsx
+++ b/__tests__/components/common/OverlappingAvatars.test.tsx
@@ -39,6 +39,26 @@ jest.mock("@/components/nft-image/utils/gateway-fallback", () => ({
 }));
 
 describe("OverlappingAvatars", () => {
+  it("portals tooltips outside paint-contained avatar rows", () => {
+    const { container } = render(
+      <OverlappingAvatars
+        items={[
+          {
+            key: "gpebbles",
+            pfpUrl: "https://cdn.warpcast.com/avatars/gpebbles.png",
+            ariaLabel: "View @gpebbles",
+            fallback: "GP",
+            title: "gpebbles",
+          },
+        ]}
+      />
+    );
+
+    const tooltip = screen.getByText("gpebbles");
+    expect(tooltip.closest("body")).toBe(document.body);
+    expect(container.contains(tooltip)).toBe(false);
+  });
+
   it("retries an optimized avatar load with unoptimized mode before showing fallback", () => {
     render(
       <OverlappingAvatars

--- a/components/brain/notifications/NotificationItems.tsx
+++ b/components/brain/notifications/NotificationItems.tsx
@@ -13,6 +13,9 @@ import NotificationItem from "./NotificationItem";
 const NOTIFICATION_ITEM_RENDERING_STYLE = {
   containIntrinsicSize: "auto 400px",
   contentVisibility: "auto",
+  // Keep paint containment for scroll performance while allowing the existing
+  // avatar and reaction hover scale to extend beyond the row boundary.
+  overflowClipMargin: "4px",
 } satisfies CSSProperties;
 
 interface NotificationItemsProps {

--- a/components/common/OverlappingAvatars.tsx
+++ b/components/common/OverlappingAvatars.tsx
@@ -6,7 +6,8 @@ import useIsTouchDevice from "@/hooks/useIsTouchDevice";
 import Image from "next/image";
 import Link from "next/link";
 import type { MouseEvent, ReactNode } from "react";
-import { useId } from "react";
+import { useId, useSyncExternalStore } from "react";
+import { createPortal } from "react-dom";
 import { Tooltip } from "react-tooltip";
 import { useGatewayImageLoadState } from "@/components/common/image/useGatewayImageLoadState";
 
@@ -83,6 +84,11 @@ export default function OverlappingAvatars({
 }: OverlappingAvatarsProps) {
   const baseId = useId();
   const isTouchDevice = useIsTouchDevice();
+  const hydrated = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false
+  );
   const slice = items.slice(0, maxCount);
   const sizeClass = SIZE_CLASS[size];
   const avatarRing =
@@ -144,14 +150,19 @@ export default function OverlappingAvatars({
           return (
             <span key={item.key} className="tw-inline-flex">
               {anchor}
-              <Tooltip
-                id={tooltipId}
-                place="top"
-                delayShow={250}
-                style={TOOLTIP_STYLES}
-              >
-                {item.tooltipContent ?? item.title}
-              </Tooltip>
+              {hydrated &&
+                createPortal(
+                  <Tooltip
+                    id={tooltipId}
+                    place="top"
+                    positionStrategy="fixed"
+                    delayShow={250}
+                    style={TOOLTIP_STYLES}
+                  >
+                    {item.tooltipContent ?? item.title}
+                  </Tooltip>,
+                  document.body
+                )}
             </span>
           );
         }


### PR DESCRIPTION
## Issue

- Reaction notification avatar handles did not appear on hover because the shared tooltip was clipped by each notification row's paint-containment boundary.
- The existing emoji/avatar hover scale was also clipped at the row edge.

## Fix

- Render shared overlapping-avatar tooltips in the document overlay layer with fixed positioning so notification containment cannot clip them.
- Preserve notification scroll optimization while allowing 4px of paint overflow for the existing 110% hover scale.

## Changes

- Portal `OverlappingAvatars` tooltips after hydration while preserving touch-device behavior.
- Add a bounded overflow clip margin to notification items.
- Add regression coverage for the tooltip portal boundary and hover overflow allowance.

## Validation

- Focused Jest suites: 2 passed, 4 tests passed.
- `6529 run check:changed` passed, including formatting, lint, type checking, and changed-file quality checks.
- React Doctor: 99/100; the only warning is the existing intentional `<img>` test mock for `next/image`.
- No local dev server or browser visual run was started.

## Risk

- Level: Low
- Why: The tooltip change is confined to a shared avatar primitive, touch behavior remains unchanged, and the notification paint allowance is bounded to 4px.
- Rollback: Revert the single commit.

## Review Notes

- Please focus on the portal lifecycle during hydration and the notification paint-margin tradeoff that preserves `content-visibility: auto`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification item rendering to prevent content from being clipped.
  * Improved avatar tooltip positioning and rendering, including more reliable behavior during page loading and hydration.
  * Tooltips now remain correctly positioned outside overlapping avatar containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->