### PR TITLE
Record Network Museum full-site production closeout

### DIFF
--- a/ops/workstreams/museum-full-site-correction/active-context.md
+++ b/ops/workstreams/museum-full-site-correction/active-context.md
@@ -8,6 +8,20 @@
   668-route crawl and decoded Casey, Magnum, and Keys and Gates media checks.
 - Follow-up PR #3735 merged as exact frontend main
   `3bf97fb98a330e9fd42bcef40b0ffaec1d415aaf`.
+- The test-contract follow-up PR #3737 merged as
+  `3fe402fc2e0c13be5ffb18bf16785c6560d7f7a2`; automatic staging E2E run
+  `31694252972` passed all 17 packs.
+- The final protected-main production candidate was
+  `6c7914a4eb270cb6acfa96eb7a8470106db91eb0`. Production deployment run
+  `31697156091` and automatic production E2E run `31698559323` passed,
+  including isolated evidence verification.
+- Three consecutive live `/api/version` readbacks matched exact production
+  `6c7914a4eb270cb6acfa96eb7a8470106db91eb0` with `stale:false`.
+- The independent production audit passed all 651 generated Museum routes,
+  with zero HTTP, soft-404, or Museum-boundary failures. The exact live
+  desktop/mobile Museum IA suite passed 6/6, including Collection membership,
+  all five Magnum photographs, all 16 Keys and Gates selections, responsive
+  layout, navigation, and WCAG A/AA checks.
 - Canonical Museum source is merged at
   `a5b64f7eb586a5a07024b56a0604d8b8ae0ea574`; post-merge run
   `31657649972` passed all six Museum, portable, catalog, and public-publication
@@ -51,8 +65,5 @@ AI-training permission.
 
 ## Next work
 
-1. Merge the test-only correction for the four stale tiering/card-count
-   assertions found by automatic staging E2E.
-2. Recompose and qualify staging on the resulting exact main.
-3. Deploy and qualify production.
-4. Audit every public Museum route live at desktop and 390px mobile widths.
+1. No release-critical work remains for this correction lane.
+2. Treat later Museum content or presentation changes as a new scoped release.

--- a/ops/workstreams/museum-full-site-correction/run-log.md
+++ b/ops/workstreams/museum-full-site-correction/run-log.md
@@ -172,3 +172,28 @@ comes first; acquisition and accession follow.` before the next hosted lane
   artwork figures rather than unrelated contextual links. The exact failing
   pack now passes 70/70 against staging across desktop and mobile. Changed
   lint, changed typecheck, formatting, and the Windows-safe diff check pass.
+- PR #3737 passed all hosted review and CI gates and merged as
+  `3fe402fc2e0c13be5ffb18bf16785c6560d7f7a2`. Staging composition
+  `e1be20a52eb197f0b2dc6ca3332a79ebb7c35e78` deployed in run
+  `31693491032`; automatic staging E2E run `31694252972` passed all 17 packs.
+- Two unrelated profile-interface PRs merged to protected main while the
+  Museum staging gates ran. The final production candidate therefore became
+  `6c7914a4eb270cb6acfa96eb7a8470106db91eb0`; neither intervening change
+  touched Museum runtime, tests, publication code, or routes. The unchanged
+  Museum release had already passed staging twice, and the final production
+  E2E exercised the complete exact candidate.
+- Production deploy run `31697156091` succeeded. Three consecutive live
+  `/api/version` checks returned exact version and announced version
+  `6c7914a4eb270cb6acfa96eb7a8470106db91eb0` with `stale:false`.
+- Automatic production E2E run `31698559323` succeeded: the read-only pack
+  job passed and the isolated verifier accepted the resulting evidence.
+- Independent live qualification expanded the current Museum surface
+  registry and publication into 651 concrete routes. All 651 passed with no
+  HTTP failure, soft 404, publication-unavailable state, or redirect outside
+  the Museum boundary. Report:
+  `C:\Users\Administrator\.codex\artifacts\museum-full-site-correction\production-6c7914a4-651-routes.json`.
+- The exact-source desktop/mobile Museum IA suite passed 6/6 on production.
+  It verified the two completed accessions in the permanent Collection,
+  Keys and Gates as selected and unminted, all five Magnum images, all 16
+  Keys and Gates images, canonical Work relations, responsive overflow,
+  keyboard/touch navigation, and automated WCAG A/AA checks.


### PR DESCRIPTION
## Summary
- record exact staging and production release SHAs and workflow runs
- record the 651-route live production audit
- record desktop/mobile image, layout, navigation, and accessibility qualification

Documentation only; no runtime, content, style, route, or deployment behavior changes.