### PR TITLE
Refine profile Quick Tags and card presentation

### DIFF
--- a/components/user/mention-shortcuts/UserPageMentionShortcuts.tsx
+++ b/components/user/mention-shortcuts/UserPageMentionShortcuts.tsx
@@ -41,6 +41,7 @@ import {
 import type { ReactNode, RefObject } from "react";
 import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import type { SupportedLocale } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
 
 const MAX_MEMBERS = 25;
@@ -50,6 +51,39 @@ const VISIBLE_QUICK_TAGS = 3;
 const LOADING_MESSAGE_KEY = "user.mentionShortcuts.loading";
 
 type QuickTagsView = "summary" | "manage" | "editor";
+
+function getAliasErrorDescription(
+  reserved: boolean,
+  aliasIsValid: boolean,
+  hasAlias: boolean
+): string | undefined {
+  if (reserved) return "mention-shortcut-reserved-error";
+  if (!aliasIsValid && hasAlias) return "mention-shortcut-name-error";
+  return undefined;
+}
+
+function getSearchStatus({
+  isFetching,
+  locale,
+  searchIsReady,
+  visibleResultCount,
+}: {
+  readonly isFetching: boolean;
+  readonly locale: SupportedLocale;
+  readonly searchIsReady: boolean;
+  readonly visibleResultCount: number;
+}): string {
+  if (!searchIsReady) {
+    return t(locale, "user.mentionShortcuts.searchPrompt");
+  }
+  if (isFetching) return t(locale, LOADING_MESSAGE_KEY);
+  if (visibleResultCount === 1) {
+    return t(locale, "user.mentionShortcuts.searchResult");
+  }
+  return t(locale, "user.mentionShortcuts.searchResults", {
+    count: visibleResultCount,
+  });
+}
 
 function AliasEditor({
   backLabel,
@@ -97,12 +131,11 @@ function AliasEditor({
   const aliasIsValid = /^\w{3,15}$/.test(normalizedAlias);
   const reserved = isReservedMentionAlias(normalizedAlias);
   const aliasHasError = alias.length > 0 && (!aliasIsValid || reserved);
-  let aliasErrorDescription: string | undefined;
-  if (reserved) {
-    aliasErrorDescription = "mention-shortcut-reserved-error";
-  } else if (!aliasIsValid && alias.length > 0) {
-    aliasErrorDescription = "mention-shortcut-name-error";
-  }
+  const aliasErrorDescription = getAliasErrorDescription(
+    reserved,
+    aliasIsValid,
+    alias.length > 0
+  );
   const canSave = aliasIsValid && !reserved && members.length > 0;
 
   const mutation = useMutation({
@@ -144,17 +177,12 @@ function AliasEditor({
     members.length < MAX_MEMBERS &&
     search.length >= MIN_SEARCH_LENGTH &&
     debouncedSearch === search;
-  let searchStatus = t(locale, "user.mentionShortcuts.searchPrompt");
-  if (searchIsReady && profileSearchQuery.isFetching) {
-    searchStatus = t(locale, LOADING_MESSAGE_KEY);
-  } else if (searchIsReady) {
-    searchStatus =
-      visibleIdentities.length === 1
-        ? t(locale, "user.mentionShortcuts.searchResult")
-        : t(locale, "user.mentionShortcuts.searchResults", {
-            count: visibleIdentities.length,
-          });
-  }
+  const searchStatus = getSearchStatus({
+    isFetching: profileSearchQuery.isFetching,
+    locale,
+    searchIsReady,
+    visibleResultCount: visibleIdentities.length,
+  });
 
   const addMember = (identity: CommunityMemberMinimal) => {
     const { profile_id: profileId, handle } = identity;

--- a/components/user/mention-shortcuts/UserPageMentionShortcuts.tsx
+++ b/components/user/mention-shortcuts/UserPageMentionShortcuts.tsx
@@ -439,7 +439,9 @@ export default function UserPageMentionShortcuts({
   const { connectedProfile, activeProfileProxy, setToast } =
     useContext(AuthContext);
   const isOwner =
-    !!profile.id && connectedProfile?.id === profile.id && !activeProfileProxy;
+    !!profile.id &&
+    connectedProfile?.id === profile.id &&
+    !activeProfileProxy;
   const queryClient = useQueryClient();
   const { aliases, isPending, isError, refetch } = useMentionAliases({
     enabled: isOwner,
@@ -480,7 +482,10 @@ export default function UserPageMentionShortcuts({
 
   const deleteMutation = useMutation({
     mutationFn: deleteMentionAlias,
-    onSuccess: async () => {
+    onSuccess: async (_data, deletedAliasId) => {
+      const deletedLastAlias = !aliases.some(
+        (alias) => alias.id !== deletedAliasId
+      );
       await queryClient.invalidateQueries({
         queryKey: [QueryKey.MENTION_ALIASES],
       });
@@ -489,6 +494,9 @@ export default function UserPageMentionShortcuts({
         message: t(locale, "user.mentionShortcuts.deleted"),
       });
       requestViewHeadingFocus();
+      if (deletedLastAlias) {
+        setView("summary");
+      }
       setAliasToDelete(null);
       setEditorAlias(null);
     },
@@ -571,13 +579,15 @@ export default function UserPageMentionShortcuts({
               {t(locale, "user.mentionShortcuts.summaryDescription")}
             </p>
           </div>
-          <button
-            type="button"
-            onClick={() => changeView("manage")}
-            className="tw-min-h-11 tw-shrink-0 tw-rounded-lg tw-border-0 tw-bg-transparent tw-px-2 tw-py-1.5 tw-text-sm tw-font-semibold tw-text-primary-300 tw-transition-colors focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 desktop-hover:hover:tw-text-primary-400 sm:tw-min-h-6 sm:tw-py-0"
-          >
-            {t(locale, "user.mentionShortcuts.manage")}
-          </button>
+          {sortedAliases.length > 0 && (
+            <button
+              type="button"
+              onClick={() => changeView("manage")}
+              className="tw-min-h-11 tw-shrink-0 tw-rounded-lg tw-border-0 tw-bg-transparent tw-px-2 tw-py-1.5 tw-text-sm tw-font-semibold tw-text-primary-300 tw-transition-colors focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 desktop-hover:hover:tw-text-primary-400 sm:tw-min-h-6 sm:tw-py-0"
+            >
+              {t(locale, "user.mentionShortcuts.manage")}
+            </button>
+          )}
         </div>
 
         <div className="tw-mt-2 tw-flex tw-min-w-0 tw-flex-wrap tw-gap-2">
@@ -591,14 +601,18 @@ export default function UserPageMentionShortcuts({
           )}
           {isError && <QuickTagsLoadError onRetry={() => void refetch()} />}
           {!isPending && !isError && sortedAliases.length === 0 && (
-            <button
-              type="button"
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={() => startEditing(null, "summary")}
-              className="tw-inline-flex tw-min-h-11 tw-items-center tw-gap-2 tw-rounded-lg tw-border-0 tw-bg-white/5 tw-px-4 tw-py-2.5 tw-text-sm tw-font-semibold tw-text-iron-100 tw-transition-colors focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 desktop-hover:hover:tw-bg-white/10 sm:tw-min-h-9 sm:tw-py-2"
+              className="tw-min-h-11 sm:tw-min-h-9"
             >
-              <PlusIcon aria-hidden="true" className="tw-size-4" />
+              <PlusIcon
+                aria-hidden="true"
+                className="-tw-ml-0.5 tw-size-4"
+              />
               {t(locale, "user.mentionShortcuts.new")}
-            </button>
+            </Button>
           )}
           {!isPending &&
             !isError &&

--- a/components/user/mention-shortcuts/UserPageMentionShortcuts.tsx
+++ b/components/user/mention-shortcuts/UserPageMentionShortcuts.tsx
@@ -483,9 +483,8 @@ export default function UserPageMentionShortcuts({
   const deleteMutation = useMutation({
     mutationFn: deleteMentionAlias,
     onSuccess: async (_data, deletedAliasId) => {
-      const deletedLastAlias = !aliases.some(
-        (alias) => alias.id !== deletedAliasId
-      );
+      const deletedLastAlias =
+        aliases.length === 1 && aliases[0]?.id === deletedAliasId;
       await queryClient.invalidateQueries({
         queryKey: [QueryKey.MENTION_ALIASES],
       });

--- a/components/user/rep/MobileTabCards.tsx
+++ b/components/user/rep/MobileTabCards.tsx
@@ -32,6 +32,9 @@ function MobileTabButton({
   const buttonStateClasses = isSelected
     ? SELECTED_BUTTON_CLASSES[tab]
     : "tw-border-transparent tw-bg-transparent desktop-hover:hover:tw-bg-white/[0.035]";
+  const labelColorClasses = isSelected
+    ? "tw-text-iron-300"
+    : "tw-text-iron-500";
   let valueColorClasses = isSelected ? "tw-text-white" : "tw-text-iron-400";
   if (tab === "rep" && isSelected) {
     valueColorClasses = "tw-text-primary-400";
@@ -43,7 +46,9 @@ function MobileTabButton({
       onClick={() => onTabChange(tab)}
       className={`tw-flex tw-min-h-16 tw-min-w-0 tw-cursor-pointer tw-flex-col tw-items-center tw-justify-center tw-gap-1 tw-rounded-lg tw-border tw-border-solid tw-py-2.5 tw-text-center tw-transition-colors tw-duration-200 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-[-2px] focus-visible:tw-outline-primary-300 active:tw-bg-white/[0.08] motion-reduce:tw-transition-none ${horizontalPaddingClasses} ${buttonStateClasses}`}
     >
-      <span className="tw-flex tw-max-w-full tw-items-center tw-justify-center tw-gap-1 tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-leading-4 tw-tracking-normal tw-text-iron-500 min-[360px]:tw-text-[0.6875rem] min-[360px]:tw-tracking-wider">
+      <span
+        className={`tw-flex tw-max-w-full tw-items-center tw-justify-center tw-gap-1 tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-leading-4 tw-tracking-normal min-[360px]:tw-text-[0.6875rem] min-[360px]:tw-tracking-wider ${labelColorClasses}`}
+      >
         <span className="tw-min-w-0 tw-whitespace-nowrap">{label}</span>
       </span>
       <span

--- a/components/user/rep/MobileTabCards.tsx
+++ b/components/user/rep/MobileTabCards.tsx
@@ -10,7 +10,7 @@ export type MobileTab = "rep" | "nic" | "statements";
 const SELECTED_BUTTON_CLASSES: Record<MobileTab, string> = {
   rep: "tw-border-primary-500/30 tw-bg-primary-500/10",
   nic: "tw-border-emerald-500/30 tw-bg-emerald-500/10",
-  statements: "tw-border-white/15 tw-bg-white/[0.06]",
+  statements: "tw-border-emerald-500/30 tw-bg-emerald-500/10",
 };
 
 function MobileTabButton({

--- a/components/waves/drops/participation/EndedParticipationDrop.tsx
+++ b/components/waves/drops/participation/EndedParticipationDrop.tsx
@@ -277,12 +277,8 @@ function EndedParticipationDropInner({
 
   return (
     <div
-      className={`${
-        location === DropLocation.WAVE
-          ? "tw-px-4 tw-py-1"
-          : location === DropLocation.PROFILE
-            ? "tw-mb-3"
-            : ""
+      className={`${location === DropLocation.WAVE ? "tw-px-4 tw-py-1" : ""} ${
+        location === DropLocation.PROFILE ? "tw-mb-3" : ""
       } tw-w-full`}
     >
       <div className="tw-group tw-relative tw-w-full">

--- a/components/waves/drops/participation/EndedParticipationDrop.tsx
+++ b/components/waves/drops/participation/EndedParticipationDrop.tsx
@@ -278,7 +278,11 @@ function EndedParticipationDropInner({
   return (
     <div
       className={`${
-        location === DropLocation.WAVE ? "tw-px-4 tw-py-1" : ""
+        location === DropLocation.WAVE
+          ? "tw-px-4 tw-py-1"
+          : location === DropLocation.PROFILE
+            ? "tw-mb-3"
+            : ""
       } tw-w-full`}
     >
       <div className="tw-group tw-relative tw-w-full">

--- a/components/waves/drops/participation/ParticipationDropContainer.tsx
+++ b/components/waves/drops/participation/ParticipationDropContainer.tsx
@@ -117,7 +117,13 @@ export default function ParticipationDropContainer({
 
   return (
     <div
-      className={`${location === DropLocation.WAVE ? "tw-px-4 tw-py-1" : ""} tw-w-full`}
+      className={`${
+        location === DropLocation.WAVE
+          ? "tw-px-4 tw-py-1"
+          : location === DropLocation.PROFILE
+            ? "tw-mb-3"
+            : ""
+      } tw-w-full`}
     >
       <div className="tw-group tw-relative tw-w-full">
         {floatingActions}

--- a/components/waves/drops/participation/ParticipationDropContainer.tsx
+++ b/components/waves/drops/participation/ParticipationDropContainer.tsx
@@ -117,12 +117,8 @@ export default function ParticipationDropContainer({
 
   return (
     <div
-      className={`${
-        location === DropLocation.WAVE
-          ? "tw-px-4 tw-py-1"
-          : location === DropLocation.PROFILE
-            ? "tw-mb-3"
-            : ""
+      className={`${location === DropLocation.WAVE ? "tw-px-4 tw-py-1" : ""} ${
+        location === DropLocation.PROFILE ? "tw-mb-3" : ""
       } tw-w-full`}
     >
       <div className="tw-group tw-relative tw-w-full">

--- a/components/waves/drops/winner/DefaultWinnerDrop.tsx
+++ b/components/waves/drops/winner/DefaultWinnerDrop.tsx
@@ -224,7 +224,11 @@ const DefaultWinnerDropInner = ({
   return (
     <div
       className={`tw-w-full ${
-        location === DropLocation.WAVE ? "tw-px-4 tw-py-1" : ""
+        location === DropLocation.WAVE
+          ? "tw-px-4 tw-py-1"
+          : location === DropLocation.PROFILE
+            ? "tw-mb-3"
+            : ""
       }`}
     >
       <div className="tw-group tw-relative tw-w-full">

--- a/components/waves/drops/winner/DefaultWinnerDrop.tsx
+++ b/components/waves/drops/winner/DefaultWinnerDrop.tsx
@@ -223,12 +223,8 @@ const DefaultWinnerDropInner = ({
 
   return (
     <div
-      className={`tw-w-full ${
-        location === DropLocation.WAVE
-          ? "tw-px-4 tw-py-1"
-          : location === DropLocation.PROFILE
-            ? "tw-mb-3"
-            : ""
+      className={`tw-w-full ${location === DropLocation.WAVE ? "tw-px-4 tw-py-1" : ""} ${
+        location === DropLocation.PROFILE ? "tw-mb-3" : ""
       }`}
     >
       <div className="tw-group tw-relative tw-w-full">


### PR DESCRIPTION
## Issue

- The Quick Tags empty state used a weak one-off action and still exposed Manage when there was nothing to manage.
- Deleting the final Quick Tag could leave the user in an empty management view.
- Participation and winner cards on profile Brain feeds had no separation, unlike regular profile posts.
- The mobile profile metric selection hierarchy was too subtle.
- The existing Quick Tags editor cleanup also addresses the SonarCloud cognitive-complexity finding.

## Fix

- Keep the editor control-flow cleanup while refining the reviewed profile UI with existing shared components, spacing tokens, and semantic color treatments.
- Scope feed spacing to profile locations so Waves rendering remains unchanged.

## Changes

- Use the shared small secondary button for the empty Quick Tags action.
- Hide Manage until at least one Quick Tag exists and return to the summary after deleting the final tag.
- Add the standard 12px profile-post gap to participation and winner cards.
- Match the selected ID Statements border and background to NIC's emerald state.
- Brighten every selected profile metric label from `iron-500` to `iron-300`.
- Keep all production data and authorization paths real; no preview aliases or development bypasses are included.

## Validation

- Manual browser review of the Quick Tags empty state, profile Brain card spacing, and mobile Identity metric states.
- Confirmed a 12px gap between adjacent profile proposal cards.
- Confirmed NIC and ID Statements resolve to the same selected border and background colors.
- Confirmed Total REP, NIC, and ID Statements selected labels all resolve to `iron-300`.
- `git diff --check`.
- Earlier cleanup head: `./bin/6529 run check:changed`, `./bin/6529 run react-doctor:diff` (100/100), and 17 focused tests passed.
- Latest-head GitHub CI passed: production build, quality/contracts, Playwright smoke, Playwright critical shell, installed-app checks, plan/security checks, Debt Ratchet, Snyk, CodeRabbit, and SonarCloud (0 new issues).

## Risk

- Level: Low
- Why: Presentation and empty-state flow changes are localized; no API, schema, dependency, auth, or deployment configuration changes.
- Rollback: Revert the signed UI follow-up commits.

## Review Notes

- The final-alias guard explicitly requires one loaded alias matching the deleted ID.
- The identical NIC/ID Statements emerald selected state is intentional and matches the reviewed design direction.
- The profile-only wrapper condition remains local in the three owning components; a shared cross-feature helper would add more coupling than this small styling rule warrants.
- Sonar-sensitive nested ternaries were removed without changing the rendered spacing classes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removing the final mention alias now returns you to the summary view.
  - The summary view only displays management controls when aliases exist.
  - Improved spacing for participation and winner cards shown on profiles.

- **Style**
  - Updated mobile Statements tab colors for clearer selected and unselected states.
  - Standardized the appearance of the alias creation action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->