### PR TITLE
Make Wave access groups clear and inspectable

### DIFF
--- a/__tests__/app/network/index.test.tsx
+++ b/__tests__/app/network/index.test.tsx
@@ -43,6 +43,9 @@ jest.mock(
 jest.mock("@/components/groups/sidebar/GroupsSidebar", () => () => (
   <div data-testid="groups-sidebar" />
 ));
+jest.mock("@/components/community/CommunityMembersGroupDetails", () => () => (
+  <div data-testid="group-details" />
+));
 jest.mock(
   "@/components/mobile-wrapper-dialog/MobileWrapperDialog",
   () =>

--- a/__tests__/components/community/CommunityMembers.test.tsx
+++ b/__tests__/components/community/CommunityMembers.test.tsx
@@ -44,6 +44,18 @@ jest.mock(
 jest.mock("@/components/groups/sidebar/GroupsSidebar", () => () => (
   <div data-testid="groups-sidebar" />
 ));
+jest.mock(
+  "@/components/community/CommunityMembersGroupDetails",
+  () =>
+    ({ groupId, onClose }: { groupId: string; onClose: () => void }) => (
+      <div data-testid="group-details">
+        {groupId}
+        <button type="button" onClick={onClose}>
+          Clear selected group
+        </button>
+      </div>
+    )
+);
 
 jest.mock(
   "@/components/mobile-wrapper-dialog/MobileWrapperDialog",
@@ -62,6 +74,7 @@ jest.mock(
 
 const push = jest.fn();
 const replace = jest.fn();
+const setActiveGroupId = jest.fn();
 
 const searchParamsMock = new Map<string, string | null>();
 (usePathname as jest.Mock).mockReturnValue("/network");
@@ -71,7 +84,7 @@ const searchParamsMock = new Map<string, string | null>();
 (useRouter as jest.Mock).mockReturnValue({ push, replace });
 (useActiveGroup as unknown as jest.Mock).mockReturnValue({
   activeGroupId: "1",
-  setActiveGroupId: jest.fn(),
+  setActiveGroupId,
 });
 
 function renderComponent() {
@@ -93,7 +106,7 @@ describe("CommunityMembers", () => {
     (useRouter as jest.Mock).mockReturnValue({ push, replace });
     (useActiveGroup as unknown as jest.Mock).mockReturnValue({
       activeGroupId: "1",
-      setActiveGroupId: jest.fn(),
+      setActiveGroupId,
     });
   });
 
@@ -116,6 +129,14 @@ describe("CommunityMembers", () => {
     renderComponent();
     expect(screen.getByTestId("table")).toHaveTextContent("2");
     expect(screen.getByTestId("pagination")).toHaveTextContent("2");
+    expect(screen.getByTestId("group-details")).toHaveTextContent("1");
+    expect(
+      screen.getByRole("heading", { name: "Members" })
+    ).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Clear selected group" })
+    );
+    expect(setActiveGroupId).toHaveBeenCalledWith(null);
   });
 
   it("navigates to nerd view on button click", () => {

--- a/__tests__/components/community/CommunityMembersGroupDetails.test.tsx
+++ b/__tests__/components/community/CommunityMembersGroupDetails.test.tsx
@@ -1,0 +1,112 @@
+import CommunityMembersGroupDetails from "@/components/community/CommunityMembersGroupDetails";
+import { commonApiFetch } from "@/services/api/common-api";
+import { useQuery } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+jest.mock("@tanstack/react-query", () => ({
+  useQuery: jest.fn(),
+}));
+
+jest.mock("@/services/api/common-api", () => ({
+  commonApiFetch: jest.fn(),
+}));
+
+jest.mock(
+  "@/components/groups/page/list/card/GroupCardConfigs",
+  () =>
+    ({ group }: any) => <div data-testid="group-criteria">{group.id}</div>
+);
+
+jest.mock("@/hooks/useBrowserLocale", () => ({
+  useBrowserLocale: () => "en-US",
+}));
+
+const useQueryMock = useQuery as jest.Mock;
+const commonApiFetchMock = commonApiFetch as jest.Mock;
+
+describe("CommunityMembersGroupDetails", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("shows a stable loading state", () => {
+    useQueryMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+
+    render(
+      <CommunityMembersGroupDetails groupId="group-1" onClose={jest.fn()} />
+    );
+
+    expect(screen.getByText("Loading group criteria")).toBeInTheDocument();
+  });
+
+  it("encodes the group id before adding it to the API path", async () => {
+    commonApiFetchMock.mockResolvedValue({});
+    useQueryMock.mockImplementation(({ queryFn }) => {
+      void queryFn();
+      return {
+        data: undefined,
+        isLoading: true,
+        isError: false,
+      };
+    });
+
+    render(
+      <CommunityMembersGroupDetails
+        groupId="group/with?segments"
+        onClose={jest.fn()}
+      />
+    );
+
+    await waitFor(() =>
+      expect(commonApiFetchMock).toHaveBeenCalledWith({
+        endpoint: "groups/group%2Fwith%3Fsegments",
+      })
+    );
+  });
+
+  it("shows a privacy-safe unavailable state", () => {
+    useQueryMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+
+    render(
+      <CommunityMembersGroupDetails groupId="private-id" onClose={jest.fn()} />
+    );
+
+    expect(screen.getByText("Group criteria unavailable")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This group may be private, deleted, or temporarily unavailable."
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByText("private-id")).not.toBeInTheDocument();
+  });
+
+  it("shows group criteria without edit controls", () => {
+    useQueryMock.mockReturnValue({
+      data: { id: "group-1", name: "Artists and curators" },
+      isLoading: false,
+      isError: false,
+    });
+
+    const onClose = jest.fn();
+    render(
+      <CommunityMembersGroupDetails groupId="group-1" onClose={onClose} />
+    );
+
+    expect(screen.getByText("Selected group")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Artists and curators" })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("group-criteria")).toHaveTextContent("group-1");
+    expect(screen.queryByText("Group options")).not.toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Clear selected group" })
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/components/community/CommunityMembersGroupDetails.test.tsx
+++ b/__tests__/components/community/CommunityMembersGroupDetails.test.tsx
@@ -87,6 +87,7 @@ describe("CommunityMembersGroupDetails", () => {
   });
 
   it.each([
+    { is_hidden: true },
     { is_private: true },
     { is_direct_message: true },
     { visible: false },

--- a/__tests__/components/community/CommunityMembersGroupDetails.test.tsx
+++ b/__tests__/components/community/CommunityMembersGroupDetails.test.tsx
@@ -1,7 +1,7 @@
 import CommunityMembersGroupDetails from "@/components/community/CommunityMembersGroupDetails";
 import { commonApiFetch } from "@/services/api/common-api";
 import { useQuery } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 jest.mock("@tanstack/react-query", () => ({
   useQuery: jest.fn(),
@@ -43,8 +43,9 @@ describe("CommunityMembersGroupDetails", () => {
 
   it("encodes the group id before adding it to the API path", async () => {
     commonApiFetchMock.mockResolvedValue({});
-    useQueryMock.mockImplementation(({ queryFn }) => {
-      void queryFn();
+    let queryFn: (() => Promise<unknown>) | undefined;
+    useQueryMock.mockImplementation((options) => {
+      queryFn = options.queryFn;
       return {
         data: undefined,
         isLoading: true,
@@ -59,11 +60,10 @@ describe("CommunityMembersGroupDetails", () => {
       />
     );
 
-    await waitFor(() =>
-      expect(commonApiFetchMock).toHaveBeenCalledWith({
-        endpoint: "groups/group%2Fwith%3Fsegments",
-      })
-    );
+    await queryFn?.();
+    expect(commonApiFetchMock).toHaveBeenCalledWith({
+      endpoint: "groups/group%2Fwith%3Fsegments",
+    });
   });
 
   it("shows a privacy-safe unavailable state", () => {
@@ -86,7 +86,31 @@ describe("CommunityMembersGroupDetails", () => {
     expect(screen.queryByText("private-id")).not.toBeInTheDocument();
   });
 
-  it("shows group criteria without edit controls", () => {
+  it.each([
+    { is_private: true },
+    { is_direct_message: true },
+    { visible: false },
+  ])("does not expose a private group returned by the API", (privacy) => {
+    useQueryMock.mockReturnValue({
+      data: {
+        id: "private-id",
+        name: "Private group name",
+        ...privacy,
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(
+      <CommunityMembersGroupDetails groupId="private-id" onClose={jest.fn()} />
+    );
+
+    expect(screen.getByText("Group criteria unavailable")).toBeInTheDocument();
+    expect(screen.queryByText("Private group name")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("group-criteria")).not.toBeInTheDocument();
+  });
+
+  it("shows visible group criteria and a clear action", () => {
     useQueryMock.mockReturnValue({
       data: { id: "group-1", name: "Artists and curators" },
       isLoading: false,
@@ -103,7 +127,6 @@ describe("CommunityMembersGroupDetails", () => {
       screen.getByRole("heading", { name: "Artists and curators" })
     ).toBeInTheDocument();
     expect(screen.getByTestId("group-criteria")).toHaveTextContent("group-1");
-    expect(screen.queryByText("Group options")).not.toBeInTheDocument();
     fireEvent.click(
       screen.getByRole("button", { name: "Clear selected group" })
     );

--- a/__tests__/components/community/CommunityMembersGroupDetails.test.tsx
+++ b/__tests__/components/community/CommunityMembersGroupDetails.test.tsx
@@ -1,4 +1,5 @@
 import CommunityMembersGroupDetails from "@/components/community/CommunityMembersGroupDetails";
+import type { ApiGroupFull } from "@/generated/models/ApiGroupFull";
 import { commonApiFetch } from "@/services/api/common-api";
 import { useQuery } from "@tanstack/react-query";
 import { fireEvent, render, screen } from "@testing-library/react";
@@ -14,7 +15,9 @@ jest.mock("@/services/api/common-api", () => ({
 jest.mock(
   "@/components/groups/page/list/card/GroupCardConfigs",
   () =>
-    ({ group }: any) => <div data-testid="group-criteria">{group.id}</div>
+    ({ group }: { readonly group: Pick<ApiGroupFull, "id"> }) => (
+      <div data-testid="group-criteria">{group.id}</div>
+    )
 );
 
 jest.mock("@/hooks/useBrowserLocale", () => ({

--- a/__tests__/components/waves/specs/WaveRulesPanel.test.tsx
+++ b/__tests__/components/waves/specs/WaveRulesPanel.test.tsx
@@ -1,0 +1,55 @@
+import WaveRulesPanel from "@/components/waves/specs/WaveRulesPanel";
+import type { WaveRules } from "@/helpers/waves/wave-rules.helpers";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const rules: WaveRules = {
+  automatic: [
+    {
+      id: "access",
+      title: "Access",
+      rows: [
+        {
+          id: "chat-access",
+          label: "Chat access",
+          value: "Artists",
+          valueHref: "/network?page=1&group=artists",
+          valueLinkLabel: "Inspect Artists group criteria and members",
+        },
+        {
+          id: "admin",
+          label: "Who can admin",
+          value: "Private group",
+        },
+      ],
+    },
+  ],
+  custom: {
+    binding: null,
+    display: null,
+    signatureRequired: false,
+  },
+};
+
+describe("WaveRulesPanel", () => {
+  it("renders visible groups as accessible links and private groups as text", () => {
+    render(<WaveRulesPanel rules={rules} showCustomRules={false} />);
+
+    const link = screen.getByRole("link", {
+      name: "Inspect Artists group criteria and members",
+    });
+    expect(link).toHaveAttribute("href", "/network?page=1&group=artists");
+    expect(link).toHaveClass("tw-min-h-11");
+    expect(link).toHaveClass("desktop-hover:hover:tw-text-primary-300");
+    expect(screen.getByText("Private group")).toBeInTheDocument();
+    expect(screen.getAllByRole("link")).toHaveLength(1);
+  });
+});

--- a/__tests__/components/waves/specs/WaveRulesPanel.test.tsx
+++ b/__tests__/components/waves/specs/WaveRulesPanel.test.tsx
@@ -1,11 +1,13 @@
 import WaveRulesPanel from "@/components/waves/specs/WaveRulesPanel";
 import type { WaveRules } from "@/helpers/waves/wave-rules.helpers";
+import type Link from "next/link";
+import type { ComponentProps } from "react";
 import { render, screen } from "@testing-library/react";
 
 jest.mock("next/link", () => ({
   __esModule: true,
-  default: ({ children, href, ...props }: any) => (
-    <a href={href} {...props}>
+  default: ({ children, href, ...props }: ComponentProps<typeof Link>) => (
+    <a href={href.toString()} {...props}>
       {children}
     </a>
   ),

--- a/__tests__/components/waves/specs/groups/group/WaveGroup.test.tsx
+++ b/__tests__/components/waves/specs/groups/group/WaveGroup.test.tsx
@@ -69,12 +69,12 @@ describe("WaveGroup", () => {
     expect(screen.getByText("Anyone")).toBeInTheDocument();
   });
 
-  it("clarifies empty chat scope only applies when chat is enabled", () => {
+  it('shows "Anyone" for an empty chat scope', () => {
     render(
       <WaveGroup {...baseProps} type={WaveGroupType.CHAT} scope={{} as any} />,
       { wrapper }
     );
 
-    expect(screen.getByText("Anyone when enabled")).toBeInTheDocument();
+    expect(screen.getByText("Anyone")).toBeInTheDocument();
   });
 });

--- a/__tests__/components/waves/specs/groups/group/WaveGroupScope.test.tsx
+++ b/__tests__/components/waves/specs/groups/group/WaveGroupScope.test.tsx
@@ -1,10 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import WaveGroupScope from "@/components/waves/specs/groups/group/WaveGroupScope";
+import type { ApiGroup } from "@/generated/models/ApiGroup";
+import { ApiProfileMin } from "@/generated/models/ApiProfileMin";
+import type Link from "next/link";
+import type { ComponentProps } from "react";
 
 jest.mock("next/link", () => ({
   __esModule: true,
-  default: ({ href, children, ...props }: any) => (
-    <a href={href} {...props}>
+  default: ({ href, children, ...props }: ComponentProps<typeof Link>) => (
+    <a href={href.toString()} {...props}>
       {children}
     </a>
   ),
@@ -16,7 +20,7 @@ jest.mock("@/helpers/image.helpers", () => ({
 
 describe("WaveGroupScope", () => {
   it("shows a non-interactive private label for hidden groups", () => {
-    const group = { is_hidden: true } as any;
+    const group = { is_hidden: true } satisfies ApiGroup;
     render(<WaveGroupScope group={group} />);
     expect(screen.getByText("Private group")).toBeInTheDocument();
     expect(screen.queryByRole("link")).not.toBeInTheDocument();
@@ -28,7 +32,7 @@ describe("WaveGroupScope", () => {
       name: "Private conversation",
       is_hidden: false,
       is_direct_message: true,
-    } as any;
+    } satisfies ApiGroup;
     render(<WaveGroupScope group={group} />);
     expect(screen.getByText("Private group")).toBeInTheDocument();
     expect(screen.queryByRole("link")).not.toBeInTheDocument();
@@ -39,8 +43,11 @@ describe("WaveGroupScope", () => {
       id: "1",
       name: "Group",
       is_hidden: false,
-      author: { handle: "alice", pfp: "img.png" },
-    } as any;
+      author: Object.assign(new ApiProfileMin(), {
+        handle: "alice",
+        pfp: "img.png",
+      }),
+    } satisfies ApiGroup;
     const { container } = render(<WaveGroupScope group={group} />);
     const link = screen.getByRole("link");
     expect(link).toHaveAttribute("href", "/network?page=1&group=1");
@@ -61,7 +68,7 @@ describe("WaveGroupScope", () => {
   it("does not reinterpret an incomplete visible group as public access", () => {
     render(
       <WaveGroupScope
-        group={{ id: "stale-group-id", is_hidden: false } as any}
+        group={{ id: "stale-group-id", is_hidden: false } satisfies ApiGroup}
       />
     );
     expect(screen.getByText("Group unavailable")).toBeInTheDocument();

--- a/__tests__/components/waves/specs/groups/group/WaveGroupScope.test.tsx
+++ b/__tests__/components/waves/specs/groups/group/WaveGroupScope.test.tsx
@@ -1,22 +1,71 @@
-import { render, screen } from '@testing-library/react';
-import WaveGroupScope from '@/components/waves/specs/groups/group/WaveGroupScope';
+import { render, screen } from "@testing-library/react";
+import WaveGroupScope from "@/components/waves/specs/groups/group/WaveGroupScope";
 
-jest.mock('next/link', () => ({ __esModule: true, default: ({ href, children, className }: any) => <a href={href} className={className}>{children}</a> }));
-jest.mock('@/helpers/image.helpers', () => ({ getScaledImageUri: (u: string) => 'scaled-' + u, ImageScale: { W_AUTO_H_50: '50' } }));
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ href, children, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+jest.mock("@/helpers/image.helpers", () => ({
+  getScaledImageUri: (u: string) => "scaled-" + u,
+  ImageScale: { W_AUTO_H_50: "50" },
+}));
 
-describe('WaveGroupScope', () => {
-  it('shows hidden label', () => {
+describe("WaveGroupScope", () => {
+  it("shows a non-interactive private label for hidden groups", () => {
     const group = { is_hidden: true } as any;
     render(<WaveGroupScope group={group} />);
-    expect(screen.getByText('Hidden')).toBeInTheDocument();
+    expect(screen.getByText("Private group")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
   });
 
-  it('renders link with image when visible', () => {
-    const group = { id: '1', name: 'Group', is_hidden: false, author: { handle: 'alice', pfp: 'img.png' } } as any;
+  it("shows a non-interactive private label for direct-message groups", () => {
+    const group = {
+      id: "dm-1",
+      name: "Private conversation",
+      is_hidden: false,
+      is_direct_message: true,
+    } as any;
     render(<WaveGroupScope group={group} />);
-    const link = screen.getByRole('link');
-    expect(link).toHaveAttribute('href', '/network?page=1&group=1');
-    expect(screen.getByRole('img')).toHaveAttribute('src', 'scaled-img.png');
-    expect(screen.getByText('Group')).toBeInTheDocument();
+    expect(screen.getByText("Private group")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("renders link with image when visible", () => {
+    const group = {
+      id: "1",
+      name: "Group",
+      is_hidden: false,
+      author: { handle: "alice", pfp: "img.png" },
+    } as any;
+    const { container } = render(<WaveGroupScope group={group} />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/network?page=1&group=1");
+    expect(link).toHaveAttribute(
+      "aria-label",
+      "Inspect Group group criteria and members"
+    );
+    expect(link).toHaveClass("tw-min-h-11");
+    expect(link).toHaveClass("desktop-hover:hover:tw-text-primary-300");
+    expect(container.querySelector("img")).toHaveAttribute(
+      "src",
+      "scaled-img.png"
+    );
+    expect(container.querySelector("img")).toHaveAttribute("alt", "");
+    expect(screen.getByText("Group")).toBeInTheDocument();
+  });
+
+  it("does not reinterpret an incomplete visible group as public access", () => {
+    render(
+      <WaveGroupScope
+        group={{ id: "stale-group-id", is_hidden: false } as any}
+      />
+    );
+    expect(screen.getByText("Group unavailable")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.queryByText("stale-group-id")).not.toBeInTheDocument();
   });
 });

--- a/__tests__/helpers/waves/wave-rules.helpers.test.ts
+++ b/__tests__/helpers/waves/wave-rules.helpers.test.ts
@@ -3,6 +3,7 @@ import { ApiWaveCreditType } from "@/generated/models/ApiWaveCreditType";
 import { ApiWaveMetadataType } from "@/generated/models/ApiWaveMetadataType";
 import { ApiWaveType } from "@/generated/models/ApiWaveType";
 import { buildWaveRules } from "@/helpers/waves/wave-rules.helpers";
+import { getScopeRuleValue } from "@/helpers/waves/wave-rules.shared";
 import type { CreateWaveConfig } from "@/types/waves.types";
 
 const createConfig = (): CreateWaveConfig => ({
@@ -92,7 +93,7 @@ describe("wave-rules.helpers", () => {
       expect.arrayContaining([
         ["Who can drop", "Artists"],
         ["Chat status", "Enabled"],
-        ["Chat access", "Anyone when enabled"],
+        ["Chat access", "Anyone"],
         ["Required metadata", "artist (Text)"],
         ["Negative voting", "Blocked"],
         ["Approval threshold", "25 Rep"],
@@ -323,7 +324,7 @@ describe("wave-rules.helpers", () => {
         }),
         expect.objectContaining({
           label: "Chat access",
-          value: "Anyone when enabled",
+          value: "Anyone",
         }),
       ])
     );
@@ -380,7 +381,7 @@ describe("wave-rules.helpers", () => {
         }),
         expect.objectContaining({
           label: "Chat access",
-          value: "Anyone when enabled",
+          value: "Anyone",
         }),
       ])
     );
@@ -442,7 +443,7 @@ describe("wave-rules.helpers", () => {
       expect.arrayContaining([
         expect.objectContaining({
           label: "Chat access",
-          value: "Anyone when enabled",
+          value: "Anyone",
         }),
         expect.objectContaining({ label: "Links", value: "Disabled" }),
         expect.objectContaining({ label: "Slow mode", value: "2m" }),
@@ -505,5 +506,75 @@ describe("wave-rules.helpers", () => {
         expect.objectContaining({ label: "Slow mode", value: "30s" }),
       ])
     );
+  });
+
+  it("keeps hidden scope groups private and non-interactive", () => {
+    expect(
+      getScopeRuleValue({
+        scope: { group: { is_hidden: true } },
+        fallback: "Anyone",
+      })
+    ).toEqual({
+      value: "Private group",
+      valueHref: undefined,
+      valueLinkLabel: undefined,
+    });
+  });
+
+  it("keeps direct-message scope groups private and non-interactive", () => {
+    expect(
+      getScopeRuleValue({
+        scope: {
+          group: {
+            id: "dm-1",
+            name: "Private conversation",
+            is_hidden: false,
+            is_direct_message: true,
+          },
+        },
+        fallback: "Anyone",
+      })
+    ).toEqual({
+      value: "Private group",
+      valueHref: undefined,
+      valueLinkLabel: undefined,
+    });
+  });
+
+  it("does not expose or link an incomplete visible group", () => {
+    expect(
+      getScopeRuleValue({
+        scope: {
+          group: {
+            id: "stale-group-id",
+            is_hidden: false,
+          },
+        },
+        fallback: "Anyone",
+      })
+    ).toEqual({
+      value: "Group unavailable",
+      valueHref: undefined,
+      valueLinkLabel: undefined,
+    });
+  });
+
+  it("links visible scope groups to criteria and members", () => {
+    expect(
+      getScopeRuleValue({
+        scope: {
+          group: {
+            id: "artists & curators",
+            name: "Artists and curators",
+            is_hidden: false,
+          },
+        },
+        fallback: "Anyone",
+      })
+    ).toEqual({
+      value: "Artists and curators",
+      valueHref: "/network?page=1&group=artists%20%26%20curators",
+      valueLinkLabel: "Inspect Artists and curators group criteria and members",
+    });
   });
 });

--- a/__tests__/helpers/waves/wave-rules.helpers.test.ts
+++ b/__tests__/helpers/waves/wave-rules.helpers.test.ts
@@ -521,6 +521,19 @@ describe("wave-rules.helpers", () => {
     });
   });
 
+  it("uses the fallback for an empty scope group", () => {
+    expect(
+      getScopeRuleValue({
+        scope: { group: null },
+        fallback: "Anyone",
+      })
+    ).toEqual({
+      value: "Anyone",
+      valueHref: undefined,
+      valueLinkLabel: undefined,
+    });
+  });
+
   it("keeps direct-message scope groups private and non-interactive", () => {
     expect(
       getScopeRuleValue({

--- a/components/community/CommunityMembers.tsx
+++ b/components/community/CommunityMembers.tsx
@@ -4,6 +4,8 @@ import type { CommunityMembersQuery } from "@/app/network/page";
 import { SortDirection } from "@/entities/ISort";
 import type { ApiCommunityMemberOverview } from "@/generated/models/ApiCommunityMemberOverview";
 import type { Page } from "@/helpers/Types";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import { t } from "@/i18n/messages";
 import { commonApiFetch } from "@/services/api/common-api";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -26,6 +28,7 @@ import {
 } from "@heroicons/react/24/outline";
 import GroupsSidebar from "../groups/sidebar/GroupsSidebar";
 import MobileWrapperDialog from "../mobile-wrapper-dialog/MobileWrapperDialog";
+import CommunityMembersGroupDetails from "./CommunityMembersGroupDetails";
 
 interface QueryUpdateInput {
   name: keyof typeof SEARCH_PARAMS_FIELDS;
@@ -91,6 +94,7 @@ function NetworkHeaderActionButton({
 
 export default function CommunityMembers() {
   useSetTitle("Network");
+  const locale = useBrowserLocale();
 
   const defaultSortBy = ApiCommunityMembersSortOption.Level;
   const defaultSortDirection = SortDirection.DESC;
@@ -101,7 +105,7 @@ export default function CommunityMembers() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const { activeGroupId } = useActiveGroup();
+  const { activeGroupId, setActiveGroupId } = useActiveGroup();
 
   const convertSortBy = useCallback(
     (sort: string | null): ApiCommunityMembersSortOption => {
@@ -403,6 +407,17 @@ export default function CommunityMembers() {
           </div>
         </div>
       </div>
+      {activeGroupId && (
+        <CommunityMembersGroupDetails
+          groupId={activeGroupId}
+          onClose={() => setActiveGroupId(null)}
+        />
+      )}
+      {activeGroupId && (
+        <h2 className="tw-mb-0 tw-mt-5 !tw-text-lg !tw-font-semibold !tw-leading-6 !tw-text-iron-50">
+          {t(locale, "network.groupInspection.membersTitle")}
+        </h2>
+      )}
       <div className="tailwind-scope tw-mt-2 tw-flow-root lg:tw-mt-3">
         {membersContent}
       </div>

--- a/components/community/CommunityMembers.tsx
+++ b/components/community/CommunityMembers.tsx
@@ -408,15 +408,15 @@ export default function CommunityMembers() {
         </div>
       </div>
       {activeGroupId && (
-        <CommunityMembersGroupDetails
-          groupId={activeGroupId}
-          onClose={() => setActiveGroupId(null)}
-        />
-      )}
-      {activeGroupId && (
-        <h2 className="tw-mb-0 tw-mt-5 !tw-text-lg !tw-font-semibold !tw-leading-6 !tw-text-iron-50">
-          {t(locale, "network.groupInspection.membersTitle")}
-        </h2>
+        <>
+          <CommunityMembersGroupDetails
+            groupId={activeGroupId}
+            onClose={() => setActiveGroupId(null)}
+          />
+          <h2 className="tw-mb-0 tw-mt-5 !tw-text-lg !tw-font-semibold !tw-leading-6 !tw-text-iron-50">
+            {t(locale, "network.groupInspection.membersTitle")}
+          </h2>
+        </>
       )}
       <div className="tailwind-scope tw-mt-2 tw-flow-root lg:tw-mt-3">
         {membersContent}

--- a/components/community/CommunityMembersGroupDetails.tsx
+++ b/components/community/CommunityMembersGroupDetails.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
+import GroupCardConfigs from "@/components/groups/page/list/card/GroupCardConfigs";
+import type { ApiGroupFull } from "@/generated/models/ApiGroupFull";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import { t } from "@/i18n/messages";
+import { commonApiFetch } from "@/services/api/common-api";
+import { XMarkIcon } from "@heroicons/react/24/outline";
+import { useQuery } from "@tanstack/react-query";
+
+export default function CommunityMembersGroupDetails({
+  groupId,
+  onClose,
+}: {
+  readonly groupId: string;
+  readonly onClose: () => void;
+}) {
+  const locale = useBrowserLocale();
+  const {
+    data: group,
+    isLoading,
+    isError,
+  } = useQuery<ApiGroupFull>({
+    queryKey: [QueryKey.GROUP, groupId],
+    queryFn: async () =>
+      await commonApiFetch<ApiGroupFull>({
+        endpoint: `groups/${encodeURIComponent(groupId)}`,
+      }),
+  });
+  const closeButton = (
+    <button
+      type="button"
+      onClick={onClose}
+      aria-label={t(locale, "network.groupInspection.close")}
+      title={t(locale, "network.groupInspection.close")}
+      className="tw-flex tw-size-11 tw-shrink-0 tw-cursor-pointer tw-items-center tw-justify-center tw-rounded-lg tw-border-0 tw-bg-transparent tw-p-0 tw-text-iron-400 tw-transition-colors tw-duration-200 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 desktop-hover:hover:tw-text-iron-50 sm:tw-size-8"
+    >
+      <XMarkIcon className="tw-size-4" aria-hidden="true" />
+    </button>
+  );
+
+  if (isLoading) {
+    return (
+      <section
+        aria-live="polite"
+        className="tw-mt-3 tw-min-h-20 tw-rounded-lg tw-border tw-border-solid tw-border-white/5 tw-bg-iron-950 tw-p-3"
+      >
+        <div className="tw-flex tw-items-start tw-justify-between tw-gap-3">
+          <p className="tw-m-0 tw-min-w-0 tw-text-sm tw-font-medium tw-text-iron-400">
+            {t(locale, "network.groupInspection.loading")}
+          </p>
+          {closeButton}
+        </div>
+      </section>
+    );
+  }
+
+  if (isError || !group) {
+    return (
+      <section
+        aria-labelledby="group-criteria-unavailable-title"
+        className="tw-mt-3 tw-rounded-lg tw-border tw-border-solid tw-border-white/5 tw-bg-iron-950 tw-p-3"
+      >
+        <div className="tw-flex tw-items-start tw-justify-between tw-gap-3">
+          <h2
+            id="group-criteria-unavailable-title"
+            className="tw-m-0 tw-min-w-0 !tw-text-base !tw-font-semibold !tw-leading-6 !tw-text-iron-100"
+          >
+            {t(locale, "network.groupInspection.unavailableTitle")}
+          </h2>
+          {closeButton}
+        </div>
+        <p className="tw-mb-0 tw-mt-1.5 tw-text-sm tw-leading-5 tw-text-iron-400">
+          {t(locale, "network.groupInspection.unavailableDescription")}
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      aria-labelledby="selected-group-name"
+      className="tw-mt-3 tw-rounded-lg tw-border tw-border-solid tw-border-white/5 tw-bg-iron-950 tw-p-3"
+    >
+      <div className="tw-flex tw-items-start tw-justify-between tw-gap-3">
+        <div className="tw-min-w-0">
+          <p className="tw-mb-1 tw-mt-0 tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-leading-4 tw-tracking-[0.08em] tw-text-iron-400">
+            {t(locale, "network.groupInspection.selectedGroup")}
+          </p>
+          <h2
+            id="selected-group-name"
+            className="tw-m-0 tw-break-words !tw-text-base !tw-font-semibold !tw-leading-5 !tw-text-iron-50"
+          >
+            {group.name}
+          </h2>
+        </div>
+        {closeButton}
+      </div>
+      <div className="tw-mt-2.5 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/5 tw-pt-2.5">
+        <GroupCardConfigs group={group} />
+      </div>
+    </section>
+  );
+}

--- a/components/community/CommunityMembersGroupDetails.tsx
+++ b/components/community/CommunityMembersGroupDetails.tsx
@@ -56,7 +56,15 @@ export default function CommunityMembersGroupDetails({
     );
   }
 
-  if (isError || !group) {
+  if (
+    isError ||
+    !group ||
+    group.name.trim().length === 0 ||
+    group.id.trim().length === 0 ||
+    group.is_private === true ||
+    group.is_direct_message === true ||
+    group.visible === false
+  ) {
     return (
       <section
         aria-labelledby="group-criteria-unavailable-title"
@@ -78,6 +86,8 @@ export default function CommunityMembersGroupDetails({
     );
   }
 
+  const groupName = group.name.trim();
+
   return (
     <section
       aria-labelledby="selected-group-name"
@@ -92,7 +102,7 @@ export default function CommunityMembersGroupDetails({
             id="selected-group-name"
             className="tw-m-0 tw-break-words !tw-text-base !tw-font-semibold !tw-leading-5 !tw-text-iron-50"
           >
-            {group.name}
+            {groupName}
           </h2>
         </div>
         {closeButton}

--- a/components/community/CommunityMembersGroupDetails.tsx
+++ b/components/community/CommunityMembersGroupDetails.tsx
@@ -61,6 +61,7 @@ export default function CommunityMembersGroupDetails({
     !group ||
     group.name.trim().length === 0 ||
     group.id.trim().length === 0 ||
+    ("is_hidden" in group && group.is_hidden === true) ||
     group.is_private === true ||
     group.is_direct_message === true ||
     group.visible === false

--- a/components/community/CommunityMembersGroupDetails.tsx
+++ b/components/community/CommunityMembersGroupDetails.tsx
@@ -2,12 +2,15 @@
 
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
 import GroupCardConfigs from "@/components/groups/page/list/card/GroupCardConfigs";
+import type { ApiGroup } from "@/generated/models/ApiGroup";
 import type { ApiGroupFull } from "@/generated/models/ApiGroupFull";
 import { useBrowserLocale } from "@/hooks/useBrowserLocale";
 import { t } from "@/i18n/messages";
 import { commonApiFetch } from "@/services/api/common-api";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { useQuery } from "@tanstack/react-query";
+
+type InspectableGroup = ApiGroupFull & Pick<Partial<ApiGroup>, "is_hidden">;
 
 export default function CommunityMembersGroupDetails({
   groupId,
@@ -21,10 +24,10 @@ export default function CommunityMembersGroupDetails({
     data: group,
     isLoading,
     isError,
-  } = useQuery<ApiGroupFull>({
+  } = useQuery<InspectableGroup>({
     queryKey: [QueryKey.GROUP, groupId],
     queryFn: async () =>
-      await commonApiFetch<ApiGroupFull>({
+      await commonApiFetch<InspectableGroup>({
         endpoint: `groups/${encodeURIComponent(groupId)}`,
       }),
   });
@@ -61,7 +64,7 @@ export default function CommunityMembersGroupDetails({
     !group ||
     group.name.trim().length === 0 ||
     group.id.trim().length === 0 ||
-    ("is_hidden" in group && group.is_hidden === true) ||
+    group.is_hidden === true ||
     group.is_private === true ||
     group.is_direct_message === true ||
     group.visible === false

--- a/components/waves/specs/WaveRulesPanel.tsx
+++ b/components/waves/specs/WaveRulesPanel.tsx
@@ -3,6 +3,7 @@ import type {
   WaveRules,
 } from "@/helpers/waves/wave-rules.helpers";
 import { waveRightPanelText } from "@/helpers/waves/wave-right-panel.helpers";
+import Link from "next/link";
 
 interface WaveRulesPanelProps {
   readonly rules: WaveRules;
@@ -149,7 +150,18 @@ export default function WaveRulesPanel({
                     {row.label}
                   </dt>
                   <dd className="tw-mb-0 tw-ml-0 tw-min-w-0 tw-break-words tw-text-right tw-font-medium tw-leading-5 tw-text-iron-50">
-                    {row.value}
+                    {row.valueHref ? (
+                      <Link
+                        href={row.valueHref}
+                        aria-label={row.valueLinkLabel}
+                        title={row.value}
+                        className="tw-inline-flex tw-min-h-11 tw-max-w-full tw-cursor-pointer tw-items-center tw-justify-end tw-break-words tw-rounded-md tw-text-right tw-text-iron-50 tw-underline tw-underline-offset-2 tw-transition-colors tw-duration-200 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 desktop-hover:hover:tw-text-primary-300 desktop-hover:hover:tw-decoration-2 sm:tw-min-h-9"
+                      >
+                        {row.value}
+                      </Link>
+                    ) : (
+                      row.value
+                    )}
                     {row.description && (
                       <span className="tw-mt-1 tw-block tw-text-xs tw-font-medium tw-leading-4 tw-text-iron-500">
                         {row.description}

--- a/components/waves/specs/groups/group/WaveGroup.tsx
+++ b/components/waves/specs/groups/group/WaveGroup.tsx
@@ -10,7 +10,7 @@ import { canEditWave } from "@/helpers/waves/waves.helpers";
 import { DEFAULT_LOCALE } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
 import WaveGroupScope from "./WaveGroupScope";
-import { WaveGroupType } from "./WaveGroup.types";
+import type { WaveGroupType } from "./WaveGroup.types";
 
 export default function WaveGroup({
   scope,
@@ -25,10 +25,7 @@ export default function WaveGroup({
   const showEdit =
     canEditWave({ connectedProfile, activeProfileProxy, wave }) &&
     !scope.group?.is_direct_message;
-  const emptyScopeLabel =
-    type === WaveGroupType.CHAT
-      ? t(DEFAULT_LOCALE, "waves.chatSettings.access.anyoneWhenEnabled")
-      : t(DEFAULT_LOCALE, "waves.chatSettings.access.anyone");
+  const emptyScopeLabel = t(DEFAULT_LOCALE, "waves.chatSettings.access.anyone");
 
   return (
     <div className="tw-group tw-relative tw-grid tw-min-h-9 tw-w-full tw-grid-cols-[minmax(5.5rem,0.7fr)_minmax(0,1.3fr)] tw-items-start tw-gap-x-2 tw-px-2 tw-py-1.5 tw-text-sm">

--- a/components/waves/specs/groups/group/WaveGroupScope.tsx
+++ b/components/waves/specs/groups/group/WaveGroupScope.tsx
@@ -1,34 +1,53 @@
 import Link from "next/link";
 import type { ApiGroup } from "@/generated/models/ApiGroup";
 import { getScaledImageUri, ImageScale } from "@/helpers/image.helpers";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 
 export default function WaveGroupScope({
   group,
 }: {
   readonly group: ApiGroup;
 }) {
-  if (group.is_hidden) {
-    return <span className="tw-font-medium tw-text-iron-50">Hidden</span>;
+  if (group.is_hidden || group.is_direct_message) {
+    return (
+      <span className="tw-py-0.5 tw-font-medium tw-text-iron-50">
+        {t(DEFAULT_LOCALE, "waves.chatSettings.access.privateGroup")}
+      </span>
+    );
+  }
+
+  const groupId = group.id?.trim();
+  const groupName = group.name?.trim();
+  if (!groupId || !groupName) {
+    return (
+      <span className="tw-py-0.5 tw-font-medium tw-text-iron-50">
+        {t(DEFAULT_LOCALE, "waves.chatSettings.access.unavailableGroup")}
+      </span>
+    );
   }
 
   return (
     <Link
-      href={`/network?page=1&group=${group.id}`}
-      title={group.name}
-      className="tw-flex tw-min-w-0 tw-items-center tw-gap-x-1.5 tw-py-0.5 tw-text-iron-50 tw-no-underline focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 desktop-hover:hover:tw-text-iron-200 desktop-hover:hover:tw-underline"
+      href={`/network?page=1&group=${encodeURIComponent(groupId)}`}
+      aria-label={t(DEFAULT_LOCALE, "waves.chatSettings.access.inspectGroup", {
+        groupName,
+      })}
+      title={groupName}
+      className="tw-flex tw-min-h-11 tw-min-w-0 tw-cursor-pointer tw-items-center tw-justify-end tw-gap-x-1.5 tw-rounded-md tw-text-iron-50 tw-no-underline focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 desktop-hover:hover:tw-text-primary-300 desktop-hover:hover:tw-underline desktop-hover:hover:tw-decoration-2 sm:tw-min-h-9"
     >
       {group.author?.pfp ? (
         <img
           className="tw-h-5 tw-w-5 tw-flex-shrink-0 tw-rounded-md tw-bg-iron-800/80 tw-shadow-sm"
           src={getScaledImageUri(group.author.pfp, ImageScale.W_AUTO_H_50)}
-          alt={group.author.handle ?? ""}
+          alt=""
         />
       ) : (
         <div className="tw-h-5 tw-w-5 tw-flex-shrink-0 tw-rounded-md tw-bg-iron-800/80" />
       )}
-      <div className="tw-min-w-0 tw-truncate tw-font-medium tw-leading-5 tw-underline tw-transition tw-duration-300 tw-ease-out desktop-hover:group-hover:tw-text-iron-400">
-        {group.name}
-      </div>
+      <span className="tw-min-w-0 tw-break-words tw-text-right tw-font-medium tw-leading-5 tw-underline tw-underline-offset-2 tw-transition tw-duration-300 tw-ease-out">
+        {groupName}
+      </span>
     </Link>
   );
 }

--- a/components/waves/specs/groups/group/edit/buttons/subcomponents/WaveGroupEditMenu.tsx
+++ b/components/waves/specs/groups/group/edit/buttons/subcomponents/WaveGroupEditMenu.tsx
@@ -123,7 +123,7 @@ export default function WaveGroupEditMenu({
   return (
     <div className="tw-relative">
       <CompactMenu
-        triggerClassName="tw-flex tw-size-7 tw-items-center tw-justify-center tw-rounded-lg tw-border-0 tw-bg-transparent tw-text-iron-500 desktop-hover:hover:tw-text-iron-300 hover:tw-bg-iron-800 tw-transition tw-duration-300 tw-ease-out"
+        triggerClassName="tw-flex tw-size-11 tw-items-center tw-justify-center tw-rounded-lg tw-border-0 tw-bg-transparent tw-text-iron-500 desktop-hover:hover:tw-text-iron-300 hover:tw-bg-iron-800 tw-transition tw-duration-300 tw-ease-out sm:tw-size-7"
         trigger={<WaveGroupEditMenuTrigger label={GROUP_OPTIONS_LABEL} />}
         aria-label={GROUP_OPTIONS_LABEL}
         items={menuItems}

--- a/helpers/waves/wave-existing-rules.helpers.ts
+++ b/helpers/waves/wave-existing-rules.helpers.ts
@@ -25,7 +25,7 @@ import {
   getDecisionRows,
   getRequiredMediaLabel,
   getRequiredMetadataLabel,
-  getScopeLabel,
+  getScopeRuleValue,
   getSubmissionStrategyRows,
   getTermsLabel,
   getWaveChatAccessRow,
@@ -44,6 +44,22 @@ interface WaveRulesContext {
 
 const getOptionalRulesText = (value: string): string | null =>
   value.length > 0 ? value : null;
+
+const getWaveScopeRow = ({
+  id,
+  label,
+  scope,
+  fallback,
+}: {
+  readonly id: string;
+  readonly label: string;
+  readonly scope: ApiWave["visibility"]["scope"];
+  readonly fallback: string;
+}): WaveRuleRow => ({
+  id,
+  label,
+  ...getScopeRuleValue({ scope, fallback }),
+});
 
 const getWaveCreditLabel = (
   creditType: ApiWaveCreditType | null | undefined
@@ -77,22 +93,18 @@ const getWaveDropAndVoteRows = ({
   }
 
   return [
-    {
+    getWaveScopeRow({
       id: "can-drop",
       label: "Who can drop",
-      value: getScopeLabel({
-        scope: wave.participation.scope,
-        fallback: "Anyone",
-      }),
-    },
-    {
+      scope: wave.participation.scope,
+      fallback: "Anyone",
+    }),
+    getWaveScopeRow({
       id: "can-vote",
       label: "Who can vote",
-      value: getScopeLabel({
-        scope: wave.voting.scope,
-        fallback: "Anyone",
-      }),
-    },
+      scope: wave.voting.scope,
+      fallback: "Anyone",
+    }),
   ];
 };
 
@@ -113,24 +125,20 @@ const getWaveAccessSection = (context: WaveRulesContext): WaveRuleSection => ({
   id: "access",
   title: "Access",
   rows: [
-    {
+    getWaveScopeRow({
       id: "can-view",
       label: "Who can view",
-      value: getScopeLabel({
-        scope: context.wave.visibility.scope,
-        fallback: "Anyone",
-      }),
-    },
+      scope: context.wave.visibility.scope,
+      fallback: "Anyone",
+    }),
     ...getWaveDropAndVoteRows(context),
     ...getWaveChatRows(context),
-    {
+    getWaveScopeRow({
       id: "admin",
       label: "Who can admin",
-      value: getScopeLabel({
-        scope: context.wave.wave.admin_group,
-        fallback: "Creator/admin group",
-      }),
-    },
+      scope: context.wave.wave.admin_group,
+      fallback: "Creator/admin group",
+    }),
   ],
 });
 

--- a/helpers/waves/wave-rules.shared.ts
+++ b/helpers/waves/wave-rules.shared.ts
@@ -201,13 +201,14 @@ export const getScopeRuleValue = ({
 }): Pick<WaveRuleRow, "value" | "valueHref" | "valueLinkLabel"> => {
   const value = getScopeLabel({ scope, fallback });
   const valueHref = getScopeLink(scope);
+  const groupName = scope?.group?.name?.trim();
 
   return {
     value,
     valueHref,
     valueLinkLabel: valueHref
       ? t(DEFAULT_LOCALE, "waves.chatSettings.access.inspectGroup", {
-          groupName: value,
+          groupName: groupName ?? value,
         })
       : undefined,
   };

--- a/helpers/waves/wave-rules.shared.ts
+++ b/helpers/waves/wave-rules.shared.ts
@@ -22,6 +22,8 @@ export interface WaveRuleRow {
   readonly id: string;
   readonly label: string;
   readonly value: string;
+  readonly valueHref?: string | undefined;
+  readonly valueLinkLabel?: string | undefined;
   readonly description?: string | undefined;
 }
 
@@ -61,9 +63,14 @@ const REQUIRED_MEDIA_LABELS: Record<ApiWaveParticipationRequirement, string> = {
 const MINUTE_IN_MS = 60 * 1000;
 const HOUR_IN_MS = 60 * MINUTE_IN_MS;
 const DAY_IN_MS = 24 * HOUR_IN_MS;
-const CHAT_ACCESS_FALLBACK = t(
+const ANYONE_LABEL = t(DEFAULT_LOCALE, "waves.chatSettings.access.anyone");
+const PRIVATE_GROUP_LABEL = t(
   DEFAULT_LOCALE,
-  "waves.chatSettings.access.anyoneWhenEnabled"
+  "waves.chatSettings.access.privateGroup"
+);
+const UNAVAILABLE_GROUP_LABEL = t(
+  DEFAULT_LOCALE,
+  "waves.chatSettings.access.unavailableGroup"
 );
 
 export const formatFiniteNumber = (
@@ -145,16 +152,66 @@ const getGroupName = (
     return name;
   }
 
-  return group?.id ?? null;
+  return null;
 };
 
-export const getScopeLabel = ({
+const getScopeLabel = ({
   scope,
   fallback,
 }: {
   readonly scope: ApiWaveScope | null | undefined;
   readonly fallback: string;
-}): string => getGroupName(scope?.group) ?? fallback;
+}): string => {
+  if (scope?.group === null || scope?.group === undefined) {
+    return fallback;
+  }
+
+  if (scope.group.is_hidden || scope.group.is_direct_message) {
+    return PRIVATE_GROUP_LABEL;
+  }
+
+  return getGroupName(scope.group) ?? UNAVAILABLE_GROUP_LABEL;
+};
+
+const getScopeLink = (
+  scope: ApiWaveScope | null | undefined
+): string | undefined => {
+  const group = scope?.group;
+  const groupId = group?.id?.trim();
+  const groupName = group?.name?.trim();
+  if (
+    !group ||
+    group.is_hidden ||
+    group.is_direct_message ||
+    !groupId ||
+    !groupName
+  ) {
+    return undefined;
+  }
+
+  return `/network?page=1&group=${encodeURIComponent(groupId)}`;
+};
+
+export const getScopeRuleValue = ({
+  scope,
+  fallback,
+}: {
+  readonly scope: ApiWaveScope | null | undefined;
+  readonly fallback: string;
+}): Pick<WaveRuleRow, "value" | "valueHref" | "valueLinkLabel"> => {
+  const value = getScopeLabel({ scope, fallback });
+  const valueHref = getScopeLink(scope);
+
+  return {
+    value,
+    valueHref,
+    valueLinkLabel: valueHref
+      ? t(DEFAULT_LOCALE, "waves.chatSettings.access.inspectGroup", {
+          groupName: value,
+        })
+      : undefined,
+  };
+};
 
 export const getChatStatusRow = ({
   enabled,
@@ -171,10 +228,19 @@ export const getChatStatusRow = ({
   ),
 });
 
-const getChatAccessRow = (value: string): WaveRuleRow => ({
+const getChatAccessRow = ({
+  value,
+  valueHref,
+  valueLinkLabel,
+}: Pick<
+  WaveRuleRow,
+  "value" | "valueHref" | "valueLinkLabel"
+>): WaveRuleRow => ({
   id: "chat-access",
   label: t(DEFAULT_LOCALE, "waves.chatSettings.access.label"),
   value,
+  valueHref,
+  valueLinkLabel,
 });
 
 export const getCreateGroupLabel = ({
@@ -200,13 +266,13 @@ export const getCreateChatAccessRow = ({
   readonly groupId: string | null | undefined;
   readonly groupsCache: Readonly<Record<string, ApiGroupFull>> | undefined;
 }): WaveRuleRow =>
-  getChatAccessRow(
-    getCreateGroupLabel({
+  getChatAccessRow({
+    value: getCreateGroupLabel({
       groupId,
       groupsCache,
-      fallback: CHAT_ACCESS_FALLBACK,
-    })
-  );
+      fallback: ANYONE_LABEL,
+    }),
+  });
 
 export const getWaveChatAccessRow = ({
   scope,
@@ -214,9 +280,9 @@ export const getWaveChatAccessRow = ({
   readonly scope: ApiWaveScope | null | undefined;
 }): WaveRuleRow =>
   getChatAccessRow(
-    getScopeLabel({
+    getScopeRuleValue({
       scope,
-      fallback: CHAT_ACCESS_FALLBACK,
+      fallback: ANYONE_LABEL,
     })
   );
 

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -1522,8 +1522,10 @@ const WAVE_STORM_COMPOSER_MESSAGES = objectMessages("waves.stormComposer", {
 
 const WAVE_CHAT_SETTINGS_MESSAGES = objectMessages("waves.chatSettings", {
   "access.anyone": "Anyone",
-  "access.anyoneWhenEnabled": "Anyone when enabled",
+  "access.inspectGroup": "Inspect {groupName} group criteria and members",
   "access.label": "Chat access",
+  "access.privateGroup": "Private group",
+  "access.unavailableGroup": "Group unavailable",
   "groups.admin": "Admin",
   "groups.drop": "Drop",
   "groups.view": "View",
@@ -1536,6 +1538,19 @@ const WAVE_CHAT_SETTINGS_MESSAGES = objectMessages("waves.chatSettings", {
   "status.enableLabel": "Enable chat",
   "status.label": "Chat status",
 } as const);
+
+const NETWORK_GROUP_INSPECTION_MESSAGES = objectMessages(
+  "network.groupInspection",
+  {
+    selectedGroup: "Selected group",
+    close: "Clear selected group",
+    membersTitle: "Members",
+    loading: "Loading group criteria",
+    unavailableTitle: "Group criteria unavailable",
+    unavailableDescription:
+      "This group may be private, deleted, or temporarily unavailable.",
+  } as const
+);
 
 const WAVE_LOADING_MESSAGES = objectMessages("waves", {
   loadingStatus: "Loading waves",
@@ -3093,6 +3108,7 @@ export const EN_US_MESSAGES = {
   ...WAVE_CHAT_MESSAGES,
   ...WAVE_STORM_COMPOSER_MESSAGES,
   ...WAVE_CHAT_SETTINGS_MESSAGES,
+  ...NETWORK_GROUP_INSPECTION_MESSAGES,
   ...WAVE_LOADING_MESSAGES,
   ...WAVE_DROPS_SEARCH_MODAL_MESSAGES,
   ...WAVE_GIF_PICKER_MESSAGES,

--- a/ops/docs/network/flow-network-group-scope.md
+++ b/ops/docs/network/flow-network-group-scope.md
@@ -41,9 +41,14 @@ This page owns only the scope handoff into network routes and cross-route scope 
 1. Open `/network/groups`.
 2. Open a group card while it is in idle state.
 3. The app opens `/network?page=1&group={groupId}` (or `/network?group={groupId}` from chat links).
-4. `/network` applies scope and shows scoped leaderboard results.
-5. Open `/network/activity` to view activity under the same scope.
-6. Return to `/network`, open `Filter`, then switch or clear scope.
+4. `/network` applies scope and shows the selected group's criteria above its
+   scoped member results.
+5. Inspect both how membership is determined and the current member list in the
+   same view.
+6. Use `Clear selected group` to close the group summary and return to the
+   default Network member view.
+7. Open `/network/activity` to view activity under the same scope.
+8. Return to `/network`, open `Filter`, then switch or clear scope.
 
 ## Common Scenarios
 
@@ -76,6 +81,9 @@ This page owns only the scope handoff into network routes and cross-route scope 
 - Scope persists in current app session/tab state, not as URL-only state.
 - `/network/activity` consumes scope but does not manage scope.
 - Membership counts in `/network` filter can refresh asynchronously after scope changes.
+- If group details are private, deleted, or temporarily unavailable, Network
+  shows a non-identifying criteria-unavailable state while keeping the scoped
+  member request stable.
 
 ## Related Pages
 

--- a/ops/docs/waves/chat/feature-chat-composer-availability.md
+++ b/ops/docs/waves/chat/feature-chat-composer-availability.md
@@ -40,8 +40,10 @@ availability. Submission availability is exposed through the Chat tab
 - `Rank` and `Approve` wave Settings show `Chat status` as `Enabled` or
   `Disabled`. Wave admins can edit this row to re-enable disabled chat.
 - The Rules panel separates `Chat status` from `Chat access` for `Rank` and
-  `Approve` waves. `Chat access` names the group that can chat when chat is
-  enabled; `Anyone when enabled` means no chat access group is attached.
+  `Approve` waves. `Chat access` names the audience independently of chat
+  status; `Anyone` means no chat access group is attached.
+- A private chat-access group that the viewer cannot inspect is shown as
+  `Private group`, without a group link or identifying metadata.
 
 ## Mode Rules
 

--- a/ops/docs/waves/sidebars/feature-right-sidebar-group-management.md
+++ b/ops/docs/waves/sidebars/feature-right-sidebar-group-management.md
@@ -17,15 +17,15 @@ Users can:
 
 - Wave thread: `/waves/{waveId}`
 - Direct-message thread: `/messages/{waveId}`
-- Rank waves: open the right-sidebar `About` tab
+- Rank waves: open Wave details, then select `Rules` or `Settings`
 - Non-rank waves: same content in default non-tabbed sidebar layout
-- Mobile `About` view reuses the same group-management content
+- Mobile Wave details reuses the same Rules and Settings content
 
 ## Entry Points
 
 - Open a wave thread and open the right sidebar.
-- On rank waves, select `About`.
-- In `General`, open `Group options` on a row.
+- On rank waves, select `Rules` to inspect or `Settings` to manage access.
+- In Settings `Access`, open `Group options` on a row.
 - In `Curation Groups` (non-chat waves), use `Add group` or row options.
 
 ## User Journey

--- a/ops/docs/waves/sidebars/feature-right-sidebar-group-management.md
+++ b/ops/docs/waves/sidebars/feature-right-sidebar-group-management.md
@@ -2,11 +2,13 @@
 
 ## Overview
 
-The right-sidebar `About` content lets users manage wave access groups in place.
+The Wave details `Rules` and `Settings` content lets users inspect access
+groups. Editors can also manage them in place from `Settings`.
 
 Users can:
 
 - review `View`, `Drop`, `Vote`, `Chat access`, and `Admin` scopes
+- follow visible group names to inspect both criteria and current members
 - add, change, or remove scope groups from row menus
 - include or exclude one identity from a scoped group
 - manage non-chat `Curation Groups` without leaving the thread
@@ -28,25 +30,28 @@ Users can:
 
 ## User Journey
 
-1. Open right-sidebar `About`.
-2. Review the `General` rows.
+1. Open Wave details from the right sidebar or mobile wave-actions menu.
+2. Select `Rules` or `Settings`, then review the access rows.
 3. Check current scope value:
    - no group: `Anyone`
-   - no chat access group: `Anyone when enabled`
-   - hidden group: `Hidden`
+   - no chat access group: `Anyone`
+   - hidden/private group: `Private group`
    - visible group: linked name to `/network?page=1&group={groupId}`
-4. Open `Group options` on the row to update.
-5. Choose an available action:
+4. Follow a visible group link. Network shows the group criteria above the
+   current filtered member list.
+5. Return with normal browser back navigation when finished inspecting.
+6. Editors can open `Group options` on the Settings row to update it.
+7. Choose an available action:
    - `Add group` or `Change group`
    - `Remove group` (not shown for `Admin`)
    - `Include identity` or `Exclude identity` (permission-gated)
-6. Complete the modal:
+8. Complete the modal:
    - group picker for add/change
    - identity search modal for include/exclude
    - confirmation modal for remove
-7. Authenticate when prompted.
-8. After success, the row refreshes.
-9. On non-chat waves, use the same actions under `Curation Groups`.
+9. Authenticate when prompted.
+10. After success, the row refreshes.
+11. On non-chat waves, use the same actions under `Curation Groups`.
 
 ## Common Scenarios
 
@@ -65,6 +70,10 @@ Users can:
   `Chat status` separately from `Chat access`.
 - Chat waves do not show `Curation Groups`.
 - General-row edit controls are hidden for direct-message groups.
+- Visible group inspection is available to read-only wave viewers; it does not
+  depend on wave edit permission.
+- Hidden/private scope stubs never render a link, group identity, or group
+  metadata.
 - `Admin` does not show `Remove group`.
 - In `General`, `Include identity` and `Exclude identity` show only when the
   user can edit the wave and is either wave admin or the scope-group author.
@@ -80,6 +89,8 @@ Users can:
 
 - While curation groups load, the section shows `Loading groups`.
 - If curation-group fetch fails, the section shows `Unavailable`.
+- If Network cannot load a linked group's criteria, it shows `Group criteria
+  unavailable` without exposing the group id or treating the scope as public.
 - If authentication fails or is canceled, users see `Failed to authenticate`
   and no changes are applied.
 - If a save request fails, an error toast is shown and existing settings stay as-is.

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -2674,8 +2674,11 @@
         "Wave chat has two separate settings for Rank and Approve waves: chat.enabled controls whether chat is on, and chat.scope controls who can chat when chat is enabled.",
         "Chat waves require chat to stay enabled, so their Settings and Rules panels do not show a Chat status enable/disable row.",
         "Rank and Approve wave Settings show Chat status as Enabled or Disabled, and wave admins can edit that row to enable or disable chat.",
-        "The Access row uses Chat access wording; `Anyone when enabled` means no chat access group is attached, not that chat is currently enabled.",
+        "The Access row uses Chat access wording; `Anyone` means no chat access group is attached, independently of whether chat is enabled.",
         "The Rank and Approve Rules panels also show Chat status separately from Chat access, so disabled chat does not look like the same thing as an unrestricted chat access group.",
+        "Visible access-group names in Rules and Settings link to a filtered Network view that shows both the group criteria and current members.",
+        "Use the Clear selected group button in Network to close the group summary and return to the default member view.",
+        "A scoped group hidden from the current viewer is labeled `Private group` without a link, name, id, author, criteria, or membership details.",
         "When chat is disabled, slow mode and disable-links settings are hidden because they only apply when chat is enabled."
       ],
       "canonical_path": "/waves",
@@ -2684,7 +2687,9 @@
       "source_refs": [
         "components/waves/specs/WaveChatStatus.tsx",
         "helpers/waves/wave-rules.helpers.ts",
+        "components/waves/specs/WaveRulesPanel.tsx",
         "components/waves/specs/groups/group/WaveGroup.tsx",
+        "components/community/CommunityMembersGroupDetails.tsx",
         "ops/docs/waves/chat/feature-chat-composer-availability.md",
         "ops/docs/waves/sidebars/feature-right-sidebar-group-management.md"
       ]

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -2670,8 +2670,11 @@
         "Wave chat has two separate settings for Rank and Approve waves: chat.enabled controls whether chat is on, and chat.scope controls who can chat when chat is enabled.",
         "Chat waves require chat to stay enabled, so their Settings and Rules panels do not show a Chat status enable/disable row.",
         "Rank and Approve wave Settings show Chat status as Enabled or Disabled, and wave admins can edit that row to enable or disable chat.",
-        "The Access row uses Chat access wording; `Anyone when enabled` means no chat access group is attached, not that chat is currently enabled.",
+        "The Access row uses Chat access wording; `Anyone` means no chat access group is attached, independently of whether chat is enabled.",
         "The Rank and Approve Rules panels also show Chat status separately from Chat access, so disabled chat does not look like the same thing as an unrestricted chat access group.",
+        "Visible access-group names in Rules and Settings link to a filtered Network view that shows both the group criteria and current members.",
+        "Use the Clear selected group button in Network to close the group summary and return to the default member view.",
+        "A scoped group hidden from the current viewer is labeled `Private group` without a link, name, id, author, criteria, or membership details.",
         "When chat is disabled, slow mode and disable-links settings are hidden because they only apply when chat is enabled."
       ],
       "canonical_path": "/waves",
@@ -2680,7 +2683,9 @@
       "source_refs": [
         "components/waves/specs/WaveChatStatus.tsx",
         "helpers/waves/wave-rules.helpers.ts",
+        "components/waves/specs/WaveRulesPanel.tsx",
         "components/waves/specs/groups/group/WaveGroup.tsx",
+        "components/community/CommunityMembersGroupDetails.tsx",
         "ops/docs/waves/chat/feature-chat-composer-availability.md",
         "ops/docs/waves/sidebars/feature-right-sidebar-group-management.md"
       ]


### PR DESCRIPTION
## Issue

- Wave rules could describe unrestricted chat access as “Anyone when enabled,” which mixed access scope with chat status.
- Visible access groups were shown as plain labels, so users could not inspect how membership was defined.
- Private or incomplete group stubs risked exposing misleading identifiers or links.

## Fix

- Keep chat status and chat access independent: an empty scope is now simply “Anyone.”
- Link only complete, visible access groups to a read-only Network inspection view.
- Render hidden and direct-message groups as non-interactive “Private group,” and incomplete groups as “Group unavailable.”

## Changes

- Added accessible, text-hover group links in Wave Rules and Settings.
- Added a compact selected-group card above scoped Network members with criteria, loading/error states, and a clear button that returns to the default Network view.
- Added privacy guards, responsive touch targets, tests, localization copy, product docs, and help-index updates.

## Validation

- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run typecheck:jest`
- Focused Jest suite: 7 suites, 33 tests passed.
- `./bin/6529 run help-index:sync`
- `./bin/6529 run react-doctor:diff` — 96/100; reported existing legacy findings in touched components.
- Desktop and 390×844 mobile browser QA covered Rules, Settings, Chat and Rank waves, visible/private/unavailable group states, link navigation, responsive targets, and clear/reset behavior. No application console errors.
- `check:changed` was also exercised; its repository-wide Knip phase reports existing unrelated debt. The scoped lint, typecheck, test, format, and diff checks pass.

## Risk

- Level: Low
- Why: Frontend-only presentation, navigation, and read-only group fetching; no API, schema, auth, or dependency changes.
- Rollback: Revert this commit to restore the prior summaries and Network layout.

## Review Notes

- Please focus on privacy handling for hidden/direct-message/incomplete group stubs and the URL/query synchronization when clearing a selected group.
- A live hidden chat-access Wave was not available in the local staging-backed dataset; that contract path is covered by focused tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selectable group details to the community members view, including loading, unavailable, member, and close states.
  * Added links from visible wave access groups to filtered Network views.
  * Improved handling and labeling of private, direct-message, and unavailable groups.

* **Bug Fixes**
  * Corrected access labels to consistently display “Anyone” when appropriate.
  * Improved accessibility, URL encoding, and image descriptions for group links.

* **Documentation**
  * Updated help content and user journeys for group inspection, scoped members, and access rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->