### PR TITLE
Filter MetaMask Mobile cyclic JSON Sentry noise

### DIFF
--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -2466,13 +2466,13 @@ describe("instrumentation-client", () => {
     expect(result).not.toBeNull();
   });
 
-  it("keeps cyclic JSON timer errors for origin diagnostics", () => {
+  it("drops exact MetaMask Mobile cyclic JSON timer noise", () => {
     const beforeSend = loadBeforeSend();
     const event = createSentryRouteParameterizationEvent();
 
     const result = beforeSend(event);
 
-    expect(result).not.toBeNull();
+    expect(result).toBeNull();
   });
 
   it("keeps iOS WKWebView cyclic JSON timer errors without app context", () => {
@@ -2567,6 +2567,23 @@ describe("instrumentation-client", () => {
         tags: {},
       }
     );
+
+    const result = beforeSend(event);
+
+    expect(result).not.toBeNull();
+  });
+
+  it("keeps sampled cyclic JSON timer diagnostics", () => {
+    const beforeSend = loadBeforeSend();
+    const event = createSentryRouteParameterizationEvent([
+      nativeJsonStringifyFrame,
+      {
+        filename: "utils/monitoring/cyclicJsonTimerDiagnostics.ts",
+        function: "diagnosticCallback",
+        lineno: 404,
+        in_app: true,
+      },
+    ]);
 
     const result = beforeSend(event);
 

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -5919,7 +5919,7 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(true);
   });
 
-  it("filters observed iOS WKWebView wave route parameterization cyclic JSON errors without app context", () => {
+  it("does not filter observed iOS WKWebView cyclic JSON errors without MetaMask evidence", () => {
     // Arrange
     const event = createObservedIosWkWebViewWaveRouteParameterizationEvent();
 
@@ -5927,10 +5927,10 @@ describe("sentry-client-filters", () => {
     const result = shouldFilterSentryRouteParameterizationError(event);
 
     // Assert
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 
-  it("filters the observed Sentry CP notifications event when the SDK frame is marked in-app", () => {
+  it("does not filter the observed Sentry CP event without MetaMask evidence", () => {
     // Arrange
     const event = createObservedSentryCpNotificationsEvent();
 
@@ -5938,7 +5938,7 @@ describe("sentry-client-filters", () => {
     const result = shouldFilterSentryRouteParameterizationError(event);
 
     // Assert
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 
   it("preserves the observed Sentry CP event when a real app-owned frame is present", () => {
@@ -5960,12 +5960,21 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(false);
   });
 
-  it("filters the observed Sentry CP event when native stringify is marked in-app", () => {
+  it("filters MetaMask Mobile noise when native stringify is marked in-app", () => {
     // Arrange
     const frames = observedSentryCpNotificationsFrames.map((frame) =>
       frame.function === "stringify" ? { ...frame, in_app: true } : frame
     );
-    const event = createObservedSentryCpNotificationsEvent({}, frames);
+    const event = createObservedSentryCpNotificationsEvent(
+      {
+        request: {
+          headers: {
+            "User-Agent": metaMaskMobileWebViewUserAgent,
+          },
+        },
+      },
+      frames
+    );
 
     // Act
     const result = shouldFilterSentryRouteParameterizationError(event);
@@ -6114,6 +6123,23 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(false);
   });
 
+  it("does not filter cyclic JSON errors with an app-owned hint stack", () => {
+    // Arrange
+    const event = createSentryRouteParameterizationEvent();
+    const hint = {
+      originalException: {
+        stack:
+          "TypeError: JSON.stringify cannot serialize cyclic structures.\n    at serializeWaveParams (webpack-internal:///(app-pages-browser)/./utils/routeParams.ts:10:1)",
+      },
+    };
+
+    // Act
+    const result = shouldFilterSentryRouteParameterizationError(event, hint);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
   it("does not filter Sentry parameterization errors when an app-owned frame is present", () => {
     // Arrange
     const event = createObservedSentryRouteParameterizationEvent({
@@ -6246,7 +6272,7 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(false);
   });
 
-  it("filters WKWebView route parameterization errors without MetaMaskMobile evidence", () => {
+  it("does not filter WKWebView route parameterization errors without MetaMaskMobile evidence", () => {
     // Arrange
     const event =
       createObservedMetaMaskMobileWkWebViewWaveRouteParameterizationEvent({
@@ -6263,7 +6289,7 @@ describe("sentry-client-filters", () => {
     const result = shouldFilterSentryRouteParameterizationError(event);
 
     // Assert
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 
   it("does not filter MetaMaskMobile route parameterization errors without route evidence", () => {

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -50,6 +50,7 @@ import {
   shouldFilterRabbyChromeUserRejectedRequest,
   shouldFilterRabbyMobileRainbowKitNotFoundError,
   shouldFilterRabbyMobileUserRejectedRequest,
+  shouldFilterSentryRouteParameterizationError,
   shouldFilterTalismanExtensionOnboardingError,
   shouldFilterThirdPartyTelemetryNetworkError,
   shouldFilterThirdPartyTelemetrySpan,
@@ -238,10 +239,9 @@ function shouldFilterEvent(
     return true;
   }
 
-  // Intentionally do not call shouldFilterSentryRouteParameterizationError.
-  // Keep all cyclic JSON timer failures while origin diagnostics are active.
-  // Generic Sentry/WKWebView frames do not prove third-party ownership, so
-  // retaining only the sampled diagnostic subset would hide genuine app errors.
+  if (shouldFilterSentryRouteParameterizationError(event, hint)) {
+    return true;
+  }
 
   if (shouldFilterAppleWebKitSortedTrackListTypeError(event)) {
     return true;

--- a/ops/telemetry/registry.json
+++ b/ops/telemetry/registry.json
@@ -412,10 +412,10 @@
       "destinations": ["sentry:owner"],
       "sampling": "eligible function timers in iOS WKWebViews are sampled independently at 1/16; only exact unhandled cyclic-JSON timer errors receive sampled provenance",
       "privacy": "timer arguments are removed from every matching event; sampled extras contain bounded sanitized function names, script basenames, line and column numbers, origin enums, WebView family, and sample rate only",
-      "externalUsage": "v1 is live; Sentry dashboard, saved-search, and alert usage could not be verified because read-only endpoints returned 403",
+      "externalUsage": "v2 is live; Sentry dashboard, saved-search, and alert usage could not be verified because read-only endpoints returned 403",
       "lifecycle": "temporary",
-      "replacement": "By the review date, verify or migrate every v1-keyed Sentry consumer to v2; remove the timer diagnostics after corrected provenance identifies the caller",
-      "reviewBy": "2026-08-17"
+      "replacement": "After the first production release with the narrow MetaMask Mobile suppression has been live for seven days, review retained diagnostic events and remove the timer diagnostics if near-miss coverage remains intact",
+      "reviewBy": "2026-09-01"
     },
     {
       "name": "reaction.*",

--- a/utils/sentry-client-filters/constants.ts
+++ b/utils/sentry-client-filters/constants.ts
@@ -226,7 +226,6 @@ export const mobileSafariWebViewContextTokens = [
   "mobile safari ui/wkwebview",
   "wkwebview",
 ];
-export const webViewUserAgentTokens = ["webview", "wkwebview"];
 export const routeParameterizationContextKeys = [
   "app",
   "browser",

--- a/utils/sentry-client-filters/errors.ts
+++ b/utils/sentry-client-filters/errors.ts
@@ -11,7 +11,6 @@ import {
   tenorCategoriesPath,
   twitterCurrentInsetReferenceErrorMessage,
   twitterInjectedWaveDocumentPathPattern,
-  webViewUserAgentTokens,
   routeParameterizationContextKeys,
   routeParameterizationTagKeys,
 } from "./constants";
@@ -229,26 +228,14 @@ export function hasMetaMaskMobileWebViewContext(
     values.some((value) =>
       matchesContextToken(value, metaMaskMobileContextTokens)
     ) &&
-    values.some(
-      (value) =>
-        matchesContextToken(value, mobileSafariWebViewContextTokens) ||
-        matchesContextToken(value, webViewUserAgentTokens)
-    )
-  );
-}
-
-function hasMobileSafariWebViewContext(event: SentryClientEvent): boolean {
-  const contextValues = getRouteParameterizationContextValues(event);
-  const userAgentValues = getRouteParameterizationUserAgentValues(event);
-  return (
-    contextValues.some((value) =>
+    (contextValues.some((value) =>
       matchesContextToken(value, mobileSafariWebViewContextTokens)
     ) ||
-    userAgentValues.some(
-      (value) =>
-        matchesContextToken(value, mobileSafariWebViewContextTokens) ||
-        isIosWebViewUserAgent(value)
-    )
+      userAgentValues.some(
+        (value) =>
+          matchesContextToken(value, mobileSafariWebViewContextTokens) ||
+          isIosWebViewUserAgent(value)
+      ))
   );
 }
 
@@ -642,10 +629,11 @@ export function shouldFilterGifPickerTenorCategoriesError(
 }
 
 export function shouldFilterSentryRouteParameterizationError(
-  event: SentryClientEvent
+  event: SentryClientEvent,
+  hint?: SentryEventHint
 ): boolean {
-  // Sentry SDK route parameterization noise observed in iOS WKWebView;
-  // keep app-owned and generic browser cyclic JSON errors.
+  // Sentry SDK route parameterization noise observed in MetaMask Mobile on
+  // iOS WKWebView; keep app-owned and generic WebView cyclic JSON errors.
   const value = event.exception?.values?.[0];
   if (
     value?.type !== "TypeError" ||
@@ -667,6 +655,7 @@ export function shouldFilterSentryRouteParameterizationError(
     (frame) => !isSentryRouteParameterizationFrame(frame)
   );
   if (
+    hasAppOwnedSourceEvidence(event, value, hint) ||
     hasLikelyAppOwnedFrame(framesWithoutSentryRouteParameterization) ||
     !hasNativeJsonStringifyFrame(frames)
   ) {
@@ -676,8 +665,7 @@ export function shouldFilterSentryRouteParameterizationError(
   return (
     (hasSentryRouteParameterizationFrame(frames) ||
       hasRouteParameterizationRouteEvidence(event)) &&
-    (hasMetaMaskMobileWebViewContext(event) ||
-      hasMobileSafariWebViewContext(event))
+    hasMetaMaskMobileWebViewContext(event)
   );
 }
 


### PR DESCRIPTION
## Issue

- `6529-FRONTEND-CQ` records high-volume `JSON.stringify cannot serialize cyclic structures.` errors from MetaMask Mobile on iOS WKWebView.
- Generic WebViews and events with app-owned stack evidence must remain reportable.

## Fix

- Re-enable the existing client-side cyclic JSON filter only for the exact MetaMask Mobile + iOS WKWebView cohort.
- Pass the original Sentry hint into classification so app-owned hint or serialized stacks fail open.
- Keep the sampled cyclic JSON timer diagnostics reportable for post-release monitoring.

## Changes

- Tighten MetaMask Mobile WebView detection and remove generic WKWebView acceptance.
- Restore the filter in `beforeSend`.
- Add focused coverage for the suppressed cohort, generic WebView near-misses, app-owned hint stacks, and sampled diagnostics.
- Record the live v2 diagnostic schema and extend its review date until the suppression has been observed in production for seven days.

## Validation

- `./bin/6529 run test --runTestsByPath __tests__/utils/sentry-client-filters.test.ts __tests__/instrumentation-client.test.ts __tests__/utils/cyclicJsonTimerDiagnostics.test.ts` — 703 tests passed.
- `./bin/6529 run lint:changed` — passed.
- `./bin/6529 run typecheck:changed` — passed.
- `git diff --check` — passed.
- `./bin/6529 run build` — compilation, full lint, and TypeScript passed twice; static export then timed out three times on the unrelated `/museum/network/about/governance` page in both runs. The hosted production build passed on the same head.

## Risk

- Level: Medium
- Why: this intentionally suppresses one telemetry cohort, so false-positive matching would hide useful errors. Exact message, mechanism, wallet, WebView, route/frame, native stringify, and app-owned stack checks keep the match narrow.
- Expected volume impact: low but monitored. Live v2 diagnostic samples identify MetaMask Mobile; generic WKWebView cases remain reportable and will be reviewed after one production release plus seven days.
- Rollback: revert this commit to resume sending all matching cyclic JSON events.

## Review Notes

- Please focus on the fail-open boundaries and whether the retained sampled diagnostics provide enough post-release evidence.
- This is a clean replacement for stale draft #3666; that broader draft was left unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy diagnostics from MetaMask Mobile WebView events.
  * Preserved diagnostics when they include evidence from the application.
  * Improved filtering accuracy by avoiding suppression of generic mobile Safari WebView errors.
* **Tests**
  * Added coverage for retained app diagnostics and updated filtering expectations.
* **Chores**
  * Updated diagnostic tracking and review timing for the refined filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->