### PR TITLE
Restore Groups checks after the card navigation update

### DIFF
--- a/tests/admin/admin-destructive-guards-readonly.spec.ts
+++ b/tests/admin/admin-destructive-guards-readonly.spec.ts
@@ -161,7 +161,7 @@ async function gotoGroupsReady(page: Page) {
     await expect(
       page
         .locator("main")
-        .getByRole("button", { name: /^Open / })
+        .getByRole("link", { name: /^Open / })
         .first()
     ).toBeVisible({ timeout: 30000 });
   }


### PR DESCRIPTION
## Issue

- Frontend PR #3762 changed each idle Groups card's accessible primary navigation control from a button to a native link.
- The read-only admin-guards E2E pack still waited for an `Open …` button, so its Groups check timed out through every retry in both staging and production even though the page and separate Groups coverage loaded successfully.

## Fix

- Align the Groups readiness assertion with the card's current accessible navigation contract by locating the visible `Open …` link.

## Changes

- Update the single stale role query in `tests/admin/admin-destructive-guards-readonly.spec.ts`.
- No application behavior, permissions, deployment code, or user-facing UI changes.

## Validation

- `./bin/6529 run check:changed`
- `./bin/6529 run test:e2e:production:admin-guards-readonly` — 3 passed
- Live staging review at desktop and mobile widths confirmed populated cards expose visible `Open …` links, no obsolete `Open …` buttons for the logged-out flow, and primary card navigation succeeds.
- The focused local staging command could not pass the repository access gate because the isolated worktree does not have `PLAYWRIGHT_STAGING_ACCESS_CODE` or `STAGING_AUTH`; the secret-backed staging E2E will be rerun through GitHub after merge.

## Risk

- Level: Low
- Why: one test locator role changes to match the existing native-link UI; runtime application code is untouched.
- Rollback: revert this commit if the card accessibility contract changes again.

## Review Notes

- Confirm the locator remains scoped to `main` and the `Open …` accessible name.
- The most recent staging E2E also recorded a separate NextGen server-render failure. This PR intentionally addresses only the confirmed Groups contract regression; any recurring NextGen failure should be diagnosed independently during staging validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the Groups route test to verify that group cards display an “Open” link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->