### PR TITLE
fix: Repaired the CI-blocking test diagnostic and strengthened regression coverage for the existing narrow Urb

### DIFF
--- a/__tests__/instrumentation-client-urban-vpn.test.ts
+++ b/__tests__/instrumentation-client-urban-vpn.test.ts
@@ -80,7 +80,10 @@ describe("instrumentation-client Urban VPN filter", () => {
 
   it("keeps a nearby application error with an additional source frame", () => {
     const beforeSend = loadBeforeSend();
-    const [value] = urbanVpnEvent.exception.values;
+    const value = urbanVpnEvent.exception.values[0];
+    if (!value) {
+      throw new Error("Missing Urban VPN test exception");
+    }
     const event = {
       exception: {
         values: [
@@ -101,6 +104,6 @@ describe("instrumentation-client Urban VPN filter", () => {
       },
     };
 
-    expect(beforeSend(event)).not.toBeNull();
+    expect(beforeSend(event)).toEqual(event);
   });
 });

--- a/__tests__/instrumentation-client-urban-vpn.test.ts
+++ b/__tests__/instrumentation-client-urban-vpn.test.ts
@@ -1,0 +1,106 @@
+const mockInit = jest.fn();
+const mockReplayIntegration = jest.fn(() => ({ name: "replay" }));
+const mockCaptureRouterTransitionStart = jest.fn();
+
+jest.mock("@sentry/nextjs", () => ({
+  __esModule: true,
+  init: mockInit,
+  replayIntegration: mockReplayIntegration,
+  captureRouterTransitionStart: mockCaptureRouterTransitionStart,
+}));
+
+const urbanVpnEvent = {
+  exception: {
+    values: [
+      {
+        type: "TypeError",
+        value: "Cannot read properties of undefined (reading 'M_ID')",
+        mechanism: {
+          type: "auto.browser.global_handlers.onunhandledrejection",
+          handled: false,
+        },
+        stacktrace: {
+          frames: [
+            {
+              filename: "app:///_next/static/chunks/2t0pw9wfgr12w.js",
+              abs_path: "app:///_next/static/chunks/2t0pw9wfgr12w.js",
+              function: "XMLHttpRequest.r",
+              lineno: 7,
+              colno: 6173,
+              in_app: true,
+            },
+            {
+              filename: "app:///executors/200.js",
+              abs_path: "app:///executors/200.js",
+              function: "XMLHttpRequest.onreadystatechange",
+              lineno: 1,
+              colno: 2598,
+              in_app: true,
+            },
+            {
+              filename: "app:///executors/200.js",
+              abs_path: "app:///executors/200.js",
+              function: "Z",
+              lineno: 1,
+              colno: 761,
+              in_app: true,
+            },
+          ],
+        },
+      },
+    ],
+  },
+};
+
+function loadBeforeSend(): (event: unknown) => unknown {
+  jest.isolateModules(() => {
+    require("@/instrumentation-client");
+  });
+  const config = mockInit.mock.calls[0]?.[0];
+  if (typeof config?.beforeSend !== "function") {
+    throw new Error("Sentry beforeSend was not configured");
+  }
+  return config.beforeSend;
+}
+
+describe("instrumentation-client Urban VPN filter", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockInit.mockReset();
+    mockReplayIntegration.mockReset();
+    mockReplayIntegration.mockImplementation(() => ({ name: "replay" }));
+    mockCaptureRouterTransitionStart.mockReset();
+  });
+
+  it("drops the exact raw executor failure before Sentry submits it", () => {
+    const beforeSend = loadBeforeSend();
+
+    expect(beforeSend(urbanVpnEvent)).toBeNull();
+  });
+
+  it("keeps a nearby application error with an additional source frame", () => {
+    const beforeSend = loadBeforeSend();
+    const [value] = urbanVpnEvent.exception.values;
+    const event = {
+      exception: {
+        values: [
+          {
+            ...value,
+            stacktrace: {
+              frames: [
+                ...value.stacktrace.frames,
+                {
+                  filename:
+                    "webpack-internal:///(app-pages-browser)/./services/api/common-api.ts",
+                  function: "executeApiRequest",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    expect(beforeSend(event)).not.toBeNull();
+  });
+});

--- a/__tests__/utils/sentry-client-filters-urban-vpn.test.ts
+++ b/__tests__/utils/sentry-client-filters-urban-vpn.test.ts
@@ -1,0 +1,192 @@
+import {
+  shouldFilterUrbanVpnExecutorMIdError,
+  type SentryClientEvent,
+  type SentryStackFrame,
+} from "@/utils/sentry-client-filters";
+
+const urbanVpnMIdErrorMessage =
+  "Cannot read properties of undefined (reading 'M_ID')";
+const urbanVpnExecutorPath = "app:///executors/200.js";
+const sentryWrapperPath = "app:///_next/static/chunks/2t0pw9wfgr12w.js";
+
+const createUrbanVpnFrames = (
+  executorFunction: "F" | "Z" = "Z"
+): SentryStackFrame[] => [
+  {
+    filename: sentryWrapperPath,
+    abs_path: sentryWrapperPath,
+    function: "XMLHttpRequest.r",
+    lineno: 7,
+    colno: 6173,
+    in_app: true,
+  },
+  {
+    filename: urbanVpnExecutorPath,
+    abs_path: urbanVpnExecutorPath,
+    function: "XMLHttpRequest.onreadystatechange",
+    lineno: 1,
+    colno: 2598,
+    in_app: true,
+  },
+  {
+    filename: urbanVpnExecutorPath,
+    abs_path: urbanVpnExecutorPath,
+    function: executorFunction,
+    lineno: 1,
+    colno: 761,
+    in_app: true,
+  },
+];
+
+const createUrbanVpnEvent = ({
+  type = "TypeError",
+  value = urbanVpnMIdErrorMessage,
+  mechanismType = "auto.browser.global_handlers.onunhandledrejection",
+  handled = false,
+  includeHandled = true,
+  frames = createUrbanVpnFrames(),
+  additionalException = false,
+  extra,
+}: {
+  type?: string | undefined;
+  value?: string | undefined;
+  mechanismType?: string | undefined;
+  handled?: boolean | undefined;
+  includeHandled?: boolean | undefined;
+  frames?: SentryStackFrame[] | undefined;
+  additionalException?: boolean | undefined;
+  extra?: Record<string, unknown> | undefined;
+} = {}): SentryClientEvent => ({
+  extra,
+  exception: {
+    values: [
+      {
+        type,
+        value,
+        mechanism: {
+          type: mechanismType,
+          ...(includeHandled ? { handled } : {}),
+        },
+        stacktrace: { frames },
+      },
+      ...(additionalException
+        ? [
+            {
+              type: "Error",
+              value: "Application failure",
+            },
+          ]
+        : []),
+    ],
+  },
+});
+
+describe("Urban VPN executor M_ID filter", () => {
+  it.each(["F", "Z"] as const)(
+    "filters the exact raw executor stack with the %s function variant",
+    (executorFunction) => {
+      const event = createUrbanVpnEvent({
+        frames: createUrbanVpnFrames(executorFunction),
+      });
+
+      expect(shouldFilterUrbanVpnExecutorMIdError(event)).toBe(true);
+    }
+  );
+
+  it.each([
+    ["changed message", { value: `${urbanVpnMIdErrorMessage}.` }],
+    ["changed type", { type: "Error" }],
+    ["changed mechanism", { mechanismType: "generic" }],
+    ["handled rejection", { handled: true }],
+    ["missing handled state", { includeHandled: false }],
+    ["additional exception", { additionalException: true }],
+  ])("keeps an event with a %s", (_caseName, overrides) => {
+    const event = createUrbanVpnEvent(overrides);
+
+    expect(shouldFilterUrbanVpnExecutorMIdError(event)).toBe(false);
+  });
+
+  it.each([
+    ["wrapper path", 0, { filename: "app:///_next/static/runtime.js" }],
+    ["wrapper function", 0, { function: "XMLHttpRequest.send" }],
+    ["wrapper line", 0, { lineno: 8 }],
+    ["wrapper column", 0, { colno: 6172 }],
+    ["XHR path", 1, { filename: "app:///executors/201.js" }],
+    ["XHR function", 1, { function: "XMLHttpRequest.onload" }],
+    ["XHR line", 1, { lineno: 2 }],
+    ["XHR column", 1, { colno: 2597 }],
+    ["executor function", 2, { function: "Y" }],
+    ["executor line", 2, { lineno: 2 }],
+    ["executor column", 2, { colno: 760 }],
+  ] satisfies ReadonlyArray<
+    readonly [string, number, Partial<SentryStackFrame>]
+  >)("keeps an event with a changed %s", (_caseName, frameIndex, change) => {
+    const frames = createUrbanVpnFrames();
+    const originalFrame = frames[frameIndex];
+    if (!originalFrame) {
+      throw new Error("Missing Urban VPN test frame");
+    }
+    frames[frameIndex] = { ...originalFrame, ...change };
+    const event = createUrbanVpnEvent({ frames });
+
+    expect(shouldFilterUrbanVpnExecutorMIdError(event)).toBe(false);
+  });
+
+  it.each([
+    ["missing executor frame", createUrbanVpnFrames().slice(0, 2)],
+    [
+      "extra executor frame",
+      [
+        ...createUrbanVpnFrames(),
+        {
+          filename: urbanVpnExecutorPath,
+          function: "Z",
+          lineno: 1,
+          colno: 761,
+        },
+      ],
+    ],
+    [
+      "application source frame",
+      [
+        ...createUrbanVpnFrames(),
+        {
+          filename:
+            "webpack-internal:///(app-pages-browser)/./services/api/common-api.ts",
+          function: "executeApiRequest",
+        },
+      ],
+    ],
+  ] satisfies ReadonlyArray<readonly [string, SentryStackFrame[]]>)(
+    "keeps an event with a %s",
+    (_caseName, frames) => {
+      const event = createUrbanVpnEvent({ frames });
+
+      expect(shouldFilterUrbanVpnExecutorMIdError(event)).toBe(false);
+    }
+  );
+
+  it("keeps an event with serialized application source evidence", () => {
+    const event = createUrbanVpnEvent({
+      extra: {
+        __serialized__: {
+          stack:
+            "Error: Application failure\n    at executeApiRequest (webpack-internal:///(app-pages-browser)/./services/api/common-api.ts:10:2)",
+        },
+      },
+    });
+
+    expect(shouldFilterUrbanVpnExecutorMIdError(event)).toBe(false);
+  });
+
+  it("keeps an event with application source evidence in the hint", () => {
+    const event = createUrbanVpnEvent();
+    const originalException = new Error("Application failure");
+    originalException.stack =
+      "Error: Application failure\n    at executeApiRequest (webpack-internal:///(app-pages-browser)/./services/api/common-api.ts:10:2)";
+
+    expect(
+      shouldFilterUrbanVpnExecutorMIdError(event, { originalException })
+    ).toBe(false);
+  });
+});

--- a/__tests__/utils/sentry-client-filters-urban-vpn.test.ts
+++ b/__tests__/utils/sentry-client-filters-urban-vpn.test.ts
@@ -10,11 +10,12 @@ const urbanVpnExecutorPath = "app:///executors/200.js";
 const sentryWrapperPath = "app:///_next/static/chunks/2t0pw9wfgr12w.js";
 
 const createUrbanVpnFrames = (
-  executorFunction: "F" | "Z" = "Z"
+  executorFunction: "F" | "Z" = "Z",
+  wrapperPath = sentryWrapperPath
 ): SentryStackFrame[] => [
   {
-    filename: sentryWrapperPath,
-    abs_path: sentryWrapperPath,
+    filename: wrapperPath,
+    abs_path: wrapperPath,
     function: "XMLHttpRequest.r",
     lineno: 7,
     colno: 6173,
@@ -44,6 +45,8 @@ const createUrbanVpnEvent = ({
   mechanismType = "auto.browser.global_handlers.onunhandledrejection",
   handled = false,
   includeHandled = true,
+  includeMechanism = true,
+  includeStacktrace = true,
   frames = createUrbanVpnFrames(),
   additionalException = false,
   extra,
@@ -53,6 +56,8 @@ const createUrbanVpnEvent = ({
   mechanismType?: string | undefined;
   handled?: boolean | undefined;
   includeHandled?: boolean | undefined;
+  includeMechanism?: boolean | undefined;
+  includeStacktrace?: boolean | undefined;
   frames?: SentryStackFrame[] | undefined;
   additionalException?: boolean | undefined;
   extra?: Record<string, unknown> | undefined;
@@ -63,11 +68,15 @@ const createUrbanVpnEvent = ({
       {
         type,
         value,
-        mechanism: {
-          type: mechanismType,
-          ...(includeHandled ? { handled } : {}),
-        },
-        stacktrace: { frames },
+        ...(includeMechanism
+          ? {
+              mechanism: {
+                type: mechanismType,
+                ...(includeHandled ? { handled } : {}),
+              },
+            }
+          : {}),
+        ...(includeStacktrace ? { stacktrace: { frames } } : {}),
       },
       ...(additionalException
         ? [
@@ -94,11 +103,24 @@ describe("Urban VPN executor M_ID filter", () => {
   );
 
   it.each([
+    "app:///_next/static/chunks/next-build-a_123.js",
+    "app:///_next/static/chunks/next-build-b-456.js",
+  ])("does not depend on the build-specific chunk name %s", (wrapperPath) => {
+    const event = createUrbanVpnEvent({
+      frames: createUrbanVpnFrames("Z", wrapperPath),
+    });
+
+    expect(shouldFilterUrbanVpnExecutorMIdError(event)).toBe(true);
+  });
+
+  it.each([
     ["changed message", { value: `${urbanVpnMIdErrorMessage}.` }],
     ["changed type", { type: "Error" }],
     ["changed mechanism", { mechanismType: "generic" }],
     ["handled rejection", { handled: true }],
     ["missing handled state", { includeHandled: false }],
+    ["missing mechanism", { includeMechanism: false }],
+    ["missing stacktrace", { includeStacktrace: false }],
     ["additional exception", { additionalException: true }],
   ])("keeps an event with a %s", (_caseName, overrides) => {
     const event = createUrbanVpnEvent(overrides);

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -36,6 +36,7 @@ import {
   shouldFilterBraveWalletPageEvaluationError,
   shouldFilterChromeMobileIosInjectedGaError,
   shouldFilterPoperBlockerOrphanFetchRejection,
+  shouldFilterUrbanVpnExecutorMIdError,
   shouldFilterExpectedWaveRequestReplacementAbort,
   shouldFilterCoinbaseWalletLinkWebSocket1006,
   shouldFilterDisconnectedWalletProviderRejection,
@@ -196,6 +197,10 @@ function shouldFilterEvent(
   }
 
   if (shouldFilterPoperBlockerOrphanFetchRejection(event, hint)) {
+    return true;
+  }
+
+  if (shouldFilterUrbanVpnExecutorMIdError(event, hint)) {
     return true;
   }
 

--- a/utils/sentry-client-filters.ts
+++ b/utils/sentry-client-filters.ts
@@ -38,7 +38,10 @@ export {
   shouldFilterBrowserExtensionSendMessageError,
   shouldFilterBrowserExtensionWalletRejection,
 } from "./sentry-client-filters/extension-messaging";
-export { shouldFilterPoperBlockerOrphanFetchRejection } from "./sentry-client-filters/extension-fetch";
+export {
+  shouldFilterPoperBlockerOrphanFetchRejection,
+  shouldFilterUrbanVpnExecutorMIdError,
+} from "./sentry-client-filters/extension-fetch";
 export { shouldFilterExpectedWaveRequestReplacementAbort } from "./sentry-client-filters/wave-abort";
 export {
   shouldFilterBraveWalletPageEvaluationError,

--- a/utils/sentry-client-filters/extension-fetch.ts
+++ b/utils/sentry-client-filters/extension-fetch.ts
@@ -23,6 +23,13 @@ const poperBlockerInjectedFetchFrameSignatures = [
   },
 ] as const;
 
+const urbanVpnExecutorMIdErrorMessage =
+  "Cannot read properties of undefined (reading 'M_ID')";
+const urbanVpnExecutorPath = "app:///executors/200.js";
+const urbanVpnSentryWrapperPathPattern =
+  /^app:\/\/\/_next\/static\/chunks\/[A-Za-z0-9_-]+\.js$/;
+const urbanVpnExecutorFunctions = new Set(["F", "Z"]);
+
 function isPoperBlockerInjectedFetchPath(path: string): boolean {
   return path === poperBlockerInjectedFetchPath;
 }
@@ -81,6 +88,62 @@ function hasExactPoperBlockerInjectedFetchFramePair(
   );
 }
 
+function hasOnlyFramePaths(
+  frame: SentryStackFrame,
+  predicate: (path: string) => boolean
+): boolean {
+  const framePaths = getFramePaths(frame);
+  return framePaths.length > 0 && framePaths.every(predicate);
+}
+
+function isExactUrbanVpnSentryWrapperFrame(frame: SentryStackFrame): boolean {
+  return (
+    frame.function === "XMLHttpRequest.r" &&
+    frame.lineno === 7 &&
+    frame.colno === 6173 &&
+    hasOnlyFramePaths(frame, (path) =>
+      urbanVpnSentryWrapperPathPattern.test(path)
+    )
+  );
+}
+
+function isExactUrbanVpnXhrFrame(frame: SentryStackFrame): boolean {
+  return (
+    frame.function === "XMLHttpRequest.onreadystatechange" &&
+    frame.lineno === 1 &&
+    frame.colno === 2598 &&
+    hasOnlyFramePaths(frame, (path) => path === urbanVpnExecutorPath)
+  );
+}
+
+function isExactUrbanVpnExecutorFrame(frame: SentryStackFrame): boolean {
+  return (
+    typeof frame.function === "string" &&
+    urbanVpnExecutorFunctions.has(frame.function) &&
+    frame.lineno === 1 &&
+    frame.colno === 761 &&
+    hasOnlyFramePaths(frame, (path) => path === urbanVpnExecutorPath)
+  );
+}
+
+function hasExactUrbanVpnExecutorStack(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  if (!Array.isArray(frames) || frames.length !== 3) {
+    return false;
+  }
+
+  const [sentryWrapperFrame, xhrFrame, executorFrame] = frames;
+  return (
+    !!sentryWrapperFrame &&
+    !!xhrFrame &&
+    !!executorFrame &&
+    isExactUrbanVpnSentryWrapperFrame(sentryWrapperFrame) &&
+    isExactUrbanVpnXhrFrame(xhrFrame) &&
+    isExactUrbanVpnExecutorFrame(executorFrame)
+  );
+}
+
 export function shouldFilterPoperBlockerOrphanFetchRejection(
   event: SentryClientEvent,
   hint?: SentryEventHint
@@ -102,4 +165,27 @@ export function shouldFilterPoperBlockerOrphanFetchRejection(
   }
 
   return hasExactPoperBlockerInjectedFetchFramePair(value.stacktrace?.frames);
+}
+
+export function shouldFilterUrbanVpnExecutorMIdError(
+  event: SentryClientEvent,
+  hint?: SentryEventHint
+): boolean {
+  const values = event.exception?.values;
+  if (!Array.isArray(values) || values.length !== 1) {
+    return false;
+  }
+
+  const [value] = values;
+  if (
+    value?.type !== "TypeError" ||
+    value.value !== urbanVpnExecutorMIdErrorMessage ||
+    value.mechanism?.type !== browserUnhandledRejectionMechanism ||
+    value.mechanism.handled !== false ||
+    hasAppOwnedSourceEvidence(event, value, hint)
+  ) {
+    return false;
+  }
+
+  return hasExactUrbanVpnExecutorStack(value.stacktrace?.frames);
 }


### PR DESCRIPTION
<!-- sentry-fix-job:58 issue:7664800881 -->
## Issue

- Sentry: [6529-FRONTEND-FA](https://seize-ff.sentry.io/issues/7664800881/)
- First seen: 2026-08-11T00:45:42.696Z
- Latest occurrence: 2026-08-11T11:26:43.000Z
- Automatic triage confidence: 98%

Add a narrow client-side Sentry filter for an Urban VPN Proxy injected-script failure. The production cohort contains only Sentry wrapper frames and the exact executors/200.js signature; no repository-owned source frame is present.

## Fix

The Sentry noise comes from an injected executors/200.js Urban VPN callback. The repair commit itself failed CI because its integration test accessed a possibly undefined exception fixture under strict Jest type checking.

## Changes

- Guarded the exception fixture before accessing its stack frames, resolving TS18048.
- Added positive tests proving different build-specific Next.js chunk names still match stable signals.
- Added fail-open tests for missing mechanism and stacktrace data.
- Strengthened the preserved-event assertion to verify unchanged content.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Four focused Jest suites passed: 178 tests.
- Jest and Playwright test typechecks passed.
- Changed-file lint passed.
- Changed-file typecheck passed for 82 TypeScript files.
- Targeted Prettier-equivalent formatting and git diff hygiene passed.
- The broader check:changed wrapper could not load the local Tailwind Prettier theme asset; it stopped at formatting after its typecheck passed.

## Risk

- Assessed risk: low
- Changed files: 5
- Changed lines: 419
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

CI has not rerun because commits and publication belong to the trusted publisher. Build and browser jobs were cancelled upstream and were not reproduced locally because this repair changes tests only. The full local quality wrapper remains blocked by a missing shared Tailwind theme asset, while an equivalent plugin-free formatting check passed for both edited files.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
