### PR TITLE
fix: Implemented a narrowly scoped Sentry filter for the WalletConnect session-settlement publish timeout whil

### DIFF
--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -42,6 +42,8 @@ describe("instrumentation-client", () => {
     "Attempt to get a record from database without an in-progress transaction";
   const talismanOnboardingMessage =
     "Talisman extension has not been configured yet. Please continue with onboarding.";
+  const walletConnectSessionSettlePublishFailureMessage =
+    "Failed to publish payload, please try again. id:1234567890 tag:1103";
   const braveWalletSelectedAddressMessage =
     "undefined is not an object (evaluating 'window.ethereum.selectedAddress = undefined')";
   const braveWalletEmitMessage =
@@ -448,6 +450,63 @@ describe("instrumentation-client", () => {
         },
       ],
     },
+  });
+
+  const createWalletConnectSessionSettlePublishFailureEvent = (
+    options: {
+      message?: string;
+      frames?: Array<Record<string, unknown>>;
+      breadcrumbs?: Array<Record<string, unknown>>;
+    } = {}
+  ) => ({
+    exception: {
+      values: [
+        {
+          type: "Error",
+          value:
+            options.message ??
+            walletConnectSessionSettlePublishFailureMessage,
+          mechanism: {
+            type: browserUnhandledRejectionMechanismType,
+            handled: false,
+          },
+          stacktrace: {
+            frames: options.frames ?? [
+              {
+                filename:
+                  "node_modules/.pnpm/@sentry+browser@10.45.0/node_modules/@sentry/browser/src/helpers.ts",
+                function: "r",
+                in_app: false,
+              },
+              {
+                filename:
+                  "node_modules/.pnpm/@walletconnect+sign-client@2.23.9/node_modules/@walletconnect/sign-client/src/controllers/engine.ts",
+                function: "<anonymous>",
+                in_app: false,
+              },
+            ],
+          },
+        },
+      ],
+    },
+    breadcrumbs: options.breadcrumbs ?? [
+      {
+        type: "default",
+        category: "ui.click",
+        level: "info",
+        message: "body.capacitor-native > w3m-modal.open",
+      },
+      {
+        type: "default",
+        category: "console",
+        level: "error",
+        message: "[object Object]",
+        data: {
+          arguments: [{ context: "core/publisher", level: 50 }],
+          logger: "console",
+        },
+      },
+    ],
   });
 
   const createRabbyChromeUserRejectedEvent = (
@@ -1911,6 +1970,63 @@ describe("instrumentation-client", () => {
     const result = beforeSend(event);
 
     expect(result).toBeNull();
+  });
+
+  it("drops the exact WalletConnect session-settlement publish failure", () => {
+    const beforeSend = loadBeforeSend();
+    const event = createWalletConnectSessionSettlePublishFailureEvent();
+
+    const result = beforeSend(event);
+
+    expect(result).toBeNull();
+  });
+
+  it.each([
+    [
+      "another payload tag",
+      createWalletConnectSessionSettlePublishFailureEvent({
+        message:
+          "Failed to publish payload, please try again. id:1234567890 tag:1105",
+      }),
+    ],
+    [
+      "missing publisher evidence",
+      createWalletConnectSessionSettlePublishFailureEvent({
+        breadcrumbs: [
+          {
+            type: "default",
+            category: "ui.click",
+            level: "info",
+            message: "body.capacitor-native > w3m-modal.open",
+          },
+        ],
+      }),
+    ],
+    [
+      "an application-owned frame",
+      createWalletConnectSessionSettlePublishFailureEvent({
+        frames: [
+          {
+            filename:
+              "node_modules/@walletconnect/sign-client/src/controllers/engine.ts",
+            function: "<anonymous>",
+            in_app: false,
+          },
+          {
+            filename:
+              "webpack-internal:///(app-pages-browser)/./services/auth/walletConnectSession.ts",
+            function: "settleWalletConnectSession",
+            in_app: true,
+          },
+        ],
+      }),
+    ],
+  ])("keeps the WalletConnect publish-failure near miss with %s", (_, event) => {
+    const beforeSend = loadBeforeSend();
+
+    const result = beforeSend(event);
+
+    expect(result).not.toBeNull();
   });
 
   it("drops exact Talisman onboarding errors from extension page.js frames", () => {

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -36,6 +36,7 @@ import {
   shouldFilterThirdPartyTelemetrySpan,
   shouldFilterTwitterCurrentInsetReferenceError,
   shouldFilterTwitterConfigReferenceError,
+  shouldFilterWalletConnectSessionSettlePublishFailure,
   shouldFilterWalletConnectStaleSessionTopic,
   tagSampledLowValueNetworkError,
   type SentryClientEvent,
@@ -338,6 +339,8 @@ describe("sentry-client-filters", () => {
     "t?.startsWith is not a function";
   const walletConnectStaleSessionTopicMessage =
     "No matching key. session topic doesn't exist: f17f5eaa1c3041fe37871f9eb24f4de53e1b11e494ec3def4b510d09acf42e32";
+  const walletConnectSessionSettlePublishFailureMessage =
+    "Failed to publish payload, please try again. id:1234567890 tag:1103";
   const extensionMessagingConnectionFailureMessage =
     "Could not establish connection. Receiving end does not exist.";
   const browserExtensionWalletRejectionMessage = "User rejected the request.";
@@ -2389,6 +2392,65 @@ describe("sentry-client-filters", () => {
         },
       ],
     },
+    ...overrides,
+  });
+
+  const walletConnectSessionSettleSymbolicatedFrames: SentryStackFrame[] = [
+    {
+      filename:
+        "node_modules/.pnpm/@sentry+browser@10.45.0/node_modules/@sentry/browser/src/helpers.ts",
+      abs_path:
+        "turbopack:///[project]/node_modules/.pnpm/@sentry+browser@10.45.0/node_modules/@sentry/browser/src/helpers.ts",
+      function: "r",
+      in_app: false,
+    },
+    {
+      filename:
+        "node_modules/.pnpm/@walletconnect+sign-client@2.23.9/node_modules/@walletconnect/sign-client/src/controllers/engine.ts",
+      abs_path:
+        "turbopack:///[project]/node_modules/.pnpm/@walletconnect+sign-client@2.23.9/node_modules/@walletconnect/sign-client/src/controllers/engine.ts",
+      function: "<anonymous>",
+      in_app: false,
+    },
+  ];
+  const walletConnectSessionSettleBreadcrumbs: TestSentryBreadcrumb[] = [
+    {
+      type: "default",
+      category: "ui.click",
+      level: "info",
+      message: "body.capacitor-native > w3m-modal.open",
+    },
+    {
+      type: "default",
+      category: "console",
+      level: "error",
+      message: "[object Object]",
+      data: {
+        arguments: [{ context: "core/publisher", level: 50 }],
+        logger: "console",
+      },
+    },
+  ];
+  const createWalletConnectSessionSettlePublishFailureEvent = (
+    overrides: TestSentryClientEventOverrides = {}
+  ): TestSentryClientEvent => ({
+    transaction: "/",
+    exception: {
+      values: [
+        {
+          type: "Error",
+          value: walletConnectSessionSettlePublishFailureMessage,
+          mechanism: {
+            type: "auto.browser.global_handlers.onunhandledrejection",
+            handled: false,
+          },
+          stacktrace: {
+            frames: walletConnectSessionSettleSymbolicatedFrames,
+          },
+        },
+      ],
+    },
+    breadcrumbs: walletConnectSessionSettleBreadcrumbs,
     ...overrides,
   });
 
@@ -7570,6 +7632,113 @@ describe("sentry-client-filters", () => {
 
     // Act
     const result = shouldFilterWalletConnectStaleSessionTopic(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("filters the exact WalletConnect session-settlement publish failure", () => {
+    // Arrange
+    const event = createWalletConnectSessionSettlePublishFailureEvent();
+
+    // Act
+    const result = shouldFilterWalletConnectSessionSettlePublishFailure(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("filters the pre-symbolication WalletConnect session-settlement publish failure", () => {
+    // Arrange
+    const event = createWalletConnectSessionSettlePublishFailureEvent();
+    event.exception!.values![0]!.stacktrace = {
+      frames: [
+        {
+          filename:
+            "app:///_next/static/chunks/runtime-a.js",
+          abs_path:
+            "app:///_next/static/chunks/runtime-a.js",
+          function: "r",
+          in_app: true,
+        },
+        {
+          filename: "app:///_next/static/chunks/app-b.js",
+          abs_path: "app:///_next/static/chunks/app-b.js",
+          in_app: true,
+        },
+      ],
+    };
+
+    // Act
+    const result = shouldFilterWalletConnectSessionSettlePublishFailure(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it.each<
+    [string, (event: TestSentryClientEvent) => void]
+  >([
+    [
+      "another WalletConnect payload tag",
+      (event) => {
+        event.exception!.values![0]!.value =
+          "Failed to publish payload, please try again. id:1234567890 tag:1105";
+      },
+    ],
+    [
+      "a message suffix",
+      (event) => {
+        event.exception!.values![0]!.value =
+          `${walletConnectSessionSettlePublishFailureMessage} retrying`;
+      },
+    ],
+    [
+      "a handled rejection",
+      (event) => {
+        event.exception!.values![0]!.mechanism!.handled = true;
+      },
+    ],
+    [
+      "another mechanism",
+      (event) => {
+        event.exception!.values![0]!.mechanism!.type =
+          "auto.browser.global_handlers.onerror";
+      },
+    ],
+    [
+      "missing publisher evidence",
+      (event) => {
+        event.breadcrumbs = [walletConnectSessionSettleBreadcrumbs[0]!];
+      },
+    ],
+    [
+      "an extra exception",
+      (event) => {
+        event.exception!.values!.push({
+          type: "Error",
+          value: "Application wallet state failed.",
+        });
+      },
+    ],
+    [
+      "an application-owned frame",
+      (event) => {
+        event.exception!.values![0]!.stacktrace!.frames!.push({
+          filename:
+            "webpack-internal:///(app-pages-browser)/./services/auth/walletConnectSession.ts",
+          function: "settleWalletConnectSession",
+          in_app: true,
+        });
+      },
+    ],
+  ])("keeps the publish-failure near miss with %s", (_, mutateEvent) => {
+    // Arrange
+    const event = createWalletConnectSessionSettlePublishFailureEvent();
+    mutateEvent(event);
+
+    // Act
+    const result = shouldFilterWalletConnectSessionSettlePublishFailure(event);
 
     // Assert
     expect(result).toBe(false);

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -56,6 +56,7 @@ import {
   shouldFilterThirdPartyTelemetrySpan,
   shouldFilterTwitterCurrentInsetReferenceError,
   shouldFilterTwitterConfigReferenceError,
+  shouldFilterWalletConnectSessionSettlePublishFailure,
   shouldFilterWalletConnectStaleSessionTopic,
   tagSampledLowValueNetworkError,
   type SentryTransactionSpan,
@@ -208,6 +209,10 @@ function shouldFilterEvent(
   }
 
   if (shouldFilterWalletConnectStaleSessionTopic(event, hint)) {
+    return true;
+  }
+
+  if (shouldFilterWalletConnectSessionSettlePublishFailure(event, hint)) {
     return true;
   }
 

--- a/utils/sentry-client-filters.ts
+++ b/utils/sentry-client-filters.ts
@@ -50,6 +50,7 @@ export {
   shouldFilterInjectedWalletCollision,
   shouldFilterKnownWalletProviderObjectRejection,
   shouldFilterTalismanExtensionOnboardingError,
+  shouldFilterWalletConnectSessionSettlePublishFailure,
   shouldFilterWalletConnectStaleSessionTopic,
 } from "./sentry-client-filters/wallets";
 export {

--- a/utils/sentry-client-filters/wallets.ts
+++ b/utils/sentry-client-filters/wallets.ts
@@ -28,12 +28,14 @@ import {
   getBreadcrumbMessages,
   getBreadcrumbValues,
   getEventMessage,
+  getFramePaths,
   getHintExceptionMessage,
   getHintExceptionStack,
   getNumericValue,
   getSerializedExceptionStack,
   getSerializedObjectRejection,
   getStringValue,
+  isRecord,
   isObjectCapturedPromiseRejectionMessage,
   normalizeErrorPrefix,
 } from "./value-utils";
@@ -60,6 +62,21 @@ import {
   hasWalletLinkWebSocketUnhandledRejectionSignature,
   isCoinbaseWalletLinkWebSocket1006Message,
 } from "./walletlink-websocket";
+
+const walletConnectSessionSettlePublishFailurePattern =
+  /^Failed to publish payload, please try again\. id:[0-9]+ tag:1103$/;
+const walletConnectPublisherBreadcrumbContext = "core/publisher";
+const walletConnectModalBreadcrumbMessage =
+  "body.capacitor-native > w3m-modal.open";
+const nextStaticChunkPathToken = "/_next/static/chunks/";
+const walletConnectEnginePathTokens = [
+  "@walletconnect/sign-client/src/controllers/engine.ts",
+  "@walletconnect+sign-client",
+];
+const sentryBrowserHelperPathTokens = [
+  "@sentry/browser/src/helpers.ts",
+  "@sentry+browser",
+];
 
 function isWalletConnectStaleSessionTopicMessage(value: string): boolean {
   const normalized = normalizeErrorPrefix(value);
@@ -96,6 +113,108 @@ function hasWalletConnectStaleSessionFrame(
       );
     })
   );
+}
+
+function isWalletConnectEnginePath(path: string): boolean {
+  return (
+    path.includes("/src/controllers/engine.ts") &&
+    walletConnectEnginePathTokens.some((token) => path.includes(token))
+  );
+}
+
+function isSentryBrowserHelperPath(path: string): boolean {
+  return (
+    path.includes("/src/helpers.ts") &&
+    sentryBrowserHelperPathTokens.some((token) => path.includes(token))
+  );
+}
+
+function isWalletConnectPublishVendorFrame(frame: SentryStackFrame): boolean {
+  const paths = getFramePaths(frame);
+  return (
+    paths.length > 0 &&
+    paths.every(
+      (path) =>
+        isWalletConnectEnginePath(path) || isSentryBrowserHelperPath(path)
+    )
+  );
+}
+
+function isRawNextStaticChunkFrame(frame: SentryStackFrame): boolean {
+  const paths = getFramePaths(frame);
+  return (
+    paths.length > 0 &&
+    paths.every((path) => path.includes(nextStaticChunkPathToken))
+  );
+}
+
+function hasWalletConnectSessionSettlePublishStack(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  if (!Array.isArray(frames) || frames.length === 0) {
+    return false;
+  }
+
+  if (frames.every(isRawNextStaticChunkFrame)) {
+    return true;
+  }
+
+  return (
+    frames.some((frame) => getFramePaths(frame).some(isWalletConnectEnginePath)) &&
+    frames.every(isWalletConnectPublishVendorFrame)
+  );
+}
+
+function isWalletConnectPublisherBreadcrumb(
+  breadcrumb: SentryBreadcrumb
+): boolean {
+  if (
+    breadcrumb.type !== "default" ||
+    breadcrumb.category !== "console" ||
+    breadcrumb.level !== "error" ||
+    breadcrumb.message !== "[object Object]" ||
+    breadcrumb.data?.["logger"] !== "console"
+  ) {
+    return false;
+  }
+
+  const args = breadcrumb.data["arguments"];
+  return (
+    Array.isArray(args) &&
+    args.some(
+      (argument) =>
+        isRecord(argument) &&
+        argument["context"] === walletConnectPublisherBreadcrumbContext
+    )
+  );
+}
+
+function isWalletConnectModalBreadcrumb(breadcrumb: SentryBreadcrumb): boolean {
+  return (
+    breadcrumb.type === "default" &&
+    breadcrumb.category === "ui.click" &&
+    breadcrumb.level === "info" &&
+    breadcrumb.message === walletConnectModalBreadcrumbMessage
+  );
+}
+
+function hasWalletConnectSessionSettlePublishBreadcrumbs(
+  event: SentryClientEvent
+): boolean {
+  let hasSeenModal = false;
+
+  for (const breadcrumb of getBreadcrumbValues(event)) {
+    if (isWalletConnectModalBreadcrumb(breadcrumb)) {
+      hasSeenModal = true;
+      continue;
+    }
+
+    if (hasSeenModal && isWalletConnectPublisherBreadcrumb(breadcrumb)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 export function matchesWalletCollisionPattern(value: string): boolean {
@@ -572,6 +691,36 @@ export function shouldFilterWalletConnectStaleSessionTopic(
   }
 
   return !hasAppOwnedSourceEvidence(event, value, hint);
+}
+
+export function shouldFilterWalletConnectSessionSettlePublishFailure(
+  event: SentryClientEvent,
+  hint?: SentryEventHint
+): boolean {
+  const values = event.exception?.values;
+  if (values?.length !== 1) {
+    return false;
+  }
+
+  const [value] = values;
+  if (
+    value?.type !== "Error" ||
+    typeof value.value !== "string" ||
+    !walletConnectSessionSettlePublishFailurePattern.test(value.value) ||
+    !hasBrowserUnhandledRejectionMechanism(value)
+  ) {
+    return false;
+  }
+
+  if (!hasWalletConnectSessionSettlePublishStack(value.stacktrace?.frames)) {
+    return false;
+  }
+
+  if (hasAppOwnedSourceEvidence(event, value, hint)) {
+    return false;
+  }
+
+  return hasWalletConnectSessionSettlePublishBreadcrumbs(event);
 }
 
 export function shouldFilterInjectedProviderProxyStartsWithError(


### PR DESCRIPTION
<!-- sentry-fix-job:61 issue:7678172563 -->
## Issue

- Sentry: [6529-FRONTEND-FX](https://seize-ff.sentry.io/issues/7678172563/)
- First seen: 2026-08-18T09:57:54.171Z
- Latest occurrence: 2026-08-18T09:57:54.000Z
- Automatic triage confidence: 94%

Create a draft PR for a narrowly scoped Sentry filter. This single event is an unhandled WalletConnect session-settlement publish timeout with no application-owned symbolicated frames; it is not evidence of a frontend defect.

## Fix

WalletConnect timed out publishing the wc_sessionSettle response (tag 1103) and rethrew the vendor error, which escaped through the browser unhandled-rejection handler.

## Changes

- Added an exact WalletConnect predicate requiring one unhandled Error, tag 1103, the observed vendor or raw chunk stack shape, ordered AppKit modal and core/publisher breadcrumbs, and no application-owned source evidence.
- Connected the predicate to the existing client beforeSend filter pipeline.
- Added positive symbolicated and pre-symbolication tests plus fail-open coverage for changed messages, other tags, handled errors, different mechanisms, missing vendor evidence, extra exceptions, and application-owned frames.
- Added beforeSend integration coverage for the exact signature and representative near misses.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Wallet filter Jest suite passed: 547 tests.
- Instrumentation-client Jest suite passed: 151 tests.
- ./bin/6529 run lint:changed passed.
- ./bin/6529 run typecheck:changed passed.
- git diff --check passed.

## Risk

- Assessed risk: low
- Changed files: 5
- Changed lines: 440
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

The event cannot distinguish device connectivity from a relay-side acknowledgement failure. This telemetry filter does not repair the underlying wallet connection failure; no full repository test suite or production runtime validation was run.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
