### PR TITLE
fix: No repair edit was warranted. The existing narrow, fail-open Sentry filter remains supported by complete 

### DIFF
--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -633,6 +633,48 @@ describe("instrumentation-client", () => {
     ],
   });
 
+  const createReactFlightConnectionClosedEvent = () => ({
+    timestamp: 1_000,
+    transaction: "/waves/:wave",
+    exception: {
+      values: [
+        {
+          type: "Error",
+          value: "Connection closed.",
+          mechanism: {
+            type: "generic",
+            handled: true,
+          },
+          stacktrace: {
+            frames: [
+              {
+                filename: "app:///_next/static/chunks/08qcqj3ricazz.js",
+                abs_path: "app:///_next/static/chunks/08qcqj3ricazz.js",
+                function: "eo",
+                lineno: 2,
+                colno: 31038,
+                in_app: true,
+              },
+            ],
+          },
+        },
+      ],
+    },
+    breadcrumbs: [
+      {
+        type: "http",
+        category: "fetch",
+        level: "error",
+        timestamp: 993.202,
+        data: {
+          url: "/api/waves/example-wave",
+          "url.is_first_party": true,
+          "url.is_first_party_api": true,
+        },
+      },
+    ],
+  });
+
   const createPoperBlockerOrphanFetchRejectionEvent = (
     value = poperBlockerNetworkErrorMessage,
     frames: Array<Record<string, unknown>> = poperBlockerProcessedFrames
@@ -2814,6 +2856,27 @@ describe("instrumentation-client", () => {
 
     expect(result).not.toBeNull();
     expect(result?.tags?.["network_noise_sampled"]).toBe("true");
+  });
+
+  it("drops the exact Waves React Flight connection close with recent API transport evidence", () => {
+    const beforeSend = loadBeforeSend();
+    const event = createReactFlightConnectionClosedEvent();
+
+    const result = beforeSend(event);
+
+    expect(result).toBeNull();
+  });
+
+  it("keeps the React Flight connection close without recent API transport evidence", () => {
+    const beforeSend = loadBeforeSend();
+    const event = {
+      ...createReactFlightConnectionClosedEvent(),
+      breadcrumbs: [],
+    };
+
+    const result = beforeSend(event);
+
+    expect(result).not.toBeNull();
   });
 
   it("drops the exact expected Wave background-sync replacement abort", () => {

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -24,6 +24,7 @@ import {
   shouldFilterKnownWalletProviderObjectRejection,
   shouldFilterReactDomInsertBeforeNotFoundError,
   shouldFilterReactDomRemoveChildNotFoundError,
+  shouldFilterReactFlightConnectionClosedError,
   shouldFilterInjectedWasmCspUnsafeEval,
   shouldFilterPoperBlockerOrphanFetchRejection,
   shouldFilterExpectedWaveRequestReplacementAbort,
@@ -174,10 +175,66 @@ type ExpectedWaveReplacementAbortOverrides = {
   breadcrumbs?: SentryClientEvent["breadcrumbs"];
   additionalException?: SentryExceptionValue | undefined;
 };
+type ReactFlightConnectionClosedOverrides = {
+  type?: string | undefined;
+  value?: string | undefined;
+  mechanismType?: string | undefined;
+  handled?: boolean | undefined;
+  transaction?: string | undefined;
+  eventTimestamp?: number | undefined;
+  includeEventTimestamp?: boolean | undefined;
+  frames?: SentryStackFrame[] | undefined;
+  breadcrumbs?: SentryClientEvent["breadcrumbs"];
+  additionalException?: SentryExceptionValue | undefined;
+};
+type ReactFlightTransportBreadcrumbOverrides = {
+  timestamp?: number | undefined;
+  includeTimestamp?: boolean | undefined;
+  statusCode?: number | undefined;
+  url?: string | undefined;
+  firstParty?: boolean | undefined;
+  firstPartyApi?: boolean | undefined;
+};
 
 const expectedWaveAbortErrorValue = "AbortError: The user aborted a request.";
 const expectedWaveAbortEventTimestamp = 1_785_689_742.621;
 const expectedWaveAbortBreadcrumbTimestamp = 1_785_689_742.5;
+const reactFlightEventTimestamp = 1_000;
+const reactFlightTransportFailureTimestamp = 993.202;
+const reactFlightRawChunkPath =
+  "app:///_next/static/chunks/08qcqj3ricazz.js";
+
+const createReactFlightRawFrame = (
+  overrides: Partial<SentryStackFrame> = {}
+): SentryStackFrame => ({
+  filename: reactFlightRawChunkPath,
+  abs_path: reactFlightRawChunkPath,
+  function: "eo",
+  lineno: 2,
+  colno: 31038,
+  in_app: true,
+  ...overrides,
+});
+
+const createReactFlightTransportBreadcrumb = ({
+  timestamp = reactFlightTransportFailureTimestamp,
+  includeTimestamp = true,
+  statusCode,
+  url = "/api/waves/example-wave",
+  firstParty = true,
+  firstPartyApi = true,
+}: ReactFlightTransportBreadcrumbOverrides = {}): TestSentryBreadcrumb => ({
+  type: "http",
+  category: "fetch",
+  level: "error",
+  ...(includeTimestamp ? { timestamp } : {}),
+  data: {
+    url,
+    ...(statusCode === undefined ? {} : { status_code: statusCode }),
+    "url.is_first_party": firstParty,
+    "url.is_first_party_api": firstPartyApi,
+  },
+});
 
 const createExpectedWaveReplacementAbortEvent = ({
   exception = {},
@@ -216,6 +273,37 @@ const createExpectedWaveReplacementAbortEvent = ({
   tags: includeDomExceptionCode
     ? { "DOMException.code": domExceptionCode }
     : {},
+  breadcrumbs,
+});
+
+const createReactFlightConnectionClosedEvent = ({
+  type = "Error",
+  value = "Connection closed.",
+  mechanismType = "generic",
+  handled = true,
+  transaction = "/waves/:wave",
+  eventTimestamp = reactFlightEventTimestamp,
+  includeEventTimestamp = true,
+  frames = [createReactFlightRawFrame()],
+  breadcrumbs = [createReactFlightTransportBreadcrumb()],
+  additionalException,
+}: ReactFlightConnectionClosedOverrides = {}): TestSentryClientEvent => ({
+  ...(includeEventTimestamp ? { timestamp: eventTimestamp } : {}),
+  transaction,
+  exception: {
+    values: [
+      {
+        type,
+        value,
+        mechanism: {
+          type: mechanismType,
+          handled,
+        },
+        stacktrace: { frames },
+      },
+      ...(additionalException ? [additionalException] : []),
+    ],
+  },
   breadcrumbs,
 });
 
@@ -11029,6 +11117,131 @@ describe("sentry-client-filters", () => {
     // Assert
     expect(result).toBe(false);
   });
+
+  it("filters the exact Waves React Flight connection close after a recent API transport failure", () => {
+    const event = createReactFlightConnectionClosedEvent();
+
+    const result = shouldFilterReactFlightConnectionClosedError(event);
+
+    expect(result).toBe(true);
+  });
+
+  it("filters the React Flight connection close at the causal time boundary", () => {
+    const event = createReactFlightConnectionClosedEvent({
+      eventTimestamp: reactFlightTransportFailureTimestamp + 10,
+    });
+
+    const result = shouldFilterReactFlightConnectionClosedError(event);
+
+    expect(result).toBe(true);
+  });
+
+  it.each([
+    ["a changed message", { value: "Connection lost." }],
+    ["a changed exception type", { type: "TypeError" }],
+    ["a changed mechanism", { mechanismType: "onerror" }],
+    ["an unhandled mechanism", { handled: false }],
+    ["another route", { transaction: "/notifications" }],
+    ["a missing event timestamp", { includeEventTimestamp: false }],
+    ["an invalid event timestamp", { eventTimestamp: Number.NaN }],
+    [
+      "a changed raw frame coordinate",
+      {
+        frames: [createReactFlightRawFrame({ colno: 31039 })],
+      },
+    ],
+    [
+      "an additional application frame",
+      {
+        frames: [
+          createReactFlightRawFrame(),
+          {
+            filename:
+              "webpack-internal:///(app-pages-browser)/./components/waves/WaveLayout.tsx",
+            in_app: true,
+          },
+        ],
+      },
+    ],
+    [
+      "an additional exception",
+      {
+        additionalException: {
+          type: "TypeError",
+          value: "Application state failed.",
+        },
+      },
+    ],
+    ["a missing transport breadcrumb", { breadcrumbs: [] }],
+    [
+      "a stale transport breadcrumb",
+      {
+        breadcrumbs: [
+          createReactFlightTransportBreadcrumb({
+            timestamp: reactFlightEventTimestamp - 10.001,
+          }),
+        ],
+      },
+    ],
+    [
+      "a missing breadcrumb timestamp",
+      {
+        breadcrumbs: [
+          createReactFlightTransportBreadcrumb({ includeTimestamp: false }),
+        ],
+      },
+    ],
+    [
+      "a breadcrumb timestamp after the event",
+      {
+        breadcrumbs: [
+          createReactFlightTransportBreadcrumb({
+            timestamp: reactFlightEventTimestamp + 0.001,
+          }),
+        ],
+      },
+    ],
+    [
+      "an HTTP status failure",
+      {
+        breadcrumbs: [
+          createReactFlightTransportBreadcrumb({ statusCode: 503 }),
+        ],
+      },
+    ],
+    [
+      "a first-party non-API transport failure",
+      {
+        breadcrumbs: [
+          createReactFlightTransportBreadcrumb({
+            url: "/waves/example-wave",
+            firstPartyApi: false,
+          }),
+        ],
+      },
+    ],
+    [
+      "a third-party transport failure",
+      {
+        breadcrumbs: [
+          createReactFlightTransportBreadcrumb({
+            url: "https://example.invalid/telemetry",
+            firstParty: false,
+            firstPartyApi: false,
+          }),
+        ],
+      },
+    ],
+  ] satisfies Array<[string, ReactFlightConnectionClosedOverrides]>)(
+    "keeps the React Flight connection-close near miss with %s",
+    (_, overrides) => {
+      const event = createReactFlightConnectionClosedEvent(overrides);
+
+      const result = shouldFilterReactFlightConnectionClosedError(event);
+
+      expect(result).toBe(false);
+    }
+  );
 
   it("filters the exact expected Wave background-sync replacement abort", () => {
     const event = createExpectedWaveReplacementAbortEvent();

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -46,6 +46,7 @@ import {
   shouldFilterKnownWalletProviderObjectRejection,
   shouldFilterReactDomInsertBeforeNotFoundError,
   shouldFilterReactDomRemoveChildNotFoundError,
+  shouldFilterReactFlightConnectionClosedError,
   shouldFilterInjectedWasmCspUnsafeEval,
   shouldFilterRabbyChromeUserRejectedRequest,
   shouldFilterRabbyMobileRainbowKitNotFoundError,
@@ -232,6 +233,10 @@ function shouldFilterEvent(
   }
 
   if (shouldFilterReactDomRemoveChildNotFoundError(event)) {
+    return true;
+  }
+
+  if (shouldFilterReactFlightConnectionClosedError(event)) {
     return true;
   }
 

--- a/utils/sentry-client-filters.ts
+++ b/utils/sentry-client-filters.ts
@@ -32,6 +32,9 @@ export {
   shouldFilterReactDomInsertBeforeNotFoundError,
   shouldFilterReactDomRemoveChildNotFoundError,
 } from "./sentry-client-filters/react-dom";
+export {
+  shouldFilterReactFlightConnectionClosedError,
+} from "./sentry-client-filters/react-flight";
 export { shouldFilterInstagramPageHideBridgeError } from "./sentry-client-filters/instagram-page-hide-bridge";
 export {
   shouldFilterBrowserExtensionMessagingConnectionError,

--- a/utils/sentry-client-filters/react-flight.ts
+++ b/utils/sentry-client-filters/react-flight.ts
@@ -1,0 +1,113 @@
+import type {
+  SentryBreadcrumb,
+  SentryClientEvent,
+  SentryStackFrame,
+} from "./types";
+import {
+  getBreadcrumbValues,
+  getRequestPathname,
+  hasWavesRoute,
+} from "./value-utils";
+import {
+  getBreadcrumbFailureKind,
+  getBreadcrumbUrl,
+  getBreadcrumbUrlIsFirstParty,
+  getBreadcrumbUrlIsFirstPartyApi,
+  isHttpBreadcrumb,
+} from "./network";
+
+const connectionClosedMessage = "Connection closed.";
+const maximumTransportFailureAgeSeconds = 10;
+const reactFlightRawChunkPath =
+  "app:///_next/static/chunks/08qcqj3ricazz.js";
+
+function isObservedReactFlightCloseFrame(frame: SentryStackFrame): boolean {
+  return (
+    frame.filename === reactFlightRawChunkPath &&
+    frame.abs_path === reactFlightRawChunkPath &&
+    frame.function === "eo" &&
+    frame.lineno === 2 &&
+    frame.colno === 31038 &&
+    frame.in_app === true
+  );
+}
+
+function hasObservedReactFlightCloseFrame(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  // beforeSend sees this minified frame before Sentry applies source maps.
+  // Keep the cohort-backed shape exact so build or minifier drift fails open.
+  return (
+    Array.isArray(frames) &&
+    frames.length === 1 &&
+    isObservedReactFlightCloseFrame(frames[0]!)
+  );
+}
+
+function isFirstPartyApiTransportFailure(
+  breadcrumb: SentryBreadcrumb
+): boolean {
+  const pathname = getRequestPathname(getBreadcrumbUrl(breadcrumb));
+  return (
+    isHttpBreadcrumb(breadcrumb) &&
+    breadcrumb.level === "error" &&
+    getBreadcrumbFailureKind(breadcrumb) === "transport" &&
+    getBreadcrumbUrlIsFirstParty(breadcrumb) === true &&
+    getBreadcrumbUrlIsFirstPartyApi(breadcrumb) === true &&
+    pathname?.startsWith("/api/") === true
+  );
+}
+
+function isRecentCausalBreadcrumb(
+  eventTimestamp: number | undefined,
+  breadcrumb: SentryBreadcrumb
+): boolean {
+  const breadcrumbTimestamp = breadcrumb.timestamp;
+  if (
+    typeof eventTimestamp !== "number" ||
+    !Number.isFinite(eventTimestamp) ||
+    typeof breadcrumbTimestamp !== "number" ||
+    !Number.isFinite(breadcrumbTimestamp)
+  ) {
+    return false;
+  }
+
+  const failureAgeSeconds = eventTimestamp - breadcrumbTimestamp;
+  return (
+    failureAgeSeconds >= 0 &&
+    failureAgeSeconds <= maximumTransportFailureAgeSeconds
+  );
+}
+
+function hasRecentFirstPartyApiTransportFailure(
+  event: SentryClientEvent
+): boolean {
+  return getBreadcrumbValues(event).some(
+    (breadcrumb) =>
+      isFirstPartyApiTransportFailure(breadcrumb) &&
+      isRecentCausalBreadcrumb(event.timestamp, breadcrumb)
+  );
+}
+
+export function shouldFilterReactFlightConnectionClosedError(
+  event: SentryClientEvent
+): boolean {
+  const values = event.exception?.values;
+  if (!Array.isArray(values) || values.length !== 1) {
+    return false;
+  }
+
+  const [value] = values;
+  if (
+    value?.type !== "Error" ||
+    value.value !== connectionClosedMessage ||
+    value.mechanism?.type !== "generic" ||
+    value.mechanism.handled !== true ||
+    !hasObservedReactFlightCloseFrame(value.stacktrace?.frames) ||
+    !hasWavesRoute(event)
+  ) {
+    return false;
+  }
+
+  return hasRecentFirstPartyApiTransportFailure(event);
+}


### PR DESCRIPTION
<!-- sentry-fix-job:59 issue:7130192992 -->
## Issue

- Sentry: [6529-FRONTEND-4N](https://seize-ff.sentry.io/issues/7130192992/)
- First seen: 2025-12-21T10:26:36.601Z
- Latest occurrence: 2026-08-11T05:01:04.000Z
- Automatic triage confidence: 91%

A useful draft fix is a narrow, fail-open Sentry telemetry filter. It should suppress this exact Waves-route React Flight signature only when a recent first-party API transport failure supports an interrupted connection. Current main still uses the affected Next.js version and has no matching classifier.

## Fix

React Flight emits `Connection closed.` when a response closes with unresolved chunks, as shown in the [React source](https://github.com/facebook/react/blob/3f0b9e61c467cd6e09cac6fb69f6e8f68cd3c5d7/packages/react-client/src/ReactFlightClient.js#L5325-L5364) and [pinned Next.js artifact](https://github.com/vercel/next.js/blob/9beca0821cf4606ae33466ed6f4fc75f2887a4da/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-client.browser.production.js#L1821-L1833). Sentry shows nearby first-party API transport failures but cannot identify which browser, network, proxy, or server endpoint closed the stream. The existing filter correctly requires the exact latest frame signature and causal breadcrumb window.

## Changes

- No files changed; the worktree remains clean at the draft PR head.
- Retained the existing exact Waves-route React Flight classifier and its fail-open regression coverage unchanged.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- PASS — focused Sentry filter suite: 557 tests.
- PASS — instrumentation integration suite: 149 tests.
- PASS — `lint:changed`.
- PASS — `typecheck:changed`.
- PASS — `typecheck:tests`, including the Jest diagnostic ratchet and Playwright typecheck.
- PASS — base-to-head whitespace validation.

## Risk

- Assessed risk: low
- Changed files: 5
- Changed lines: 397
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

The evidence cannot identify which network participant closed the stream. The raw frame signature is intentionally build-specific and will fail open after bundle drift. The cancelled critical-shell lane and Electron responsiveness run still require publisher-owned reruns; no GitHub or Sentry state was mutated.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
