### PR TITLE
docs: close Research production release

### DIFF
--- a/ops/workstreams/museum-full-site-correction/active-context.md
+++ b/ops/workstreams/museum-full-site-correction/active-context.md
@@ -174,3 +174,41 @@ AI-training permission.
   and CI with zero unresolved threads, merge, qualify staging, deploy the exact
   staging-qualified revision to production, and repeat the 11-route
   desktop/mobile live audit.
+
+## 2026-08-18 production release complete
+
+- Frontend PR #3753 merged as exact main
+  `336d3f9ed6839fd2fa97a677b25d5353aa4fc884`. Its runtime tree is identical to
+  reviewed candidate `2e87c0bbfc1f99a24063e5b9397d37b19a575a87` and remains
+  bound to Museum catalog commit
+  `a3977a8f020f58d0c9e79f23bc4f37245be65879` and reviewed publication
+  `f52fe5513423d8049bb557749a9fce1070ace64b`.
+- Staging deploy `32165422116` succeeded. The automatic staging E2E run
+  `32166673862` passed every selected Museum pack and failed only on the
+  pre-existing non-Museum profile Server Components fault. A retained 22-check
+  Research sweep found no heading, media, overflow, fallback, or soft-404
+  failure at desktop or 390-pixel mobile widths.
+- Production deploy `32170385482` succeeded after immutable builder
+  `32170437082` and verifier `32171381138` passed. Three uncached
+  `/api/version` reads returned exact main for both runtime and announced
+  version with `stale:false`.
+- Automatic Production E2E `32171973579` stalled for 22 minutes in the
+  GitHub-hosted Playwright browser installer before executing any pack and was
+  force-cancelled under the recorded temporary production E2E waiver. Isolated
+  completion run `32174375703` released the exact authority as failed; no
+  production byte changed during that infrastructure disposition.
+- The same five fail-closed Museum production packs were run directly against
+  exact live production. About passed 2/2, Rights 6/6, Inside the System 8/8,
+  Data Architecture 6/6 on clean rerun, and Institutional Practice plus the
+  complete public IA contract passed 79 with 3 intentional skips. Aggregate:
+  101 passed, 3 skipped, 0 product failures. The first Data Architecture
+  attempt saw two transient 502 responses from unrelated `Waves` and
+  `Join 6529` navigation prefetches; the immediate exact rerun passed 6/6.
+- Final live Research acceptance covered all 11 routes at 1440 and 390 pixels:
+  22/22 correct H1s, no broken images, no horizontal overflow, and no
+  soft-404s. Evidence report:
+  `C:\Users\Administrator\.codex\artifacts\museum-research-production-336d3f9\report.json`,
+  SHA-256 `bb4c318d2a4a4432859f4a659b8a493a551c930e84cc2a1d8d824e2a1e845794`.
+
+The Research release is complete on production. No runtime work remains in
+this workstream.

--- a/ops/workstreams/museum-full-site-correction/run-log.md
+++ b/ops/workstreams/museum-full-site-correction/run-log.md
@@ -343,3 +343,29 @@ comes first; acquisition and accession follow.` before the next hosted lane
   and public-publication Ubuntu and Windows.
 - The branch is ready for exact-head push, hosted review and CI, merge, staging
   qualification, production deployment, and live route-by-route acceptance.
+
+## 2026-08-18T19:03:00Z - Research release shipped and live-qualified
+
+- Merged frontend PR #3753 as exact main
+  `336d3f9ed6839fd2fa97a677b25d5353aa4fc884` after all exact-head review and CI
+  gates passed.
+- Deployed and inspected staging with run `32165422116`. All selected Museum
+  packs passed in staging E2E `32166673862`; its sole failure was the existing
+  non-Museum profile route fault. The retained Research sweep passed 22/22
+  desktop/mobile checks.
+- Production authority, immutable artifact build, and independent verification
+  passed in deploy `32170385482`, builder `32170437082`, and verifier
+  `32171381138`. Production serves and announces exact main with `stale:false`.
+- Automatic Production E2E `32171973579` never reached tests because its
+  GitHub-hosted runner stalled in Playwright installation for 22 minutes. It
+  was force-cancelled under the active owner-approved E2E waiver; authority
+  completion `32174375703` successfully recorded the failed qualifier and
+  released the lock.
+- Ran the five exact Museum production packs directly against live production:
+  101 passed and 3 intentional skips, with zero product failures. A first
+  Data Architecture pass observed unrelated navigation-prefetch 502s for
+  `/waves` and `/join-6529`; immediate rerun passed 6/6.
+- Rechecked every Research route at 1440 and 390 pixels in the signed-in app
+  browser. All 22 checks had the expected heading, intact media, bounded width,
+  and no soft-404. Retained report SHA-256:
+  `bb4c318d2a4a4432859f4a659b8a493a551c930e84cc2a1d8d824e2a1e845794`.


### PR DESCRIPTION
## Summary

Records the completed Network Museum Research release: canonical source/catalog commits, frontend production SHA, staging and production deployment evidence, direct production Museum qualification, and the final 22-route desktop/mobile browser audit.

## Runtime impact

Documentation only. No application code, content, build configuration, or production bytes change. No redeploy is required.

## Production qualification

- Production runtime: \336d3f9ed6839fd2fa97a677b25d5353aa4fc884\`n- Deploy run: https://github.com/6529-Collections/6529seize-frontend/actions/runs/32170385482
- Immutable builder: https://github.com/6529-Collections/6529seize-frontend/actions/runs/32170437082
- Artifact verifier: https://github.com/6529-Collections/6529seize-frontend/actions/runs/32171381138
- Exact five Museum production packs: 101 passed, 3 intentional skips, 0 product failures
- Live Research browser sweep: 11 routes x desktop/mobile = 22/22 pass

The automatic Production E2E runner was canceled after its hosted Playwright installation hung before tests began. The owner-approved release waiver and direct exact-runtime qualification are recorded without representing that infrastructure run as a successful E2E run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a completed release record for the Research update.
  * Documented successful staging and production deployments with live version verification.
  * Recorded production validation results, including the waived automated E2E run and successful direct checks.
  * Confirmed final desktop and mobile acceptance across all 11 routes.
  * Closed the workstream with no remaining runtime work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->