### PR TITLE
Balance Museum acquisition and artist media

### DIFF
--- a/__tests__/components/museum/MuseumProposalImage.test.tsx
+++ b/__tests__/components/museum/MuseumProposalImage.test.tsx
@@ -65,11 +65,14 @@ describe("MuseumProposalImage", () => {
         sourceByteSize={16_871_807}
         alt="Lorenzo Meloni exhibition photograph"
         requireIntentForLargeSource={false}
+        containerClassName="tw-h-full tw-w-full"
       />
     );
 
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
-    expect(screen.getByRole("img")).toHaveAttribute("src", media.src);
+    const image = screen.getByRole("img");
+    expect(image).toHaveAttribute("src", media.src);
+    expect(image.parentElement).toHaveClass("tw-h-full", "tw-w-full");
   });
 
   it("delivers a large governed source through a responsive runtime derivative", () => {

--- a/__tests__/components/museum/acquisition/MuseumAcquisitionLanding.test.tsx
+++ b/__tests__/components/museum/acquisition/MuseumAcquisitionLanding.test.tsx
@@ -230,6 +230,10 @@ describe("Museum acquisitions landing", () => {
     expect(screen.queryByText(/connected work/u)).not.toBeInTheDocument();
     expect(screen.getAllByTestId("museum-acquisition-card")).toHaveLength(3);
     expect(screen.getAllByRole("img")).toHaveLength(3);
+    for (const card of screen.getAllByTestId("museum-acquisition-card")) {
+      expect(card.querySelector(".tw-aspect-\\[4\\/3\\]")).not.toBeNull();
+      expect(card.querySelector(".lg\\:tw-aspect-\\[4\\/5\\]")).not.toBeNull();
+    }
   });
 
   it("keeps proposal disclosure controls outside navigation links", () => {

--- a/__tests__/components/museum/directory/MuseumDirectoryMediaCard.test.tsx
+++ b/__tests__/components/museum/directory/MuseumDirectoryMediaCard.test.tsx
@@ -119,6 +119,7 @@ describe("MuseumDirectoryMediaStage", () => {
     await user.click(imageGate);
     const image = screen.getByRole("img", { name: presentation.altText });
     expect(image).toHaveAttribute("src", presentation.mediaUrl);
+    expect(image).toHaveClass("tw-h-full", "tw-w-full", "tw-object-contain");
   });
 
   it("shows the governed presentation image on the artist card", async () => {
@@ -155,6 +156,11 @@ describe("MuseumDirectoryMediaStage", () => {
     expect(
       screen.getByRole("img", { name: presentation.altText })
     ).toHaveAttribute("src", presentation.mediaUrl);
+    expect(
+      screen
+        .getByRole("img", { name: presentation.altText })
+        .closest(".tw-aspect-\\[4\\/3\\]")
+    ).toBeInTheDocument();
   });
 
   it("fills and centers metadata-only states in the directory media frame", () => {

--- a/__tests__/components/museum/directory/MuseumDirectoryMediaCard.test.tsx
+++ b/__tests__/components/museum/directory/MuseumDirectoryMediaCard.test.tsx
@@ -186,8 +186,8 @@ describe("MuseumDirectoryMediaStage", () => {
               kind: "still",
               role: "source",
               mediaType: "image/jpeg",
-              width: 2400,
-              height: 1600,
+              width: null,
+              height: null,
               altText: "A retained source photograph.",
               credit: metadata.credit,
               sourcePath: "records/media/retained-01.json",
@@ -203,6 +203,9 @@ describe("MuseumDirectoryMediaStage", () => {
     );
 
     fireEvent.error(screen.getByRole("img"));
+    expect(
+      screen.getByRole("alert").closest(".tw-aspect-square")
+    ).toBeInTheDocument();
     expect(screen.getByRole("alert")).toHaveClass(
       "tw-h-full",
       "tw-items-center",

--- a/components/museum/MuseumProposalImage.tsx
+++ b/components/museum/MuseumProposalImage.tsx
@@ -26,6 +26,7 @@ export function MuseumProposalImage({
   eager = false,
   requireIntentForLargeSource = true,
   optimizeSource = false,
+  containerClassName,
   className,
 }: {
   readonly src: string;
@@ -47,6 +48,7 @@ export function MuseumProposalImage({
    * browser delivery and avoids transferring a multi-megabyte original.
    */
   readonly optimizeSource?: boolean;
+  readonly containerClassName?: string;
   readonly className?: string;
 }) {
   const responsiveVariants = [...variants].sort(
@@ -137,7 +139,7 @@ export function MuseumProposalImage({
         ref={focusRevealedMedia}
         tabIndex={-1}
         aria-label={statusMessage}
-        className="tw-outline-none"
+        className={`tw-outline-none ${containerClassName ?? ""}`}
       >
         <span className="tw-sr-only" aria-live="polite">
           {statusMessage}
@@ -173,7 +175,7 @@ export function MuseumProposalImage({
       ref={focusRevealedMedia}
       tabIndex={-1}
       aria-label={statusMessage}
-      className="tw-outline-none"
+      className={`tw-outline-none ${containerClassName ?? ""}`}
     >
       <span className="tw-sr-only" aria-live="polite">
         {statusMessage}

--- a/components/museum/MuseumProposalImage.tsx
+++ b/components/museum/MuseumProposalImage.tsx
@@ -81,6 +81,9 @@ export function MuseumProposalImage({
     focusOnRevealRef.current = false;
     node.focus();
   }, []);
+  const containerClasses = containerClassName
+    ? `tw-outline-none ${containerClassName}`
+    : "tw-outline-none";
 
   if (!revealed) {
     let statusMessage: string | null = null;
@@ -139,7 +142,7 @@ export function MuseumProposalImage({
         ref={focusRevealedMedia}
         tabIndex={-1}
         aria-label={statusMessage}
-        className={`tw-outline-none ${containerClassName ?? ""}`}
+        className={containerClasses}
       >
         <span className="tw-sr-only" aria-live="polite">
           {statusMessage}
@@ -175,7 +178,7 @@ export function MuseumProposalImage({
       ref={focusRevealedMedia}
       tabIndex={-1}
       aria-label={statusMessage}
-      className={`tw-outline-none ${containerClassName ?? ""}`}
+      className={containerClasses}
     >
       <span className="tw-sr-only" aria-live="polite">
         {statusMessage}

--- a/components/museum/acquisition/MuseumAcquisitionLanding.tsx
+++ b/components/museum/acquisition/MuseumAcquisitionLanding.tsx
@@ -302,40 +302,6 @@ function workCountLabel(count: number): string {
   );
 }
 
-function mediaAspectRatio(
-  media: MuseumAcquisitionLandingMedia | undefined,
-  metadata: MuseumMediaMetadata | undefined
-): string | undefined {
-  let dimensions: {
-    readonly width: number | null;
-    readonly height: number | null;
-  } | null = null;
-  if (media?.kind === "governed" || media?.kind === "proposal") {
-    dimensions = { width: media.width, height: media.height };
-  } else if (media?.kind === "program") {
-    dimensions = {
-      width: media.media.sourceWidth ?? media.media.variants[0]?.width ?? null,
-      height:
-        media.media.sourceHeight ?? media.media.variants[0]?.height ?? null,
-    };
-  } else if (metadata !== undefined) {
-    dimensions = { width: metadata.width, height: metadata.height };
-  }
-  const width = dimensions?.width;
-  const height = dimensions?.height;
-  if (
-    width === undefined ||
-    width === null ||
-    height === undefined ||
-    height === null ||
-    width <= 0 ||
-    height <= 0
-  ) {
-    return undefined;
-  }
-  return `${width} / ${height}`;
-}
-
 function MuseumAcquisitionMediaFrame({
   media,
   metadata,
@@ -352,7 +318,7 @@ function MuseumAcquisitionMediaFrame({
   }
   if (media === undefined) {
     return (
-      <div className="tw-flex tw-min-h-48 tw-items-end tw-bg-iron-950 tw-p-5">
+      <div className="tw-flex tw-h-full tw-items-end tw-bg-iron-950 tw-p-5">
         <p className="tw-m-0 tw-max-w-xs tw-text-sm tw-leading-6 tw-text-iron-400">
           {t(DEFAULT_LOCALE, "museum.network.media.unavailable")}
         </p>
@@ -361,7 +327,7 @@ function MuseumAcquisitionMediaFrame({
   }
 
   const imageClassName =
-    "tw-block tw-h-auto tw-w-full tw-object-contain tw-transition-transform tw-duration-300 group-hover:tw-scale-[1.01] motion-reduce:tw-transition-none";
+    "tw-block tw-h-full tw-w-full tw-object-contain tw-transition-transform tw-duration-300 group-hover:tw-scale-[1.01] motion-reduce:tw-transition-none";
   if (media.kind === "governed") {
     return (
       <MuseumManagedImage
@@ -397,6 +363,7 @@ function MuseumAcquisitionMediaFrame({
       sourceByteSize={media.sourceByteSize}
       variants={media.variants}
       eager={eager}
+      containerClassName="tw-h-full tw-w-full"
       className={imageClassName}
     />
   );
@@ -412,7 +379,6 @@ function MuseumAcquisitionLandingMediaCard({
   const { acquisition } = record;
   const sourceHref =
     record.media?.kind === "proposal" ? record.media.sourceHref : undefined;
-  const aspectRatio = mediaAspectRatio(record.media, record.metadata);
   const displayMediaTitle = /^6529NM[-.]/u.test(record.mediaTitle.trim())
     ? acquisition.title
     : record.mediaTitle;
@@ -423,8 +389,8 @@ function MuseumAcquisitionLandingMediaCard({
       data-testid="museum-acquisition-landing-media-card"
     >
       <div
-        className="tw-overflow-hidden tw-rounded-xl tw-bg-iron-950"
-        style={aspectRatio === undefined ? undefined : { aspectRatio }}
+        className="tw-flex tw-aspect-[4/3] tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-xl tw-bg-iron-950 lg:tw-aspect-[4/5]"
+        data-testid="museum-acquisition-media-stage"
       >
         <MuseumAcquisitionMediaFrame
           {...(record.media === undefined ? {} : { media: record.media })}
@@ -435,7 +401,7 @@ function MuseumAcquisitionLandingMediaCard({
           eager={eager}
         />
       </div>
-      <figcaption className="tw-pt-4">
+      <figcaption className="tw-pt-4 lg:tw-min-h-44">
         {hasDistinctMediaTitle ? (
           <span className="tw-block tw-text-sm tw-font-semibold tw-leading-6 tw-text-iron-100">
             {displayMediaTitle}
@@ -505,9 +471,12 @@ function AcquisitionFeature({
   const href = museumAcquisitionHref(acquisition.slug);
   const program = pathwayRelation(acquisition);
   return (
-    <article className="tw-min-w-0" data-testid="museum-acquisition-card">
+    <article
+      className="tw-flex tw-h-full tw-min-w-0 tw-flex-col"
+      data-testid="museum-acquisition-card"
+    >
       <MuseumAcquisitionLandingMediaCard record={record} eager={index < 3} />
-      <div className="tw-mt-5">
+      <div className="tw-mt-5 tw-flex tw-flex-1 tw-flex-col">
         <p className="tw-m-0 tw-text-xs tw-font-semibold tw-uppercase tw-tracking-[0.16em] tw-text-primary-300">
           {t(DEFAULT_LOCALE, "museum.network.acquisitions.eyebrow")}
         </p>
@@ -549,7 +518,7 @@ function AcquisitionFeature({
             </dd>
           </div>
         </dl>
-        <div className="tw-mt-4 tw-flex tw-flex-wrap tw-items-center tw-gap-x-5 tw-gap-y-2">
+        <div className="tw-mt-auto tw-flex tw-flex-wrap tw-items-center tw-gap-x-5 tw-gap-y-2 tw-pt-4">
           <Link
             href={href}
             className="hover:tw-text-primary-200 tw-inline-flex tw-min-h-11 tw-items-center tw-text-sm tw-font-semibold tw-text-primary-300 tw-underline tw-underline-offset-4 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"

--- a/components/museum/directory/MuseumDirectoryMediaCard.tsx
+++ b/components/museum/directory/MuseumDirectoryMediaCard.tsx
@@ -19,23 +19,41 @@ import { museumDirectoryStatusText } from "./MuseumDirectoryData";
 
 type MuseumDirectoryMediaStageShape = "source" | "artist";
 
+function hasMuseumDirectoryMediaDimensions(
+  width: number | null,
+  height: number | null
+): boolean {
+  return width !== null && height !== null && width > 0 && height > 0;
+}
+
 function museumDirectoryMediaStageStyle(
   shape: MuseumDirectoryMediaStageShape,
   width: number | null,
   height: number | null
 ): { readonly aspectRatio: string } | undefined {
   if (shape === "artist") return undefined;
-  return width !== null && height !== null && width > 0 && height > 0
+  return hasMuseumDirectoryMediaDimensions(width, height)
     ? { aspectRatio: `${width} / ${height}` }
     : undefined;
 }
 
 function museumDirectoryMediaStageClassName(
-  shape: MuseumDirectoryMediaStageShape
+  shape: MuseumDirectoryMediaStageShape,
+  width: number | null,
+  height: number | null
 ): string {
-  return `tw-flex tw-w-full tw-items-center tw-justify-center tw-overflow-hidden tw-bg-black ${
-    shape === "artist" ? "tw-aspect-[4/3]" : ""
-  }`;
+  const aspectClassName =
+    shape === "artist"
+      ? "tw-aspect-[4/3]"
+      : hasMuseumDirectoryMediaDimensions(width, height)
+        ? ""
+        : "tw-aspect-square";
+  return [
+    "tw-flex tw-w-full tw-items-center tw-justify-center tw-overflow-hidden tw-bg-black",
+    aspectClassName,
+  ]
+    .filter(Boolean)
+    .join(" ");
 }
 
 function MuseumDirectoryEmptyStage({
@@ -70,7 +88,11 @@ function MuseumDirectoryMediaStage({
   if (retained !== undefined) {
     return (
       <div
-        className={museumDirectoryMediaStageClassName(shape)}
+        className={museumDirectoryMediaStageClassName(
+          shape,
+          retained.width,
+          retained.height
+        )}
         style={museumDirectoryMediaStageStyle(
           shape,
           retained.width,
@@ -105,7 +127,11 @@ function MuseumDirectoryMediaStage({
     );
     return (
       <div
-        className={museumDirectoryMediaStageClassName(shape)}
+        className={museumDirectoryMediaStageClassName(
+          shape,
+          presentation.width,
+          presentation.height
+        )}
         style={museumDirectoryMediaStageStyle(
           shape,
           presentation.width,

--- a/components/museum/directory/MuseumDirectoryMediaCard.tsx
+++ b/components/museum/directory/MuseumDirectoryMediaCard.tsx
@@ -31,10 +31,10 @@ function museumDirectoryMediaStageStyle(
   width: number | null,
   height: number | null
 ): { readonly aspectRatio: string } | undefined {
-  if (shape === "artist") return undefined;
-  return hasMuseumDirectoryMediaDimensions(width, height)
-    ? { aspectRatio: `${width} / ${height}` }
-    : undefined;
+  if (shape === "artist" || !hasMuseumDirectoryMediaDimensions(width, height)) {
+    return undefined;
+  }
+  return { aspectRatio: `${String(width)} / ${String(height)}` };
 }
 
 function museumDirectoryMediaStageClassName(
@@ -42,12 +42,12 @@ function museumDirectoryMediaStageClassName(
   width: number | null,
   height: number | null
 ): string {
-  const aspectClassName =
-    shape === "artist"
-      ? "tw-aspect-[4/3]"
-      : hasMuseumDirectoryMediaDimensions(width, height)
-        ? ""
-        : "tw-aspect-square";
+  let aspectClassName = "";
+  if (shape === "artist") {
+    aspectClassName = "tw-aspect-[4/3]";
+  } else if (!hasMuseumDirectoryMediaDimensions(width, height)) {
+    aspectClassName = "tw-aspect-square";
+  }
   return [
     "tw-flex tw-w-full tw-items-center tw-justify-center tw-overflow-hidden tw-bg-black",
     aspectClassName,

--- a/components/museum/directory/MuseumDirectoryMediaCard.tsx
+++ b/components/museum/directory/MuseumDirectoryMediaCard.tsx
@@ -17,9 +17,39 @@ import type {
 } from "./MuseumDirectoryData";
 import { museumDirectoryStatusText } from "./MuseumDirectoryData";
 
-function MuseumDirectoryEmptyStage() {
+type MuseumDirectoryMediaStageShape = "source" | "artist";
+
+function museumDirectoryMediaStageStyle(
+  shape: MuseumDirectoryMediaStageShape,
+  width: number | null,
+  height: number | null
+): { readonly aspectRatio: string } | undefined {
+  if (shape === "artist") return undefined;
+  return width !== null && height !== null && width > 0 && height > 0
+    ? { aspectRatio: `${width} / ${height}` }
+    : undefined;
+}
+
+function museumDirectoryMediaStageClassName(
+  shape: MuseumDirectoryMediaStageShape
+): string {
+  return `tw-flex tw-w-full tw-items-center tw-justify-center tw-overflow-hidden tw-bg-black ${
+    shape === "artist" ? "tw-aspect-[4/3]" : ""
+  }`;
+}
+
+function MuseumDirectoryEmptyStage({
+  shape,
+}: {
+  readonly shape: MuseumDirectoryMediaStageShape;
+}) {
   return (
-    <div className="tw-flex tw-aspect-square tw-items-center tw-justify-center tw-bg-iron-950 tw-p-8 tw-text-center tw-text-sm tw-leading-6 tw-text-iron-500">
+    <div
+      className={`tw-flex tw-items-center tw-justify-center tw-bg-iron-950 tw-p-8 tw-text-center tw-text-sm tw-leading-6 tw-text-iron-500 ${
+        shape === "artist" ? "tw-aspect-[4/3]" : "tw-aspect-square"
+      }`}
+      data-testid="museum-directory-media-stage"
+    >
       {t(DEFAULT_LOCALE, "museum.network.media.unavailable")}
     </div>
   );
@@ -28,26 +58,25 @@ function MuseumDirectoryEmptyStage() {
 function MuseumDirectoryMediaStage({
   record,
   eager = false,
+  shape = "source",
 }: {
   readonly record: MuseumDirectoryWorkRecord | null;
   readonly eager?: boolean;
+  readonly shape?: MuseumDirectoryMediaStageShape;
 }) {
-  if (record === null) return <MuseumDirectoryEmptyStage />;
-
-  const mediaStageStyle = (
-    width: number | null,
-    height: number | null
-  ): { readonly aspectRatio: string } | undefined =>
-    width !== null && height !== null && width > 0 && height > 0
-      ? { aspectRatio: `${width} / ${height}` }
-      : undefined;
+  if (record === null) return <MuseumDirectoryEmptyStage shape={shape} />;
 
   const retained = selectMuseumStillMedia(record.work.media);
   if (retained !== undefined) {
     return (
       <div
-        className="tw-w-full tw-overflow-hidden tw-bg-black"
-        style={mediaStageStyle(retained.width, retained.height)}
+        className={museumDirectoryMediaStageClassName(shape)}
+        style={museumDirectoryMediaStageStyle(
+          shape,
+          retained.width,
+          retained.height
+        )}
+        data-testid="museum-directory-media-stage"
       >
         <MuseumManagedImage
           src={retained.url}
@@ -76,8 +105,13 @@ function MuseumDirectoryMediaStage({
     );
     return (
       <div
-        className="tw-w-full tw-overflow-hidden tw-bg-black"
-        style={mediaStageStyle(presentation.width, presentation.height)}
+        className={museumDirectoryMediaStageClassName(shape)}
+        style={museumDirectoryMediaStageStyle(
+          shape,
+          presentation.width,
+          presentation.height
+        )}
+        data-testid="museum-directory-media-stage"
       >
         <MuseumProposalImage
           src={presentation.mediaUrl}
@@ -96,6 +130,7 @@ function MuseumDirectoryMediaStage({
                   "museum.network.acquisitions.openPresentation"
                 ),
               })}
+          containerClassName="tw-h-full tw-w-full"
           className="tw-block tw-h-full tw-w-full tw-object-contain"
         />
       </div>
@@ -105,7 +140,12 @@ function MuseumDirectoryMediaStage({
   const metadata = record.work.mediaMetadata?.[0];
   if (metadata !== undefined) {
     return (
-      <div className="tw-aspect-square tw-w-full tw-overflow-hidden tw-bg-black">
+      <div
+        className={`${
+          shape === "artist" ? "tw-aspect-[4/3]" : "tw-aspect-square"
+        } tw-w-full tw-overflow-hidden tw-bg-black`}
+        data-testid="museum-directory-media-stage"
+      >
         <MuseumMediaMetadataPlaceholder
           title={record.work.title}
           metadata={metadata}
@@ -114,7 +154,7 @@ function MuseumDirectoryMediaStage({
     );
   }
 
-  return <MuseumDirectoryEmptyStage />;
+  return <MuseumDirectoryEmptyStage shape={shape} />;
 }
 
 export function MuseumDirectoryWorkCard({
@@ -182,9 +222,13 @@ export function MuseumDirectoryArtistCard({
   readonly eager?: boolean;
 }) {
   return (
-    <article className="tw-group tw-min-w-0">
-      <MuseumDirectoryMediaStage record={record.representative} eager={eager} />
-      <div className="tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-iron-800 tw-py-4">
+    <article className="tw-group tw-flex tw-h-full tw-min-w-0 tw-flex-col">
+      <MuseumDirectoryMediaStage
+        record={record.representative}
+        eager={eager}
+        shape="artist"
+      />
+      <div className="tw-flex tw-flex-1 tw-flex-col tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-iron-800 tw-py-4">
         <h2 className="tw-m-0 tw-text-lg tw-font-semibold tw-text-iron-50">
           <Link
             href={museumArtistHref(record.artist.slug)}

--- a/ops/workstreams/museum-full-site-correction/active-context.md
+++ b/ops/workstreams/museum-full-site-correction/active-context.md
@@ -212,3 +212,27 @@ AI-training permission.
 
 The Research release is complete on production. No runtime work remains in
 this workstream.
+
+## 2026-08-18 Acquisitions and Artists image-stage balance
+
+- This follow-up starts from frontend main
+  `f3e3032725a87d30aca21cafb554a7a19a541549`; the completed Research release
+  remains unchanged.
+- Production inspection found that both index pages inherited every source
+  image's native aspect ratio. Square, portrait, and landscape works therefore
+  produced uneven image boxes, misaligned titles, and irregular rows.
+- The Acquisitions index now gives all three curated acquisitions a consistent
+  4:5 desktop art stage and a more compact 4:3 stage below the three-column
+  breakpoint. The complete Casey, Magnum, and Keys and Gates images remain
+  visible with `object-fit: contain`.
+- The Artists index now uses a compact 4:3 directory stage for all 21 artists.
+  The source-specific behavior of the separate Works directory is preserved.
+- Initial rendered checks pass at 1440 and 390 pixels: all measured stages
+  have the intended ratio, image and copy baselines are balanced, and neither
+  page has horizontal overflow. Focused component, lint, and changed-TypeScript
+  checks pass. The exact rendered acceptance contract also passes at 1440,
+  820, and 390 pixels. Two local full-build attempts passed lint, compilation,
+  TypeScript, and page-data collection but the unchanged Governance route
+  exceeded the static export's 60-second limit; hosted CI is the authoritative
+  full-build gate. Remaining sequence: ready PR and bots, staging
+  qualification, production deployment, and live desktop/mobile readback.

--- a/ops/workstreams/museum-full-site-correction/run-log.md
+++ b/ops/workstreams/museum-full-site-correction/run-log.md
@@ -396,3 +396,7 @@ comes first; acquisition and accession follow.` before the next hosted lane
   `/museum/network/about/governance` static-generation timeout; the second was
   stopped after the duplicate infrastructure condition. Hosted exact-head CI
   will provide the authoritative full-build result.
+- PR #3780 review follow-up adds an explicit square fallback for dimensionless
+  source media in the unchanged Works-card behavior, removes a hardcoded
+  responsive-breakpoint expectation from the browser contract, and avoids an
+  empty class-name suffix. No Acquisitions or Artists layout pixel changes.

--- a/ops/workstreams/museum-full-site-correction/run-log.md
+++ b/ops/workstreams/museum-full-site-correction/run-log.md
@@ -400,3 +400,8 @@ comes first; acquisition and accession follow.` before the next hosted lane
   source media in the unchanged Works-card behavior, removes a hardcoded
   responsive-breakpoint expectation from the browser contract, and avoids an
   empty class-name suffix. No Acquisitions or Artists layout pixel changes.
+- Hosted App PR CI exposed four Linux lint errors in the new fallback helper:
+  nullable dimensions in a template literal and nested conditional branches.
+  Replaced the conditional expression with explicit branches and string
+  conversion. The focused 16 tests, changed lint, changed typecheck, formatting,
+  and diff checks pass; there is no runtime or visual change.

--- a/ops/workstreams/museum-full-site-correction/run-log.md
+++ b/ops/workstreams/museum-full-site-correction/run-log.md
@@ -369,3 +369,30 @@ comes first; acquisition and accession follow.` before the next hosted lane
   browser. All 22 checks had the expected heading, intact media, bounded width,
   and no soft-404. Retained report SHA-256:
   `bb4c318d2a4a4432859f4a659b8a493a551c930e84cc2a1d8d824e2a1e845794`.
+
+## 2026-08-18T20:10:00Z - Acquisitions and Artists balancing follow-up
+
+- Audited the live Acquisitions and Artists indexes at desktop width. Native
+  source aspect ratios caused visibly unequal image boxes and cascading row
+  heights on both primary Museum pages.
+- Implemented a fixed 4:5 desktop acquisition stage, a compact 4:3 responsive
+  acquisition stage, and a 4:3 artist-directory stage, preserving complete
+  images without cropping. Acquisition cards now share equal heights; the
+  Works directory keeps its prior source-ratio behavior.
+- Added component assertions and read-only browser contracts for exact stage
+  counts and ratios. Focused unit tests, changed lint, and changed typecheck
+  pass. Initial local browser checks at 1440 and 390 pixels show no horizontal
+  overflow and the expected 3 acquisition and 21 artist stages.
+- Completed the full-page visual sweep at desktop, tablet, and mobile widths.
+  The responsive acquisition stage is 4:5 only with the three-column desktop
+  composition and 4:3 below it; every artist stage remains 4:3. The deterministic
+  release acceptance suite passes all three owned viewports.
+- The acceptance suite exposed that a responsive Magnum derivative was visually
+  hidden by overflow but retained bounds taller than its frame. Added an
+  explicit full-height proposal-image container; all principal media now remain
+  geometrically within their stages.
+- Two clean-build attempts passed repository lint, optimized compilation,
+  TypeScript, and page-data collection. Both encountered the same unchanged
+  `/museum/network/about/governance` static-generation timeout; the second was
+  stopped after the duplicate infrastructure condition. Hosted exact-head CI
+  will provide the authoritative full-build result.

--- a/tests/museum/network-ia-readonly.spec.ts
+++ b/tests/museum/network-ia-readonly.spec.ts
@@ -287,10 +287,13 @@ test.describe("Museum public IA rendered contract @surface @readonly", () => {
           return width / height;
         })
     );
-    const acquisitionRatio =
-      (page.viewportSize()?.width ?? 1440) >= 1024 ? 4 / 5 : 4 / 3;
+    expect(
+      new Set(acquisitionStageRatios.map((ratio) => ratio.toFixed(3))).size
+    ).toBe(1);
     for (const ratio of acquisitionStageRatios) {
-      expect(ratio).toBeCloseTo(acquisitionRatio, 2);
+      expect(
+        [4 / 5, 4 / 3].some((expected) => Math.abs(ratio - expected) < 0.01)
+      ).toBe(true);
     }
     await retainScreenshot(page, testInfo, "museum-network-acquisitions");
 

--- a/tests/museum/network-ia-readonly.spec.ts
+++ b/tests/museum/network-ia-readonly.spec.ts
@@ -262,9 +262,36 @@ test.describe("Museum public IA rendered contract @surface @readonly", () => {
         ...new Set(links.map((link) => link.getAttribute("href"))),
       ]);
     expect(artistHrefs).toHaveLength(21);
+    const artistMediaStages = page.getByTestId("museum-directory-media-stage");
+    await expect(artistMediaStages).toHaveCount(21);
+    const artistStageRatios = await artistMediaStages.evaluateAll((stages) =>
+      stages.map((stage) => {
+        const { width, height } = stage.getBoundingClientRect();
+        return width / height;
+      })
+    );
+    for (const ratio of artistStageRatios) {
+      expect(ratio).toBeCloseTo(4 / 3, 2);
+    }
 
     await openRoute(page, "/museum/network/acquisitions");
     await expect(page.locator("article")).toHaveCount(3);
+    const acquisitionMediaStages = page.getByTestId(
+      "museum-acquisition-media-stage"
+    );
+    await expect(acquisitionMediaStages).toHaveCount(3);
+    const acquisitionStageRatios = await acquisitionMediaStages.evaluateAll(
+      (stages) =>
+        stages.map((stage) => {
+          const { width, height } = stage.getBoundingClientRect();
+          return width / height;
+        })
+    );
+    const acquisitionRatio =
+      (page.viewportSize()?.width ?? 1440) >= 1024 ? 4 / 5 : 4 / 3;
+    for (const ratio of acquisitionStageRatios) {
+      expect(ratio).toBeCloseTo(acquisitionRatio, 2);
+    }
     await retainScreenshot(page, testInfo, "museum-network-acquisitions");
 
     for (const [path, status] of [


### PR DESCRIPTION
## What changed

- gives the three Acquisitions cards one responsive visual system: 4:5 in the desktop three-column composition and 4:3 below it
- gives all 21 Artists cards a consistent 4:3 directory stage while preserving each complete image with `object-fit: contain`
- preserves source-proportional media on the separate Works directory
- makes governed proposal-image containers fill their stage so responsive Magnum derivatives are geometrically contained, not merely hidden by overflow
- adds deterministic stage-count, aspect-ratio, and responsive geometry coverage

## Why

The two primary Museum indexes inherited each source image's native aspect ratio. Square, portrait, and landscape works therefore produced uneven boxes, misaligned labels, and cascading row heights.

## Validation

- 4 focused Jest suites / 16 tests pass
- changed lint and changed TypeScript checks pass
- deterministic Museum release acceptance passes at 1440, 820, and 390 pixels
- complete rendered review covers all 3 acquisition cards and all 21 artist cards with no broken media or horizontal overflow
- two local full-build attempts passed repository lint, optimized compilation, TypeScript, and page-data collection; both were stopped by the same timeout on the unchanged `/museum/network/about/governance` static export, so hosted CI is the authoritative full-build gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Standardized image presentation across museum acquisition and artist directories.
  - Acquisition cards now use responsive 4:3 and 4:5 image stages for more consistent layouts.
  - Artist directory cards use consistent 4:3 image areas.
  - Images preserve intended proportions and avoid unintended cropping.
  - Missing image dimensions receive an appropriate square fallback.
  - Acquisition card content and footer links are aligned more consistently.
  - Proposal images reliably fill their available display area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->