### PR TITLE
Load staging SSR credentials and harden Playwright CI

### DIFF
--- a/.github/workflows/app-pr-ci.yml
+++ b/.github/workflows/app-pr-ci.yml
@@ -36,6 +36,8 @@ jobs:
       reviewbot_contract_required: ${{ steps.plan_outputs.outputs.reviewbot_contract_required }}
       agent_files_sync_required: ${{ steps.plan_outputs.outputs.agent_files_sync_required }}
       app_check_matrix: ${{ steps.plan_outputs.outputs.app_check_matrix }}
+      core_playwright_required: ${{ steps.plan_outputs.outputs.core_playwright_required }}
+      core_playwright_matrix: ${{ steps.plan_outputs.outputs.core_playwright_matrix }}
 
     steps:
       - name: Checkout code
@@ -177,14 +179,15 @@ jobs:
           const appCheckLanes = [
             { lane: "quality", label: "Quality and contracts", runner: defaultRunner },
           ];
+          const corePlaywrightLanes = [];
           if (plan.checks.build.required) {
             appCheckLanes.push({ lane: "build", label: "Production build", runner: buildRunner });
           }
           if (plan.checks.playwright_smoke.required) {
-            appCheckLanes.push({ lane: "playwright-smoke", label: "Playwright smoke", runner: defaultRunner });
+            corePlaywrightLanes.push({ lane: "playwright-smoke", label: "Playwright smoke", runner: defaultRunner });
           }
           if (plan.checks.playwright_critical_shell.required) {
-            appCheckLanes.push({
+            corePlaywrightLanes.push({
               lane: "playwright-critical-shell",
               label: "Playwright critical shell",
               runner: defaultRunner,
@@ -207,6 +210,8 @@ jobs:
             );
           }
           write("app_check_matrix", JSON.stringify({ include: appCheckLanes }));
+          write("core_playwright_required", String(corePlaywrightLanes.length > 0));
+          write("core_playwright_matrix", JSON.stringify({ include: corePlaywrightLanes }));
           NODE
 
       - name: Summarize CI plan
@@ -261,6 +266,109 @@ jobs:
             test-results/app-pr-ci/ci-plan.json
             test-results/app-pr-ci/secret-scan.json
             test-results/app-pr-ci/workflow-security.json
+          if-no-files-found: ignore
+          retention-days: 14
+
+  core-playwright-checks:
+    name: App check / ${{ matrix.label }}
+    needs: plan
+    if: needs.plan.outputs.core_playwright_required == 'true'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      issues: read
+    container:
+      image: mcr.microsoft.com/playwright:v1.61.1-noble@sha256:5b8f294aff9041b7191c34a4bab3ac270157a28774d4b0660e9743297b697e48
+      options: --ipc=host
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: true
+      matrix: ${{ fromJSON(needs.plan.outputs.core_playwright_matrix) }}
+
+    env:
+      API_ENDPOINT: "https://api.6529.io"
+      WS_ENDPOINT: "wss://ws.6529.io"
+      ALLOWLIST_API_ENDPOINT: "https://allowlist-api.6529.io"
+      BASE_ENDPOINT: "http://localhost:3001"
+      PLAYWRIGHT_BASE_URL: "http://localhost:3001"
+      PLAYWRIGHT_WEB_SERVER_COMMAND: "./bin/6529 run dev"
+      PLAYWRIGHT_WEB_SERVER_URL: "http://localhost:3001"
+      NEXTGEN_CHAIN_ID: "1"
+      MOBILE_APP_SCHEME: "mobile6529"
+      CORE_SCHEME: "core6529"
+      IPFS_API_ENDPOINT: "https://api-ipfs.6529.io"
+      IPFS_GATEWAY_ENDPOINT: "https://ipfs.6529.io"
+      GIPHY_API_KEY: ${{ vars.GIPHY_API_KEY }}
+      ASSETS_FROM_S3: "false"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22.17.1"
+
+      - name: Activate pinned pnpm
+        run: |
+          corepack enable pnpm
+          corepack prepare "$(node -p 'require("./package.json").packageManager')" --activate
+          pnpm --version
+
+      - name: Restore pnpm store
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-node22-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node22-pnpm-
+
+      - name: Use cached pnpm store
+        run: ./bin/6529 exec pnpm config set store-dir ~/.pnpm-store
+
+      - name: Install Socket Firewall
+        id: socket_firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall
+
+      - name: Assert npm lockfile is absent
+        run: ./bin/6529 guard:no-package-lock
+
+      - name: Install dependencies
+        env:
+          SFW_BIN: ${{ steps.socket_firewall.outputs.firewall-path-binary }}
+        run: ./bin/6529 install:frozen
+
+      - name: Run small Playwright smoke pack
+        if: matrix.lane == 'playwright-smoke'
+        env:
+          NEXT_DEV_DIST_DIR: ".next-playwright-smoke"
+          PLAYWRIGHT_READONLY: "1"
+        run: ./bin/6529 run test:e2e:smoke
+
+      - name: Run critical route-shell Playwright pack
+        if: matrix.lane == 'playwright-critical-shell'
+        env:
+          NEXT_DEV_DIST_DIR: ".next-playwright-critical-shell"
+          PLAYWRIGHT_READONLY: "1"
+        run: ./bin/6529 run test:e2e:critical-shell
+
+      - name: Upload app check artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: app-pr-ci-results-${{ matrix.lane }}-${{ github.event.pull_request.number || github.run_id }}
+          path: |
+            test-results/**
+            playwright-report/**
           if-no-files-found: ignore
           retention-days: 14
 
@@ -883,23 +991,42 @@ jobs:
           key: ${{ steps.nextjs_build_cache.outputs.cache-primary-key }}
 
       - name: Restore Playwright browser
-        if: startsWith(matrix.lane, 'playwright-')
+        if: startsWith(matrix.lane, 'playwright-museum-')
         id: playwright_browser_cache
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-node22-playwright-chromium-${{ hashFiles('pnpm-lock.yaml') }}
 
-      - name: Install Playwright browser
-        if: startsWith(matrix.lane, 'playwright-')
+      - name: Install Playwright dependencies
+        id: playwright_dependencies_primary
+        if: startsWith(matrix.lane, 'playwright-museum-')
+        timeout-minutes: 3
+        continue-on-error: true
+        run: ./bin/6529 exec playwright install-deps chromium
+
+      - name: Retry Playwright dependencies
+        id: playwright_dependencies_retry
+        if: startsWith(matrix.lane, 'playwright-museum-') && steps.playwright_dependencies_primary.outcome != 'success'
+        timeout-minutes: 3
+        continue-on-error: true
+        run: ./bin/6529 exec playwright install-deps chromium
+
+      - name: Verify Playwright dependencies
+        if: startsWith(matrix.lane, 'playwright-museum-')
         env:
-          PLAYWRIGHT_CACHE_HIT: ${{ steps.playwright_browser_cache.outputs.cache-hit }}
+          PRIMARY_OUTCOME: ${{ steps.playwright_dependencies_primary.outcome }}
+          RETRY_OUTCOME: ${{ steps.playwright_dependencies_retry.outcome }}
         run: |
-          if [ "$PLAYWRIGHT_CACHE_HIT" = true ]; then
-            ./bin/6529 exec playwright install-deps chromium
-          else
-            ./bin/6529 exec playwright install --with-deps chromium
+          if [ "$PRIMARY_OUTCOME" != success ] && [ "$RETRY_OUTCOME" != success ]; then
+            echo "Playwright system dependency installation failed twice." >&2
+            exit 1
           fi
+
+      - name: Install Playwright browser
+        if: startsWith(matrix.lane, 'playwright-museum-')
+        timeout-minutes: 10
+        run: ./bin/6529 exec playwright install chromium
 
       - name: Resolve exact Museum publication for Playwright
         id: museum_publication
@@ -1061,20 +1188,6 @@ jobs:
             ].join("\n")
           );
           NODE
-
-      - name: Run small Playwright smoke pack
-        if: matrix.lane == 'playwright-smoke'
-        env:
-          NEXT_DEV_DIST_DIR: ".next-playwright-smoke"
-          PLAYWRIGHT_READONLY: "1"
-        run: ./bin/6529 run test:e2e:smoke
-
-      - name: Run critical route-shell Playwright pack
-        if: matrix.lane == 'playwright-critical-shell'
-        env:
-          NEXT_DEV_DIST_DIR: ".next-playwright-critical-shell"
-          PLAYWRIGHT_READONLY: "1"
-        run: ./bin/6529 run test:e2e:critical-shell
 
       - name: Run Network Museum Playwright packs
         if: startsWith(matrix.lane, 'playwright-museum-')
@@ -1385,6 +1498,7 @@ jobs:
     needs:
       - plan
       - app-checks
+      - core-playwright-checks
     if: always() && needs.plan.result == 'success' && needs.plan.outputs.install_required == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1395,4 +1509,10 @@ jobs:
       - name: Require successful parallel app checks
         env:
           APP_CHECKS_RESULT: ${{ needs.app-checks.result }}
-        run: test "$APP_CHECKS_RESULT" = "success"
+          CORE_PLAYWRIGHT_REQUIRED: ${{ needs.plan.outputs.core_playwright_required }}
+          CORE_PLAYWRIGHT_RESULT: ${{ needs.core-playwright-checks.result }}
+        run: |
+          test "$APP_CHECKS_RESULT" = "success"
+          if [ "$CORE_PLAYWRIGHT_REQUIRED" = true ]; then
+            test "$CORE_PLAYWRIGHT_RESULT" = "success"
+          fi

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -555,9 +555,14 @@ jobs:
           PUBLIC_REVIEW_DISCUSSION_DESTINATIONS: ${{ secrets.PUBLIC_REVIEW_DISCUSSION_DESTINATIONS }}
           REPO_DIR: ${{ env.STAGING_REPO_DIR }}
           RUN_AS: ${{ env.STAGING_RUN_AS }}
+          STAGING_SSR_CLIENT_ID: ${{ secrets.STAGING_SSR_CLIENT_ID }}
+          STAGING_SSR_CLIENT_SECRET: ${{ secrets.STAGING_SSR_CLIENT_SECRET }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+
+          test -n "$STAGING_SSR_CLIENT_ID"
+          test -n "$STAGING_SSR_CLIENT_SECRET"
 
           jq -e '
             type == "object" and
@@ -584,6 +589,12 @@ jobs:
             printf '%q' \
               "$(printf '%s' "$PUBLIC_REVIEW_DISCUSSION_DESTINATIONS" | base64 -w0)"
           )"
+          ssr_client_id_b64_q="$(
+            printf '%q' "$(printf '%s' "$STAGING_SSR_CLIENT_ID" | base64 -w0)"
+          )"
+          ssr_client_secret_b64_q="$(
+            printf '%q' "$(printf '%s' "$STAGING_SSR_CLIENT_SECRET" | base64 -w0)"
+          )"
 
           remote_script="$(
             cat <<REMOTE_SCRIPT_VARS
@@ -595,6 +606,8 @@ jobs:
           EXPECTED_DIGEST=$expected_digest_q
           EXPECTED_SHA=$expected_sha_q
           PUBLIC_REVIEW_DISCUSSION_DESTINATIONS_B64=$public_review_destinations_b64_q
+          SSR_CLIENT_ID_B64=$ssr_client_id_b64_q
+          SSR_CLIENT_SECRET_B64=$ssr_client_secret_b64_q
           REMOTE_SCRIPT_VARS
             cat <<'REMOTE_SCRIPT_BODY'
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -660,6 +660,8 @@ jobs:
           PUBLIC_REVIEW_DISCUSSION_DESTINATIONS_B64="$PUBLIC_REVIEW_DISCUSSION_DESTINATIONS_B64" \
           REPO_DIR="$REPO_DIR" \
           RUN_AS="$RUN_AS" \
+          SSR_CLIENT_ID_B64="$SSR_CLIENT_ID_B64" \
+          SSR_CLIENT_SECRET_B64="$SSR_CLIENT_SECRET_B64" \
             bash ops/scripts/deploy-staging-artifact.sh
           REMOTE_SCRIPT_BODY
           )"

--- a/.github/workflows/production-e2e.yml
+++ b/.github/workflows/production-e2e.yml
@@ -386,18 +386,39 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-chromium-${{ hashFiles('pnpm-lock.yaml') }}
-      - name: Install Playwright browser
-        id: playwright
+      - name: Install Playwright dependencies
         if: steps.dependencies.outcome == 'success'
+        id: playwright_dependencies_primary
+        timeout-minutes: 3
+        continue-on-error: true
+        run: ./bin/6529 exec playwright install-deps chromium
+
+      - name: Retry Playwright dependencies
+        if: steps.dependencies.outcome == 'success' && steps.playwright_dependencies_primary.outcome != 'success'
+        id: playwright_dependencies_retry
+        timeout-minutes: 3
+        continue-on-error: true
+        run: ./bin/6529 exec playwright install-deps chromium
+
+      - name: Verify Playwright dependencies
+        if: steps.dependencies.outcome == 'success'
+        id: playwright_dependencies
         continue-on-error: true
         env:
-          PLAYWRIGHT_CACHE_HIT: ${{ steps.playwright-cache.outputs.cache-hit }}
+          PRIMARY_OUTCOME: ${{ steps.playwright_dependencies_primary.outcome }}
+          RETRY_OUTCOME: ${{ steps.playwright_dependencies_retry.outcome }}
         run: |
-          if [ "$PLAYWRIGHT_CACHE_HIT" = true ]; then
-            ./bin/6529 exec playwright install-deps chromium
-          else
-            ./bin/6529 exec playwright install --with-deps chromium
+          if [ "$PRIMARY_OUTCOME" != success ] && [ "$RETRY_OUTCOME" != success ]; then
+            echo "Playwright system dependency installation failed twice." >&2
+            exit 1
           fi
+
+      - name: Install Playwright browser
+        id: playwright
+        if: steps.dependencies.outcome == 'success' && steps.playwright_dependencies.outcome == 'success'
+        timeout-minutes: 10
+        continue-on-error: true
+        run: ./bin/6529 exec playwright install chromium
       - name: Run production-safe read-only packs
         id: e2e
         if: steps.museum-publication.outcome == 'success' && steps.playwright.outcome == 'success'

--- a/.github/workflows/release-bus-deploy-staging.yml
+++ b/.github/workflows/release-bus-deploy-staging.yml
@@ -475,19 +475,6 @@ jobs:
             sudo -H -u "$RUN_AS" pm2 save || return 1
           }
 
-          install -d -o "$RUN_AS" -g "$RUN_AS" "$release_root"
-          runtime_secrets_tmp="$(mktemp "$release_root/runtime-secrets.XXXXXX.json")"
-          jq -n \
-            --arg ssr_client_id "$ssr_client_id" \
-            --arg ssr_client_secret "$ssr_client_secret" \
-            '{SSR_CLIENT_ID:$ssr_client_id,SSR_CLIENT_SECRET:$ssr_client_secret}' \
-            > "$runtime_secrets_tmp"
-          chown "$RUN_AS:$RUN_AS" "$runtime_secrets_tmp"
-          chmod 600 "$runtime_secrets_tmp"
-          mv -f "$runtime_secrets_tmp" "$runtime_secrets_file"
-          runtime_secrets_tmp=''
-          unset ssr_client_id SSR_CLIENT_ID_B64 ssr_client_secret SSR_CLIENT_SECRET_B64
-
           install -d -o "$RUN_AS" -g "$RUN_AS" "$release_dir"
           http_status="$(curl --silent --show-error --proto '=https' \
             --output "$release_dir/package.zip" \
@@ -517,6 +504,17 @@ jobs:
             "$release_dir/public-review-discussion-destinations.json"
           chmod 600 "$release_dir/public-review-discussion-destinations.json"
           unset review_destinations PUBLIC_REVIEW_DISCUSSION_DESTINATIONS_B64
+          runtime_secrets_tmp="$(mktemp "$release_root/runtime-secrets.XXXXXX.json")"
+          jq -n \
+            --arg ssr_client_id "$ssr_client_id" \
+            --arg ssr_client_secret "$ssr_client_secret" \
+            '{SSR_CLIENT_ID:$ssr_client_id,SSR_CLIENT_SECRET:$ssr_client_secret}' \
+            > "$runtime_secrets_tmp"
+          chown "$RUN_AS:$RUN_AS" "$runtime_secrets_tmp"
+          chmod 600 "$runtime_secrets_tmp"
+          mv -f "$runtime_secrets_tmp" "$runtime_secrets_file"
+          runtime_secrets_tmp=''
+          unset ssr_client_id SSR_CLIENT_ID_B64 ssr_client_secret SSR_CLIENT_SECRET_B64
           ln -sfn "$release_dir/app" "$current_link"
           cat > "$release_root/ecosystem.config.cjs" <<'PM2_CONFIG'
           const fs = require('node:fs');

--- a/.github/workflows/release-bus-deploy-staging.yml
+++ b/.github/workflows/release-bus-deploy-staging.yml
@@ -304,6 +304,25 @@ jobs:
           release_root="$REPO_DIR/.release-bus"
           release_dir="$release_root/releases/$EXPECTED_SHA"
           current_link="$release_root/current"
+          runtime_env_path="$REPO_DIR/.env"
+          test -r "$runtime_env_path" || {
+            echo "Staging runtime environment file '$runtime_env_path' is not readable." >&2
+            exit 1
+          }
+          sudo -H -u "$RUN_AS" node - "$runtime_env_path" <<'NODE'
+          const fs = require('node:fs');
+          const { parseEnv } = require('node:util');
+
+          const runtimeEnvPath = process.argv[2];
+          const runtimeEnv = parseEnv(fs.readFileSync(runtimeEnvPath, 'utf8'));
+          for (const name of ['SSR_CLIENT_ID', 'SSR_CLIENT_SECRET']) {
+            if (typeof runtimeEnv[name] !== 'string' || !runtimeEnv[name].trim()) {
+              throw new Error(
+                `Required staging runtime value ${name} is missing from ${runtimeEnvPath}.`
+              );
+            }
+          }
+          NODE
           previous_target="$(readlink -f "$current_link" 2>/dev/null || true)"
           pm2_json="$(sudo -H -u "$RUN_AS" pm2 jlist)"
           process_count="$(jq '[.[] | select(.name == "6529seize")] | length' <<<"$pm2_json")"
@@ -486,8 +505,20 @@ jobs:
           cat > "$release_root/ecosystem.config.cjs" <<'PM2_CONFIG'
           const fs = require('node:fs');
           const path = require('node:path');
+          const { parseEnv } = require('node:util');
 
           const currentApp = fs.realpathSync(path.join(__dirname, 'current'));
+          const runtimeEnvPath = path.join(__dirname, '..', '.env');
+          const runtimeEnv = parseEnv(fs.readFileSync(runtimeEnvPath, 'utf8'));
+          const requireRuntimeEnv = (name) => {
+            const value = runtimeEnv[name];
+            if (typeof value !== 'string' || !value.trim()) {
+              throw new Error(
+                `Required staging runtime value ${name} is missing from ${runtimeEnvPath}.`
+              );
+            }
+            return value;
+          };
           const destinationsPath = path.join(
             path.dirname(currentApp),
             'public-review-discussion-destinations.json'
@@ -518,6 +549,8 @@ jobs:
                 PORT: '3001',
                 HOSTNAME: '0.0.0.0',
                 NODE_ENV: 'production',
+                ['SSR_CLIENT_ID']: requireRuntimeEnv('SSR_CLIENT_ID'),
+                ['SSR_CLIENT_SECRET']: requireRuntimeEnv('SSR_CLIENT_SECRET'),
                 ...(publicReviewDiscussionDestinations
                   ? {
                       PUBLIC_REVIEW_DISCUSSION_DESTINATIONS:

--- a/.github/workflows/release-bus-deploy-staging.yml
+++ b/.github/workflows/release-bus-deploy-staging.yml
@@ -281,9 +281,13 @@ jobs:
           PUBLIC_REVIEW_DISCUSSION_DESTINATIONS: ${{ secrets.PUBLIC_REVIEW_DISCUSSION_DESTINATIONS }}
           REPO_DIR: ${{ env.STAGING_REPO_DIR }}
           RUN_AS: ${{ env.STAGING_RUN_AS }}
+          STAGING_SSR_CLIENT_ID: ${{ secrets.STAGING_SSR_CLIENT_ID }}
+          STAGING_SSR_CLIENT_SECRET: ${{ secrets.STAGING_SSR_CLIENT_SECRET }}
         run: |
           set -euo pipefail
           test -n "$INSTANCE_ID"
+          test -n "$STAGING_SSR_CLIENT_ID"
+          test -n "$STAGING_SSR_CLIENT_SECRET"
           jq -e '
             type == "object" and
             has("staging") and
@@ -299,30 +303,29 @@ jobs:
               "$(printf '%s' "$PUBLIC_REVIEW_DISCUSSION_DESTINATIONS" | base64 -w0)"
             printf 'REPO_DIR=%q\n' "$REPO_DIR"
             printf 'RUN_AS=%q\n' "$RUN_AS"
+            printf 'SSR_CLIENT_ID_B64=%q\n' \
+              "$(printf '%s' "$STAGING_SSR_CLIENT_ID" | base64 -w0)"
+            printf 'SSR_CLIENT_SECRET_B64=%q\n' \
+              "$(printf '%s' "$STAGING_SSR_CLIENT_SECRET" | base64 -w0)"
             cat <<'REMOTE'
           set -euo pipefail
           release_root="$REPO_DIR/.release-bus"
           release_dir="$release_root/releases/$EXPECTED_SHA"
           current_link="$release_root/current"
-          runtime_env_path="$REPO_DIR/.env"
-          test -r "$runtime_env_path" || {
-            echo "Staging runtime environment file '$runtime_env_path' is not readable." >&2
-            exit 1
+          runtime_secrets_file="$release_root/runtime-secrets.json"
+          ssr_client_id="$(printf '%s' "$SSR_CLIENT_ID_B64" | base64 -d)"
+          ssr_client_secret="$(printf '%s' "$SSR_CLIENT_SECRET_B64" | base64 -d)"
+          test -n "$ssr_client_id"
+          test -n "$ssr_client_secret"
+          runtime_secrets_tmp=''
+          cleanup_runtime_secrets() {
+            unset ssr_client_id SSR_CLIENT_ID_B64 \
+              ssr_client_secret SSR_CLIENT_SECRET_B64
+            if [ -n "$runtime_secrets_tmp" ]; then
+              rm -f -- "$runtime_secrets_tmp"
+            fi
           }
-          sudo -H -u "$RUN_AS" node - "$runtime_env_path" <<'NODE'
-          const fs = require('node:fs');
-          const { parseEnv } = require('node:util');
-
-          const runtimeEnvPath = process.argv[2];
-          const runtimeEnv = parseEnv(fs.readFileSync(runtimeEnvPath, 'utf8'));
-          for (const name of ['SSR_CLIENT_ID', 'SSR_CLIENT_SECRET']) {
-            if (typeof runtimeEnv[name] !== 'string' || !runtimeEnv[name].trim()) {
-              throw new Error(
-                `Required staging runtime value ${name} is missing from ${runtimeEnvPath}.`
-              );
-            }
-          }
-          NODE
+          trap cleanup_runtime_secrets EXIT HUP INT TERM
           previous_target="$(readlink -f "$current_link" 2>/dev/null || true)"
           pm2_json="$(sudo -H -u "$RUN_AS" pm2 jlist)"
           process_count="$(jq '[.[] | select(.name == "6529seize")] | length' <<<"$pm2_json")"
@@ -472,6 +475,19 @@ jobs:
             sudo -H -u "$RUN_AS" pm2 save || return 1
           }
 
+          install -d -o "$RUN_AS" -g "$RUN_AS" "$release_root"
+          runtime_secrets_tmp="$(mktemp "$release_root/runtime-secrets.XXXXXX.json")"
+          jq -n \
+            --arg ssr_client_id "$ssr_client_id" \
+            --arg ssr_client_secret "$ssr_client_secret" \
+            '{SSR_CLIENT_ID:$ssr_client_id,SSR_CLIENT_SECRET:$ssr_client_secret}' \
+            > "$runtime_secrets_tmp"
+          chown "$RUN_AS:$RUN_AS" "$runtime_secrets_tmp"
+          chmod 600 "$runtime_secrets_tmp"
+          mv -f "$runtime_secrets_tmp" "$runtime_secrets_file"
+          runtime_secrets_tmp=''
+          unset ssr_client_id SSR_CLIENT_ID_B64 ssr_client_secret SSR_CLIENT_SECRET_B64
+
           install -d -o "$RUN_AS" -g "$RUN_AS" "$release_dir"
           http_status="$(curl --silent --show-error --proto '=https' \
             --output "$release_dir/package.zip" \
@@ -505,16 +521,17 @@ jobs:
           cat > "$release_root/ecosystem.config.cjs" <<'PM2_CONFIG'
           const fs = require('node:fs');
           const path = require('node:path');
-          const { parseEnv } = require('node:util');
 
           const currentApp = fs.realpathSync(path.join(__dirname, 'current'));
-          const runtimeEnvPath = path.join(__dirname, '..', '.env');
-          const runtimeEnv = parseEnv(fs.readFileSync(runtimeEnvPath, 'utf8'));
+          const runtimeSecretsPath = path.join(__dirname, 'runtime-secrets.json');
+          const runtimeEnv = JSON.parse(
+            fs.readFileSync(runtimeSecretsPath, 'utf8')
+          );
           const requireRuntimeEnv = (name) => {
             const value = runtimeEnv[name];
             if (typeof value !== 'string' || !value.trim()) {
               throw new Error(
-                `Required staging runtime value ${name} is missing from ${runtimeEnvPath}.`
+                `Required staging runtime value ${name} is missing from ${runtimeSecretsPath}.`
               );
             }
             return value;

--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -517,18 +517,39 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-chromium-${{ hashFiles('pnpm-lock.yaml') }}
 
-      - name: Install Playwright browser
+      - name: Install Playwright dependencies
         if: steps.dependencies.outcome == 'success'
-        id: playwright
+        id: playwright_dependencies_primary
+        timeout-minutes: 3
+        continue-on-error: true
+        run: ./bin/6529 exec playwright install-deps chromium
+
+      - name: Retry Playwright dependencies
+        if: steps.dependencies.outcome == 'success' && steps.playwright_dependencies_primary.outcome != 'success'
+        id: playwright_dependencies_retry
+        timeout-minutes: 3
+        continue-on-error: true
+        run: ./bin/6529 exec playwright install-deps chromium
+
+      - name: Verify Playwright dependencies
+        if: steps.dependencies.outcome == 'success'
+        id: playwright_dependencies
         continue-on-error: true
         env:
-          PLAYWRIGHT_CACHE_HIT: ${{ steps.playwright-cache.outputs.cache-hit }}
+          PRIMARY_OUTCOME: ${{ steps.playwright_dependencies_primary.outcome }}
+          RETRY_OUTCOME: ${{ steps.playwright_dependencies_retry.outcome }}
         run: |
-          if [ "$PLAYWRIGHT_CACHE_HIT" = true ]; then
-            ./bin/6529 exec playwright install-deps chromium
-          else
-            ./bin/6529 exec playwright install --with-deps chromium
+          if [ "$PRIMARY_OUTCOME" != success ] && [ "$RETRY_OUTCOME" != success ]; then
+            echo "Playwright system dependency installation failed twice." >&2
+            exit 1
           fi
+
+      - name: Install Playwright browser
+        if: steps.dependencies.outcome == 'success' && steps.playwright_dependencies.outcome == 'success'
+        id: playwright
+        timeout-minutes: 10
+        continue-on-error: true
+        run: ./bin/6529 exec playwright install chromium
 
       - name: Run staging packs against staging.6529.io
         if: steps.dependencies.outcome == 'success' && steps.museum-publication.outcome == 'success' && steps.playwright.outcome == 'success'

--- a/__tests__/scripts/deploy-staging-artifact.test.ts
+++ b/__tests__/scripts/deploy-staging-artifact.test.ts
@@ -73,11 +73,15 @@ describe("manual staging immutable artifact deployment", () => {
     expect(script).not.toMatch(/\beval\b/u);
   });
 
-  it("loads required SSR credentials from the host runtime environment", () => {
+  it("loads required SSR credentials from deployment secrets", () => {
     for (const source of [script, releaseBusWorkflowSource]) {
-      expect(source).toContain('runtime_env_path="$REPO_DIR/.env"');
-      expect(source).toContain("const { parseEnv } = require('node:util');");
-      expect(source).toContain("['SSR_CLIENT_ID', 'SSR_CLIENT_SECRET']");
+      expect(source).toContain(
+        'runtime_secrets_file="$release_root/runtime-secrets.json"'
+      );
+      expect(source).toContain("chmod 600");
+      expect(source).toContain(
+        "const runtimeSecretsPath = path.join(__dirname, 'runtime-secrets.json');"
+      );
       expect(source).toContain(
         "['SSR_CLIENT_ID']: requireRuntimeEnv('SSR_CLIENT_ID')"
       );
@@ -85,12 +89,20 @@ describe("manual staging immutable artifact deployment", () => {
         "['SSR_CLIENT_SECRET']: requireRuntimeEnv('SSR_CLIENT_SECRET')"
       );
     }
-
-    expect(script.indexOf('runtime_env_path="$REPO_DIR/.env"')).toBeLessThan(
-      script.indexOf(
-        'install -d -o "$RUN_AS" -g "$RUN_AS" "$release_root/releases"'
-      )
+    expect(workflowSource).toContain(
+      "STAGING_SSR_CLIENT_ID: ${{ secrets.STAGING_SSR_CLIENT_ID }}"
     );
+    expect(workflowSource).toContain(
+      "STAGING_SSR_CLIENT_SECRET: ${{ secrets.STAGING_SSR_CLIENT_SECRET }}"
+    );
+    expect(releaseBusWorkflowSource).toContain(
+      "STAGING_SSR_CLIENT_ID: ${{ secrets.STAGING_SSR_CLIENT_ID }}"
+    );
+    expect(releaseBusWorkflowSource).toContain(
+      "STAGING_SSR_CLIENT_SECRET: ${{ secrets.STAGING_SSR_CLIENT_SECRET }}"
+    );
+    expect(workflowSource).not.toContain("secrets.SSR_CLIENT_");
+    expect(releaseBusWorkflowSource).not.toContain("secrets.SSR_CLIENT_");
   });
 
   it("builds without deployment credentials and deploys only verified exact-SHA bytes", () => {

--- a/__tests__/scripts/deploy-staging-artifact.test.ts
+++ b/__tests__/scripts/deploy-staging-artifact.test.ts
@@ -103,6 +103,35 @@ describe("manual staging immutable artifact deployment", () => {
     );
     expect(workflowSource).not.toContain("secrets.SSR_CLIENT_");
     expect(releaseBusWorkflowSource).not.toContain("secrets.SSR_CLIENT_");
+    expect(workflowSource).toContain(
+      'SSR_CLIENT_ID_B64="$SSR_CLIENT_ID_B64" \\'
+    );
+    expect(workflowSource).toContain(
+      'SSR_CLIENT_SECRET_B64="$SSR_CLIENT_SECRET_B64" \\'
+    );
+    expect(
+      workflowSource.indexOf(
+        'SSR_CLIENT_SECRET_B64="$SSR_CLIENT_SECRET_B64" \\'
+      )
+    ).toBeLessThan(
+      workflowSource.indexOf("bash ops/scripts/deploy-staging-artifact.sh")
+    );
+    expect(
+      releaseBusWorkflowSource.indexOf('test -n "$ssr_client_secret"')
+    ).toBeLessThan(
+      releaseBusWorkflowSource.indexOf(
+        'install -d -o "$RUN_AS" -g "$RUN_AS" "$release_dir"'
+      )
+    );
+    expect(
+      releaseBusWorkflowSource.indexOf(
+        'echo "$EXPECTED_DIGEST  $release_dir/package.zip" | sha256sum -c -'
+      )
+    ).toBeLessThan(
+      releaseBusWorkflowSource.indexOf(
+        'runtime_secrets_tmp="$(mktemp "$release_root/runtime-secrets.XXXXXX.json")"'
+      )
+    );
   });
 
   it("builds without deployment credentials and deploys only verified exact-SHA bytes", () => {

--- a/__tests__/scripts/deploy-staging-artifact.test.ts
+++ b/__tests__/scripts/deploy-staging-artifact.test.ts
@@ -15,6 +15,10 @@ const workflowSource = fs.readFileSync(
   path.join(root, ".github", "workflows", "deploy-staging.yml"),
   "utf8"
 );
+const releaseBusWorkflowSource = fs.readFileSync(
+  path.join(root, ".github", "workflows", "release-bus-deploy-staging.yml"),
+  "utf8"
+);
 const workflow = YAML.parse(workflowSource);
 
 describe("manual staging immutable artifact deployment", () => {
@@ -67,6 +71,26 @@ describe("manual staging immutable artifact deployment", () => {
     ).toBeLessThan(script.indexOf('rm -rf -- "$release_app"'));
     expect(script).not.toContain("curl -k");
     expect(script).not.toMatch(/\beval\b/u);
+  });
+
+  it("loads required SSR credentials from the host runtime environment", () => {
+    for (const source of [script, releaseBusWorkflowSource]) {
+      expect(source).toContain('runtime_env_path="$REPO_DIR/.env"');
+      expect(source).toContain("const { parseEnv } = require('node:util');");
+      expect(source).toContain("['SSR_CLIENT_ID', 'SSR_CLIENT_SECRET']");
+      expect(source).toContain(
+        "['SSR_CLIENT_ID']: requireRuntimeEnv('SSR_CLIENT_ID')"
+      );
+      expect(source).toContain(
+        "['SSR_CLIENT_SECRET']: requireRuntimeEnv('SSR_CLIENT_SECRET')"
+      );
+    }
+
+    expect(script.indexOf('runtime_env_path="$REPO_DIR/.env"')).toBeLessThan(
+      script.indexOf(
+        'install -d -o "$RUN_AS" -g "$RUN_AS" "$release_root/releases"'
+      )
+    );
   });
 
   it("builds without deployment credentials and deploys only verified exact-SHA bytes", () => {

--- a/__tests__/scripts/release-bus-performance-contract.test.ts
+++ b/__tests__/scripts/release-bus-performance-contract.test.ts
@@ -84,7 +84,13 @@ describe("Release Bus frontend performance contract", () => {
     expect(appPrCi).not.toContain('"dependency-analysis-or-plan-not-required"');
     expect(appPrCi).toContain("Run related Jest tests");
     expect(appPrCi).toContain("./bin/6529 run build:ci");
-    expect(appPrCi).toContain("playwright install --with-deps chromium");
+    expect(appPrCi).not.toContain("playwright install --with-deps chromium");
+    expect(appPrCi).toContain(
+      "mcr.microsoft.com/playwright:v1.61.1-noble@sha256:5b8f294aff9041b7191c34a4bab3ac270157a28774d4b0660e9743297b697e48"
+    );
+    expect(appPrCi).toContain("core-playwright-checks:");
+    expect(appPrCi).toContain("playwright install-deps chromium");
+    expect(appPrCi).toContain("playwright install chromium");
     expect(appPrCi).toContain("test:e2e:smoke");
     expect(appPrCi).toContain("test:e2e:critical-shell");
     expect(appPrCi).toContain("./bin/6529 exec playwright test");
@@ -95,9 +101,7 @@ describe("Release Bus frontend performance contract", () => {
     expect(appPrCi).toContain("tests/museum/inside-system-readonly.spec.ts");
     expect(appPrCi).toContain("tests/museum/rights-readonly.spec.ts");
     expect(appPrCi).not.toContain("./bin/6529 run test:e2e:museum-");
-    expect(appPrCi).toContain(
-      "startsWith(matrix.lane, 'playwright-museum-')"
-    );
+    expect(appPrCi).toContain("startsWith(matrix.lane, 'playwright-museum-')");
     expect(appPrCi).toContain("Restore Playwright browser");
     if (appPrCi.includes("exact-merge-tree-pr-ci-v1")) {
       expect(appPrCi).toContain(

--- a/__tests__/scripts/testing-strategy.test.ts
+++ b/__tests__/scripts/testing-strategy.test.ts
@@ -453,6 +453,10 @@ describe("testing strategy CI plan", () => {
       path.join(process.cwd(), ".github/workflows/staging-e2e.yml"),
       "utf8"
     );
+    const productionWorkflow = fs.readFileSync(
+      path.join(process.cwd(), ".github/workflows/production-e2e.yml"),
+      "utf8"
+    );
     const museumReleaseSelector = fs.readFileSync(
       path.join(process.cwd(), "scripts/museum-release-selection.cjs"),
       "utf8"
@@ -473,7 +477,13 @@ describe("testing strategy CI plan", () => {
       "utf8"
     );
 
-    expect(workflow).toContain("playwright install --with-deps chromium");
+    expect(workflow).not.toContain("playwright install --with-deps chromium");
+    expect(stagingWorkflow).not.toContain(
+      "playwright install --with-deps chromium"
+    );
+    expect(productionWorkflow).not.toContain(
+      "playwright install --with-deps chromium"
+    );
     expect(workflow).toContain("test:e2e:smoke");
     expect(workflow).toContain("test:e2e:critical-shell");
     for (const museumBrowserSpec of [
@@ -576,7 +586,17 @@ describe("testing strategy CI plan", () => {
           needs?: string | string[];
           strategy?: { matrix?: string };
           "runs-on"?: string;
-          steps?: Array<{ name?: string; if?: string; run?: string }>;
+          "timeout-minutes"?: number;
+          container?: { image?: string; options?: string };
+          defaults?: { run?: { shell?: string } };
+          steps?: Array<{
+            name?: string;
+            if?: string;
+            id?: string;
+            run?: string;
+            "timeout-minutes"?: number;
+            "continue-on-error"?: boolean;
+          }>;
         }
       >;
     };
@@ -594,6 +614,36 @@ describe("testing strategy CI plan", () => {
           if: "matrix.lane == 'build'",
         }),
         expect.objectContaining({
+          name: "Run Network Museum Playwright packs",
+          if: "startsWith(matrix.lane, 'playwright-museum-')",
+        }),
+      ])
+    );
+    expect(parsed.jobs["app-checks"]?.steps).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "Run small Playwright smoke pack" }),
+        expect.objectContaining({
+          name: "Run critical route-shell Playwright pack",
+        }),
+      ])
+    );
+    expect(parsed.jobs["core-playwright-checks"]).toMatchObject({
+      if: "needs.plan.outputs.core_playwright_required == 'true'",
+      "runs-on": "${{ matrix.runner }}",
+      "timeout-minutes": 20,
+      container: {
+        image:
+          "mcr.microsoft.com/playwright:v1.61.1-noble@sha256:5b8f294aff9041b7191c34a4bab3ac270157a28774d4b0660e9743297b697e48",
+        options: "--ipc=host",
+      },
+      defaults: { run: { shell: "bash" } },
+      strategy: {
+        matrix: "${{ fromJSON(needs.plan.outputs.core_playwright_matrix) }}",
+      },
+    });
+    expect(parsed.jobs["core-playwright-checks"]?.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
           name: "Run small Playwright smoke pack",
           if: "matrix.lane == 'playwright-smoke'",
         }),
@@ -601,10 +651,13 @@ describe("testing strategy CI plan", () => {
           name: "Run critical route-shell Playwright pack",
           if: "matrix.lane == 'playwright-critical-shell'",
         }),
-        expect.objectContaining({
-          name: "Run Network Museum Playwright packs",
-          if: "startsWith(matrix.lane, 'playwright-museum-')",
-        }),
+      ])
+    );
+    expect(parsed.jobs["core-playwright-checks"]?.steps).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "Restore Playwright browser" }),
+        expect.objectContaining({ name: "Install Playwright dependencies" }),
+        expect.objectContaining({ name: "Install Playwright browser" }),
       ])
     );
     const museumBrowserStep = parsed.jobs["app-checks"]?.steps?.find(
@@ -699,15 +752,61 @@ describe("testing strategy CI plan", () => {
     expect(museumBrowserRun).not.toContain("start:standalone");
     expect(parsed.jobs["installed-checks"]).toMatchObject({
       name: "Installed app checks",
-      needs: ["plan", "app-checks"],
+      needs: ["plan", "app-checks", "core-playwright-checks"],
       if: "always() && needs.plan.result == 'success' && needs.plan.outputs.install_required == 'true'",
     });
     expect(workflow).toContain(
       'write("app_check_matrix", JSON.stringify({ include: appCheckLanes }))'
     );
+    expect(workflow).toContain(
+      'write("core_playwright_matrix", JSON.stringify({ include: corePlaywrightLanes }))'
+    );
+    expect(workflow).toContain(
+      'write("core_playwright_required", String(corePlaywrightLanes.length > 0))'
+    );
     expect(workflow).toContain("BUILD_CI_RUNNER");
     expect(workflow).toContain("Restore Playwright browser");
     expect(workflow).toContain("node22-pr-production-nextjs");
+
+    for (const source of [workflow, stagingWorkflow, productionWorkflow]) {
+      const workflowJobs = YAML.parse(source) as {
+        jobs: Record<
+          string,
+          {
+            steps?: Array<{
+              name?: string;
+              run?: string;
+              "timeout-minutes"?: number;
+              "continue-on-error"?: boolean;
+            }>;
+          }
+        >;
+      };
+      const steps = Object.values(workflowJobs.jobs).flatMap(
+        (job) => job.steps ?? []
+      );
+      expect(steps).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: "Install Playwright dependencies",
+            run: "./bin/6529 exec playwright install-deps chromium",
+            "timeout-minutes": 3,
+            "continue-on-error": true,
+          }),
+          expect.objectContaining({
+            name: "Retry Playwright dependencies",
+            run: "./bin/6529 exec playwright install-deps chromium",
+            "timeout-minutes": 3,
+            "continue-on-error": true,
+          }),
+          expect.objectContaining({
+            name: "Install Playwright browser",
+            run: "./bin/6529 exec playwright install chromium",
+            "timeout-minutes": 10,
+          }),
+        ])
+      );
+    }
   });
 
   it("keeps full-history CI checkouts blobless", () => {

--- a/ops/scripts/deploy-staging-artifact.sh
+++ b/ops/scripts/deploy-staging-artifact.sh
@@ -3,7 +3,8 @@
 set -euo pipefail
 
 for name in ARTIFACT_URL EXPECTED_DIGEST EXPECTED_SHA \
-  PUBLIC_REVIEW_DISCUSSION_DESTINATIONS_B64 REPO_DIR RUN_AS; do
+  PUBLIC_REVIEW_DISCUSSION_DESTINATIONS_B64 REPO_DIR RUN_AS \
+  SSR_CLIENT_ID_B64 SSR_CLIENT_SECRET_B64; do
   if [[ -z "${!name:-}" ]]; then
     echo "Required deployment value $name is missing." >&2
     exit 1
@@ -46,31 +47,19 @@ sudo -H -u "$RUN_AS" pm2 --version >/dev/null 2>&1 || {
   exit 1
 }
 
-runtime_env_path="$REPO_DIR/.env"
-[[ -r "$runtime_env_path" ]] || {
-  echo "Staging runtime environment file '$runtime_env_path' is not readable." >&2
+ssr_client_id="$(printf '%s' "$SSR_CLIENT_ID_B64" | base64 -d)"
+ssr_client_secret="$(printf '%s' "$SSR_CLIENT_SECRET_B64" | base64 -d)"
+[[ -n "$ssr_client_id" && -n "$ssr_client_secret" ]] || {
+  echo "Decoded staging SSR credentials must be non-empty." >&2
   exit 1
 }
-sudo -H -u "$RUN_AS" node - "$runtime_env_path" <<'NODE'
-const fs = require('node:fs');
-const { parseEnv } = require('node:util');
-
-const runtimeEnvPath = process.argv[2];
-const runtimeEnv = parseEnv(fs.readFileSync(runtimeEnvPath, 'utf8'));
-for (const name of ['SSR_CLIENT_ID', 'SSR_CLIENT_SECRET']) {
-  if (typeof runtimeEnv[name] !== 'string' || !runtimeEnv[name].trim()) {
-    throw new Error(
-      `Required staging runtime value ${name} is missing from ${runtimeEnvPath}.`
-    );
-  }
-}
-NODE
 
 release_root="$REPO_DIR/.release-bus"
 release_id="$EXPECTED_SHA-$EXPECTED_DIGEST"
 release_dir="$release_root/releases/$release_id"
 release_app="$release_dir/app"
 current_link="$release_root/current"
+runtime_secrets_file="$release_root/runtime-secrets.json"
 install -d -o "$RUN_AS" -g "$RUN_AS" "$release_root/releases"
 if [[ -e "$current_link" && ! -L "$current_link" ]]; then
   echo "Refusing to replace a non-symlink staging current path." >&2
@@ -259,14 +248,19 @@ artifact_tmp="$(mktemp "$release_dir/package.XXXXXX.zip")"
 staging_app=""
 destinations_file=""
 retain_destinations_file=false
+runtime_secrets_tmp=""
 cleanup() {
-  unset review_destinations PUBLIC_REVIEW_DISCUSSION_DESTINATIONS_B64
+  unset review_destinations PUBLIC_REVIEW_DISCUSSION_DESTINATIONS_B64 \
+    ssr_client_id SSR_CLIENT_ID_B64 ssr_client_secret SSR_CLIENT_SECRET_B64
   rm -f "$artifact_tmp"
   if [[ -n "$staging_app" && -d "$staging_app" ]]; then
     rm -rf -- "$staging_app"
   fi
   if [[ "$retain_destinations_file" != true && -n "$destinations_file" ]]; then
     rm -f -- "$destinations_file"
+  fi
+  if [[ -n "$runtime_secrets_tmp" ]]; then
+    rm -f -- "$runtime_secrets_tmp"
   fi
 }
 trap cleanup EXIT HUP INT TERM
@@ -308,20 +302,31 @@ chown "$RUN_AS:$RUN_AS" "$destinations_file"
 unset review_destinations PUBLIC_REVIEW_DISCUSSION_DESTINATIONS_B64
 retain_destinations_file=true
 
+runtime_secrets_tmp="$(mktemp "$release_root/runtime-secrets.XXXXXX.json")"
+jq -n \
+  --arg ssr_client_id "$ssr_client_id" \
+  --arg ssr_client_secret "$ssr_client_secret" \
+  '{SSR_CLIENT_ID:$ssr_client_id,SSR_CLIENT_SECRET:$ssr_client_secret}' \
+  > "$runtime_secrets_tmp"
+chown "$RUN_AS:$RUN_AS" "$runtime_secrets_tmp"
+chmod 600 "$runtime_secrets_tmp"
+mv -f "$runtime_secrets_tmp" "$runtime_secrets_file"
+runtime_secrets_tmp=""
+unset ssr_client_id SSR_CLIENT_ID_B64 ssr_client_secret SSR_CLIENT_SECRET_B64
+
 ln -sfn "$release_app" "$current_link"
 cat > "$release_root/ecosystem.config.cjs" <<'PM2_CONFIG'
 const fs = require('node:fs');
 const path = require('node:path');
-const { parseEnv } = require('node:util');
 
 const currentApp = fs.realpathSync(path.join(__dirname, 'current'));
-const runtimeEnvPath = path.join(__dirname, '..', '.env');
-const runtimeEnv = parseEnv(fs.readFileSync(runtimeEnvPath, 'utf8'));
+const runtimeSecretsPath = path.join(__dirname, 'runtime-secrets.json');
+const runtimeEnv = JSON.parse(fs.readFileSync(runtimeSecretsPath, 'utf8'));
 const requireRuntimeEnv = (name) => {
   const value = runtimeEnv[name];
   if (typeof value !== 'string' || !value.trim()) {
     throw new Error(
-      `Required staging runtime value ${name} is missing from ${runtimeEnvPath}.`
+      `Required staging runtime value ${name} is missing from ${runtimeSecretsPath}.`
     );
   }
   return value;

--- a/ops/scripts/deploy-staging-artifact.sh
+++ b/ops/scripts/deploy-staging-artifact.sh
@@ -46,6 +46,26 @@ sudo -H -u "$RUN_AS" pm2 --version >/dev/null 2>&1 || {
   exit 1
 }
 
+runtime_env_path="$REPO_DIR/.env"
+[[ -r "$runtime_env_path" ]] || {
+  echo "Staging runtime environment file '$runtime_env_path' is not readable." >&2
+  exit 1
+}
+sudo -H -u "$RUN_AS" node - "$runtime_env_path" <<'NODE'
+const fs = require('node:fs');
+const { parseEnv } = require('node:util');
+
+const runtimeEnvPath = process.argv[2];
+const runtimeEnv = parseEnv(fs.readFileSync(runtimeEnvPath, 'utf8'));
+for (const name of ['SSR_CLIENT_ID', 'SSR_CLIENT_SECRET']) {
+  if (typeof runtimeEnv[name] !== 'string' || !runtimeEnv[name].trim()) {
+    throw new Error(
+      `Required staging runtime value ${name} is missing from ${runtimeEnvPath}.`
+    );
+  }
+}
+NODE
+
 release_root="$REPO_DIR/.release-bus"
 release_id="$EXPECTED_SHA-$EXPECTED_DIGEST"
 release_dir="$release_root/releases/$release_id"
@@ -292,8 +312,20 @@ ln -sfn "$release_app" "$current_link"
 cat > "$release_root/ecosystem.config.cjs" <<'PM2_CONFIG'
 const fs = require('node:fs');
 const path = require('node:path');
+const { parseEnv } = require('node:util');
 
 const currentApp = fs.realpathSync(path.join(__dirname, 'current'));
+const runtimeEnvPath = path.join(__dirname, '..', '.env');
+const runtimeEnv = parseEnv(fs.readFileSync(runtimeEnvPath, 'utf8'));
+const requireRuntimeEnv = (name) => {
+  const value = runtimeEnv[name];
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(
+      `Required staging runtime value ${name} is missing from ${runtimeEnvPath}.`
+    );
+  }
+  return value;
+};
 const destinationsPath = path.join(
   path.dirname(currentApp),
   'public-review-discussion-destinations.json'
@@ -321,6 +353,8 @@ module.exports = {
       PORT: '3001',
       HOSTNAME: '0.0.0.0',
       NODE_ENV: 'production',
+      ['SSR_CLIENT_ID']: requireRuntimeEnv('SSR_CLIENT_ID'),
+      ['SSR_CLIENT_SECRET']: requireRuntimeEnv('SSR_CLIENT_SECRET'),
       ...(publicReviewDiscussionDestinations
         ? {
             PUBLIC_REVIEW_DISCUSSION_DESTINATIONS:


### PR DESCRIPTION
## What changed

- source staging credentials exclusively from the GitHub Actions secrets `STAGING_SSR_CLIENT_ID` and `STAGING_SSR_CLIENT_SECRET`
- require both staging-specific secrets before sending a deployment command
- transport them only in the deploy jobs, outside the immutable Next.js build artifact
- install them atomically as an owner-only runtime file and expose them to the PM2 process as `SSR_CLIENT_ID` and `SSR_CLIENT_SECRET`
- apply the same runtime contract to manual and Release Bus staging activation without changing production's existing secrets
- add regression coverage for both deployment paths

## Why

Immutable staging artifacts run from `.release-bus/current`, and the PM2 process was not receiving SSR signing credentials. Server-rendered API requests then fell back to unsigned traffic and could hit the staging API's public IP rate limit, surfacing intermittent Server Component error pages in E2E. Staging-specific names keep these credentials separate from the repository-level pair used by production.

## Validation

- focused deployment Jest suites: 36 tests passed
- changed-file lint
- shell and extracted workflow syntax checks
- changed-secret scan


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved staging deployments to securely provide and validate SSR credentials.
  * Credentials are now protected during transfer and runtime, with temporary values automatically removed after deployment.
  * Staging application startup validates required credentials before loading them.

* **Bug Fixes**
  * Improved reliability and security of staging secret handling.
  * Added validation to prevent deployments with missing or invalid SSR credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->