### PR TITLE
fix: No additional repair was needed. The current draft already addresses the complete latest Sentry evidence,

### DIFF
--- a/__tests__/components/brain/notifications/drop-quoted/NotificationDropQuoted.test.tsx
+++ b/__tests__/components/brain/notifications/drop-quoted/NotificationDropQuoted.test.tsx
@@ -75,10 +75,9 @@ describe("NotificationDropQuoted", () => {
   it("renders nothing when the related drop is missing", () => {
     const { container } = render(
       <NotificationDropQuoted
-        notification={{ ...notification, related_drops: [] } as never}
+        notification={{ related_drops: [] } as never}
         activeDrop={null}
         onReply={jest.fn()}
-        onQuote={jest.fn()}
       />
     );
 

--- a/__tests__/components/brain/notifications/drop-quoted/NotificationDropQuoted.test.tsx
+++ b/__tests__/components/brain/notifications/drop-quoted/NotificationDropQuoted.test.tsx
@@ -72,6 +72,19 @@ describe("NotificationDropQuoted", () => {
     created_at: Date.now(),
   } as never;
 
+  it("renders nothing when the related drop is missing", () => {
+    const { container } = render(
+      <NotificationDropQuoted
+        notification={{ ...notification, related_drops: [] } as never}
+        activeDrop={null}
+        onReply={jest.fn()}
+        onQuote={jest.fn()}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it("navigates on reply click", async () => {
     const user = userEvent.setup();
     render(

--- a/__tests__/components/brain/notifications/identity-mentioned/NotificationIdentityMentioned.test.tsx
+++ b/__tests__/components/brain/notifications/identity-mentioned/NotificationIdentityMentioned.test.tsx
@@ -56,10 +56,9 @@ describe("NotificationIdentityMentioned", () => {
   it("renders nothing when the related drop is missing", () => {
     const { container } = render(
       <NotificationIdentityMentioned
-        notification={{ ...notification, related_drops: [] } as any}
+        notification={{ related_drops: [] } as never}
         activeDrop={null}
         onReply={jest.fn()}
-        onQuote={jest.fn()}
       />
     );
 

--- a/__tests__/components/brain/notifications/identity-mentioned/NotificationIdentityMentioned.test.tsx
+++ b/__tests__/components/brain/notifications/identity-mentioned/NotificationIdentityMentioned.test.tsx
@@ -53,6 +53,19 @@ const notification = {
 };
 
 describe("NotificationIdentityMentioned", () => {
+  it("renders nothing when the related drop is missing", () => {
+    const { container } = render(
+      <NotificationIdentityMentioned
+        notification={{ ...notification, related_drops: [] } as any}
+        activeDrop={null}
+        onReply={jest.fn()}
+        onQuote={jest.fn()}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it("calls navigation on drop actions", () => {
     const push = jest.fn();
     (mockUseRouter as jest.Mock).mockReturnValue({ push });

--- a/components/brain/notifications/drop-quoted/NotificationDropQuoted.tsx
+++ b/components/brain/notifications/drop-quoted/NotificationDropQuoted.tsx
@@ -17,9 +17,14 @@ export default function NotificationDropQuoted({
   readonly onReply: (param: DropInteractionParams) => void;
   readonly onDropContentClick?: ((drop: ExtendedDrop) => void) | undefined;
 }) {
+  const drop = notification.related_drops[0];
+  if (!drop) {
+    return null;
+  }
+
   return (
     <NotificationWithDrop
-      drop={notification.related_drops[0]!}
+      drop={drop}
       actionText="quoted you"
       createdAt={notification.created_at}
       activeDrop={activeDrop}

--- a/components/brain/notifications/identity-mentioned/NotificationIdentityMentioned.tsx
+++ b/components/brain/notifications/identity-mentioned/NotificationIdentityMentioned.tsx
@@ -17,9 +17,14 @@ export default function NotificationIdentityMentioned({
   readonly onReply: (param: DropInteractionParams) => void;
   readonly onDropContentClick?: ((drop: ExtendedDrop) => void) | undefined;
 }) {
+  const drop = notification.related_drops[0];
+  if (!drop) {
+    return null;
+  }
+
   return (
     <NotificationWithDrop
-      drop={notification.related_drops[0]!}
+      drop={drop}
       actionText="mentioned you"
       createdAt={notification.created_at}
       activeDrop={activeDrop}


### PR DESCRIPTION
<!-- sentry-fix-job:65 issue:7669422134 -->
## Issue

- Sentry: [6529-FRONTEND-FC](https://seize-ff.sentry.io/issues/7669422134/)
- First seen: 2026-08-13T07:19:17.972Z
- Latest occurrence: 2026-08-19T02:33:57.000Z
- Automatic triage confidence: 98%

A small repository fix is useful. Two notification renderers pass a potentially missing first related drop through a non-null assertion, causing the observed render crash. They should skip only malformed rows that lack the required drop.

## Fix

Empty mapped related-drop arrays previously allowed two notification renderers to pass undefined into NotificationWithDrop. The revision-2 Sentry record has the same occurrence time as revision 1 and references an older production release from roughly 14 hours before the guard commit; it is not a post-fix regression.

## Changes

- Preserved the existing runtime guards in both affected notification renderers and their focused empty-array regression tests.
- Confirmed local HEAD matches the draft PR head and made no new file changes.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Focused Jest validation passed: 2 suites, 5 tests.
- Changed-file lint and typecheck passed.
- React Doctor ran but skipped because the synchronized clean branch has no uncommitted source diff; the earlier exact-change run reported 100/100.
- Working-tree and base-to-head whitespace checks passed; the worktree is clean.
- All current required GitHub checks pass; the broader check rollup also reports successful quality, production-build, security, and analysis lanes.

## Risk

- Assessed risk: low
- Changed files: 4
- Changed lines: 38
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

The draft has not been deployed, so there is no post-fix production runtime evidence yet. No merge, readiness change, deployment, or Sentry mutation was performed.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
