### PR TITLE
fix: Implemented a narrow Rabby Mobile iOS telemetry fix with focused regression coverage. No commit, push, PR

### DIFF
--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -56,6 +56,13 @@ describe("instrumentation-client", () => {
     "    at Object.userRejectedRequest (chrome-extension://acmacodkjbdgmoleebolmdjonilkdbch/content-script.js:423:124412)",
     "    at h.dispose (chrome-extension://acmacodkjbdgmoleebolmdjonilkdbch/content-script.js:423:297934)",
   ].join("\n");
+  const rabbyMobileIosUserRejectedStack = [
+    "Error: Not Allowed",
+    "    at EthereumProviderError (address at /vendor/container/RabbyMobile.app/main.jsbundle:1:100)",
+    "    at userRejectedRequest (address at /vendor/container/RabbyMobile.app/main.jsbundle:1:200)",
+  ].join("\n");
+  const rabbyMobileUserAgent =
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 RabbyMobile/1.0 RabbyMobileIOS/1.0 Mobile/15E148";
   const reactDomInsertBeforeMessage =
     "Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.";
   const gifPickerTenorUndefinedTagsMessage =
@@ -482,6 +489,36 @@ describe("instrumentation-client", () => {
       __serialized__: {
         code: 4001,
         message: "User rejected the request.",
+        stack: serializedStack,
+      },
+    },
+  });
+
+  const createRabbyMobileIosUserRejectedEvent = (
+    serializedStack = rabbyMobileIosUserRejectedStack
+  ) => ({
+    event_id: "rabby-mobile-ios-user-rejected",
+    exception: {
+      values: [
+        {
+          type: "UnhandledRejection",
+          value: objectCapturedPromiseRejectionMessage,
+          mechanism: {
+            type: browserUnhandledRejectionMechanismType,
+            handled: false,
+          },
+        },
+      ],
+    },
+    request: {
+      headers: {
+        "User-Agent": rabbyMobileUserAgent,
+      },
+    },
+    extra: {
+      __serialized__: {
+        code: 4001,
+        message: "Not Allowed",
         stack: serializedStack,
       },
     },
@@ -1244,6 +1281,29 @@ describe("instrumentation-client", () => {
     const result = beforeSend(event);
 
     expect(result).toBeNull();
+  });
+
+  it("drops the production-shaped RabbyMobile iOS user rejection", () => {
+    const beforeSend = loadBeforeSend();
+    const event = createRabbyMobileIosUserRejectedEvent();
+
+    const result = beforeSend(event);
+
+    expect(result).toBeNull();
+  });
+
+  it("keeps the RabbyMobile iOS rejection with a later app-owned serialized frame", () => {
+    const beforeSend = loadBeforeSend();
+    const event = createRabbyMobileIosUserRejectedEvent(
+      [
+        rabbyMobileIosUserRejectedStack,
+        "    at signDrop (app:///hooks/drops/useDropSignature.ts:1:1)",
+      ].join("\n")
+    );
+
+    const result = beforeSend(event);
+
+    expect(result).not.toBeNull();
   });
 
   it("keeps Rabby Chrome user rejections with app-owned frames", () => {

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -251,6 +251,11 @@ describe("sentry-client-filters", () => {
   ].join("\n");
   const rabbyMobileUserRejectedStack =
     "Error: Not Allowed\n    at userRejectedRequest (RabbyMobile://native-bundle/background.js:1:1)";
+  const rabbyMobileIosUserRejectedStack = [
+    "Error: Not Allowed",
+    "    at EthereumProviderError (address at /vendor/container/RabbyMobile.app/main.jsbundle:1:100)",
+    "    at userRejectedRequest (address at /vendor/container/RabbyMobile.app/main.jsbundle:1:200)",
+  ].join("\n");
   const rabbyMobileAndroidUserRejectedStack = [
     "EthereumProviderError: Not Allowed",
     "    at getEthProviderError (inpage.js:1:1)",
@@ -2184,21 +2189,24 @@ describe("sentry-client-filters", () => {
     ...overrides,
   });
 
+  const createRabbyMobileUserRejectedExceptionValue = (
+    overrides: Partial<SentryExceptionValue> = {}
+  ): SentryExceptionValue => ({
+    type: "UnhandledRejection",
+    value: objectCapturedPromiseRejectionMessage,
+    mechanism: {
+      type: "auto.browser.global_handlers.onunhandledrejection",
+      handled: false,
+    },
+    ...overrides,
+  });
+
   const createRabbyMobileUserRejectedRequestEvent = (
     overrides: TestSentryClientEventOverrides = {}
   ): TestSentryClientEvent =>
     ({
       exception: {
-        values: [
-          {
-            type: "UnhandledRejection",
-            value: objectCapturedPromiseRejectionMessage,
-            mechanism: {
-              type: "auto.browser.global_handlers.onunhandledrejection",
-              handled: false,
-            },
-          },
-        ],
+        values: [createRabbyMobileUserRejectedExceptionValue()],
       },
       extra: {
         __serialized__: {
@@ -2209,6 +2217,25 @@ describe("sentry-client-filters", () => {
       },
       ...overrides,
     }) as TestSentryClientEvent;
+
+  const createRabbyMobileIosUserRejectedRequestEvent = (
+    overrides: TestSentryClientEventOverrides = {}
+  ): TestSentryClientEvent =>
+    createRabbyMobileUserRejectedRequestEvent({
+      request: {
+        headers: {
+          "User-Agent": rabbyMobileUserAgent,
+        },
+      },
+      extra: {
+        __serialized__: {
+          code: 4001,
+          message: "Not Allowed",
+          stack: rabbyMobileIosUserRejectedStack,
+        },
+      },
+      ...overrides,
+    });
 
   const createRabbyChromeUserRejectedExceptionValue = (
     overrides: Partial<SentryExceptionValue> = {}
@@ -8670,6 +8697,17 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(true);
   });
 
+  it("filters the production-shaped RabbyMobile iOS user rejection", () => {
+    // Arrange
+    const event = createRabbyMobileIosUserRejectedRequestEvent();
+
+    // Act
+    const result = shouldFilterRabbyMobileUserRejectedRequest(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
   it("filters the exact Rabby Chrome user-rejected object rejection", () => {
     // Arrange
     const event = createRabbyChromeUserRejectedRequestEvent();
@@ -10093,12 +10131,10 @@ describe("sentry-client-filters", () => {
 
   it("does not filter RabbyMobile user-rejected object rejections with app-owned frames", () => {
     // Arrange
-    const event = createRabbyMobileUserRejectedRequestEvent({
+    const event = createRabbyMobileIosUserRejectedRequestEvent({
       exception: {
         values: [
-          {
-            type: "UnhandledRejection",
-            value: objectCapturedPromiseRejectionMessage,
+          createRabbyMobileUserRejectedExceptionValue({
             stacktrace: {
               frames: [
                 {
@@ -10107,7 +10143,7 @@ describe("sentry-client-filters", () => {
                 },
               ],
             },
-          },
+          }),
         ],
       },
     });
@@ -10303,6 +10339,44 @@ describe("sentry-client-filters", () => {
 
     // Act
     const result = shouldFilterRabbyMobileUserRejectedRequest(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter the RabbyMobile iOS rejection with a later app-owned serialized frame", () => {
+    // Arrange
+    const event = createRabbyMobileIosUserRejectedRequestEvent({
+      extra: {
+        __serialized__: {
+          code: 4001,
+          message: "Not Allowed",
+          stack: [
+            rabbyMobileIosUserRejectedStack,
+            "    at signDrop (app:///hooks/drops/useDropSignature.ts:1:1)",
+          ].join("\n"),
+        },
+      },
+    });
+
+    // Act
+    const result = shouldFilterRabbyMobileUserRejectedRequest(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter the RabbyMobile iOS rejection with an app-owned hint stack", () => {
+    // Arrange
+    const event = createRabbyMobileIosUserRejectedRequestEvent();
+    const appError = new Error("Application failure");
+    appError.stack =
+      "Error: Application failure\n    at signDrop (app:///hooks/drops/useDropSignature.ts:1:1)";
+
+    // Act
+    const result = shouldFilterRabbyMobileUserRejectedRequest(event, {
+      originalException: appError,
+    });
 
     // Assert
     expect(result).toBe(false);
@@ -10999,6 +11073,102 @@ describe("sentry-client-filters", () => {
           code: 4100,
           message: "Not Allowed",
           stack: rabbyMobileUserRejectedStack,
+        },
+      },
+    });
+
+    // Act
+    const result = shouldFilterRabbyMobileUserRejectedRequest(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it.each([
+    {
+      caseName: "a different mechanism",
+      values: [
+        createRabbyMobileUserRejectedExceptionValue({
+          mechanism: {
+            type: "auto.browser.global_handlers.onerror",
+            handled: false,
+          },
+        }),
+      ],
+    },
+    {
+      caseName: "a handled mechanism",
+      values: [
+        createRabbyMobileUserRejectedExceptionValue({
+          mechanism: {
+            type: "auto.browser.global_handlers.onunhandledrejection",
+            handled: true,
+          },
+        }),
+      ],
+    },
+    {
+      caseName: "an additional exception",
+      values: [
+        createRabbyMobileUserRejectedExceptionValue(),
+        { type: "Error", value: "Application failure" },
+      ],
+    },
+  ])("does not filter the RabbyMobile iOS rejection with $caseName", ({ values }) => {
+    // Arrange
+    const event = createRabbyMobileIosUserRejectedRequestEvent({
+      exception: { values },
+    });
+
+    // Act
+    const result = shouldFilterRabbyMobileUserRejectedRequest(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it.each([
+    {
+      caseName: "another native app bundle",
+      stack: rabbyMobileIosUserRejectedStack.replace(
+        "RabbyMobile.app",
+        "OtherWallet.app"
+      ),
+    },
+    {
+      caseName: "no userRejectedRequest frame",
+      stack: rabbyMobileIosUserRejectedStack.replace(
+        "userRejectedRequest",
+        "requestRejected"
+      ),
+    },
+  ])("does not filter the RabbyMobile iOS near-miss with $caseName", ({ stack }) => {
+    // Arrange
+    const event = createRabbyMobileIosUserRejectedRequestEvent({
+      extra: {
+        __serialized__: {
+          code: 4001,
+          message: "Not Allowed",
+          stack,
+        },
+      },
+    });
+
+    // Act
+    const result = shouldFilterRabbyMobileUserRejectedRequest(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter the RabbyMobile iOS rejection with another message", () => {
+    // Arrange
+    const event = createRabbyMobileIosUserRejectedRequestEvent({
+      extra: {
+        __serialized__: {
+          code: 4001,
+          message: "Permission denied",
+          stack: rabbyMobileIosUserRejectedStack,
         },
       },
     });

--- a/utils/sentry-client-filters/rabby.ts
+++ b/utils/sentry-client-filters/rabby.ts
@@ -19,7 +19,6 @@ import type {
 } from "./types";
 import {
   getContextString,
-  getEventMessage,
   getHintExceptionMessage,
   getHintExceptionStack,
   getNumericValue,
@@ -33,6 +32,9 @@ import { hasBrowserUnhandledRejectionMechanism } from "./walletlink-websocket";
 
 const rabbyRainbowKitRawChunkPathPrefix = "app:///_next/static/chunks/";
 const stackFrameLocationSuffixPattern = /:\d+:\d+\)$/;
+// Rabby's native iOS bundle path contains the shared `app/` source token.
+const rabbyMobileIosBundleStackPathPattern =
+  /\/RabbyMobile\.app\/main\.jsbundle(?=:)/gi;
 
 function matchesStackPattern(
   value: string | undefined,
@@ -57,6 +59,25 @@ function hasRabbyMobileUserRejectedStack(
   return [serializedStack, getHintExceptionStack(hint)].some((stack) =>
     matchesStackPattern(stack, rabbyMobileUserRejectedStackPattern)
   );
+}
+
+function omitRabbyMobileIosBundlePathFromAppEvidence(
+  stack: string | undefined
+): string | undefined {
+  return stack?.replace(
+    rabbyMobileIosBundleStackPathPattern,
+    "/rabby-mobile-ios-bundle"
+  );
+}
+
+function hasRabbyMobileAppOwnedStackEvidence(
+  event: SentryClientEvent,
+  serializedStack: string | undefined,
+  hint?: SentryEventHint
+): boolean {
+  return [serializedStack, getHintExceptionStack(hint)]
+    .map(omitRabbyMobileIosBundlePathFromAppEvidence)
+    .some((stack) => hasAppOwnedStackEvidence(event, stack));
 }
 
 function isRabbyChromeContentScriptFrame(stackLine: string): boolean {
@@ -218,7 +239,7 @@ export function shouldFilterRabbyMobileUserRejectedRequest(
   event: SentryClientEvent,
   hint?: SentryEventHint
 ): boolean {
-  if (getEventMessage(event) !== objectCapturedPromiseRejectionMessage) {
+  if (!hasSingleFramelessBrowserUnhandledRejection(event)) {
     return false;
   }
 
@@ -249,7 +270,7 @@ export function shouldFilterRabbyMobileUserRejectedRequest(
     return false;
   }
 
-  return !hasAppOwnedStackEvidence(event, stack, hint);
+  return !hasRabbyMobileAppOwnedStackEvidence(event, stack, hint);
 }
 
 export function shouldFilterRabbyMobileRainbowKitNotFoundError(


### PR DESCRIPTION
<!-- sentry-fix-job:63 issue:7072807355 -->
## Issue

- Sentry: [6529-FRONTEND-Q](https://seize-ff.sentry.io/issues/7072807355/)
- First seen: 2025-11-28T17:38:51.908Z
- Latest occurrence: 2026-08-19T11:05:37.000Z
- Automatic triage confidence: 99%

A useful draft fix remains, but it is not the previously proposed Rabby Chrome filter—that fix was merged. Current production still reports Rabby Mobile iOS user cancellations because the existing app-owned-stack guard mistakes Rabby's native `.app` bundle path for the repository's `app/` source directory.

## Fix

Rabby’s native `RabbyMobile.app/main.jsbundle` path contains the generic `app/` token, so the shared classifier incorrectly treated the third-party rejection stack as application-owned.

## Changes

- Excluded only the exact observed Rabby iOS bundle path from app-owned substring matching while continuing to inspect all remaining serialized stacks, hint stacks, and exception frames.
- Required the exact single, frameless, unhandled rejection shape before filtering Rabby Mobile cancellations.
- Added production-shaped predicate and beforeSend tests plus negative coverage for application frames, later serialized frames, hint stacks, other app bundles, and signature near-misses.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Focused Jest suites passed: 2 suites, 700 tests.
- `./bin/6529 run lint:changed` passed.
- `./bin/6529 run typecheck:changed` passed.
- `git diff --check` passed.

## Risk

- Assessed risk: low
- Changed files: 3
- Changed lines: 287
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

The stored production stack has a truncated tail, so unrecorded frames cannot be inspected. The filter continues to preserve events whenever any available non-vendor stack or exception frame contains application-owned evidence.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
