### PR TITLE
fix: No repository edit was needed. The current draft already contains the narrow Rabby telemetry fix, and the

### DIFF
--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -333,6 +333,10 @@ describe("instrumentation-client", () => {
   const injectedIosAutoplayNotAllowedMessage =
     "The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.";
   const rainbowKitNotFoundMessage = "not found rainbowkit";
+  const rabbyMobileAndroidJavaBridgePostMessageErrorMessage =
+    "Error invoking postMessage: Java bridge method invocation error";
+  const rabbyMobileAndroidUserAgent =
+    "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 RabbyMobile/0.6.78 RabbyMobileAndroid/0.6.78 Mobile Safari/537.36";
   const nativeJsonStringifyFrame = {
     filename: "[native code]",
     function: "stringify",
@@ -1010,11 +1014,13 @@ describe("instrumentation-client", () => {
     },
   ];
 
-  const createObservedRabbyRainbowKitRawFrames = () => [
+  const createObservedRabbyRainbowKitRawFrames = (
+    wrapperFunction = "n"
+  ) => [
     {
       filename: "app:///_next/static/chunks/observed-rabby-webview.js",
       abs_path: "app:///_next/static/chunks/observed-rabby-webview.js",
-      function: "n",
+      function: wrapperFunction,
       in_app: true,
     },
     {
@@ -1026,7 +1032,8 @@ describe("instrumentation-client", () => {
   ];
 
   const createRabbyMobileRainbowKitNotFoundEvent = (
-    overrides: Record<string, unknown> = {}
+    overrides: Record<string, unknown> = {},
+    wrapperFunction = "n"
   ) => ({
     event_id: "rabby-mobile-rainbowkit-not-found",
     exception: {
@@ -1039,12 +1046,80 @@ describe("instrumentation-client", () => {
             handled: false,
           },
           stacktrace: {
-            frames: createObservedRabbyRainbowKitRawFrames(),
+            frames: createObservedRabbyRainbowKitRawFrames(wrapperFunction),
           },
         },
       ],
     },
     ...overrides,
+  });
+
+  const createObservedRabbyAndroidJavaBridgeFrames = () => [
+    {
+      filename: "app:///_next/static/chunks/observed-rabby-webview.js",
+      abs_path: "app:///_next/static/chunks/observed-rabby-webview.js",
+      function: "r",
+      lineno: 7,
+      colno: 6173,
+      in_app: true,
+    },
+    {
+      filename: "<anonymous>",
+      abs_path: "<anonymous>",
+      function: "?",
+      lineno: 140,
+      colno: 7,
+      in_app: true,
+    },
+    {
+      filename: "<anonymous>",
+      abs_path: "<anonymous>",
+      function: "__rabby__updateUrl",
+      lineno: 115,
+      colno: 12,
+      in_app: true,
+    },
+    {
+      filename: "<anonymous>",
+      abs_path: "<anonymous>",
+      function: "window.__RABBY_WEBVIEW_BRIDGE_POSTER__",
+      lineno: 74,
+      colno: 35,
+      in_app: true,
+    },
+    {
+      filename: "<anonymous>",
+      abs_path: "<anonymous>",
+      function: "Proxy.myPostMessage",
+      lineno: 28,
+      colno: 12,
+      in_app: true,
+    },
+  ];
+
+  const createRabbyMobileAndroidJavaBridgePostMessageEvent = () => ({
+    event_id: "rabby-mobile-android-java-bridge-post-message",
+    transaction: "/the-memes",
+    request: {
+      headers: {
+        "User-Agent": rabbyMobileAndroidUserAgent,
+      },
+    },
+    exception: {
+      values: [
+        {
+          type: "Error",
+          value: rabbyMobileAndroidJavaBridgePostMessageErrorMessage,
+          mechanism: {
+            type: "auto.browser.browserapierrors.setTimeout",
+            handled: false,
+          },
+          stacktrace: {
+            frames: createObservedRabbyAndroidJavaBridgeFrames(),
+          },
+        },
+      ],
+    },
   });
 
   beforeEach(() => {
@@ -3088,6 +3163,24 @@ describe("instrumentation-client", () => {
   it("drops the observed raw RainbowKit lookup error without wallet context", () => {
     const beforeSend = loadBeforeSend();
     const event = createRabbyMobileRainbowKitNotFoundEvent();
+
+    const result = beforeSend(event);
+
+    expect(result).toBeNull();
+  });
+
+  it("drops the observed raw RainbowKit lookup error with the r wrapper", () => {
+    const beforeSend = loadBeforeSend();
+    const event = createRabbyMobileRainbowKitNotFoundEvent({}, "r");
+
+    const result = beforeSend(event);
+
+    expect(result).toBeNull();
+  });
+
+  it("drops the exact RabbyMobile Android Java bridge postMessage error", () => {
+    const beforeSend = loadBeforeSend();
+    const event = createRabbyMobileAndroidJavaBridgePostMessageEvent();
 
     const result = beforeSend(event);
 

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -28,6 +28,7 @@ import {
   shouldFilterPoperBlockerOrphanFetchRejection,
   shouldFilterExpectedWaveRequestReplacementAbort,
   shouldFilterRabbyChromeUserRejectedRequest,
+  shouldFilterRabbyMobileAndroidJavaBridgePostMessageError,
   shouldFilterRabbyMobileRainbowKitNotFoundError,
   shouldFilterRabbyMobileUserRejectedRequest,
   shouldFilterSentryRouteParameterizationError,
@@ -164,6 +165,15 @@ type InstagramPageHideBridgeEventOptions = {
   includeAdditionalException?: boolean | undefined;
   extra?: Record<string, unknown> | undefined;
 };
+type RabbyMobileAndroidJavaBridgeEventOptions = {
+  exceptionType?: string | undefined;
+  message?: string | undefined;
+  userAgent?: string | undefined;
+  mechanismType?: string | undefined;
+  handled?: boolean | undefined;
+  frames?: SentryStackFrame[] | undefined;
+  additionalException?: SentryExceptionValue | undefined;
+};
 
 type ExpectedWaveReplacementAbortOverrides = {
   exception?: Partial<SentryExceptionValue> | undefined;
@@ -260,6 +270,8 @@ describe("sentry-client-filters", () => {
     "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 RabbyMobile/1.0 RabbyMobileIOS/1.0 Mobile/15E148";
   const rabbyMobileAndroidUserAgent =
     "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 RabbyMobile/0.6.78 RabbyMobileAndroid/0.6.78 Mobile Safari/537.36";
+  const rabbyMobileAndroidJavaBridgePostMessageErrorMessage =
+    "Error invoking postMessage: Java bridge method invocation error";
   const braveWalletUserAgent =
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1 Safari/605.1.15 Brave";
   const rainbowKitNotFoundMessage = "not found rainbowkit";
@@ -2238,11 +2250,13 @@ describe("sentry-client-filters", () => {
     ...overrides,
   });
 
-  const createObservedRabbyRainbowKitRawFrames = () => [
+  const createObservedRabbyRainbowKitRawFrames = (
+    wrapperFunction = "n"
+  ) => [
     {
       filename: "app:///_next/static/chunks/observed-rabby-webview.js",
       abs_path: "app:///_next/static/chunks/observed-rabby-webview.js",
-      function: "n",
+      function: wrapperFunction,
       in_app: true,
     },
     {
@@ -2254,7 +2268,8 @@ describe("sentry-client-filters", () => {
   ];
 
   const createRabbyMobileRainbowKitNotFoundEvent = (
-    overrides: TestSentryClientEventOverrides = {}
+    overrides: TestSentryClientEventOverrides = {},
+    wrapperFunction = "n"
   ): TestSentryClientEvent =>
     ({
       event_id: "rabby-mobile-rainbowkit-not-found",
@@ -2269,13 +2284,88 @@ describe("sentry-client-filters", () => {
               handled: false,
             },
             stacktrace: {
-              frames: createObservedRabbyRainbowKitRawFrames(),
+              frames: createObservedRabbyRainbowKitRawFrames(wrapperFunction),
             },
           },
         ],
       },
       ...overrides,
     }) as TestSentryClientEvent;
+
+  const createObservedRabbyAndroidJavaBridgeFrames = (): SentryStackFrame[] => [
+    {
+      filename: "app:///_next/static/chunks/observed-rabby-webview.js",
+      abs_path: "app:///_next/static/chunks/observed-rabby-webview.js",
+      function: "r",
+      lineno: 7,
+      colno: 6173,
+      in_app: true,
+    },
+    {
+      filename: "<anonymous>",
+      abs_path: "<anonymous>",
+      function: "?",
+      lineno: 140,
+      colno: 7,
+      in_app: true,
+    },
+    {
+      filename: "<anonymous>",
+      abs_path: "<anonymous>",
+      function: "__rabby__updateUrl",
+      lineno: 115,
+      colno: 12,
+      in_app: true,
+    },
+    {
+      filename: "<anonymous>",
+      abs_path: "<anonymous>",
+      function: "window.__RABBY_WEBVIEW_BRIDGE_POSTER__",
+      lineno: 74,
+      colno: 35,
+      in_app: true,
+    },
+    {
+      filename: "<anonymous>",
+      abs_path: "<anonymous>",
+      function: "Proxy.myPostMessage",
+      lineno: 28,
+      colno: 12,
+      in_app: true,
+    },
+  ];
+
+  const createRabbyMobileAndroidJavaBridgePostMessageEvent = ({
+    exceptionType = "Error",
+    message = rabbyMobileAndroidJavaBridgePostMessageErrorMessage,
+    userAgent = rabbyMobileAndroidUserAgent,
+    mechanismType = "auto.browser.browserapierrors.setTimeout",
+    handled = false,
+    frames = createObservedRabbyAndroidJavaBridgeFrames(),
+    additionalException,
+  }: RabbyMobileAndroidJavaBridgeEventOptions = {}): TestSentryClientEvent => ({
+    event_id: "rabby-mobile-android-java-bridge-post-message",
+    transaction: "/the-memes",
+    request: {
+      headers: {
+        "User-Agent": userAgent,
+      },
+    },
+    exception: {
+      values: [
+        {
+          type: exceptionType,
+          value: message,
+          mechanism: {
+            type: mechanismType,
+            handled,
+          },
+          stacktrace: { frames },
+        },
+        ...(additionalException ? [additionalException] : []),
+      ],
+    },
+  });
 
   const createThirdPartyTelemetryNetworkErrorEvent = (
     overrides: TestSentryClientEventOverrides = {}
@@ -8734,16 +8824,34 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(true);
   });
 
-  it("filters the observed raw RainbowKit lookup error without wallet context", () => {
+  it("filters the exact RabbyMobile Android Java bridge postMessage error", () => {
     // Arrange
-    const event = createRabbyMobileRainbowKitNotFoundEvent();
+    const event = createRabbyMobileAndroidJavaBridgePostMessageEvent();
 
     // Act
-    const result = shouldFilterRabbyMobileRainbowKitNotFoundError(event);
+    const result =
+      shouldFilterRabbyMobileAndroidJavaBridgePostMessageError(event);
 
     // Assert
     expect(result).toBe(true);
   });
+
+  it.each(["n", "r"])(
+    "filters the observed raw RainbowKit lookup error with the %s wrapper",
+    (wrapperFunction) => {
+      // Arrange
+      const event = createRabbyMobileRainbowKitNotFoundEvent(
+        {},
+        wrapperFunction
+      );
+
+      // Act
+      const result = shouldFilterRabbyMobileRainbowKitNotFoundError(event);
+
+      // Assert
+      expect(result).toBe(true);
+    }
+  );
 
   it("keeps symbolicated RainbowKit lookup errors without the raw signature", () => {
     // Arrange
@@ -10303,6 +10411,144 @@ describe("sentry-client-filters", () => {
 
     // Act
     const result = shouldFilterRabbyMobileUserRejectedRequest(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it.each([
+    {
+      caseName: "a different exception type",
+      event: createRabbyMobileAndroidJavaBridgePostMessageEvent({
+        exceptionType: "TypeError",
+      }),
+    },
+    {
+      caseName: "a different message",
+      event: createRabbyMobileAndroidJavaBridgePostMessageEvent({
+        message: "Error invoking postMessage: bridge unavailable",
+      }),
+    },
+    {
+      caseName: "a non-Rabby user agent",
+      event: createRabbyMobileAndroidJavaBridgePostMessageEvent({
+        userAgent: "Mozilla/5.0 (Linux; Android 14) Chrome/137.0.0.0",
+      }),
+    },
+    {
+      caseName: "a RabbyMobile iOS user agent",
+      event: createRabbyMobileAndroidJavaBridgePostMessageEvent({
+        userAgent: rabbyMobileUserAgent,
+      }),
+    },
+    {
+      caseName: "a different mechanism",
+      event: createRabbyMobileAndroidJavaBridgePostMessageEvent({
+        mechanismType: "auto.browser.global_handlers.onerror",
+      }),
+    },
+    {
+      caseName: "a handled mechanism",
+      event: createRabbyMobileAndroidJavaBridgePostMessageEvent({
+        handled: true,
+      }),
+    },
+    {
+      caseName: "a different raw wrapper function",
+      event: createRabbyMobileAndroidJavaBridgePostMessageEvent({
+        frames: createObservedRabbyAndroidJavaBridgeFrames().map(
+          (frame, index) =>
+            index === 0 ? { ...frame, function: "n" } : frame
+        ),
+      }),
+    },
+    {
+      caseName: "a missing frame",
+      event: createRabbyMobileAndroidJavaBridgePostMessageEvent({
+        frames: createObservedRabbyAndroidJavaBridgeFrames().slice(1),
+      }),
+    },
+    {
+      caseName: "reordered frames",
+      event: createRabbyMobileAndroidJavaBridgePostMessageEvent({
+        frames: createObservedRabbyAndroidJavaBridgeFrames().reverse(),
+      }),
+    },
+    {
+      caseName: "a changed injected function",
+      event: createRabbyMobileAndroidJavaBridgePostMessageEvent({
+        frames: createObservedRabbyAndroidJavaBridgeFrames().map(
+          (frame, index) =>
+            index === 2 ? { ...frame, function: "__rabby__refreshUrl" } : frame
+        ),
+      }),
+    },
+    {
+      caseName: "a missing anonymous-frame function sentinel",
+      event: createRabbyMobileAndroidJavaBridgePostMessageEvent({
+        frames: createObservedRabbyAndroidJavaBridgeFrames().map(
+          (frame, index) =>
+            index === 1 ? { ...frame, function: undefined } : frame
+        ),
+      }),
+    },
+    {
+      caseName: "an additional exception",
+      event: createRabbyMobileAndroidJavaBridgePostMessageEvent({
+        additionalException: {
+          type: "Error",
+          value: "Application failure",
+        },
+      }),
+    },
+    {
+      caseName: "an app-owned source frame",
+      event: createRabbyMobileAndroidJavaBridgePostMessageEvent({
+        frames: [
+          ...createObservedRabbyAndroidJavaBridgeFrames(),
+          {
+            filename: "app:///components/providers/WagmiSetup.tsx",
+            function: "initializeWallet",
+            in_app: true,
+          },
+        ],
+      }),
+    },
+  ])(
+    "does not filter the RabbyMobile Android Java bridge error with $caseName",
+    ({ event }) => {
+      // Act
+      const result =
+        shouldFilterRabbyMobileAndroidJavaBridgePostMessageError(event);
+
+      // Assert
+      expect(result).toBe(false);
+    }
+  );
+
+  it("does not filter the RabbyMobile Android Java bridge error with an app-owned hint stack", () => {
+    // Arrange
+    const event = createRabbyMobileAndroidJavaBridgePostMessageEvent();
+    const appError = new Error("Application failure");
+    appError.stack =
+      "Error: Application failure\n    at initializeWallet (app:///components/providers/WagmiSetup.tsx:1:1)";
+
+    // Act
+    const result = shouldFilterRabbyMobileAndroidJavaBridgePostMessageError(
+      event,
+      { originalException: appError }
+    );
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter RainbowKit lookup errors with another raw wrapper function", () => {
+    // Arrange
+    const event = createRabbyMobileRainbowKitNotFoundEvent({}, "x");
+
+    // Act
+    const result = shouldFilterRabbyMobileRainbowKitNotFoundError(event);
 
     // Assert
     expect(result).toBe(false);

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -48,6 +48,7 @@ import {
   shouldFilterReactDomRemoveChildNotFoundError,
   shouldFilterInjectedWasmCspUnsafeEval,
   shouldFilterRabbyChromeUserRejectedRequest,
+  shouldFilterRabbyMobileAndroidJavaBridgePostMessageError,
   shouldFilterRabbyMobileRainbowKitNotFoundError,
   shouldFilterRabbyMobileUserRejectedRequest,
   shouldFilterSentryRouteParameterizationError,
@@ -168,6 +169,10 @@ function shouldFilterEvent(
   }
 
   if (shouldFilterRabbyMobileUserRejectedRequest(event, hint)) {
+    return true;
+  }
+
+  if (shouldFilterRabbyMobileAndroidJavaBridgePostMessageError(event, hint)) {
     return true;
   }
 

--- a/utils/sentry-client-filters.ts
+++ b/utils/sentry-client-filters.ts
@@ -54,6 +54,7 @@ export {
 } from "./sentry-client-filters/wallets";
 export {
   shouldFilterRabbyChromeUserRejectedRequest,
+  shouldFilterRabbyMobileAndroidJavaBridgePostMessageError,
   shouldFilterRabbyMobileRainbowKitNotFoundError,
   shouldFilterRabbyMobileUserRejectedRequest,
 } from "./sentry-client-filters/rabby";

--- a/utils/sentry-client-filters/constants.ts
+++ b/utils/sentry-client-filters/constants.ts
@@ -173,6 +173,7 @@ export const appOwnedStackPatterns = [
 ];
 export const LOW_VALUE_NETWORK_ERROR_SAMPLE_RATE = 0.1;
 export const RABBY_MOBILE_USER_AGENT_TOKEN = "rabbymobile";
+export const RABBY_MOBILE_ANDROID_USER_AGENT_TOKEN = "rabbymobileandroid/";
 export const RABBY_MOBILE_RAINBOWKIT_NOT_FOUND_MESSAGE = "not found rainbowkit";
 
 export const REACT_DOM_INSERT_BEFORE_NOT_FOUND_ERROR_MESSAGE =

--- a/utils/sentry-client-filters/rabby.ts
+++ b/utils/sentry-client-filters/rabby.ts
@@ -9,6 +9,7 @@ import {
   rabbyMobileUserRejectedCode,
   rabbyMobileUserRejectedMessage,
   rabbyMobileUserRejectedStackPattern,
+  RABBY_MOBILE_ANDROID_USER_AGENT_TOKEN,
   RABBY_MOBILE_RAINBOWKIT_NOT_FOUND_MESSAGE,
   RABBY_MOBILE_USER_AGENT_TOKEN,
 } from "./constants";
@@ -20,6 +21,7 @@ import type {
 import {
   getContextString,
   getEventMessage,
+  getFramePaths,
   getHintExceptionMessage,
   getHintExceptionStack,
   getNumericValue,
@@ -28,10 +30,27 @@ import {
   getSerializedObjectRejection,
   getStringValue,
 } from "./value-utils";
-import { hasAppOwnedStackEvidence } from "./app-frame-utils";
+import {
+  hasAppOwnedSourceEvidence,
+  hasAppOwnedStackEvidence,
+} from "./app-frame-utils";
 import { hasBrowserUnhandledRejectionMechanism } from "./walletlink-websocket";
 
-const rabbyRainbowKitRawChunkPathPrefix = "app:///_next/static/chunks/";
+const rabbyRawChunkPathPrefix = "app:///_next/static/chunks/";
+const rabbyRawWrapperFunctions = new Set(["n", "r"]);
+const rabbyAndroidRawWrapperFunction = "r";
+const rabbyAndroidJavaBridgeErrorMessage =
+  "Error invoking postMessage: Java bridge method invocation error";
+const browserSetTimeoutMechanismType =
+  "auto.browser.browserapierrors.setTimeout";
+const anonymousFramePath = "<anonymous>";
+const sentryUnknownFunction = "?";
+const rabbyAndroidInjectedFrameFunctions = [
+  sentryUnknownFunction,
+  "__rabby__updateUrl",
+  "window.__RABBY_WEBVIEW_BRIDGE_POSTER__",
+  "Proxy.myPostMessage",
+] as const;
 const stackFrameLocationSuffixPattern = /:\d+:\d+\)$/;
 
 function matchesStackPattern(
@@ -92,10 +111,14 @@ function hasExactRabbyChromeUserRejectedStack(
   );
 }
 
-function isObservedRabbyRainbowKitRawChunkFrame(
+function isObservedRabbyRawChunkFrame(
   frame: SentryStackFrame | undefined
 ): boolean {
-  if (frame?.in_app !== true || frame.function !== "n") {
+  if (
+    frame?.in_app !== true ||
+    !frame.function ||
+    !rabbyRawWrapperFunctions.has(frame.function)
+  ) {
     return false;
   }
 
@@ -106,9 +129,57 @@ function isObservedRabbyRainbowKitRawChunkFrame(
     paths.length > 0 &&
     paths.every(
       (path) =>
-        path.startsWith(rabbyRainbowKitRawChunkPathPrefix) &&
+        path.startsWith(rabbyRawChunkPathPrefix) &&
         path.endsWith(".js")
     )
+  );
+}
+
+function hasOnlyFramePath(
+  frame: SentryStackFrame | undefined,
+  expectedPath: string
+): boolean {
+  if (!frame) {
+    return false;
+  }
+
+  const paths = getFramePaths(frame);
+  return paths.length > 0 && paths.every((path) => path === expectedPath);
+}
+
+function isObservedRabbyAndroidRawChunkFrame(
+  frame: SentryStackFrame | undefined
+): boolean {
+  return (
+    frame?.function === rabbyAndroidRawWrapperFunction &&
+    isObservedRabbyRawChunkFrame(frame)
+  );
+}
+
+function isObservedRabbyAndroidInjectedFrame(
+  frame: SentryStackFrame | undefined,
+  expectedFunction: string
+): boolean {
+  return (
+    frame?.in_app === true &&
+    frame.function === expectedFunction &&
+    hasOnlyFramePath(frame, anonymousFramePath)
+  );
+}
+
+function hasObservedRabbyAndroidJavaBridgeFrames(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  if (
+    !Array.isArray(frames) ||
+    frames.length !== rabbyAndroidInjectedFrameFunctions.length + 1 ||
+    !isObservedRabbyAndroidRawChunkFrame(frames[0])
+  ) {
+    return false;
+  }
+
+  return rabbyAndroidInjectedFrameFunctions.every((functionName, index) =>
+    isObservedRabbyAndroidInjectedFrame(frames[index + 1], functionName)
   );
 }
 
@@ -133,7 +204,7 @@ function hasObservedRabbyRainbowKitRawFrames(
   return (
     Array.isArray(frames) &&
     frames.length === 2 &&
-    isObservedRabbyRainbowKitRawChunkFrame(frames[0]) &&
+    isObservedRabbyRawChunkFrame(frames[0]) &&
     isObservedRabbyRainbowKitNativePromiseFrame(frames[1])
   );
 }
@@ -186,6 +257,21 @@ function hasRabbyMobileContext(event: SentryClientEvent): boolean {
     (candidate) =>
       typeof candidate === "string" &&
       candidate.toLowerCase().includes(RABBY_MOBILE_USER_AGENT_TOKEN)
+  );
+}
+
+function hasRabbyMobileAndroidContext(event: SentryClientEvent): boolean {
+  const candidates = [
+    getRequestHeaderString(event, "user-agent"),
+    getRuntimeUserAgentString(),
+    getStringValue(event.tags?.["user_agent"]),
+    getStringValue(event.tags?.["userAgent"]),
+  ];
+
+  return candidates.some(
+    (candidate) =>
+      typeof candidate === "string" &&
+      candidate.toLowerCase().includes(RABBY_MOBILE_ANDROID_USER_AGENT_TOKEN)
   );
 }
 
@@ -280,4 +366,28 @@ export function shouldFilterRabbyMobileRainbowKitNotFoundError(
   }
 
   return hasObservedRabbyRainbowKitRawFrames(value.stacktrace?.frames);
+}
+
+export function shouldFilterRabbyMobileAndroidJavaBridgePostMessageError(
+  event: SentryClientEvent,
+  hint?: SentryEventHint
+): boolean {
+  const values = event.exception?.values;
+  if (!Array.isArray(values) || values.length !== 1) {
+    return false;
+  }
+
+  const [value] = values;
+  if (
+    value?.type !== "Error" ||
+    value.value !== rabbyAndroidJavaBridgeErrorMessage ||
+    value.mechanism?.type !== browserSetTimeoutMechanismType ||
+    value.mechanism.handled !== false ||
+    !hasRabbyMobileAndroidContext(event) ||
+    hasAppOwnedSourceEvidence(event, value, hint)
+  ) {
+    return false;
+  }
+
+  return hasObservedRabbyAndroidJavaBridgeFrames(value.stacktrace?.frames);
 }


### PR DESCRIPTION
<!-- sentry-fix-job:62 issue:7680300094 -->
## Issue

- Sentry: [6529-FRONTEND-FY](https://seize-ff.sentry.io/issues/7680300094/)
- First seen: 2026-08-19T09:05:03.147Z
- Latest occurrence: 2026-08-19T15:33:47.000Z
- Automatic triage confidence: 99%

A narrow draft telemetry fix is useful. Both occurrences are errors from Rabby Mobile scripts injected into its WebView, not failures in 6529 application code. The current repository has the right beforeSend filtering structure, but it does not cover the Android bridge signature, and its existing RainbowKit matcher missed the second occurrence after a minified wrapper name changed.

## Fix

Rabby Mobile’s injected Android WebView bridge throws the exact Java bridge postMessage error; the grouped iOS event comes from Rabby’s injected RainbowKit retry. The draft filters only those production-backed raw signatures and fails open for changed or app-owned evidence. The responsiveness job exceeded its configured time budget after 27 passing cases, before producing its summary and artifacts.

## Changes

- Not reported.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Focused Jest validation passed: 2 suites, 708 tests.
- Changed-file lint passed.
- Changed-file typecheck passed.
- git diff --check passed; worktree remains clean at the draft head.
- All hosted PR checks pass, including Playwright smoke and critical shell, production build, quality/contracts, CodeQL, SonarCloud, Snyk, DCO, and secret scan.

## Risk

- Assessed risk: low
- Changed files: 6
- Changed lines: 490
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

No live Rabby Android device reproduction was performed. Future changed Rabby or minifier signatures intentionally fail open. The external responsiveness review produced no complete report because of its timeout.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
