### PR TITLE
fix: No further repair was needed. The existing draft fix is coherent, non-suppressing, privacy-safe, and the 

### DIFF
--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -101,6 +101,8 @@ describe("instrumentation-client", () => {
     "auto.browser.browserapierrors.setTimeout";
   const browserUnhandledRejectionMechanismType =
     "auto.browser.global_handlers.onunhandledrejection";
+  const stylesheetLoadRejectionValue =
+    "Event `Event` (type=error) captured as promise rejection";
   const browserExtensionWalletRejectionMessage = "User rejected the request.";
   const browserExtensionWalletBridgePath = "app:///content-scripts/bridge.js";
   const browserExtensionWalletBridgeFrames = [
@@ -377,6 +379,7 @@ describe("instrumentation-client", () => {
           >;
         }
       | undefined;
+    contexts?: Record<string, Record<string, unknown> | undefined> | undefined;
     message?: string | undefined;
   } | null;
 
@@ -459,6 +462,38 @@ describe("instrumentation-client", () => {
       ],
     },
   });
+
+  const createStylesheetLoadRejectionEvent = (
+    valueOverrides: Record<string, unknown> = {}
+  ) => ({
+    level: "error",
+    exception: {
+      values: [
+        {
+          type: "Event",
+          value: stylesheetLoadRejectionValue,
+          mechanism: {
+            type: browserUnhandledRejectionMechanismType,
+            synthetic: true,
+            handled: false,
+          },
+          ...valueOverrides,
+        },
+      ],
+    },
+  });
+
+  const createResourceErrorEvent = (
+    target: EventTarget | null,
+    isTrusted = true
+  ): Event =>
+    new Proxy(new Event("error"), {
+      get(source, property) {
+        if (property === "target") return target;
+        if (property === "isTrusted") return isTrusted;
+        return Reflect.get(source, property, source);
+      },
+    });
 
   const createRabbyChromeUserRejectedEvent = (
     exceptionValueOverrides: Record<string, unknown> = {},
@@ -1071,6 +1106,103 @@ describe("instrumentation-client", () => {
       filterKeys: ["6529-frontend"],
       behaviour: "drop-error-if-exclusively-contains-third-party-frames",
     });
+  });
+
+  it("keeps stylesheet load rejections and adds only the sanitized failed path", () => {
+    const beforeSend = loadBeforeSend();
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href =
+      "https://synthetic-user:synthetic-password@example.invalid/_next/static/css/app.css?token=synthetic-token#section";
+    const event = createStylesheetLoadRejectionEvent();
+
+    const result = beforeSend(event, {
+      originalException: createResourceErrorEvent(link),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.level).toBe("error");
+    expect(result?.exception?.values?.[0]?.mechanism).toEqual({
+      type: browserUnhandledRejectionMechanismType,
+      synthetic: true,
+      handled: false,
+    });
+    expect(result?.contexts?.["resource_load"]).toEqual({
+      type: "resource_load",
+      resource_type: "stylesheet",
+      url: "/_next/static/css/app.css",
+    });
+  });
+
+  it.each([
+    ["icon links", "link", "icon", true, {}],
+    ["script targets", "script", "", true, {}],
+    ["missing targets", "missing", "", true, {}],
+    ["untrusted events", "link", "stylesheet", false, {}],
+    [
+      "handled events",
+      "link",
+      "stylesheet",
+      true,
+      {
+        mechanism: {
+          type: browserUnhandledRejectionMechanismType,
+          synthetic: true,
+          handled: true,
+        },
+      },
+    ],
+    [
+      "other mechanisms",
+      "link",
+      "stylesheet",
+      true,
+      {
+        mechanism: {
+          type: "auto.browser.global_handlers.onerror",
+          synthetic: true,
+          handled: false,
+        },
+      },
+    ],
+    ["non-Event exception types", "link", "stylesheet", true, { type: "Error" }],
+  ])(
+    "keeps %s reportable without stylesheet diagnostics",
+    (_, targetType, rel, isTrusted, valueOverrides) => {
+      const beforeSend = loadBeforeSend();
+      let target: EventTarget | null = null;
+      if (targetType === "link") {
+        const link = document.createElement("link");
+        link.rel = rel;
+        link.href = "https://example.invalid/_next/static/css/app.css";
+        target = link;
+      } else if (targetType === "script") {
+        target = document.createElement("script");
+      }
+
+      const result = beforeSend(
+        createStylesheetLoadRejectionEvent(valueOverrides),
+        {
+          originalException: createResourceErrorEvent(target, isTrusted),
+        }
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.contexts?.["resource_load"]).toBeUndefined();
+    }
+  );
+
+  it("keeps ordinary application errors without resource diagnostics", () => {
+    const beforeSend = loadBeforeSend();
+    const error = new Error("Application stylesheet state failed");
+
+    const result = beforeSend(
+      createUnhandledRejectionEvent(error.message),
+      { originalException: error }
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.contexts?.["resource_load"]).toBeUndefined();
   });
 
   it.each([

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -95,6 +95,10 @@ const RAW_BROWSER_NETWORK_ERROR_PATTERNS = [
   /\bnetwork connection was lost\b/i,
   /\bnetwork request failed\b/i,
 ];
+const STYLESHEET_LOAD_REJECTION_VALUE =
+  "Event `Event` (type=error) captured as promise rejection";
+const UNHANDLED_REJECTION_MECHANISM =
+  "auto.browser.global_handlers.onunhandledrejection";
 type SentryTransactionEvent = Sentry.Event & {
   spans?: SentryTransactionSpan[] | undefined;
   tags?: Record<string, unknown> | undefined;
@@ -114,6 +118,57 @@ function getFallbackMessage(hint?: Sentry.EventHint): string {
     return hint.originalException.message;
   }
   return "";
+}
+
+function enrichStylesheetLoadError(
+  event: Sentry.Event,
+  hint?: Sentry.EventHint
+): void {
+  try {
+    const values = event.exception?.values;
+    const value = values?.[0];
+    const originalException = hint?.originalException;
+    if (
+      values?.length !== 1 ||
+      value?.type !== "Event" ||
+      value.value !== STYLESHEET_LOAD_REJECTION_VALUE ||
+      value.mechanism?.type !== UNHANDLED_REJECTION_MECHANISM ||
+      value.mechanism.handled !== false ||
+      value.mechanism.synthetic !== true ||
+      typeof Event === "undefined" ||
+      typeof HTMLLinkElement === "undefined" ||
+      !(originalException instanceof Event) ||
+      originalException.type !== "error" ||
+      originalException.isTrusted !== true ||
+      !(originalException.target instanceof HTMLLinkElement)
+    ) {
+      return;
+    }
+
+    const link = originalException.target;
+    if (
+      link.rel.trim().toLowerCase() !== "stylesheet" ||
+      !link.hasAttribute("href")
+    ) {
+      return;
+    }
+
+    const url = sanitizeUrlString(link.href);
+    if (typeof url !== "string" || !url) {
+      return;
+    }
+
+    event.contexts = {
+      ...event.contexts,
+      resource_load: {
+        type: "resource_load",
+        resource_type: "stylesheet",
+        url,
+      },
+    };
+  } catch {
+    // Diagnostics must never interfere with reporting the original failure.
+  }
 }
 
 function shouldFilterNoisyPatterns(message: string): boolean {
@@ -571,6 +626,8 @@ Sentry.init({
       tagSampledLowValueNetworkError(event);
       redactDropReactionFailureIdentifiers(event);
     }
+
+    enrichStylesheetLoadError(event, hint);
 
     return sanitizeSentryEvent(event);
   },


### PR DESCRIPTION
<!-- sentry-fix-job:66 issue:7569819652 -->
## Issue

- Sentry: [6529-FRONTEND-DR](https://seize-ff.sentry.io/issues/7569819652/)
- First seen: 2026-06-23T09:56:30.873Z
- Latest occurrence: 2026-08-19T14:12:11.000Z
- Automatic triage confidence: 91%

A useful draft change is available, but it should enrich this telemetry rather than suppress it. All 14 events are native stylesheet-link load errors emitted through React DOM and then captured by Sentry without the failed href. A narrow, fail-open beforeSend enricher can preserve the error while attaching a sanitized stylesheet path so the underlying asset, CDN, cache, or browser failure becomes actionable.

## Fix

React DOM rejects its stylesheet-loading Promise with the native link error Event. Sentry reports the rejection but normalizes away the failed href, so the committed fix adds only a sanitized stylesheet diagnostic context.

## Changes

- No files changed during this repair round.
- Retained the existing focused instrumentation and regression-test changes.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Focused instrumentation-client suite passed: 157 tests.
- Changed-file lint passed.
- Changed-file typecheck passed.
- Direct sanitizer probes confirmed safe handling of data, blob, and cross-origin URLs.
- React Doctor exited successfully but skipped scanning because the committed worktree had no uncommitted source diff.
- Branch diff check passed; the worktree is clean.
- Live exact-head PR checks are passing, including quality/contracts, production build, Playwright, CodeQL, SonarCloud, Snyk, DCO, and secret scanning.

## Risk

- Assessed risk: low
- Changed files: 2
- Changed lines: 189
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

Historical events do not identify the failed stylesheet or distinguish asset, CDN, cache, network, and browser causes. A later deployed occurrence is still required to provide the sanitized stylesheet path.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
