### PR TITLE
Fix Wave Score staging E2E selector

### DIFF
--- a/tests/surfaces/core-surfaces.spec.ts
+++ b/tests/surfaces/core-surfaces.spec.ts
@@ -174,7 +174,9 @@ test.describe("Core app surface coverage @surface @medium @large", () => {
       page.getByRole("link", { name: "Back to wave" })
     ).toHaveAttribute("href", "/waves/test-wave");
     await page.locator("#wave-score-calculator-input").fill("x");
-    await page.getByRole("button", { name: "Score" }).click();
+    await page
+      .getByRole("button", { name: "Score", exact: true })
+      .click();
 
     await expect(page.locator("#wave-score-calculator-error")).toContainText(
       "Enter a wave name, wave id, or wave URL."


### PR DESCRIPTION
## Issue

- Automatic staging E2E fails on the Wave Score short-input test because the `Score` button locator also matches the About navigation button whose accessible name contains “Wave Score.”

## Fix

- Require an exact accessible-name match when selecting the calculator submit button.

## Changes

- Update the Wave Score surface test to target only the button named exactly `Score`.

## Validation

- `git diff --check` passed.
- Local Playwright was not run because it starts a local development server; CI will exercise the corrected selector.

## Risk

- Level: Low
- Why: Test-only selector refinement with no application runtime changes.
- Rollback: Revert the single test commit.

## Review Notes

- Confirm the locator remains scoped to the calculator submit action and does not match navigation controls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Wave Score calculator test reliability by targeting the exact **Score** button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->