### PR TITLE
Require fresh staging drain checks before manual mutations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,19 +28,36 @@
 - Raw mode and `ALL` are internal emergency fences, not normal routing or UI
   controls. Never bypass them. Use the backend fast-off helper only for an
   emergency hard stop.
-- In manual fallback, dispatch backend `Deploy a service` workflows one at a
-  time and wait for exact success before starting the next. Shared concurrency
-  can cancel sibling service runs, including independent DAG-frontier units.
-- Immediately before pushing frontend `1a-staging`, and immediately before
-  dispatching each backend staging service, take one fresh bounded read-only
-  staging-drain snapshot across both repositories. Require the authoritative
-  staging gate and environment lock to be clear and no frontend/backend staging
-  deployment or staging E2E to be queued or in progress. Ignore production
-  deploy/E2E, PR CI, and unrelated workflows. If blocked or uncertain, stop
-  before mutation, report the exact blocking runs, and never wait, poll, cancel,
-  or retry automatically. Never reuse one snapshot for multiple mutations.
-  Existing workflow authorization and rejection/failure alerts remain the final
-  race protection and must not be changed or suppressed.
+- In manual fallback, dispatch exactly one backend `Deploy a service` workflow
+  and stop. A later continuation may dispatch another service only after the
+  prior run's exact success is already established and a new staging-drain
+  snapshot is clear. Shared concurrency can cancel sibling service runs,
+  including independent DAG-frontier units.
+- Immediately before pushing frontend `1a-staging`, and separately immediately
+  before dispatching each backend staging service, take one fresh bounded
+  read-only staging-drain snapshot across both repositories. Finish preparatory
+  work first, including the final shared-ref fetch and any recomputation. Then
+  read each existing source once: the repo-local Release Bus status helper for
+  the effective staging lane, `/deploy/ui/bus` or its versioned read API for the
+  `staging-environment` lock plus active trains and operations, and GitHub
+  Actions for `queued` and `in_progress` runs in both repositories. Bound the
+  Actions scan to ten pages of 100 runs per status and repository; fail closed
+  if that bound or any source cannot prove current state. The status helper
+  alone is not a staging-drain snapshot.
+- A clear snapshot requires staging `OFF` with `changeable: true`, an unowned
+  staging lock, no active `STAGING` or `PRODUCTION_QUALIFICATION` train or
+  nonterminal operation, and no queued/running staging mutation or staging E2E.
+  Staging mutations include frontend/backend staging deploys and both staging-
+  ref advance workflows. Production deploy/E2E, PR CI, and unrelated workflows
+  do not block staging.
+- Snapshot collection is the final read-only sequence before one mutation; do
+  not reuse it for another service, a batch, or a later push. If blocked,
+  unavailable, incomplete, or ambiguous, stop and return control without
+  waiting, polling, cancelling, retrying, or mutating. For a workflow blocker,
+  report repository, workflow, status, run ID, and link. Otherwise report the
+  gate/lock/train/operation/source, exact state or error, observation time, and
+  available owner, identity, or link. Existing workflow authorization and all
+  rejection/failure alerts remain unchanged as final race protection.
 - For coupled work, declare backend dependencies and preserve backend-before-
   frontend ordering. Within v2, only independent backend DAG frontier units run
   together.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,16 @@
 - In manual fallback, dispatch backend `Deploy a service` workflows one at a
   time and wait for exact success before starting the next. Shared concurrency
   can cancel sibling service runs, including independent DAG-frontier units.
+- Immediately before pushing frontend `1a-staging`, and immediately before
+  dispatching each backend staging service, take one fresh bounded read-only
+  staging-drain snapshot across both repositories. Require the authoritative
+  staging gate and environment lock to be clear and no frontend/backend staging
+  deployment or staging E2E to be queued or in progress. Ignore production
+  deploy/E2E, PR CI, and unrelated workflows. If blocked or uncertain, stop
+  before mutation, report the exact blocking runs, and never wait, poll, cancel,
+  or retry automatically. Never reuse one snapshot for multiple mutations.
+  Existing workflow authorization and rejection/failure alerts remain the final
+  race protection and must not be changed or suppressed.
 - For coupled work, declare backend dependencies and preserve backend-before-
   frontend ordering. Within v2, only independent backend DAG frontier units run
   together.

--- a/ops/docs/developer/simple-release-bus-v2.md
+++ b/ops/docs/developer/simple-release-bus-v2.md
@@ -27,6 +27,20 @@ operation to be terminal. Both lanes `OFF` means full manual fallback after both
 drain gates. Raw `RELEASE_BUS_V2_MODE` and `ALL` remain internal emergency
 fences; they are not normal routing or UI controls and must never be bypassed.
 
+For manual shared-staging work, take one fresh bounded read-only drain snapshot
+across both repositories as the final action immediately before pushing
+frontend `1a-staging`, and take a new snapshot immediately before every backend
+staging-service dispatch. The snapshot must confirm that the authoritative
+staging gate and environment lock are clear and that no frontend staging
+deployment, backend staging deployment, or staging E2E is queued or in
+progress. Production deploy/E2E activity, PR CI, and unrelated workflows are
+independent and do not block staging. A blocked, unavailable, or ambiguous
+snapshot stops the operation before mutation: report the exact blocking
+repository, workflow, status, run ID, and link, and do not wait, poll, cancel,
+or retry automatically. Never reuse a snapshot for more than one mutation. The
+workflow-side authorization guard and all existing rejection/failure alerts
+remain unchanged as the final race protection.
+
 There is no inferred control-plane or self-upgrade exception. While a target
 lane is `ON`, every deploy for that environment—including API, `releaseBus`,
 cleaner/reconciler, and other control-plane changes—must be an authenticated

--- a/ops/docs/developer/simple-release-bus-v2.md
+++ b/ops/docs/developer/simple-release-bus-v2.md
@@ -27,17 +27,41 @@ operation to be terminal. Both lanes `OFF` means full manual fallback after both
 drain gates. Raw `RELEASE_BUS_V2_MODE` and `ALL` remain internal emergency
 fences; they are not normal routing or UI controls and must never be bypassed.
 
-For manual shared-staging work, take one fresh bounded read-only drain snapshot
-across both repositories as the final action immediately before pushing
-frontend `1a-staging`, and take a new snapshot immediately before every backend
-staging-service dispatch. The snapshot must confirm that the authoritative
-staging gate and environment lock are clear and that no frontend staging
-deployment, backend staging deployment, or staging E2E is queued or in
-progress. Production deploy/E2E activity, PR CI, and unrelated workflows are
-independent and do not block staging. A blocked, unavailable, or ambiguous
-snapshot stops the operation before mutation: report the exact blocking
-repository, workflow, status, run ID, and link, and do not wait, poll, cancel,
-or retry automatically. Never reuse a snapshot for more than one mutation. The
+For manual shared-staging work, finish all preparation first, including the
+final shared-ref fetch and any recomputation. Then take one fresh bounded
+read-only staging-drain snapshot as the final sequence immediately before
+pushing frontend `1a-staging`, and take a completely new snapshot immediately
+before every individual backend staging-service dispatch.
+
+The snapshot consists of all three existing read-only sources:
+
+1. Run `./bin/6529 exec node ops/scripts/release-bus-status.mjs` once. Require
+   the effective staging lane to be `OFF` with `changeable: true`. This helper
+   does not inspect locks or workflows and is not sufficient by itself.
+2. Read `/deploy/ui/bus` or its versioned read API once. Require the
+   `staging-environment` lock to be unowned, no active `STAGING` or
+   `PRODUCTION_QUALIFICATION` train, and no nonterminal operation in either
+   lane.
+3. Make one bounded GitHub Actions pass over both repositories for `queued` and
+   `in_progress` runs, examining at most ten pages of 100 runs for each status
+   and repository. Treat these workflow paths as staging blockers:
+   - backend `deploy.yml` only when the `Deploy a service` display title targets
+     `staging`;
+   - frontend `deploy-staging.yml`, `release-bus-deploy-staging.yml`, and
+     `staging-e2e.yml`;
+   - `release-bus-v2-advance-staging-ref.yml` in either repository.
+   Match by workflow path; use the current workflow name only as a legacy
+   fallback.
+
+Production deploy/E2E activity, PR CI, and unrelated workflows are independent
+and do not block staging. Fail closed if any source is unavailable, malformed,
+incomplete, ambiguous, or exceeds its bound. A clear snapshot applies only to
+the immediately following single mutation; never reuse it for another backend
+service, a batch, or a later frontend push. If blocked, stop and return control
+without waiting, polling, cancelling, retrying, or mutating. For a workflow
+blocker, report repository, workflow, status, run ID, and link. For a gate,
+lock, train, operation, or source failure, report the source, exact state or
+error, observation time, and any available owner, identity, or link. The
 workflow-side authorization guard and all existing rejection/failure alerts
 remain unchanged as the final race protection.
 

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -86,25 +86,43 @@ manifest-bound E2E. V2 never publishes release notes.
    are authorized. Then prove the target environment lock is free, no target
    mutation/E2E workflow is active, and every already-dispatched exact operation
    is terminal. Fetch the exact remote target head.
-2. Re-fetch immediately before pushing. If a shared ref moved, recompute from
-   the new head. Never force-push.
-3. As the final read-only action immediately before pushing frontend
-   `1a-staging`, and separately immediately before dispatching each backend
-   staging service, take a fresh bounded staging-drain snapshot across both
-   repositories. Require the authoritative staging gate and environment lock to
-   be clear and no frontend/backend staging deployment or staging E2E to be
-   queued or in progress. Production deploy/E2E, PR CI, and unrelated workflows
-   are not staging blockers. If the snapshot is blocked, unavailable, or
-   ambiguous, stop before mutation and report each exact blocking repository,
-   workflow, status, run ID, and link. Never wait, poll, cancel, or retry
-   automatically, and never reuse one snapshot for a later mutation or backend
-   batch. The existing workflow authorization guard and all rejection/failure
-   alerts remain unchanged as final race protection.
+2. Finish every preparatory action before the staging-drain snapshot. In
+   particular, re-fetch the shared ref and, if it moved, recompute from its new
+   head. Never force-push or fetch again after the snapshot.
+3. Immediately before pushing frontend `1a-staging`, and separately immediately
+   before dispatching each backend staging service, take one fresh bounded
+   read-only staging-drain snapshot across both repositories:
+   - Run `./bin/6529 exec node ops/scripts/release-bus-status.mjs` once and
+     require the effective staging lane to be `OFF` with `changeable: true`.
+     This helper alone is not a staging-drain snapshot.
+   - Read `/deploy/ui/bus` or its versioned read API once. Require the
+     `staging-environment` lock to be unowned, with no active `STAGING` or
+     `PRODUCTION_QUALIFICATION` train and no nonterminal operation in either
+     lane.
+   - Make one bounded GitHub Actions pass for `queued` and `in_progress` runs in
+     both repositories, examining at most ten pages of 100 runs for each status
+     and repository. Block on backend `Deploy a service` runs whose display
+     title targets `staging`; frontend `deploy-staging.yml`,
+     `release-bus-deploy-staging.yml`, and `staging-e2e.yml`; and either repo's
+     `release-bus-v2-advance-staging-ref.yml`. Match by workflow path, using the
+     current workflow name only as a legacy fallback.
+   Production deploy/E2E, PR CI, and unrelated workflows are not staging
+   blockers. Fail closed if any source is unavailable, malformed, incomplete,
+   ambiguous, or exceeds its bound. Snapshot collection is the final read-only
+   sequence before one mutation; do not reuse it for another backend service, a
+   batch, or a later frontend push. On a blocker, stop and return control without
+   waiting, polling, cancelling, retrying, or mutating. For a workflow blocker,
+   report repository, workflow, status, run ID, and link. Otherwise report the
+   gate/lock/train/operation/source, exact state or error, observation time, and
+   available owner, identity, or link. The existing workflow authorization
+   guard and all rejection/failure alerts remain unchanged as final race
+   protection.
 4. Deploy required backend units in DAG order before merging/deploying dependent
    frontend work to `1a-staging`. Dispatch exactly one backend service workflow
-   (`Deploy a service`) at a time and wait for exact success before starting the
-   next; shared workflow concurrency can cancel sibling runs, even for
-   independent DAG-frontier units.
+   (`Deploy a service`) and stop. A later continuation may dispatch the next
+   service only after the prior run's exact success is already established and
+   step 3 produces a new clear snapshot. Shared workflow concurrency can cancel
+   sibling runs, even for independent DAG-frontier units.
 5. Record exact deployed frontend/backend SHAs before E2E and freeze staging
    until E2E is terminal.
 6. With the production lane `OFF`, production requires explicit owner

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -85,18 +85,29 @@ manifest-bound E2E. V2 never publishes release notes.
    credential, or deployment mutation unless the exact run and drain state
    are authorized. Then prove the target environment lock is free, no target
    mutation/E2E workflow is active, and every already-dispatched exact operation
-   is terminal. Fetch the exact remote target head. Wait; never cancel another
-   actor.
+   is terminal. Fetch the exact remote target head.
 2. Re-fetch immediately before pushing. If a shared ref moved, recompute from
    the new head. Never force-push.
-3. Deploy required backend units in DAG order before merging/deploying dependent
+3. As the final read-only action immediately before pushing frontend
+   `1a-staging`, and separately immediately before dispatching each backend
+   staging service, take a fresh bounded staging-drain snapshot across both
+   repositories. Require the authoritative staging gate and environment lock to
+   be clear and no frontend/backend staging deployment or staging E2E to be
+   queued or in progress. Production deploy/E2E, PR CI, and unrelated workflows
+   are not staging blockers. If the snapshot is blocked, unavailable, or
+   ambiguous, stop before mutation and report each exact blocking repository,
+   workflow, status, run ID, and link. Never wait, poll, cancel, or retry
+   automatically, and never reuse one snapshot for a later mutation or backend
+   batch. The existing workflow authorization guard and all rejection/failure
+   alerts remain unchanged as final race protection.
+4. Deploy required backend units in DAG order before merging/deploying dependent
    frontend work to `1a-staging`. Dispatch exactly one backend service workflow
    (`Deploy a service`) at a time and wait for exact success before starting the
    next; shared workflow concurrency can cancel sibling runs, even for
    independent DAG-frontier units.
-4. Record exact deployed frontend/backend SHAs before E2E and freeze staging
+5. Record exact deployed frontend/backend SHAs before E2E and freeze staging
    until E2E is terminal.
-5. With the production lane `OFF`, production requires explicit owner
+6. With the production lane `OFF`, production requires explicit owner
    authorization but not prior staging deployment or validation. Re-fetch
    `main` and preserve dependency
    order. For backend services, pass the same merged PR number and full


### PR DESCRIPTION
## Issue

- Agent guidance allowed frontend staging pushes to queue behind active deploys, even though the queued run can begin during staging E2E and be rejected.

## Fix

- Require one fresh bounded shared-staging drain snapshot immediately before every frontend staging push and backend staging-service dispatch.
- Stop before mutation and report exact blockers without waiting, polling, cancelling, or retrying automatically.

## Changes

- Update frontend agent and deployment-skill instructions.
- Document the shared staging snapshot scope, one-mutation lifetime, and production independence.
- Preserve workflow-side authorization and all rejection/failure alerts as the race-condition backstop.

## Validation

- `git diff --check`
- Documentation link validation across 300 Markdown files
- No workflow or executable deployment code changed.

## Risk

- Level: Low
- Why: Documentation-only operational guidance.
- Rollback: Revert the documentation commit.

## Review Notes

- Review the snapshot timing and blocker scope. Workflow definitions and alert behavior are intentionally unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added staging deployment safety requirements requiring a fresh, read-only status check before each staging change.
  * Staging changes must stop when gates, locks, deployments, or end-to-end runs are active, queued, blocked, or unclear.
  * Status checks cannot be reused, and automatic waiting, polling, cancellation, or retrying is not permitted.
  * Existing authorization and failure-alert protections remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->