### PR TITLE
Make wave rule acceptance and wallet signing clear

### DIFF
--- a/__tests__/components/TermsSignatureFlow.test.tsx
+++ b/__tests__/components/TermsSignatureFlow.test.tsx
@@ -26,11 +26,13 @@ describe("TermsSignatureFlow", () => {
       document.dispatchEvent(event);
     });
 
-    expect(await screen.findByText("Terms of Service")).toBeInTheDocument();
+    expect(await screen.findByText("Submission rules")).toBeInTheDocument();
 
     const checkbox = screen.getByRole("checkbox");
     await userEvent.click(checkbox);
-    const button = screen.getByRole("button", { name: /agree & continue/i });
+    const button = screen.getByRole("button", {
+      name: /agree & sign submission/i,
+    });
     await userEvent.click(button);
 
     await waitFor(() => {
@@ -54,7 +56,7 @@ describe("TermsSignatureFlow", () => {
       document.dispatchEvent(event);
     });
 
-    expect(await screen.findByText("Terms of Service")).toBeInTheDocument();
+    expect(await screen.findByText("Submission rules")).toBeInTheDocument();
     const close = screen.getByLabelText("Close modal");
     await userEvent.click(close);
 
@@ -74,7 +76,7 @@ describe("TermsSignatureFlow", () => {
       document.dispatchEvent(event);
     });
 
-    expect(screen.queryByText("Terms of Service")).not.toBeInTheDocument();
+    expect(screen.queryByText("Submission rules")).not.toBeInTheDocument();
     expect(onComplete).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/components/terms/TermsOfServiceModal.test.tsx
+++ b/__tests__/components/terms/TermsOfServiceModal.test.tsx
@@ -48,7 +48,7 @@ describe("TermsOfServiceModal", () => {
         termsContent="terms"
       />
     );
-    const dialog = screen.getByRole("dialog", { name: "Terms of Service" });
+    const dialog = screen.getByRole("dialog", { name: "Submission rules" });
     expect(dialog).toHaveClass("tailwind-scope", "tw-z-[1100]");
     expect(container).not.toContainElement(dialog);
     const checkbox = screen.getByRole("checkbox");
@@ -69,7 +69,7 @@ describe("TermsOfServiceModal", () => {
         termsContent={null}
       />
     );
-    expect(screen.getByText("No terms of service found.")).toBeInTheDocument();
+    expect(screen.getByText("No submission rules found.")).toBeInTheDocument();
   });
 
   it("closes on Escape", async () => {
@@ -86,7 +86,7 @@ describe("TermsOfServiceModal", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it("toggles via Enter key", async () => {
+  it("toggles via Space key", async () => {
     render(
       <TermsOfServiceModal
         isOpen
@@ -96,10 +96,27 @@ describe("TermsOfServiceModal", () => {
       />
     );
     const checkbox = screen.getByRole("checkbox");
-    expect(checkbox).toHaveAttribute("aria-checked", "false");
+    expect(checkbox).not.toBeChecked();
     checkbox.focus();
-    await userEvent.keyboard("{Enter}");
-    expect(checkbox).toHaveAttribute("aria-checked", "true");
+    await userEvent.keyboard(" ");
+    expect(checkbox).toBeChecked();
+  });
+
+  it("keeps the dialog open while signing", async () => {
+    const onClose = jest.fn();
+    render(
+      <TermsOfServiceModal
+        isOpen
+        onClose={onClose}
+        onAccept={jest.fn()}
+        termsContent="t"
+        isLoading
+      />
+    );
+
+    expect(screen.getByRole("checkbox")).toBeDisabled();
+    await userEvent.keyboard("{Escape}");
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   it("resets acknowledgement when reopened", async () => {
@@ -134,10 +151,7 @@ describe("TermsOfServiceModal", () => {
       />
     );
 
-    expect(screen.getByRole("checkbox")).toHaveAttribute(
-      "aria-checked",
-      "false"
-    );
+    expect(screen.getByRole("checkbox")).not.toBeChecked();
     expect(screen.getByTestId("primary")).toBeDisabled();
   });
 });

--- a/__tests__/components/waves/groups/WaveSettingsSections.test.tsx
+++ b/__tests__/components/waves/groups/WaveSettingsSections.test.tsx
@@ -62,6 +62,8 @@ const makeWave = (
     readonly winningThreshold?: number | null | undefined;
     readonly winningThresholdMinDurationMs?: number | null | undefined;
     readonly decisionsStrategy?: any;
+    readonly participationTerms?: string | null | undefined;
+    readonly participationSignatureRequired?: boolean | undefined;
   } = {}
 ): any => ({
   id: "wave-1",
@@ -92,9 +94,9 @@ const makeWave = (
     no_of_applications_allowed_per_participant: null,
     required_media: null,
     required_metadata: [],
-    signature_required: false,
+    signature_required: overrides.participationSignatureRequired ?? false,
     period: null,
-    terms: null,
+    terms: overrides.participationTerms ?? null,
     submission_strategy: null,
   },
   wave: {
@@ -906,6 +908,58 @@ describe("WaveSettingsSections", () => {
       {
         terms: "Must be original.",
         signature_required: true,
+      }
+    );
+  });
+
+  it("shows and repairs legacy terms without a signature requirement", async () => {
+    const user = userEvent.setup();
+    renderSettings({
+      wave: makeWave({
+        canAdmin: true,
+        waveType: ApiWaveType.Rank,
+        participationTerms: "Legacy rules",
+        participationSignatureRequired: false,
+      }),
+    });
+
+    expect(screen.getByText("Not required")).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "Edit acceptance rules" })
+    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(commonApiPostMock).toHaveBeenCalled());
+    expect(commonApiPostMock.mock.calls[0][0].body.participation).toMatchObject(
+      {
+        terms: "Legacy rules",
+        signature_required: true,
+      }
+    );
+  });
+
+  it("shows and clears a legacy signature requirement without terms", async () => {
+    const user = userEvent.setup();
+    renderSettings({
+      wave: makeWave({
+        canAdmin: true,
+        waveType: ApiWaveType.Rank,
+        participationTerms: null,
+        participationSignatureRequired: true,
+      }),
+    });
+
+    expect(screen.getByText("Signature only")).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "Edit acceptance rules" })
+    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(commonApiPostMock).toHaveBeenCalled());
+    expect(commonApiPostMock.mock.calls[0][0].body.participation).toMatchObject(
+      {
+        terms: null,
+        signature_required: false,
       }
     );
   });

--- a/__tests__/components/waves/memes/submission/steps/AgreementStep.test.tsx
+++ b/__tests__/components/waves/memes/submission/steps/AgreementStep.test.tsx
@@ -1,39 +1,60 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import React from 'react';
-import AgreementStep from '@/components/waves/memes/submission/steps/AgreementStep';
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import AgreementStep from "@/components/waves/memes/submission/steps/AgreementStep";
 
-jest.mock('@/components/utils/button/PrimaryButton', () => (props: any) => (
-  <button onClick={props.onClicked} disabled={props.disabled} data-testid="primary">
+jest.mock("@/components/utils/button/PrimaryButton", () => (props: any) => (
+  <button
+    onClick={props.onClicked}
+    disabled={props.disabled}
+    data-testid="primary"
+  >
     {props.children}
   </button>
 ));
 
 type Wave = { participation: { terms: string } };
-jest.mock('@/components/waves/memes/submission/steps/AgreementStepAgreement', () => (p: any) => <div data-testid="agreement">{p.text}</div>);
+jest.mock(
+  "@/components/waves/memes/submission/steps/AgreementStepAgreement",
+  () => (p: any) => <div data-testid="agreement">{p.text}</div>
+);
 
-const wave: Wave = { participation: { terms: 'terms' } } as any;
+const wave: Wave = { participation: { terms: "terms" } } as any;
 
-describe('AgreementStep', () => {
-  it('toggles agreement and calls continue', async () => {
+describe("AgreementStep", () => {
+  it("updates agreement through the native checkbox", async () => {
     const setAgreements = jest.fn();
     const onContinue = jest.fn();
     const user = userEvent.setup();
     render(
-      <AgreementStep wave={wave as any} agreements={false} setAgreements={setAgreements} onContinue={onContinue} />
+      <AgreementStep
+        wave={wave as any}
+        agreements={false}
+        setAgreements={setAgreements}
+        onContinue={onContinue}
+      />
     );
-    await user.click(screen.getByRole('button', { name: /Check terms agreement/i }));
+    const checkbox = screen.getByRole("checkbox", {
+      name: "I have read and agree to the rules above.",
+    });
+    checkbox.focus();
+    await user.keyboard(" ");
     expect(setAgreements).toHaveBeenCalledWith(true);
   });
 
-  it('enables continue when agreed', async () => {
+  it("enables continue when agreed", async () => {
     const setAgreements = jest.fn();
     const onContinue = jest.fn();
     const user = userEvent.setup();
     render(
-      <AgreementStep wave={wave as any} agreements={true} setAgreements={setAgreements} onContinue={onContinue} />
+      <AgreementStep
+        wave={wave as any}
+        agreements={true}
+        setAgreements={setAgreements}
+        onContinue={onContinue}
+      />
     );
-    const btn = screen.getByTestId('primary');
+    const btn = screen.getByTestId("primary");
     expect(btn).not.toBeDisabled();
     await user.click(btn);
     expect(onContinue).toHaveBeenCalled();

--- a/components/terms/TermsOfServiceModal.tsx
+++ b/components/terms/TermsOfServiceModal.tsx
@@ -4,6 +4,8 @@ import type { FC } from "react";
 import { useEffect, useId, useState } from "react";
 import { createPortal } from "react-dom";
 import { FocusTrap } from "focus-trap-react";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import { t } from "@/i18n/messages";
 import ModalLayout from "../waves/memes/submission/layout/ModalLayout";
 
 import PrimaryButton from "../utils/button/PrimaryButton";
@@ -24,15 +26,14 @@ const OpenTermsOfServiceModal: FC<OpenTermsOfServiceModalProps> = ({
   termsContent,
   isLoading = false,
 }) => {
+  const locale = useBrowserLocale();
   const titleId = useId();
+  const guidanceId = useId();
   const [hasAcknowledged, setHasAcknowledged] = useState(false);
-  const toggleAcknowledgement = () => {
-    setHasAcknowledged((current) => !current);
-  };
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
+      if (event.key === "Escape" && !isLoading) {
         onClose();
       }
     };
@@ -42,7 +43,7 @@ const OpenTermsOfServiceModal: FC<OpenTermsOfServiceModalProps> = ({
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [onClose]);
+  }, [isLoading, onClose]);
 
   return (
     <FocusTrap active>
@@ -54,8 +55,9 @@ const OpenTermsOfServiceModal: FC<OpenTermsOfServiceModalProps> = ({
       >
         <div className="tw-max-h-[calc(100dvh-2rem)] tw-w-full tw-max-w-4xl tw-overflow-y-auto tw-px-0 sm:tw-px-2">
           <ModalLayout
-            title="Terms of Service"
+            title={t(locale, "waves.submission.acceptanceRules.modalTitle")}
             onCancel={onClose}
+            closeDisabled={isLoading}
             titleId={titleId}
           >
             <div className="tw-p-4">
@@ -69,27 +71,35 @@ const OpenTermsOfServiceModal: FC<OpenTermsOfServiceModalProps> = ({
                   </div>
                 ) : (
                   <div className="tw-py-8 tw-text-center tw-text-iron-300">
-                    No terms of service found.
+                    {t(locale, "waves.submission.acceptanceRules.modalEmpty")}
                   </div>
                 )}
               </div>
 
-              <button
-                type="button"
-                onClick={toggleAcknowledgement}
-                className="tw-mb-4 tw-flex tw-items-start tw-gap-3 tw-border-0 tw-bg-transparent tw-p-0 tw-pt-4 tw-text-left tw-transition-opacity hover:tw-opacity-80"
-                aria-label="Agree to terms of service checkbox"
-                aria-checked={hasAcknowledged}
-                role="checkbox"
-                disabled={isLoading}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    toggleAcknowledgement();
-                  }
-                }}
+              <p
+                id={guidanceId}
+                className="tw-mb-0 tw-text-sm tw-leading-5 tw-text-iron-400"
               >
-                <div
+                {t(locale, "waves.submission.acceptanceRules.modalGuidance")}
+              </p>
+
+              <label
+                className={`tw-mb-4 tw-flex tw-items-start tw-gap-3 tw-rounded-lg tw-py-3 tw-text-left tw-transition-opacity focus-within:tw-ring-2 focus-within:tw-ring-primary-400 focus-within:tw-ring-offset-2 focus-within:tw-ring-offset-iron-950 ${
+                  isLoading
+                    ? "tw-cursor-not-allowed tw-opacity-60"
+                    : "tw-cursor-pointer desktop-hover:hover:tw-opacity-80"
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  checked={hasAcknowledged}
+                  onChange={(event) => setHasAcknowledged(event.target.checked)}
+                  aria-describedby={guidanceId}
+                  disabled={isLoading}
+                  className="tw-sr-only"
+                />
+                <span
+                  aria-hidden="true"
                   className={`tw-h-5 tw-w-5 tw-flex-shrink-0 tw-rounded tw-border tw-border-solid ${
                     hasAcknowledged
                       ? "tw-border-primary-600 tw-bg-primary-500"
@@ -111,11 +121,14 @@ const OpenTermsOfServiceModal: FC<OpenTermsOfServiceModalProps> = ({
                       />
                     </svg>
                   )}
-                </div>
-                <span className="tw-text-sm tw-font-bold tw-text-iron-300">
-                  I have read and agree to the terms of service
                 </span>
-              </button>
+                <span className="tw-text-sm tw-font-bold tw-text-iron-300">
+                  {t(
+                    locale,
+                    "waves.submission.acceptanceRules.modalCheckboxLabel"
+                  )}
+                </span>
+              </label>
             </div>
 
             <div className="tw-flex tw-justify-end tw-gap-3 tw-border-t tw-border-iron-700 tw-p-4">
@@ -124,7 +137,7 @@ const OpenTermsOfServiceModal: FC<OpenTermsOfServiceModalProps> = ({
                 disabled={!hasAcknowledged}
                 loading={isLoading}
               >
-                Agree & Continue
+                {t(locale, "waves.submission.acceptanceRules.modalSubmit")}
               </PrimaryButton>
             </div>
           </ModalLayout>

--- a/components/waves/memes/submission/hooks/useArtworkSubmissionMutation.ts
+++ b/components/waves/memes/submission/hooks/useArtworkSubmissionMutation.ts
@@ -374,7 +374,7 @@ export function useArtworkSubmissionMutation() {
   return {
     submitArtwork,
     isSubmitting:
-      uploadMutation.isPending ?? isSigningDrop ?? submissionMutation.isPending,
+      uploadMutation.isPending || isSigningDrop || submissionMutation.isPending,
     isUploading: uploadMutation.isPending,
     isSigning: isSigningDrop,
     isProcessing: submissionMutation.isPending,
@@ -382,7 +382,7 @@ export function useArtworkSubmissionMutation() {
     submissionPhase,
     submissionError,
     isSuccess: submissionMutation.isSuccess,
-    isError: uploadMutation.isError ?? submissionMutation.isError,
+    isError: uploadMutation.isError || submissionMutation.isError,
     error: uploadMutation.error ?? submissionMutation.error,
     reset: () => {
       uploadMutation.reset();

--- a/components/waves/memes/submission/layout/ModalLayout.tsx
+++ b/components/waves/memes/submission/layout/ModalLayout.tsx
@@ -5,6 +5,7 @@ import React from "react";
 interface ModalLayoutProps {
   readonly title: string;
   readonly onCancel: () => void;
+  readonly closeDisabled?: boolean | undefined;
   readonly children: React.ReactNode;
   readonly titleId?: string | undefined;
   readonly contentClassName?: string | undefined;
@@ -24,13 +25,14 @@ interface ModalLayoutProps {
 const ModalLayout: React.FC<ModalLayoutProps> = ({
   title,
   onCancel,
+  closeDisabled = false,
   children,
   titleId,
   contentClassName = "tw-relative tw-z-10 tw-px-6 tw-py-6",
   surfaceClassName = "tw-w-full tw-bg-iron-950 tw-rounded-t-xl md:tw-rounded-xl tw-relative tw-border tw-border-solid tw-border-white/10 tw-border-b-0 md:tw-border-b tw-overflow-hidden",
   headerClassName = "tw-relative tw-z-10 tw-px-6 tw-py-4 tw-border-b tw-border-solid tw-border-white/5 tw-border-t-0 tw-border-x-0 tw-flex tw-justify-between tw-items-center",
   titleClassName = "tw-text-lg tw-font-bold tw-text-white tw-mb-0",
-  closeButtonClassName = "tw-flex tw-items-center tw-justify-center tw-border-0 tw-bg-transparent tw-text-white/40 desktop-hover:hover:tw-text-white tw-transition-colors",
+  closeButtonClassName = "tw-flex tw-items-center tw-justify-center tw-border-0 tw-bg-transparent tw-text-white/40 tw-transition-colors disabled:tw-cursor-not-allowed disabled:tw-opacity-40 desktop-hover:hover:tw-text-white",
   closeIconClassName = "tw-size-6 tw-flex-shrink-0",
   headerActions,
   showAmbientBackground = true,
@@ -60,7 +62,9 @@ const ModalLayout: React.FC<ModalLayoutProps> = ({
               )}
             </div>
             <motion.button
+              type="button"
               onClick={onCancel}
+              disabled={closeDisabled}
               className={closeButtonClassName}
               aria-label="Close modal"
             >

--- a/components/waves/memes/submission/steps/AgreementStep.tsx
+++ b/components/waves/memes/submission/steps/AgreementStep.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import PrimaryButton from "@/components/utils/button/PrimaryButton";
 import type { ApiWave } from "@/generated/models/ApiWave";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import { t } from "@/i18n/messages";
 import AgreementStepAgreement from "./AgreementStepAgreement";
 
 interface AgreementStepProps {
@@ -16,20 +18,18 @@ const AgreementStep: React.FC<AgreementStepProps> = ({
   setAgreements,
   onContinue,
 }) => {
+  const locale = useBrowserLocale();
+
   return (
     <div className="tw-relative tw-flex tw-h-full tw-flex-col">
       <div className="tw-flex-1 tw-overflow-y-auto tw-overflow-x-hidden tw-px-4 tw-pb-6 tw-pt-2 tw-scrollbar-thin tw-scrollbar-track-iron-800 tw-scrollbar-thumb-iron-500 desktop-hover:hover:tw-scrollbar-thumb-iron-300 md:tw-px-8">
         <div className="tw-mx-auto tw-max-w-5xl">
           <div className="tw-mt-6 tw-max-w-4xl tw-space-y-2 tw-text-base tw-text-iron-300">
             <p className="tw-mb-0">
-              Before you submit your work to The Memes, we would like to make
-              sure we are all on the same page about what this means for you and
-              your work!
+              {t(locale, "waves.submission.acceptanceRules.memesIntro")}
             </p>
             <p className="tw-mb-0">
-              Please read the important information below and confirm that you
-              understand and agree. If you have any questions, please reach out
-              to one of the team members before you submit!
+              {t(locale, "waves.submission.acceptanceRules.memesSigningTiming")}
             </p>
           </div>
           <div className="tw-mt-6 tw-flex tw-flex-col tw-rounded-xl tw-bg-iron-900 tw-p-4 tw-ring-1 tw-ring-iron-800 lg:tw-p-6">
@@ -40,14 +40,15 @@ const AgreementStep: React.FC<AgreementStepProps> = ({
       <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-800 tw-bg-iron-950">
         <div className="tw-px-4 tw-py-4 md:tw-px-8">
           <div className="tw-mx-auto tw-flex tw-max-w-5xl tw-flex-col tw-items-center tw-justify-between tw-gap-4 md:tw-flex-row">
-            <button
-              onClick={() => setAgreements(!agreements)}
-              className="tw-flex tw-flex-1 tw-items-start tw-gap-3 tw-rounded-lg tw-border-none tw-bg-iron-900/50 tw-px-4 tw-py-3 tw-text-left tw-ring-1 tw-ring-iron-800 tw-transition-all desktop-hover:hover:tw-ring-iron-700"
-              aria-label={
-                agreements ? "Uncheck terms agreement" : "Check terms agreement"
-              }
-            >
+            <label className="tw-flex tw-w-full tw-flex-1 tw-cursor-pointer tw-items-start tw-gap-3 tw-rounded-lg tw-bg-iron-900/50 tw-px-4 tw-py-3 tw-text-left tw-ring-1 tw-ring-iron-800 tw-transition-all focus-within:tw-ring-2 focus-within:tw-ring-primary-400 desktop-hover:hover:tw-ring-iron-700 md:tw-w-auto">
+              <input
+                type="checkbox"
+                checked={agreements}
+                onChange={(event) => setAgreements(event.target.checked)}
+                className="tw-sr-only"
+              />
               <div
+                aria-hidden="true"
                 className={`tw-h-5 tw-w-5 tw-flex-shrink-0 tw-rounded tw-border tw-border-solid tw-transition-all tw-duration-300 ${
                   agreements
                     ? "tw-border-primary-500 tw-bg-primary-500 tw-shadow-[0_0_0_4px_rgba(139,92,246,0.1)]"
@@ -75,17 +76,19 @@ const AgreementStep: React.FC<AgreementStepProps> = ({
                   agreements ? "tw-text-iron-100" : "tw-text-iron-300"
                 }`}
               >
-                I have read and understood the above and will certify it with a
-                signature from my wallet.
+                {t(
+                  locale,
+                  "waves.submission.acceptanceRules.memesCheckboxLabel"
+                )}
               </span>
-            </button>
+            </label>
             <PrimaryButton
               onClicked={onContinue}
               loading={false}
               disabled={!agreements}
               size="lg"
             >
-              I Agree & Continue
+              {t(locale, "waves.submission.acceptanceRules.memesContinue")}
             </PrimaryButton>
           </div>
         </div>

--- a/components/waves/specs/WaveBindingRules.tsx
+++ b/components/waves/specs/WaveBindingRules.tsx
@@ -2,6 +2,8 @@
 
 import type { ApiWave } from "@/generated/models/ApiWave";
 import { normalizeWaveCustomRules } from "@/helpers/waves/wave-metadata.helpers";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import { t } from "@/i18n/messages";
 import { useCallback, useMemo, useState } from "react";
 import WaveSettingEditorActions from "./WaveSettingEditorActions";
 import WaveSettingRow from "./WaveSettingRow";
@@ -28,6 +30,7 @@ function WaveBindingRulesEditor({
   onDraftChange,
   onSubmit,
 }: WaveBindingRulesEditorProps) {
+  const locale = useBrowserLocale();
   const helperId = "wave-binding-rules-helper";
 
   return (
@@ -42,7 +45,7 @@ function WaveBindingRulesEditor({
         htmlFor="wave-binding-rules"
         className="tw-text-sm tw-font-medium tw-text-iron-100"
       >
-        Rules that require acceptance
+        {t(locale, "waves.settings.acceptanceRules.editorLabel")}
       </label>
       <textarea
         id="wave-binding-rules"
@@ -53,14 +56,13 @@ function WaveBindingRulesEditor({
         value={draft}
         onChange={(event) => onDraftChange(event.target.value)}
         className="tw-form-textarea tw-block tw-w-full tw-appearance-none tw-rounded-lg tw-border-0 tw-bg-iron-900 tw-px-3 tw-py-2 tw-text-sm tw-font-medium tw-text-white tw-shadow-sm tw-ring-1 tw-ring-inset tw-ring-iron-650 placeholder:tw-text-iron-500 focus:tw-bg-iron-900 focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-inset focus:tw-ring-primary-400"
-        placeholder="Add rules participants must accept before submitting..."
+        placeholder={t(locale, "waves.settings.acceptanceRules.placeholder")}
       />
       <p
         id={helperId}
         className="tw-mb-0 tw-text-xs tw-font-medium tw-leading-4 tw-text-iron-500"
       >
-        Participants sign these rules with their wallet before submitting. Clear
-        the field to remove the acceptance requirement.
+        {t(locale, "waves.settings.acceptanceRules.helper")}
       </p>
       <WaveSettingEditorActions
         disabled={mutating}
@@ -72,6 +74,7 @@ function WaveBindingRulesEditor({
 }
 
 export default function WaveBindingRules({ wave }: WaveBindingRulesProps) {
+  const locale = useBrowserLocale();
   const { canEdit, mutating, saveParticipationUpdate } =
     useWaveSettingUpdater(wave);
   const bindingRules = useMemo(
@@ -85,7 +88,28 @@ export default function WaveBindingRules({ wave }: WaveBindingRulesProps) {
   }, [bindingRules]);
 
   const normalizedDraft = normalizeWaveCustomRules(draft);
-  const saveDisabled = normalizedDraft === bindingRules;
+  const configurationIsConsistent =
+    Boolean(bindingRules) === wave.participation.signature_required;
+  const saveDisabled =
+    normalizedDraft === bindingRules && configurationIsConsistent;
+
+  const valueLabel = (() => {
+    if (bindingRules) {
+      return t(
+        locale,
+        wave.participation.signature_required
+          ? "waves.settings.acceptanceRules.statusRequired"
+          : "waves.settings.acceptanceRules.statusNotRequired"
+      );
+    }
+
+    return t(
+      locale,
+      wave.participation.signature_required
+        ? "waves.settings.acceptanceRules.statusSignatureOnly"
+        : "waves.settings.acceptanceRules.statusNone"
+    );
+  })();
 
   const saveBindingRules = (closeEditor: () => void) => {
     saveParticipationUpdate(closeEditor, (participation) => ({
@@ -98,8 +122,8 @@ export default function WaveBindingRules({ wave }: WaveBindingRulesProps) {
   return (
     <WaveSettingRow
       canEdit={canEdit}
-      editLabel="Edit acceptance rules"
-      label="Acceptance rules"
+      editLabel={t(locale, "waves.settings.acceptanceRules.editLabel")}
+      label={t(locale, "waves.settings.acceptanceRules.rowLabel")}
       onOpen={resetEditor}
       renderEditor={({ closeEditor }) => (
         <WaveBindingRulesEditor
@@ -111,7 +135,7 @@ export default function WaveBindingRules({ wave }: WaveBindingRulesProps) {
           onSubmit={() => saveBindingRules(closeEditor)}
         />
       )}
-      valueLabel={bindingRules ? "Added" : "None"}
+      valueLabel={valueLabel}
     />
   );
 }

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -1461,11 +1461,46 @@ const WAVE_CREATE_RULES_MESSAGES = objectMessages("waves.create.rules", {
   acceptanceTitle: "Rules that require acceptance",
   acceptanceToggle: "Require acceptance",
   acceptanceDescription:
-    "Use this only for custom creator rules that participants must accept and sign before submitting.",
+    "Participants see these rules during submission: as the first step for The Memes, or in a confirmation dialog after they use the wave's submit action in other waves.",
   acceptancePlaceholder:
     "Enter rules participants must accept before submitting...",
-  acceptanceHelper: "Participants will sign these rules with their wallet",
+  acceptanceHelper:
+    "Acknowledging the rules does not sign anything. In The Memes, the wallet prompt opens only after the final submit action; in other waves, it opens after Agree & Sign Submission. The signature covers both the submission and these rules.",
 } as const);
+
+const WAVE_ACCEPTANCE_RULES_SETTINGS_MESSAGES = objectMessages(
+  "waves.settings.acceptanceRules",
+  {
+    editLabel: "Edit acceptance rules",
+    rowLabel: "Acceptance rules",
+    editorLabel: "Rules that require acceptance",
+    placeholder: "Add rules participants must accept before submitting...",
+    helper:
+      "Saving non-empty rules shows them during submission: as the first step for The Memes, or in a confirmation dialog after participants use the wave's submit action in other waves. Acknowledging the rules does not sign anything. In The Memes, the wallet prompt opens only after the final submit action; in other waves, it opens after Agree & Sign Submission. The signature covers both the submission and these rules. Clear the field to remove both requirements.",
+    statusRequired: "Required",
+    statusNotRequired: "Not required",
+    statusSignatureOnly: "Signature only",
+    statusNone: "None",
+  } as const
+);
+
+const WAVE_SUBMISSION_ACCEPTANCE_RULES_MESSAGES = objectMessages(
+  "waves.submission.acceptanceRules",
+  {
+    memesIntro:
+      "Before you submit your work to The Memes, please read the rules below and confirm that you understand and agree. If you have questions, contact a team member before continuing.",
+    memesSigningTiming:
+      "Continuing confirms your agreement; it does not open your wallet. Your wallet will ask for a signature when you submit your completed work.",
+    memesCheckboxLabel: "I have read and agree to the rules above.",
+    memesContinue: "I Agree & Continue",
+    modalTitle: "Submission rules",
+    modalGuidance:
+      "Checking the box only confirms that you have read and agree to the rules. Select Agree & Sign Submission to open your wallet and sign both this submission and the rules.",
+    modalCheckboxLabel: "I have read and agree to the rules above.",
+    modalSubmit: "Agree & Sign Submission",
+    modalEmpty: "No submission rules found.",
+  } as const
+);
 
 const WAVE_CREATE_VOTING_MESSAGES = objectMessages("waves.create.voting", {
   title: "How Drops are Voted",
@@ -3263,6 +3298,8 @@ export const EN_US_MESSAGES = {
   ...WAVE_CREATE_DROPS_MESSAGES,
   ...WAVE_CREATE_OUTCOMES_MESSAGES,
   ...WAVE_CREATE_RULES_MESSAGES,
+  ...WAVE_ACCEPTANCE_RULES_SETTINGS_MESSAGES,
+  ...WAVE_SUBMISSION_ACCEPTANCE_RULES_MESSAGES,
   ...WAVE_CREATE_VOTING_MESSAGES,
   ...WAVE_CREATE_DROPDOWN_MESSAGES,
   ...WAVE_CREATE_PROGRESS_MESSAGES,

--- a/ops/docs/waves/composer/feature-curation-url-submissions.md
+++ b/ops/docs/waves/composer/feature-curation-url-submissions.md
@@ -57,8 +57,11 @@ This flow appears in two places:
 2. Validation appears after blur or submit attempt.
 3. Submit with `Enter` or composer submit button (`Drop` in thread composer,
    `Submit to Curation` in leaderboard modal).
-4. If auth/signature/terms are required, complete that step.
-5. If auth/signature/terms is canceled, the typed URL remains in the input.
+4. If acceptance rules apply, review them in `Submission rules`, check the
+   acknowledgement, then use `Agree & Sign Submission` to open the wallet. The
+   signature covers the URL submission and the displayed rules.
+5. If the rules dialog is closed or the wallet request is canceled, the typed
+   URL remains in the input.
 6. When submission is queued, the input clears.
 7. In leaderboard variant only, success toast appears after server success:
    `Drop submitted successfully`.
@@ -109,8 +112,9 @@ rejected.
 
 ## Failure and Recovery
 
-- If authentication/signature is canceled, submission stops and the typed URL
-  stays available to retry.
+- If authentication is canceled, the rules dialog is closed, or the wallet
+  request is canceled, submission stops and the typed URL stays available to
+  retry.
 - If server submission fails after queueing, users get an error toast and can
   retry by re-entering the URL.
 - If validation fails, users can correct the URL and resubmit immediately.

--- a/ops/docs/waves/composer/feature-metadata-submissions.md
+++ b/ops/docs/waves/composer/feature-metadata-submissions.md
@@ -80,8 +80,12 @@ editor.
 
 ## Failure and Recovery
 
-- If wallet auth/signature/terms is canceled, submission stops and current
-  draft state stays.
+- If acceptance rules apply, `Submission rules` opens after the user starts
+  submission. Checking the box acknowledges the rules; `Agree & Sign
+  Submission` opens the wallet and signs the prepared submission together with
+  those rules.
+- Closing the rules dialog or canceling the wallet request stops submission and
+  keeps the current draft state.
 - If upload or signing preparation fails, the composer shows an error and keeps
   draft state for retry.
 - Upload progress is clamped to `0%`-`100%`.

--- a/ops/docs/waves/create/feature-rules-step.md
+++ b/ops/docs/waves/create/feature-rules-step.md
@@ -24,6 +24,13 @@ preview.
 - Step label: `Rules`
 - User-reachable in `Chat`, `Rank`, and `Approve` creation
 
+## Entry Points
+
+- Start a wave from an available create-wave control, then continue to `Rules`.
+- For an existing Rank or Approve wave, open its right sidebar, select
+  `Settings`, and edit `Acceptance rules` when the connected profile can
+  administer the wave.
+
 ## Step Path
 
 - `Chat`: `Overview -> Groups -> Rules -> Description`
@@ -60,8 +67,11 @@ Use display-only creator rules for wave-specific guidance that participants
 should see but do not need to sign.
 
 For `Rank` and `Approve` waves, use rules that require acceptance when
-participants must explicitly accept and sign those rules before submitting.
-These rules use the existing participation terms and wallet-signature flow.
+participants must explicitly agree to creator-written rules. Participants first
+acknowledge the displayed rules, then sign their completed submission and those
+rules together. Acknowledging the rules does not open a wallet or create a
+signature.
+
 `Chat` waves do not show acceptance-required rules because they do not have a
 submission step.
 
@@ -74,7 +84,8 @@ submission step.
    and Approve, only when creator-written rules are needed.
 5. Optionally enter display-only creator rules.
 6. For `Rank` and `Approve`, optionally enable `Require acceptance` and enter
-   rules participants must accept before submitting.
+   rules participants must accept before submitting. The guidance explains
+   where participants see the rules and which later action opens their wallet.
 7. Collapse the section if desired; entered rules remain in the draft
    and the disclosure shows `Customized`.
 8. Click `Next` to continue to `Description` for `Chat`, or `Voting` for
@@ -86,8 +97,15 @@ submission step.
 - Mobile participants see the rules panel from the wave `About` information
   path.
 - Display-only custom rules appear in the rules panel.
-- For `Rank` and `Approve`, rules that require acceptance appear in the rules
-  panel and are enforced by the existing submit terms/signature modal.
+- For The Memes, rules that require acceptance are the first step inside the
+  artwork-submission flow. `I Agree & Continue` records the acknowledgement but
+  does not open the participant's wallet.
+- For other participatory waves, the rules appear in a separate `Submission
+  rules` dialog after the participant uses the wave's submit action.
+- In The Memes, the wallet prompt opens only from the final artwork submit
+  action. In other waves, it opens from `Agree & Sign Submission`.
+- The resulting wallet signature covers both the completed submission and the
+  displayed rules.
 
 ## Settings
 
@@ -111,6 +129,31 @@ use the existing submit acceptance flow.
   acceptance-required rules text.
 - For `Rank` and `Approve`, acceptance-required rules require a wallet
   signature only when rules text is present.
+- Older waves can contain rules without a signature requirement, or a signature
+  requirement without rules. Settings label those states `Not required` or
+  `Signature only` instead of implying that both are active. Saving the
+  acceptance-rules editor restores the normal pairing: non-empty rules require
+  acceptance and signing, while an empty field removes both requirements.
+
+## Failure and Recovery
+
+- If acceptance-rule settings fail to save, the editor stays open so the
+  creator can retry without re-entering the rules.
+- If a participant closes the generic rules dialog, cancels the wallet request,
+  or signing fails, the submission stops and the current draft remains
+  available for another attempt.
+- Upload failures in The Memes happen before the wallet request. Submission API
+  failures happen after signing; retrying starts the final submit sequence
+  again.
+
+## Limitations / Notes
+
+- Acceptance rules are creator-authored text. The app displays them as entered
+  and does not evaluate whether the wording is complete or suitable.
+- A successful wallet signature does not by itself confirm submission success;
+  the app must still accept and save the submission.
+- The wallet prompt signs a message for the submission. It does not request a
+  payment or blockchain transaction.
 
 ## Related Pages
 

--- a/ops/docs/waves/flow-wave-participation.md
+++ b/ops/docs/waves/flow-wave-participation.md
@@ -74,10 +74,17 @@ same context.
 - If no wave is selected on desktop list routes, the UI shows selection
   placeholders (`Select a Wave` or `Select a Conversation`).
 - `Rank` and `Approve` rules show two layers: automatic rules generated from
-  wave settings and optional creator rules. Creator rules that require
-  acceptance are enforced by the existing submit terms/signature modal.
+  wave settings and optional creator rules. Creator rules can be display-only
+  or require acknowledgement plus a wallet signature during submission.
 - `Chat` rules show automatic chat/access rules and optional display-only
   creator rules.
+- In The Memes, acceptance-required rules appear as the first submission step;
+  continuing acknowledges them without opening the wallet. The wallet prompt
+  opens only when the participant submits the completed artwork.
+- In other participatory waves, acceptance-required rules appear in a separate
+  `Submission rules` dialog after the participant starts submission. Checking
+  the acknowledgement does not sign anything; `Agree & Sign Submission` opens
+  the wallet and signs the submission together with the rules.
 - When posting is blocked, thread content stays readable and the composer area
   shows blocked states (for example
   `Connect your wallet to participate in this wave`,
@@ -105,6 +112,13 @@ same context.
   shows `Start the conversation`.
 - Temporary drops (`temp-*`) keep some actions limited; link copy is disabled
   until the drop is persisted.
+- Closing a `Submission rules` dialog stops that attempt and keeps the current
+  draft.
+- Canceling or rejecting a wallet request stops submission and shows an error;
+  use the submit action again when ready to retry.
+- If signing succeeds but the submission request fails, the draft or current
+  submission screen remains available for recovery. A retry can require a new
+  wallet signature.
 
 ## Limitations / Notes
 

--- a/ops/docs/waves/memes/feature-memes-preview-and-submit-states.md
+++ b/ops/docs/waves/memes/feature-memes-preview-and-submit-states.md
@@ -38,10 +38,15 @@ On `success`, the modal auto-closes after a short delay.
    - click `Submit Artwork` directly
 3. If you open preview, review both card layouts and use `Back to Edit` if
    needed.
-4. Click `Submit Artwork`.
-5. While submit is running, action buttons show loading and block repeated
+4. Click `Submit Artwork`. For resubmissions, the equivalent action is `Submit
+   New Version`.
+5. The app resolves or uploads the media, then opens the wallet request. The
+   signature covers the complete submission and the rules acknowledged in the
+   first step.
+6. After signing, the app sends the signed submission.
+7. While submit is running, action buttons show loading and block repeated
    clicks.
-6. On `success`, the modal closes after a short delay.
+8. On `success`, the modal closes after a short delay.
 
 ## Common Scenarios
 
@@ -61,6 +66,8 @@ On `success`, the modal auto-closes after a short delay.
 
 - Interactive URL submissions skip upload and start at `signing`.
 - File submissions include `uploading` before signing/processing.
+- The earlier agreement checkbox is only an acknowledgement. It never opens the
+  wallet and is not itself a signature.
 - Preview image requirements for `Video`/`HTML`/`GLB` must pass before preview
   or submit actions enable.
 - `Back` (`Additional Information`) and `Back to Edit` (`Preview`) are disabled
@@ -77,6 +84,11 @@ On `success`, the modal auto-closes after a short delay.
   submitting.
 - If upload, auth, signing, or API submission fails, the modal keeps current
   draft state and supports retry from the current screen.
+- If the wallet request is canceled or rejected, no submission is sent. The
+  app shows a signing error and keeps the completed draft available for retry.
+- If upload fails, the wallet request has not happened yet. If the API request
+  fails after signing, retry the final submit action and complete any new wallet
+  request.
 - If submission is attempted with an over-limit metadata payload, the app stops
   before upload/signing and can show a toast naming the offending metadata
   sections.

--- a/ops/docs/waves/memes/feature-memes-submission.md
+++ b/ops/docs/waves/memes/feature-memes-submission.md
@@ -49,24 +49,27 @@ reached), select the header restriction control to see the reason, then use
 ## User Journey
 
 1. Open the memes submit modal from an available submit control.
-3. In `Agreement`, review terms, check the certification box, and click
-   `I Agree & Continue`.
-4. In `Artwork`, complete the required metadata fields:
+2. In `Agreement`, review the creator's rules, check `I have read and agree to
+   the rules above`, and click `I Agree & Continue`.
+   This acknowledges the rules but does not open the wallet or sign anything.
+3. In `Artwork`, complete the required metadata fields:
    - `Artwork Details` (`Artwork Title`, `Description`)
    - all required trait fields grouped under sections such as
      `Basic Information`, `Card Points`, and `Card Attributes`
-5. Choose one media source:
+4. Choose one media source:
    - `Upload File`: drag/drop or use the file picker, review the grouped format
      badges in the drop zone, then preview the selected artwork.
    - `Interactive HTML`: switch to `Interactive HTML`, pick `IPFS` or
      `Arweave` from the `Hosting Network` tabs, enter the root
      CID/transaction ID in `Content Hash or Path` (or paste an approved
      gateway URL), review the resulting URL, and wait for validation.
-6. Click `Continue` to open `Additional Information`.
+5. Click `Continue` to open `Additional Information`.
 
 ## Common Scenarios
 
 - `I Agree & Continue` stays disabled until the agreement checkbox is checked.
+- The Agreement guidance states that the wallet prompt opens later, when the
+  participant submits the completed work.
 - Required fields in `Artwork` show visible `*` markers.
 - Filled text and select fields show success styling, including a green ring and
   checkmark, until a validation error replaces that state.
@@ -120,6 +123,9 @@ reached), select the header restriction control to see the reason, then use
 - `Close` icon, backdrop click, `Cancel`, or `Escape` closes the modal from any
   step.
 - Closing the modal discards the draft. Reopening starts a new draft.
+- A resubmission shows its separate replacement acknowledgement first, then the
+  same rules acknowledgement. The final `Submit New Version` action requests
+  the wallet signature for the replacement submission and the current rules.
 
 ## Limitations / Notes
 

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -2472,6 +2472,8 @@
         "Automatic rules are generated from wave setup. Chat rules focus on wave type, access, and chat settings; Rank and Approve rules also include timing, submissions, voting, approval, and outcome visibility.",
         "Creators can add display-only custom rules that are saved as wave metadata.",
         "For Rank and Approve waves, creators can add rules that require acceptance; those use the existing participation terms and wallet-signature submit flow.",
+        "For The Memes, acceptance-required rules are the first submission step. Other participatory waves show them in a separate Submission rules dialog after the participant uses the wave's submit action.",
+        "Acknowledging acceptance rules does not sign anything. The Memes opens the wallet from the final submit action; other waves open it from Agree & Sign Submission, and the signature covers both the completed submission and the rules.",
         "Wave admins can edit display-only custom rules later from wave settings. For Rank and Approve waves, admins can also edit acceptance-required rules.",
         "Participants can review rules in the desktop wave right sidebar or from the mobile About information path."
       ],
@@ -2835,6 +2837,8 @@
         "Submission availability depends on login, proxy mode, participation eligibility, the submission window, and per-user submission limits.",
         "If the submit control is hidden or shows a restriction icon or label, select or focus the restriction control to read why submission is unavailable, then recover by logging in, disabling proxy mode, waiting for the submission window, or freeing submission capacity.",
         "On The Memes Main Stage, the desktop How to Submit control and native app lock both open Unlock submissions with the current 50,000 MemesNominee REP requirement, live progress, and a Get nominated action.",
+        "The Memes agreement checkbox only acknowledges the displayed rules. I Agree & Continue does not open a wallet; the wallet request happens later from Submit Artwork or Submit New Version and covers the completed submission plus those rules.",
+        "If The Memes upload, signing, or API submission fails, the completed draft remains available for retry; canceling the wallet request sends no submission.",
         "Use the wave composer and Memes-specific submission surfaces when participating in Memes waves."
       ],
       "canonical_path": "/waves",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -2468,6 +2468,8 @@
         "Automatic rules are generated from wave setup. Chat rules focus on wave type, access, and chat settings; Rank and Approve rules also include timing, submissions, voting, approval, and outcome visibility.",
         "Creators can add display-only custom rules that are saved as wave metadata.",
         "For Rank and Approve waves, creators can add rules that require acceptance; those use the existing participation terms and wallet-signature submit flow.",
+        "For The Memes, acceptance-required rules are the first submission step. Other participatory waves show them in a separate Submission rules dialog after the participant uses the wave's submit action.",
+        "Acknowledging acceptance rules does not sign anything. The Memes opens the wallet from the final submit action; other waves open it from Agree & Sign Submission, and the signature covers both the completed submission and the rules.",
         "Wave admins can edit display-only custom rules later from wave settings. For Rank and Approve waves, admins can also edit acceptance-required rules.",
         "Participants can review rules in the desktop wave right sidebar or from the mobile About information path."
       ],
@@ -2831,6 +2833,8 @@
         "Submission availability depends on login, proxy mode, participation eligibility, the submission window, and per-user submission limits.",
         "If the submit control is hidden or shows a restriction icon or label, select or focus the restriction control to read why submission is unavailable, then recover by logging in, disabling proxy mode, waiting for the submission window, or freeing submission capacity.",
         "On The Memes Main Stage, the desktop How to Submit control and native app lock both open Unlock submissions with the current 50,000 MemesNominee REP requirement, live progress, and a Get nominated action.",
+        "The Memes agreement checkbox only acknowledges the displayed rules. I Agree & Continue does not open a wallet; the wallet request happens later from Submit Artwork or Submit New Version and covers the completed submission plus those rules.",
+        "If The Memes upload, signing, or API submission fails, the completed draft remains available for retry; canceling the wallet request sends no submission.",
         "Use the wave composer and Memes-specific submission surfaces when participating in Memes waves."
       ],
       "canonical_path": "/waves",


### PR DESCRIPTION
## Issue

Wave creators were told that participants “sign these rules with their wallet before submitting,” which hid important differences between The Memes and ordinary participatory waves. Participant copy also blurred acknowledging rules with signing the completed submission.

## Fix

Explain the real two-part interaction at the points where creators configure rules and participants accept them: acknowledgement confirms agreement, while a later explicit submit action opens the wallet and signs the prepared submission together with the applicable rules.

## Notable changes

- Clarifies where acceptance rules appear in The Memes versus other participatory waves and names the action that opens the wallet in each flow.
- Rewords The Memes agreement step and the generic submission-rules dialog so acknowledgement is never presented as a signature.
- Uses native accessible checkboxes with visible focus treatment and keeps the generic dialog locked while signing is in progress.
- Corrects The Memes aggregate loading/error flags so signing and processing states block repeated final submissions.
- Labels legacy `terms` / `signature_required` combinations truthfully in Wave settings and normalizes them when saved.
- Updates focused tests, Wave documentation, and the generated Help Bot index.

## Validation

- Authenticated localhost walkthrough of the creator flow using the repository agent-login bridge and staging QA data.
- Desktop and narrow-viewport visual checks, including long/multiline guidance, focus, keyboard, and touch-sized controls.
- `./bin/6529 run test __tests__/components/terms/TermsOfServiceModal.test.tsx __tests__/components/TermsSignatureFlow.test.tsx __tests__/components/waves/memes/submission/steps/AgreementStep.test.tsx __tests__/components/waves/groups/WaveSettingsSections.test.tsx` (48 tests passed).
- `./bin/6529 run check:changed`
- `./bin/6529 run react-doctor:diff` (99/100; two pre-existing pattern warnings, no new correctness finding).
- `./bin/6529 exec python3 ops/skills/commit-docs-updater/scripts/validate_docs_links.py` (300 Markdown files passed).
- `./bin/6529 run build` (full lint, TypeScript, 3,675 static pages, and sitemap generation passed).
- `git diff --check`

## Risks and edge cases

- Copy intentionally differs between The Memes and generic submission paths because their interaction order differs.
- Empty rules still remove both terms and the signature requirement. Existing signature binding is unchanged: the request hash includes the completed submission and terms.
- Legacy rules-without-signature and signature-without-rules states remain readable and can be repaired from the existing settings editor.
- Closing before signing, wallet cancellation/rejection, upload failure, post-sign submission failure, retry, resubmission, and signing-in-progress states are documented and covered by the existing flow plus focused tests.
- No API schema, dependency, route, or backend behavior changes.

## Rollback

Revert the single signed commit. This restores the previous wording and control behavior without data migration because the persisted Wave participation shape is unchanged.

## Review notes

- The scope is deliberately limited to wording, checkbox semantics, loading protection, legacy-state presentation, tests, docs, and help content.
- Agent-login covers localhost authentication only. Action-specific submission signing was verified through the current hashing/signing code boundaries and focused UI-flow tests; it was not represented as a real wallet-action signature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized submission-rules guidance, labels, and status messaging.
  * Replaced agreement controls with accessible checkboxes and improved keyboard support.
  * Prevented rules dialogs from closing while signing is in progress.
  * Clarified when wallet signing occurs and what it covers.
  * Improved handling of legacy participation-rule configurations.

* **Bug Fixes**
  * Preserved submission drafts when dialogs close, wallets are canceled, or requests fail.
  * Improved submission status handling during signing and mutation operations.

* **Documentation**
  * Updated submission, recovery, retry, and signing guidance across wave documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->