### PR TITLE
Make creator rules easy to find and scan

### DIFF
--- a/__tests__/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.test.tsx
+++ b/__tests__/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.test.tsx
@@ -158,4 +158,37 @@ describe("MyStreamWaveTabsHeader", () => {
     expect(screen.queryByTestId("wave-score")).toBeNull();
     expect(screen.queryByText("Add REP")).toBeNull();
   });
+
+  it("puts wave details first in the compact overflow menu", () => {
+    render(
+      <MyStreamWaveTabsHeader
+        wave={wave}
+        activeContentTab={MyStreamWaveTab.CHAT}
+        setActiveContentTab={jest.fn()}
+        onSelectCuration={jest.fn()}
+        isCompact={true}
+        showBackButton={false}
+        headerActionsTooltipId="header-actions"
+        headerClassName="tw-flex"
+        actionsClassName="tw-flex"
+        renderOverflowMenuItems={() => [
+          {
+            id: "boosted-drops-display-section",
+            kind: "section",
+            label: "Boosted drops: Compact",
+          },
+          {
+            id: "boosted-drops-display-compact",
+            label: "Compact",
+          },
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "More wave actions" }));
+
+    expect(
+      screen.getAllByRole("menuitem").map((item) => item.textContent?.trim())
+    ).toEqual(["Wave details", "Compact", "Copy wave link"]);
+  });
 });

--- a/__tests__/components/waves/specs/WaveRulesPanel.test.tsx
+++ b/__tests__/components/waves/specs/WaveRulesPanel.test.tsx
@@ -75,4 +75,31 @@ describe("WaveRulesPanel", () => {
     expect(screen.queryByText("Artists")).not.toBeInTheDocument();
     expect(screen.getByText("Private group")).toBeInTheDocument();
   });
+
+  it("shows creator rules before automatic rules when creator rules exist", () => {
+    render(
+      <WaveRulesPanel
+        rules={{
+          ...rules,
+          custom: {
+            binding: null,
+            display: "Keep submissions focused on the weekly theme.",
+            signatureRequired: false,
+          },
+        }}
+      />
+    );
+
+    expect(
+      screen.getAllByRole("heading").map((heading) => heading.textContent)
+    ).toEqual(["Rules", "Creator rules", "Access"]);
+  });
+
+  it("keeps the empty creator-rules state after automatic rules", () => {
+    render(<WaveRulesPanel rules={rules} />);
+
+    expect(
+      screen.getAllByRole("heading").map((heading) => heading.textContent)
+    ).toEqual(["Rules", "Access", "Creator rules"]);
+  });
 });

--- a/__tests__/components/waves/specs/WaveRulesPanel.test.tsx
+++ b/__tests__/components/waves/specs/WaveRulesPanel.test.tsx
@@ -95,7 +95,10 @@ describe("WaveRulesPanel", () => {
     expect(
       screen.getAllByRole("heading").map((heading) => heading.textContent)
     ).toEqual(["Rules", "Creator rules", "Access"]);
-    expect(screen.queryByText(creatorRule)).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Includes a display-only creator rule.")
+    ).toBeVisible();
+    expect(screen.getByText(creatorRule)).not.toBeVisible();
   });
 
   it("keeps creator-rule status visible and reveals the full text on demand", () => {
@@ -115,25 +118,33 @@ describe("WaveRulesPanel", () => {
       />
     );
 
-    expect(screen.getByText("Requires acceptance")).toBeVisible();
+    expect(screen.getAllByText("Requires acceptance")[0]).toBeVisible();
     expect(
-      screen.getByText(
+      screen.getAllByText(
         "Participants sign these rules with their wallet before submitting."
-      )
+      )[0]
     ).toBeVisible();
-    expect(screen.queryByText(acceptanceRule)).not.toBeInTheDocument();
+    expect(screen.getByText(acceptanceRule)).not.toBeVisible();
 
     const showButton = screen.getByRole("button", {
       name: "Show full creator rules",
     });
     expect(showButton).toHaveAttribute("aria-expanded", "false");
+    expect(showButton).toHaveAttribute("aria-controls");
+    expect(
+      document.getElementById(showButton.getAttribute("aria-controls")!)
+    ).not.toBeVisible();
 
     fireEvent.click(showButton);
 
     expect(screen.getByText(acceptanceRule)).toBeVisible();
+    const hideButton = screen.getByRole("button", {
+      name: "Hide full creator rules",
+    });
+    expect(hideButton).toHaveAttribute("aria-expanded", "true");
     expect(
-      screen.getByRole("button", { name: "Hide full creator rules" })
-    ).toHaveAttribute("aria-expanded", "true");
+      document.getElementById(hideButton.getAttribute("aria-controls")!)
+    ).toBeVisible();
   });
 
   it("keeps the empty creator-rules state after automatic rules", () => {

--- a/__tests__/components/waves/specs/WaveRulesPanel.test.tsx
+++ b/__tests__/components/waves/specs/WaveRulesPanel.test.tsx
@@ -2,7 +2,7 @@ import WaveRulesPanel from "@/components/waves/specs/WaveRulesPanel";
 import type { WaveRules } from "@/helpers/waves/wave-rules.helpers";
 import type Link from "next/link";
 import type { ComponentProps } from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 jest.mock("next/link", () => ({
   __esModule: true,
@@ -77,13 +77,15 @@ describe("WaveRulesPanel", () => {
   });
 
   it("shows creator rules before automatic rules when creator rules exist", () => {
+    const creatorRule = "Keep submissions focused on the weekly theme.";
+
     render(
       <WaveRulesPanel
         rules={{
           ...rules,
           custom: {
             binding: null,
-            display: "Keep submissions focused on the weekly theme.",
+            display: creatorRule,
             signatureRequired: false,
           },
         }}
@@ -93,6 +95,45 @@ describe("WaveRulesPanel", () => {
     expect(
       screen.getAllByRole("heading").map((heading) => heading.textContent)
     ).toEqual(["Rules", "Creator rules", "Access"]);
+    expect(screen.queryByText(creatorRule)).not.toBeInTheDocument();
+  });
+
+  it("keeps creator-rule status visible and reveals the full text on demand", () => {
+    const acceptanceRule =
+      "I agree to keep my submission available through the voting period.";
+
+    render(
+      <WaveRulesPanel
+        rules={{
+          ...rules,
+          custom: {
+            binding: acceptanceRule,
+            display: null,
+            signatureRequired: true,
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByText("Requires acceptance")).toBeVisible();
+    expect(
+      screen.getByText(
+        "Participants sign these rules with their wallet before submitting."
+      )
+    ).toBeVisible();
+    expect(screen.queryByText(acceptanceRule)).not.toBeInTheDocument();
+
+    const showButton = screen.getByRole("button", {
+      name: "Show full creator rules",
+    });
+    expect(showButton).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(showButton);
+
+    expect(screen.getByText(acceptanceRule)).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Hide full creator rules" })
+    ).toHaveAttribute("aria-expanded", "true");
   });
 
   it("keeps the empty creator-rules state after automatic rules", () => {

--- a/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.tsx
+++ b/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.tsx
@@ -144,9 +144,7 @@ function MyStreamWaveHeaderIdentity({
         mode="summary"
         learnMoreHref={waveScoreLearnMoreHref}
       />
-      {showWaveRepAction && (
-        <WaveRepButton wave={wave} variant="compact" />
-      )}
+      {showWaveRepAction && <WaveRepButton wave={wave} variant="compact" />}
     </span>
   ) : null;
 
@@ -357,18 +355,8 @@ export default function MyStreamWaveTabsHeader({
   const externalOverflowMenuItems = isCompact
     ? (renderOverflowMenuItems?.(actionContext) ?? [])
     : [];
-  const headerOverflowMenuItems: CompactMenuItem[] = isCompact
+  const compactMenuItems: CompactMenuItem[] = isCompact
     ? [
-        ...(showShareAction
-          ? [
-              {
-                id: "wave-link",
-                label: waveLinkActionLabel,
-                icon: renderWaveLinkActionIcon(),
-                onSelect: handleWaveLinkActionClick,
-              },
-            ]
-          : []),
         {
           id: "wave-details",
           label: rightSidebarCompactLabel,
@@ -382,12 +370,19 @@ export default function MyStreamWaveTabsHeader({
           ),
           onSelect: toggleRightSidebar,
         },
+        ...externalOverflowMenuItems,
+        ...(showShareAction
+          ? [
+              {
+                id: "wave-link",
+                label: waveLinkActionLabel,
+                icon: renderWaveLinkActionIcon(),
+                onSelect: handleWaveLinkActionClick,
+              },
+            ]
+          : []),
       ]
     : [];
-  const compactMenuItems = [
-    ...externalOverflowMenuItems,
-    ...headerOverflowMenuItems,
-  ];
 
   useLayoutEffect(() => {
     if (!showDescriptionPreview || isCompact) {

--- a/components/waves/specs/WaveRulesPanel.tsx
+++ b/components/waves/specs/WaveRulesPanel.tsx
@@ -79,9 +79,9 @@ function WaveRulesCustomSection({
         {!isExpanded && (
           <div className="tw-flex tw-flex-col tw-gap-2 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/5 tw-pt-3">
             {custom.display && (
-              <p className="tw-mb-0 tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-iron-500 sm:tw-tracking-[0.08em]">
+              <p className="tw-mb-0 tw-text-xs tw-font-medium tw-leading-4 tw-text-iron-400">
                 {waveRightPanelText(
-                  "waves.sidebar.rightPanel.rules.displayOnly"
+                  "waves.sidebar.rightPanel.rules.displayOnlySummary"
                 )}
               </p>
             )}
@@ -104,47 +104,49 @@ function WaveRulesCustomSection({
           </div>
         )}
 
-        {isExpanded && (
-          <div id={contentId} className="tw-flex tw-flex-col tw-gap-3">
-            {custom.display && (
-              <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/5 tw-pt-3">
-                <p className="tw-mb-2 tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-iron-500 sm:tw-tracking-[0.08em]">
-                  {waveRightPanelText(
-                    "waves.sidebar.rightPanel.rules.displayOnly"
-                  )}
-                </p>
-                <p className="tw-mb-0 tw-whitespace-pre-wrap tw-break-words tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-100">
-                  {custom.display}
-                </p>
-              </div>
-            )}
-            {custom.binding && (
-              <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-primary-400/15 tw-pt-3">
-                <p className="tw-mb-2 tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-primary-300 sm:tw-tracking-[0.08em]">
-                  {waveRightPanelText(
-                    "waves.sidebar.rightPanel.rules.requiresAcceptance"
-                  )}
-                </p>
-                <p className="tw-mb-0 tw-whitespace-pre-wrap tw-break-words tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-100">
-                  {custom.binding}
-                </p>
-                {custom.signatureRequired && (
-                  <p className="tw-mb-0 tw-mt-2 tw-text-xs tw-font-medium tw-leading-4 tw-text-iron-400">
-                    {waveRightPanelText(
-                      "waves.sidebar.rightPanel.rules.signatureRequired"
-                    )}
-                  </p>
+        <div
+          id={contentId}
+          hidden={!isExpanded}
+          className={isExpanded ? "tw-flex tw-flex-col tw-gap-3" : undefined}
+        >
+          {custom.display && (
+            <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/5 tw-pt-3">
+              <p className="tw-mb-2 tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-iron-500 sm:tw-tracking-[0.08em]">
+                {waveRightPanelText(
+                  "waves.sidebar.rightPanel.rules.displayOnly"
                 )}
-              </div>
-            )}
-          </div>
-        )}
+              </p>
+              <p className="tw-mb-0 tw-whitespace-pre-wrap tw-break-words tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-100">
+                {custom.display}
+              </p>
+            </div>
+          )}
+          {custom.binding && (
+            <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-primary-400/15 tw-pt-3">
+              <p className="tw-mb-2 tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-primary-300 sm:tw-tracking-[0.08em]">
+                {waveRightPanelText(
+                  "waves.sidebar.rightPanel.rules.requiresAcceptance"
+                )}
+              </p>
+              <p className="tw-mb-0 tw-whitespace-pre-wrap tw-break-words tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-100">
+                {custom.binding}
+              </p>
+              {custom.signatureRequired && (
+                <p className="tw-mb-0 tw-mt-2 tw-text-xs tw-font-medium tw-leading-4 tw-text-iron-400">
+                  {waveRightPanelText(
+                    "waves.sidebar.rightPanel.rules.signatureRequired"
+                  )}
+                </p>
+              )}
+            </div>
+          )}
+        </div>
 
         {collapsible && (
           <button
             type="button"
             aria-expanded={isExpanded}
-            aria-controls={isExpanded ? contentId : undefined}
+            aria-controls={contentId}
             onClick={() => setIsCreatorRulesExpanded((current) => !current)}
             className="tw-flex tw-min-h-11 tw-w-full tw-cursor-pointer tw-items-center tw-justify-between tw-gap-3 tw-rounded-lg tw-border tw-border-solid tw-border-white/10 tw-bg-iron-900/70 tw-px-3 tw-py-2 tw-text-left tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-200 tw-transition-colors tw-duration-200 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 desktop-hover:hover:tw-border-white/20 desktop-hover:hover:tw-bg-iron-900 desktop-hover:hover:tw-text-iron-50"
           >

--- a/components/waves/specs/WaveRulesPanel.tsx
+++ b/components/waves/specs/WaveRulesPanel.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { ChevronDownIcon } from "@heroicons/react/24/outline";
 import type {
   WaveCustomRules,
   WaveRules,
@@ -6,7 +9,7 @@ import WaveRulesGroupMembersLink from "@/components/waves/specs/WaveRulesGroupMe
 import type { WaveRuleRow } from "@/helpers/waves/wave-rules.shared";
 import { waveRightPanelText } from "@/helpers/waves/wave-right-panel.helpers";
 import Link from "next/link";
-import type { ReactNode } from "react";
+import { useId, useState, type ReactNode } from "react";
 
 interface WaveRulesPanelProps {
   readonly rules: WaveRules;
@@ -42,12 +45,17 @@ function getSectionHeadingLevel({
 
 function WaveRulesCustomSection({
   custom,
+  collapsible,
   headingLevel,
 }: {
   readonly custom: WaveCustomRules;
+  readonly collapsible: boolean;
   readonly headingLevel: "h2" | "h3" | "h4";
 }) {
   const Heading = headingLevel;
+  const contentId = useId();
+  const [isCreatorRulesExpanded, setIsCreatorRulesExpanded] = useState(false);
+  const isExpanded = !collapsible || isCreatorRulesExpanded;
 
   if (!hasCustomRules(custom)) {
     return (
@@ -68,34 +76,90 @@ function WaveRulesCustomSection({
         {waveRightPanelText("waves.sidebar.rightPanel.rules.creatorTitle")}
       </Heading>
       <div className="tw-mt-3 tw-flex tw-flex-col tw-gap-3">
-        {custom.display && (
-          <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/5 tw-pt-3">
-            <p className="tw-mb-2 tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-iron-500 sm:tw-tracking-[0.08em]">
-              {waveRightPanelText("waves.sidebar.rightPanel.rules.displayOnly")}
-            </p>
-            <p className="tw-mb-0 tw-whitespace-pre-wrap tw-break-words tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-100">
-              {custom.display}
-            </p>
-          </div>
-        )}
-        {custom.binding && (
-          <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-primary-400/15 tw-pt-3">
-            <p className="tw-mb-2 tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-primary-300 sm:tw-tracking-[0.08em]">
-              {waveRightPanelText(
-                "waves.sidebar.rightPanel.rules.requiresAcceptance"
-              )}
-            </p>
-            <p className="tw-mb-0 tw-whitespace-pre-wrap tw-break-words tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-100">
-              {custom.binding}
-            </p>
-            {custom.signatureRequired && (
-              <p className="tw-mb-0 tw-mt-2 tw-text-xs tw-font-medium tw-leading-4 tw-text-iron-400">
+        {!isExpanded && (
+          <div className="tw-flex tw-flex-col tw-gap-2 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/5 tw-pt-3">
+            {custom.display && (
+              <p className="tw-mb-0 tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-iron-500 sm:tw-tracking-[0.08em]">
                 {waveRightPanelText(
-                  "waves.sidebar.rightPanel.rules.signatureRequired"
+                  "waves.sidebar.rightPanel.rules.displayOnly"
                 )}
               </p>
             )}
+            {custom.binding && (
+              <>
+                <p className="tw-mb-0 tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-primary-300 sm:tw-tracking-[0.08em]">
+                  {waveRightPanelText(
+                    "waves.sidebar.rightPanel.rules.requiresAcceptance"
+                  )}
+                </p>
+                {custom.signatureRequired && (
+                  <p className="tw-mb-0 tw-text-xs tw-font-medium tw-leading-4 tw-text-iron-400">
+                    {waveRightPanelText(
+                      "waves.sidebar.rightPanel.rules.signatureRequired"
+                    )}
+                  </p>
+                )}
+              </>
+            )}
           </div>
+        )}
+
+        {isExpanded && (
+          <div id={contentId} className="tw-flex tw-flex-col tw-gap-3">
+            {custom.display && (
+              <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/5 tw-pt-3">
+                <p className="tw-mb-2 tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-iron-500 sm:tw-tracking-[0.08em]">
+                  {waveRightPanelText(
+                    "waves.sidebar.rightPanel.rules.displayOnly"
+                  )}
+                </p>
+                <p className="tw-mb-0 tw-whitespace-pre-wrap tw-break-words tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-100">
+                  {custom.display}
+                </p>
+              </div>
+            )}
+            {custom.binding && (
+              <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-primary-400/15 tw-pt-3">
+                <p className="tw-mb-2 tw-text-[0.625rem] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-primary-300 sm:tw-tracking-[0.08em]">
+                  {waveRightPanelText(
+                    "waves.sidebar.rightPanel.rules.requiresAcceptance"
+                  )}
+                </p>
+                <p className="tw-mb-0 tw-whitespace-pre-wrap tw-break-words tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-100">
+                  {custom.binding}
+                </p>
+                {custom.signatureRequired && (
+                  <p className="tw-mb-0 tw-mt-2 tw-text-xs tw-font-medium tw-leading-4 tw-text-iron-400">
+                    {waveRightPanelText(
+                      "waves.sidebar.rightPanel.rules.signatureRequired"
+                    )}
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {collapsible && (
+          <button
+            type="button"
+            aria-expanded={isExpanded}
+            aria-controls={isExpanded ? contentId : undefined}
+            onClick={() => setIsCreatorRulesExpanded((current) => !current)}
+            className="tw-flex tw-min-h-11 tw-w-full tw-cursor-pointer tw-items-center tw-justify-between tw-gap-3 tw-rounded-lg tw-border tw-border-solid tw-border-white/10 tw-bg-iron-900/70 tw-px-3 tw-py-2 tw-text-left tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-200 tw-transition-colors tw-duration-200 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 desktop-hover:hover:tw-border-white/20 desktop-hover:hover:tw-bg-iron-900 desktop-hover:hover:tw-text-iron-50"
+          >
+            <span>
+              {waveRightPanelText(
+                isExpanded
+                  ? "waves.sidebar.rightPanel.rules.hideFullCreatorRules"
+                  : "waves.sidebar.rightPanel.rules.showFullCreatorRules"
+              )}
+            </span>
+            <ChevronDownIcon
+              aria-hidden="true"
+              className={`tw-size-4 tw-shrink-0 tw-transition-transform tw-duration-200 motion-reduce:tw-transition-none ${isExpanded ? "tw-rotate-180" : ""}`}
+            />
+          </button>
         )}
       </div>
     </section>
@@ -133,6 +197,7 @@ export default function WaveRulesPanel({
   const customRulesSection = showCustomRules ? (
     <WaveRulesCustomSection
       custom={rules.custom}
+      collapsible={variant !== "form"}
       headingLevel={SectionHeading}
     />
   ) : null;

--- a/components/waves/specs/WaveRulesPanel.tsx
+++ b/components/waves/specs/WaveRulesPanel.tsx
@@ -129,6 +129,13 @@ export default function WaveRulesPanel({
       : "!tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.06em] !tw-text-iron-400 sm:tw-tracking-[0.1em]";
   const backgroundClasses =
     variant === "form" ? "tw-bg-iron-900/60" : "tw-bg-iron-950";
+  const creatorRulesFirst = hasCustomRules(rules.custom);
+  const customRulesSection = showCustomRules ? (
+    <WaveRulesCustomSection
+      custom={rules.custom}
+      headingLevel={SectionHeading}
+    />
+  ) : null;
   // `undefined` keeps the standard row value; `null` intentionally renders an
   // empty value so a caller can suppress the fallback without changing it.
   const getRenderedRowValue = (row: WaveRuleRow): ReactNode => {
@@ -177,6 +184,7 @@ export default function WaveRulesPanel({
       )}
 
       <div className="tw-divide-x-0 tw-divide-y tw-divide-solid tw-divide-iron-800">
+        {creatorRulesFirst && customRulesSection}
         {rules.automatic.map((section) => (
           <section key={section.id} className="tw-px-4 tw-py-4">
             <SectionHeading className="tw-mb-2.5 tw-mt-0 !tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.06em] !tw-text-iron-400 sm:tw-tracking-[0.1em]">
@@ -206,12 +214,7 @@ export default function WaveRulesPanel({
             </dl>
           </section>
         ))}
-        {showCustomRules && (
-          <WaveRulesCustomSection
-            custom={rules.custom}
-            headingLevel={SectionHeading}
-          />
-        )}
+        {!creatorRulesFirst && customRulesSection}
       </div>
     </div>
   );

--- a/i18n/messages/wavesRightPanel.en-US.json
+++ b/i18n/messages/wavesRightPanel.en-US.json
@@ -36,6 +36,7 @@
   "waves.sidebar.rightPanel.rules.creatorTitle": "Creator rules",
   "waves.sidebar.rightPanel.rules.emptyCreator": "No custom creator rules added.",
   "waves.sidebar.rightPanel.rules.displayOnly": "Display only",
+  "waves.sidebar.rightPanel.rules.displayOnlySummary": "Includes a display-only creator rule.",
   "waves.sidebar.rightPanel.rules.requiresAcceptance": "Requires acceptance",
   "waves.sidebar.rightPanel.rules.signatureRequired": "Participants sign these rules with their wallet before submitting.",
   "waves.sidebar.rightPanel.rules.showFullCreatorRules": "Show full creator rules",

--- a/i18n/messages/wavesRightPanel.en-US.json
+++ b/i18n/messages/wavesRightPanel.en-US.json
@@ -38,6 +38,8 @@
   "waves.sidebar.rightPanel.rules.displayOnly": "Display only",
   "waves.sidebar.rightPanel.rules.requiresAcceptance": "Requires acceptance",
   "waves.sidebar.rightPanel.rules.signatureRequired": "Participants sign these rules with their wallet before submitting.",
+  "waves.sidebar.rightPanel.rules.showFullCreatorRules": "Show full creator rules",
+  "waves.sidebar.rightPanel.rules.hideFullCreatorRules": "Hide full creator rules",
   "waves.sidebar.rightPanel.settings.rules": "Rules",
   "waves.sidebar.rightPanel.settings.display": "Display",
   "waves.sidebar.rightPanel.settings.approvalTabs": "Approval tabs",

--- a/ops/docs/waves/sidebars/feature-right-sidebar-tabs.md
+++ b/ops/docs/waves/sidebars/feature-right-sidebar-tabs.md
@@ -33,11 +33,13 @@ linked section pages.
 
 - Base section order for all waves: `About`, `Rules`, `REP`, `Settings`.
 - `Rank` and `Approve` waves add `Voters` and `Activity` after `Settings`.
-- `Rules` shows a compact creator-rules summary first when creator rules exist.
-  Full creator-authored text is collapsed by default and can be expanded on
-  demand, so the automatic rules generated from wave setup remain immediately
-  reachable. When no creator rules exist, the automatic rules remain first and
-  the creator-rules empty state follows them.
+- `Rules` shows a compact creator-rules summary first when creator rules exist,
+  including whether display-only or acceptance-required rules are present and
+  whether a wallet signature is required. Full creator-authored text is
+  collapsed by default and can be expanded on demand, so the automatic rules
+  generated from wave setup remain immediately reachable. When no creator
+  rules exist, the automatic rules remain first and the creator-rules empty
+  state follows them.
 - Desktop labels the first section `About` because it is a standalone sidebar
   tab.
 - Native app labels the same first section `Overview` because it is nested

--- a/ops/docs/waves/sidebars/feature-right-sidebar-tabs.md
+++ b/ops/docs/waves/sidebars/feature-right-sidebar-tabs.md
@@ -31,7 +31,9 @@ linked section pages.
 
 - Base section order for all waves: `About`, `Rules`, `REP`, `Settings`.
 - `Rank` and `Approve` waves add `Voters` and `Activity` after `Settings`.
-- `Rules` shows automatic wave rules plus optional creator rules.
+- `Rules` shows creator rules first when they exist, followed by the automatic
+  rules generated from wave setup. When no creator rules exist, the automatic
+  rules remain first and the creator-rules empty state follows them.
 - Desktop labels the first section `About` because it is a standalone sidebar
   tab.
 - Native app labels the same first section `Overview` because it is nested

--- a/ops/docs/waves/sidebars/feature-right-sidebar-tabs.md
+++ b/ops/docs/waves/sidebars/feature-right-sidebar-tabs.md
@@ -23,6 +23,8 @@ linked section pages.
 ## Entry Points
 
 - Desktop: open a wave thread, open the right sidebar, and select a tab.
+- Compact layouts: open `More wave actions` and select `Wave details`, which is
+  the first menu action.
 - Native app: open an active wave, select the main `About` tab, and select an
   information pill. The information pills replace the subwave pills while
   `About` is active; selecting another main tab restores the subwave pills.
@@ -31,9 +33,11 @@ linked section pages.
 
 - Base section order for all waves: `About`, `Rules`, `REP`, `Settings`.
 - `Rank` and `Approve` waves add `Voters` and `Activity` after `Settings`.
-- `Rules` shows creator rules first when they exist, followed by the automatic
-  rules generated from wave setup. When no creator rules exist, the automatic
-  rules remain first and the creator-rules empty state follows them.
+- `Rules` shows a compact creator-rules summary first when creator rules exist.
+  Full creator-authored text is collapsed by default and can be expanded on
+  demand, so the automatic rules generated from wave setup remain immediately
+  reachable. When no creator rules exist, the automatic rules remain first and
+  the creator-rules empty state follows them.
 - Desktop labels the first section `About` because it is a standalone sidebar
   tab.
 - Native app labels the same first section `Overview` because it is nested

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -2473,7 +2473,8 @@
         "Creators can add display-only custom rules that are saved as wave metadata.",
         "For Rank and Approve waves, creators can add rules that require acceptance; those use the existing participation terms and wallet-signature submit flow.",
         "Wave admins can edit display-only custom rules later from wave settings. For Rank and Approve waves, admins can also edit acceptance-required rules.",
-        "Participants can review rules in the desktop wave right sidebar or from the mobile About information path."
+        "Participants can review rules in the desktop wave right sidebar or from the mobile About information path.",
+        "When creator rules exist, the Rules view shows them before the automatic rules generated from wave setup. When none exist, automatic rules remain first and the creator-rules empty state follows."
       ],
       "canonical_path": "/waves/create",
       "related_paths": ["/waves", "/waves/create"],

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -2475,7 +2475,7 @@
         "For Rank and Approve waves, creators can add rules that require acceptance; those use the existing participation terms and wallet-signature submit flow.",
         "Wave admins can edit display-only custom rules later from wave settings. For Rank and Approve waves, admins can also edit acceptance-required rules.",
         "Participants can review rules in the desktop wave right sidebar or from the mobile About information path.",
-        "When creator rules exist, the Rules view shows their acceptance and wallet-signature status first while keeping the full creator-authored text collapsed until requested; automatic rules follow immediately. When none exist, automatic rules remain first and the creator-rules empty state follows."
+        "When creator rules exist, the Rules view shows which creator-rule types are present plus any acceptance and wallet-signature requirements, while keeping the full creator-authored text collapsed until requested; automatic rules follow immediately. When none exist, automatic rules remain first and the creator-rules empty state follows."
       ],
       "canonical_path": "/waves/create",
       "related_paths": ["/waves", "/waves/create"],

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -2430,6 +2430,7 @@
         "In the native app, the main About view opens compact Overview, Rules, and REP pills; More exposes the remaining sections.",
         "While native About is active, its information pills replace the subwave pills in the same contextual row; selecting another main tab restores the subwave pills.",
         "In the native app, More contains Settings and, for Rank and Approve waves, Voters and Activity.",
+        "On compact layouts, More wave actions lists Wave details first; selecting it opens the wave information panel.",
         "Selecting a section switches information for the active wave without navigating away from the thread."
       ],
       "canonical_path": "/waves",
@@ -2474,7 +2475,7 @@
         "For Rank and Approve waves, creators can add rules that require acceptance; those use the existing participation terms and wallet-signature submit flow.",
         "Wave admins can edit display-only custom rules later from wave settings. For Rank and Approve waves, admins can also edit acceptance-required rules.",
         "Participants can review rules in the desktop wave right sidebar or from the mobile About information path.",
-        "When creator rules exist, the Rules view shows them before the automatic rules generated from wave setup. When none exist, automatic rules remain first and the creator-rules empty state follows."
+        "When creator rules exist, the Rules view shows their acceptance and wallet-signature status first while keeping the full creator-authored text collapsed until requested; automatic rules follow immediately. When none exist, automatic rules remain first and the creator-rules empty state follows."
       ],
       "canonical_path": "/waves/create",
       "related_paths": ["/waves", "/waves/create"],

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -2471,7 +2471,7 @@
         "For Rank and Approve waves, creators can add rules that require acceptance; those use the existing participation terms and wallet-signature submit flow.",
         "Wave admins can edit display-only custom rules later from wave settings. For Rank and Approve waves, admins can also edit acceptance-required rules.",
         "Participants can review rules in the desktop wave right sidebar or from the mobile About information path.",
-        "When creator rules exist, the Rules view shows their acceptance and wallet-signature status first while keeping the full creator-authored text collapsed until requested; automatic rules follow immediately. When none exist, automatic rules remain first and the creator-rules empty state follows."
+        "When creator rules exist, the Rules view shows which creator-rule types are present plus any acceptance and wallet-signature requirements, while keeping the full creator-authored text collapsed until requested; automatic rules follow immediately. When none exist, automatic rules remain first and the creator-rules empty state follows."
       ],
       "canonical_path": "/waves/create",
       "related_paths": ["/waves", "/waves/create"],

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -2426,6 +2426,7 @@
         "In the native app, the main About view opens compact Overview, Rules, and REP pills; More exposes the remaining sections.",
         "While native About is active, its information pills replace the subwave pills in the same contextual row; selecting another main tab restores the subwave pills.",
         "In the native app, More contains Settings and, for Rank and Approve waves, Voters and Activity.",
+        "On compact layouts, More wave actions lists Wave details first; selecting it opens the wave information panel.",
         "Selecting a section switches information for the active wave without navigating away from the thread."
       ],
       "canonical_path": "/waves",
@@ -2470,7 +2471,7 @@
         "For Rank and Approve waves, creators can add rules that require acceptance; those use the existing participation terms and wallet-signature submit flow.",
         "Wave admins can edit display-only custom rules later from wave settings. For Rank and Approve waves, admins can also edit acceptance-required rules.",
         "Participants can review rules in the desktop wave right sidebar or from the mobile About information path.",
-        "When creator rules exist, the Rules view shows them before the automatic rules generated from wave setup. When none exist, automatic rules remain first and the creator-rules empty state follows."
+        "When creator rules exist, the Rules view shows their acceptance and wallet-signature status first while keeping the full creator-authored text collapsed until requested; automatic rules follow immediately. When none exist, automatic rules remain first and the creator-rules empty state follows."
       ],
       "canonical_path": "/waves/create",
       "related_paths": ["/waves", "/waves/create"],

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -2469,7 +2469,8 @@
         "Creators can add display-only custom rules that are saved as wave metadata.",
         "For Rank and Approve waves, creators can add rules that require acceptance; those use the existing participation terms and wallet-signature submit flow.",
         "Wave admins can edit display-only custom rules later from wave settings. For Rank and Approve waves, admins can also edit acceptance-required rules.",
-        "Participants can review rules in the desktop wave right sidebar or from the mobile About information path."
+        "Participants can review rules in the desktop wave right sidebar or from the mobile About information path.",
+        "When creator rules exist, the Rules view shows them before the automatic rules generated from wave setup. When none exist, automatic rules remain first and the creator-rules empty state follows."
       ],
       "canonical_path": "/waves/create",
       "related_paths": ["/waves", "/waves/create"],


### PR DESCRIPTION
## Issue

Creator-authored rules were hard to reach in the wave information experience. On compact layouts, Wave details appeared below the boosted-drops controls, and once Rules was open, a long creator-authored rule could push Wave, Access, Timing, Submissions, Voting, and Outcomes far below the fold.

## Fix

- List Wave details first in the compact More wave actions menu.
- Surface creator-rule status before the automatic rules when creator rules exist.
- Keep the full creator-authored text collapsed by default behind Show full creator rules.
- Keep acceptance and wallet-signature requirements visible in the collapsed summary.
- Leave the empty creator-rules state after automatic rules when no creator rules exist.

## Notable changes

- Adds an accessible expand/collapse control with a 44px minimum touch target and localized labels.
- Preserves the Create Wave form and the wave rules data model; this only changes presentation in the existing-wave Rules panel.
- Updates right-sidebar documentation and the Help6529 index.
- Adds focused coverage for creator-rule disclosure and compact-menu ordering.

## Validation

- `./bin/6529 run test --runInBand --runTestsByPath __tests__/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.test.tsx __tests__/components/waves/specs/WaveRulesPanel.test.tsx` (9 tests passed)
- `./bin/6529 run check:changed`
- `./bin/6529 run react-doctor:diff` (99/100; two pre-existing header warnings remain)
- `./bin/6529 run help-index:sync`
- Manual browser QA at a 390 × 844 viewport, including expand/collapse behavior and compact-menu order

## Risk

Low. The change is limited to display ordering and local disclosure state. Rule values, acceptance requirements, signatures, API behavior, and wave creation are unchanged.

## Review notes

The key review path is compact More wave actions → Wave details → Rules. Confirm that the automatic Wave and Access sections are visible immediately below the collapsed creator-rules summary and that Show full creator rules reveals the complete authored text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapsible creator rules with summaries and accessible expand/collapse controls.
  * Clarified rule ordering, acceptance requirements, wallet-signature status, and empty states.
  * Improved compact wave navigation by placing Wave details first in the More actions menu.

* **Documentation**
  * Updated wave sidebar and help content with the latest navigation and rules guidance.

* **Tests**
  * Added coverage for overflow-menu ordering and wave-rule display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->