### PR TITLE
Fix Museum accession image delivery

### DIFF
--- a/__tests__/app/api/museum.media.route.test.ts
+++ b/__tests__/app/api/museum.media.route.test.ts
@@ -1,0 +1,189 @@
+jest.mock("undici", () => ({
+  Agent: jest.fn().mockImplementation(() => ({})),
+  fetch: jest.fn(),
+}));
+
+jest.mock("@/lib/security/urlGuard", () => {
+  const actual = jest.requireActual("@/lib/security/urlGuard");
+  return {
+    ...actual,
+    fetchPublicUrl: jest.fn(),
+  };
+});
+
+class MockNextResponse {
+  readonly body: BodyInit | null;
+  readonly headers: { get: (name: string) => string | null };
+  readonly status: number;
+
+  constructor(body: BodyInit | null, init?: ResponseInit) {
+    const headerValues = new Map<string, string>();
+    Object.entries(init?.headers ?? {}).forEach(([key, value]) => {
+      headerValues.set(key.toLowerCase(), `${value}`);
+    });
+    this.body = body;
+    this.headers = {
+      get: (name: string) => headerValues.get(name.toLowerCase()) ?? null,
+    };
+    this.status = init?.status ?? 200;
+  }
+
+  static json(body: unknown, init?: ResponseInit): MockNextResponse {
+    return new MockNextResponse(JSON.stringify(body), {
+      ...init,
+      headers: { ...init?.headers, "Content-Type": "application/json" },
+    });
+  }
+
+  async json(): Promise<unknown> {
+    if (typeof this.body !== "string") {
+      throw new TypeError("Mock JSON response body must be a string.");
+    }
+    return JSON.parse(this.body);
+  }
+}
+
+jest.mock("next/server", () => ({
+  NextResponse: MockNextResponse,
+}));
+
+import { dynamic, GET } from "@/app/api/museum/media/route";
+import { UrlGuardError, fetchPublicUrl } from "@/lib/security/urlGuard";
+import type { NextRequest } from "next/server";
+
+const mockFetchPublicUrl = fetchPublicUrl as jest.Mock;
+const SOURCE =
+  "https://d3lqz0a4bldqgf.cloudfront.net/museum/accessions/6529NM.2026.003/6529NM-W-0029/c1b6541832f2a237555adffae2f4870143a976549e591e2dbaa4d3d87f75d166/webp-v2-q82-m6-fixed-icc/640.webp";
+const SMALL_WEBP = Buffer.from([0x52, 0x49, 0x46, 0x46]);
+
+function createRequest(sourceUrl: string): NextRequest {
+  return {
+    nextUrl: new URL(
+      `http://localhost:3001/api/museum/media?url=${encodeURIComponent(sourceUrl)}`
+    ),
+  } as NextRequest;
+}
+
+function createReadableBody(chunks: readonly Uint8Array[]) {
+  let index = 0;
+  const cancel = jest.fn();
+  return {
+    cancel,
+    getReader: () => ({
+      cancel,
+      read: jest.fn(async () => {
+        const value = chunks[index];
+        index += 1;
+        return value === undefined
+          ? { done: true, value: undefined }
+          : { done: false, value };
+      }),
+      releaseLock: jest.fn(),
+    }),
+  };
+}
+
+function mockResponse({
+  body = createReadableBody([new Uint8Array(SMALL_WEBP)]),
+  contentLength = `${SMALL_WEBP.byteLength}`,
+  contentType = "image/webp",
+  ok = true,
+  status = 200,
+  url = SOURCE,
+}: {
+  body?: ReturnType<typeof createReadableBody> | null;
+  contentLength?: string | null;
+  contentType?: string;
+  ok?: boolean;
+  status?: number;
+  url?: string;
+} = {}) {
+  const values = new Map<string, string>();
+  if (contentLength !== null) values.set("content-length", contentLength);
+  values.set("content-type", contentType);
+  mockFetchPublicUrl.mockResolvedValueOnce({
+    body,
+    headers: { get: (name: string) => values.get(name.toLowerCase()) ?? null },
+    ok,
+    status,
+    url,
+  });
+  return body;
+}
+
+describe("/api/museum/media", () => {
+  beforeEach(() => {
+    mockFetchPublicUrl.mockReset();
+  });
+
+  it("is rendered at request time and returns immutable WebP bytes", async () => {
+    mockResponse();
+
+    const response = await GET(createRequest(SOURCE));
+
+    expect(dynamic).toBe("force-dynamic");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/webp");
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=31536000, immutable"
+    );
+    expect(mockFetchPublicUrl).toHaveBeenCalledWith(
+      new URL(SOURCE),
+      { headers: { accept: "image/webp" } },
+      expect.objectContaining({ timeoutMs: 8_000 })
+    );
+  });
+
+  it("rejects unsupported source and redirected URLs", async () => {
+    const invalid = await GET(createRequest("https://example.com/image.webp"));
+    expect(invalid.status).toBe(400);
+    expect(mockFetchPublicUrl).not.toHaveBeenCalled();
+
+    mockResponse({ url: SOURCE.replace("/640.webp", "/private.webp") });
+    const redirected = await GET(createRequest(SOURCE));
+    expect(redirected.status).toBe(400);
+  });
+
+  it("rejects upstream failures, missing bodies, and non-WebP content", async () => {
+    mockResponse({ ok: false, status: 503 });
+    expect((await GET(createRequest(SOURCE))).status).toBe(502);
+
+    mockResponse({ body: null });
+    expect((await GET(createRequest(SOURCE))).status).toBe(502);
+
+    mockResponse({ contentType: "text/html" });
+    expect((await GET(createRequest(SOURCE))).status).toBe(415);
+  });
+
+  it("rejects declared and streamed bodies above 16 MiB", async () => {
+    mockResponse({ contentLength: `${16 * 1024 * 1024 + 1}` });
+    expect((await GET(createRequest(SOURCE))).status).toBe(413);
+
+    const streamedBody = mockResponse({
+      contentLength: null,
+      body: createReadableBody([new Uint8Array(16 * 1024 * 1024 + 1)]),
+    });
+    expect((await GET(createRequest(SOURCE))).status).toBe(413);
+    expect(streamedBody?.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("streams safely when content-length is malformed", async () => {
+    mockResponse({ contentLength: "not-a-number" });
+    expect((await GET(createRequest(SOURCE))).status).toBe(200);
+
+    mockResponse({ contentLength: "-1" });
+    expect((await GET(createRequest(SOURCE))).status).toBe(200);
+  });
+
+  it("maps timeout and fetch failures to stable gateway errors", async () => {
+    mockFetchPublicUrl.mockRejectedValueOnce(
+      new UrlGuardError("timeout", "timeout", 504)
+    );
+    expect((await GET(createRequest(SOURCE))).status).toBe(504);
+
+    mockFetchPublicUrl.mockRejectedValueOnce(
+      new UrlGuardError("failed", "fetch-failed", 502)
+    );
+    expect((await GET(createRequest(SOURCE))).status).toBe(502);
+  });
+});

--- a/__tests__/components/museum/MuseumManagedImage.test.tsx
+++ b/__tests__/components/museum/MuseumManagedImage.test.tsx
@@ -29,4 +29,27 @@ describe("MuseumManagedImage", () => {
       screen.queryByRole("button", { name: "Retry" })
     ).not.toBeInTheDocument();
   });
+
+  it("delivers approved accession derivatives through the same-origin Museum endpoint", () => {
+    const source =
+      "https://d3lqz0a4bldqgf.cloudfront.net/museum/accessions/6529NM.2026.003/6529NM-W-0029/c1b6541832f2a237555adffae2f4870143a976549e591e2dbaa4d3d87f75d166/webp-v2-q82-m6-fixed-icc/640.webp";
+    render(
+      <MuseumManagedImage
+        {...props}
+        src={source}
+        srcSet={`${source} 640w, ${source.replace("/640.webp", "/1280.webp")} 1280w`}
+        alt="A governed accession image"
+      />
+    );
+
+    const image = screen.getByRole("img");
+    expect(image).toHaveAttribute(
+      "src",
+      `/api/museum/media?url=${encodeURIComponent(source)}`
+    );
+    expect(image).toHaveAttribute(
+      "srcset",
+      `/api/museum/media?url=${encodeURIComponent(source)} 640w, /api/museum/media?url=${encodeURIComponent(source.replace("/640.webp", "/1280.webp"))} 1280w`
+    );
+  });
 });

--- a/__tests__/components/museum/MuseumProposalImage.test.tsx
+++ b/__tests__/components/museum/MuseumProposalImage.test.tsx
@@ -1,5 +1,9 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { MuseumProposalImage } from "@/components/museum/MuseumProposalImage";
+import {
+  getMuseumMediaDeliverySrcSet,
+  getMuseumMediaDeliveryUrl,
+} from "@/lib/museum/runtime/mediaDelivery";
 
 describe("MuseumProposalImage", () => {
   const media = {
@@ -127,10 +131,15 @@ describe("MuseumProposalImage", () => {
 
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
     const image = screen.getByRole("img");
-    expect(image).toHaveAttribute("src", variants[0].url);
+    expect(image).toHaveAttribute(
+      "src",
+      getMuseumMediaDeliveryUrl(variants[0].url)
+    );
     expect(image).toHaveAttribute(
       "srcset",
-      `${variants[0].url} 640w, ${variants[1].url} 1280w, ${variants[2].url} 2400w`
+      getMuseumMediaDeliverySrcSet(
+        `${variants[0].url} 640w, ${variants[1].url} 1280w, ${variants[2].url} 2400w`
+      )
     );
     expect(image).toHaveAttribute("sizes", "(min-width: 1280px) 30vw, 100vw");
     expect(image).not.toHaveAttribute("src", media.src);

--- a/__tests__/lib/museum/runtime/mediaDelivery.test.ts
+++ b/__tests__/lib/museum/runtime/mediaDelivery.test.ts
@@ -40,5 +40,8 @@ describe("Museum media delivery", () => {
     ).toBe(
       `/api/museum/media?url=${encodeURIComponent(SOURCE)} 640w, /api/museum/media?url=${encodeURIComponent(source1280)} 1280w`
     );
+    expect(getMuseumMediaDeliverySrcSet(`${SOURCE}\t640w`)).toBe(
+      `/api/museum/media?url=${encodeURIComponent(SOURCE)} 640w`
+    );
   });
 });

--- a/__tests__/lib/museum/runtime/mediaDelivery.test.ts
+++ b/__tests__/lib/museum/runtime/mediaDelivery.test.ts
@@ -1,0 +1,44 @@
+import {
+  getMuseumMediaDeliverySrcSet,
+  getMuseumMediaDeliveryUrl,
+  isMuseumMediaProxyAllowedUrl,
+} from "@/lib/museum/runtime/mediaDelivery";
+
+const SOURCE =
+  "https://d3lqz0a4bldqgf.cloudfront.net/museum/accessions/6529NM.2026.003/6529NM-W-0029/c1b6541832f2a237555adffae2f4870143a976549e591e2dbaa4d3d87f75d166/webp-v2-q82-m6-fixed-icc/640.webp";
+
+describe("Museum media delivery", () => {
+  it("accepts only governed accession derivative paths", () => {
+    expect(isMuseumMediaProxyAllowedUrl(SOURCE)).toBe(true);
+    expect(
+      isMuseumMediaProxyAllowedUrl(SOURCE.replace("/640.webp", "/1280.webp"))
+    ).toBe(true);
+    expect(
+      isMuseumMediaProxyAllowedUrl(SOURCE.replace("/640.webp", "/2400.webp"))
+    ).toBe(true);
+
+    for (const invalid of [
+      SOURCE.replace("https://", "http://"),
+      SOURCE.replace("d3lqz0a4bldqgf.cloudfront.net", "example.com"),
+      SOURCE.replace("/museum/accessions/", "/private/"),
+      SOURCE.replace("/640.webp", "/641.webp"),
+      `${SOURCE}?redirect=https://example.com`,
+      SOURCE.replace("https://", "https://user:pass@"),
+    ]) {
+      expect(isMuseumMediaProxyAllowedUrl(invalid)).toBe(false);
+      expect(getMuseumMediaDeliveryUrl(invalid)).toBe(invalid);
+    }
+  });
+
+  it("maps approved sources and responsive candidates to the same-origin endpoint", () => {
+    const source1280 = SOURCE.replace("/640.webp", "/1280.webp");
+    expect(getMuseumMediaDeliveryUrl(SOURCE)).toBe(
+      `/api/museum/media?url=${encodeURIComponent(SOURCE)}`
+    );
+    expect(
+      getMuseumMediaDeliverySrcSet(`${SOURCE} 640w, ${source1280} 1280w`)
+    ).toBe(
+      `/api/museum/media?url=${encodeURIComponent(SOURCE)} 640w, /api/museum/media?url=${encodeURIComponent(source1280)} 1280w`
+    );
+  });
+});

--- a/app/api/museum/media/route.ts
+++ b/app/api/museum/media/route.ts
@@ -1,0 +1,149 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+import {
+  MUSEUM_MEDIA_PROXY_ALLOWED_HOSTS,
+  isMuseumMediaProxyAllowedUrl,
+} from "@/lib/museum/runtime/mediaDelivery";
+import {
+  UrlGuardError,
+  fetchPublicUrl,
+  parsePublicUrl,
+  type FetchPublicUrlOptions,
+} from "@/lib/security/urlGuard";
+
+const REQUEST_TIMEOUT_MS = 8_000;
+const MAX_ASSET_BYTES = 16 * 1024 * 1024;
+const CACHE_CONTROL = "public, max-age=31536000, immutable";
+const USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+const FETCH_OPTIONS: FetchPublicUrlOptions = {
+  policy: { allowedHosts: MUSEUM_MEDIA_PROXY_ALLOWED_HOSTS },
+  timeoutMs: REQUEST_TIMEOUT_MS,
+  userAgent: USER_AGENT,
+};
+const ERROR_CACHE_HEADERS = { "Cache-Control": "no-store" };
+
+function jsonError(message: string, status: number): NextResponse {
+  return NextResponse.json(
+    { error: message },
+    { status, headers: ERROR_CACHE_HEADERS }
+  );
+}
+
+function parseAssetUrl(value: string | null): URL | NextResponse {
+  try {
+    const parsed = parsePublicUrl(value, { allowedProtocols: ["https:"] });
+    if (!isMuseumMediaProxyAllowedUrl(parsed.toString())) {
+      return jsonError("Unsupported Museum media URL", 400);
+    }
+    return parsed;
+  } catch (error) {
+    if (error instanceof UrlGuardError) {
+      return jsonError("Invalid Museum media URL", error.statusCode);
+    }
+    return jsonError("Invalid Museum media URL", 400);
+  }
+}
+
+function isOversizedResponse(headers: Headers): boolean {
+  const contentLength = headers.get("content-length");
+  if (contentLength === null) return false;
+  const bytes = Number(contentLength);
+  return !Number.isFinite(bytes) || bytes < 0 || bytes > MAX_ASSET_BYTES;
+}
+
+async function readBodyWithLimit(
+  body: ReadableStream<Uint8Array>
+): Promise<ArrayBuffer | NextResponse> {
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_ASSET_BYTES) {
+        await reader.cancel("Museum media response is too large");
+        return jsonError("Museum media response is too large", 413);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const result = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result.buffer;
+}
+
+function guardErrorResponse(error: UrlGuardError): NextResponse {
+  if (error.kind === "timeout") {
+    return jsonError("Museum media upstream timeout", 504);
+  }
+  if (
+    error.kind === "fetch-failed" ||
+    error.kind === "too-many-redirects" ||
+    error.kind === "redirect-location-missing" ||
+    error.kind === "redirect-location-invalid"
+  ) {
+    return jsonError("Failed to fetch Museum media", 502);
+  }
+  return jsonError("Unsupported Museum media URL", error.statusCode);
+}
+
+async function proxyAsset(url: URL): Promise<NextResponse> {
+  try {
+    const response = await fetchPublicUrl(
+      url,
+      { headers: { accept: "image/webp" } },
+      FETCH_OPTIONS
+    );
+    if (!response.ok || response.body === null) {
+      return jsonError(
+        `Failed to fetch Museum media (${response.status})`,
+        502
+      );
+    }
+
+    const finalUrl = response.url.length > 0 ? new URL(response.url) : url;
+    if (!isMuseumMediaProxyAllowedUrl(finalUrl.toString())) {
+      return jsonError("Unsupported Museum media URL", 400);
+    }
+    if (response.headers.get("content-type")?.toLowerCase() !== "image/webp") {
+      return jsonError("Unsupported Museum media content type", 415);
+    }
+    if (isOversizedResponse(response.headers)) {
+      return jsonError("Museum media response is too large", 413);
+    }
+
+    const body = await readBodyWithLimit(response.body);
+    if (body instanceof NextResponse) return body;
+    return new NextResponse(body, {
+      status: 200,
+      headers: {
+        "Cache-Control": CACHE_CONTROL,
+        "Content-Type": "image/webp",
+        "Cross-Origin-Resource-Policy": "same-origin",
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  } catch (error) {
+    if (error instanceof UrlGuardError) return guardErrorResponse(error);
+    return jsonError("Failed to fetch Museum media", 502);
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const parsed = parseAssetUrl(request.nextUrl.searchParams.get("url"));
+  return parsed instanceof NextResponse ? parsed : proxyAsset(parsed);
+}
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;

--- a/app/api/museum/media/route.ts
+++ b/app/api/museum/media/route.ts
@@ -50,7 +50,7 @@ function isOversizedResponse(headers: Headers): boolean {
   const contentLength = headers.get("content-length");
   if (contentLength === null) return false;
   const bytes = Number(contentLength);
-  return !Number.isFinite(bytes) || bytes < 0 || bytes > MAX_ASSET_BYTES;
+  return Number.isFinite(bytes) && bytes > MAX_ASSET_BYTES;
 }
 
 async function readBodyWithLimit(

--- a/components/museum/MuseumManagedImage.tsx
+++ b/components/museum/MuseumManagedImage.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { useState, type CSSProperties } from "react";
+import {
+  getMuseumMediaDeliverySrcSet,
+  getMuseumMediaDeliveryUrl,
+} from "@/lib/museum/runtime/mediaDelivery";
 
 export interface MuseumManagedImageProps {
   readonly src: string;
@@ -81,6 +85,8 @@ export function MuseumManagedImage({
   sourceLabel,
   onStatusChange,
 }: MuseumManagedImageProps) {
+  const deliveredSrc = getMuseumMediaDeliveryUrl(src);
+  const deliveredSrcSet = getMuseumMediaDeliverySrcSet(srcSet);
   const [failed, setFailed] = useState(alt.trim().length === 0);
   const [attempt, setAttempt] = useState(0);
   if (failed) {
@@ -104,17 +110,18 @@ export function MuseumManagedImage({
     );
   }
   return (
-    // Governed media must use the exact upstream URI; Next Image would create an unapproved derivative.
+    // The publication retains the exact governed URI. Approved accession bytes
+    // traverse the strict same-origin delivery route without re-derivation.
     <img
-      key={`${src}:${attempt}`}
-      src={src}
+      key={`${deliveredSrc}:${attempt}`}
+      src={deliveredSrc}
       alt={alt}
       width={width}
       height={height}
       loading={loading}
       fetchPriority={fetchPriority}
       decoding="async"
-      srcSet={srcSet}
+      srcSet={deliveredSrcSet}
       sizes={sizes}
       style={style}
       onError={() => {

--- a/lib/museum/runtime/mediaDelivery.ts
+++ b/lib/museum/runtime/mediaDelivery.ts
@@ -5,7 +5,7 @@ export const MUSEUM_MEDIA_PROXY_ALLOWED_HOSTS = [
 ] as const;
 
 const ACCESSION_DERIVATIVE_PATH =
-  /^\/museum\/accessions\/6529NM\.[0-9]{4}\.[0-9]{3}\/6529NM-W-[0-9]{4}\/[0-9a-f]{64}\/webp-v2-q82-m6-fixed-icc\/(?:640|1280|2400)\.webp$/u;
+  /^\/museum\/accessions\/6529NM\.\d{4}\.\d{3}\/6529NM-W-\d{4}\/[0-9a-f]{64}\/webp-v2-q82-m6-fixed-icc\/(?:640|1280|2400)\.webp$/u;
 
 export function isMuseumMediaProxyAllowedUrl(value: string): boolean {
   let parsed: URL;

--- a/lib/museum/runtime/mediaDelivery.ts
+++ b/lib/museum/runtime/mediaDelivery.ts
@@ -1,0 +1,56 @@
+const MUSEUM_MEDIA_PROXY_PATH = "/api/museum/media";
+
+export const MUSEUM_MEDIA_PROXY_ALLOWED_HOSTS = [
+  "d3lqz0a4bldqgf.cloudfront.net",
+] as const;
+
+const ACCESSION_DERIVATIVE_PATH =
+  /^\/museum\/accessions\/6529NM\.[0-9]{4}\.[0-9]{3}\/6529NM-W-[0-9]{4}\/[0-9a-f]{64}\/webp-v2-q82-m6-fixed-icc\/(?:640|1280|2400)\.webp$/u;
+
+export function isMuseumMediaProxyAllowedUrl(value: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+
+  if (
+    parsed.protocol !== "https:" ||
+    (parsed.port.length > 0 && parsed.port !== "443") ||
+    parsed.username.length > 0 ||
+    parsed.password.length > 0 ||
+    parsed.search.length > 0 ||
+    parsed.hash.length > 0
+  ) {
+    return false;
+  }
+
+  const allowedHosts: readonly string[] = MUSEUM_MEDIA_PROXY_ALLOWED_HOSTS;
+  return (
+    allowedHosts.includes(parsed.hostname.toLowerCase()) &&
+    ACCESSION_DERIVATIVE_PATH.test(parsed.pathname)
+  );
+}
+
+export function getMuseumMediaDeliveryUrl(value: string): string {
+  if (!isMuseumMediaProxyAllowedUrl(value)) return value;
+  return `${MUSEUM_MEDIA_PROXY_PATH}?url=${encodeURIComponent(value)}`;
+}
+
+export function getMuseumMediaDeliverySrcSet(
+  value: string | undefined
+): string | undefined {
+  if (value === undefined) return undefined;
+  return value
+    .split(",")
+    .map((candidate) => {
+      const trimmed = candidate.trim();
+      const separator = trimmed.lastIndexOf(" ");
+      if (separator < 1) return trimmed;
+      const url = trimmed.slice(0, separator);
+      const descriptor = trimmed.slice(separator + 1);
+      return `${getMuseumMediaDeliveryUrl(url)} ${descriptor}`;
+    })
+    .join(", ");
+}

--- a/lib/museum/runtime/mediaDelivery.ts
+++ b/lib/museum/runtime/mediaDelivery.ts
@@ -42,6 +42,8 @@ export function getMuseumMediaDeliverySrcSet(
   value: string | undefined
 ): string | undefined {
   if (value === undefined) return undefined;
+  // Governed derivative URLs cannot contain commas or query parameters, so
+  // each comma is an unambiguous candidate boundary here.
   return value
     .split(",")
     .map((candidate) => {

--- a/lib/museum/runtime/mediaDelivery.ts
+++ b/lib/museum/runtime/mediaDelivery.ts
@@ -48,10 +48,11 @@ export function getMuseumMediaDeliverySrcSet(
     .split(",")
     .map((candidate) => {
       const trimmed = candidate.trim();
-      const separator = trimmed.lastIndexOf(" ");
+      const separator = trimmed.search(/[\t\n\f\r ]/u);
       if (separator < 1) return trimmed;
       const url = trimmed.slice(0, separator);
-      const descriptor = trimmed.slice(separator + 1);
+      const descriptor = trimmed.slice(separator).trim();
+      if (descriptor.length === 0) return trimmed;
       return `${getMuseumMediaDeliveryUrl(url)} ${descriptor}`;
     })
     .join(", ");

--- a/ops/workstreams/vera-molnar-accession/active-context.md
+++ b/ops/workstreams/vera-molnar-accession/active-context.md
@@ -2,7 +2,7 @@
 
 ## Objective
 
-Publish the accepted and delivered gift of *Themes and Variations* #210 as a
+Publish the accepted and delivered gift of _Themes and Variations_ #210 as a
 complete Museum accession: Collection, acquisition, artist/collaborator,
 project, Work, and Research surfaces, with the official still, responsive
 Museum delivery copies, live generator, rights, provenance, and source links.
@@ -44,7 +44,16 @@ Museum delivery copies, live generator, rights, provenance, and source links.
   compatibility suite passes a further 18 tests, including 29 works, 23
   artists, seven projects, four acquisitions, all catalog commitments, and the
   complete Vera media boundary. Changed lint, changed typecheck, and the
-  optimized 3,675-route production build pass. Frontend PR #3812 is open; its
-  amended exact head includes the final review fixes, debt-ratchet split,
-  Museum surface-registry entry, and DCO sign-off. No staging or production
-  mutation has occurred.
+  optimized 3,675-route production build pass. Frontend PR #3812 merged as
+  `59ccd83442c3dca207b06701395b11878906f804`; staging deployment and automatic
+  E2E passed, production deployment and automatic isolated E2E passed, and the
+  exact commit is live.
+- Final installed-Chrome readback found that the Museum CloudFront origin
+  returned browser subresource requests as blocked responses, despite serving
+  the exact derivative bytes to server-side clients. This affected the new
+  Vera still and older accession derivatives. The corrective branch preserves
+  the governed source URI and exact bytes while delivering approved accession
+  derivatives through a strict same-origin Museum endpoint. Local Chrome
+  decodes all 640, 1280, and 2400 variants, and their SHA-256 values match the
+  reviewed presentation manifest. Corrective PR, staging, and production
+  qualification remain to be completed.

--- a/ops/workstreams/vera-molnar-accession/run-log.md
+++ b/ops/workstreams/vera-molnar-accession/run-log.md
@@ -159,3 +159,7 @@
   its descriptor. The parser now recognizes every permitted ASCII whitespace
   separator and a regression test proves a tab-delimited accession derivative
   still traverses the same-origin delivery route.
+- Sonar's passing quality gate reported three instances of the same minor
+  regex-style issue. The accession path grammar now uses the concise ASCII
+  digit class for year, accession sequence, and Work sequence; behavior and
+  the exact allowed path boundary are unchanged.

--- a/ops/workstreams/vera-molnar-accession/run-log.md
+++ b/ops/workstreams/vera-molnar-accession/run-log.md
@@ -147,3 +147,11 @@
   decodes 640, 1280, and 2400 pixels with no request failure. Their SHA-256
   values exactly match reviewed manifest B: `a53b0dbd...bcbc1`,
   `3e9a68c8...42555`, and `0ec810b0...dc436`.
+- Corrective PR #3813 review required direct route coverage before merge. The
+  route now distinguishes a genuinely oversized declared response from a
+  malformed `content-length` and relies on the streaming ceiling for the
+  latter. Six route tests cover the immutable WebP success path, URL and
+  redirect rejection, content-type rejection, upstream and missing-body
+  failures, declared and streamed overage, malformed lengths, timeout, and
+  fetch-failure mapping. The focused corrective set passes 16 tests; changed
+  lint, changed typecheck, and the Windows-safe diff check pass.

--- a/ops/workstreams/vera-molnar-accession/run-log.md
+++ b/ops/workstreams/vera-molnar-accession/run-log.md
@@ -155,3 +155,7 @@
   failures, declared and streamed overage, malformed lengths, timeout, and
   fetch-failure mapping. The focused corrective set passes 16 tests; changed
   lint, changed typecheck, and the Windows-safe diff check pass.
+- CodeRabbit identified that HTML `srcset` also permits a tab between a URL and
+  its descriptor. The parser now recognizes every permitted ASCII whitespace
+  separator and a regression test proves a tab-delimited accession derivative
+  still traverses the same-origin delivery route.

--- a/ops/workstreams/vera-molnar-accession/run-log.md
+++ b/ops/workstreams/vera-molnar-accession/run-log.md
@@ -130,3 +130,20 @@
   scroll widths (820/820), and no console or page error was observed. Direct
   visual readback found no clipped boxes, collapsed columns, stranded labels,
   or artwork distortion.
+- Frontend PR #3812 merged as
+  `59ccd83442c3dca207b06701395b11878906f804`. Staging composition
+  `1a083eceaf0e3865312f72470f3f9d9ac1236f3b` passed deploy run 32660459394,
+  automatic dispatch 32660997762, and Staging E2E 32661001514. Production
+  deploy 32662032108, authority completion 32662902084, automatic Production
+  E2E 32662908738, and its isolated verifier all passed on exact main.
+- The mandatory installed-Chrome production readback then caught a defect the
+  hosted pack had missed: direct browser requests for approved CloudFront
+  accession derivatives were rejected with `ERR_BLOCKED_BY_ORB`, and the Vera
+  image component displayed its fallback. The corrective implementation maps
+  only exact `6529NM` WebP derivative paths on the approved host to
+  `/api/museum/media`, uses the existing DNS-pinned public URL guard, rejects
+  redirects outside the exact path grammar, limits responses to 16 MiB, and
+  serves the unchanged bytes from the site origin. Local installed Chrome
+  decodes 640, 1280, and 2400 pixels with no request failure. Their SHA-256
+  values exactly match reviewed manifest B: `a53b0dbd...bcbc1`,
+  `3e9a68c8...42555`, and `0ec810b0...dc436`.

--- a/ops/workstreams/vera-molnar-accession/run-log.md
+++ b/ops/workstreams/vera-molnar-accession/run-log.md
@@ -167,6 +167,10 @@
   successfully in the mobile browser, but the Network IA test queried the
   retired `canonical-work-presentation-title` section ID. The live DOM and
   retained Playwright snapshot place canonical media under
-  `canonical-work-media-title`; both stale Work-image selectors now use that
-  public semantic boundary. This is test-only and does not alter runtime code,
-  copy, media, or pixels.
+  `canonical-work-media-title`, so the Vera image assertion now uses that
+  public semantic boundary. Exact-head rerun 32665959639 passed the Vera check
+  and reached the existing Magnum Work assertion. Its retained DOM confirms
+  that the historical Wave image remains, correctly, in the distinct
+  `canonical-work-presentation-title` section. That Magnum selector therefore
+  remains presentation-specific. These are test-only corrections and do not
+  alter runtime code, copy, media, or pixels.

--- a/ops/workstreams/vera-molnar-accession/run-log.md
+++ b/ops/workstreams/vera-molnar-accession/run-log.md
@@ -163,3 +163,10 @@
   regex-style issue. The accession path grammar now uses the concise ASCII
   digit class for year, accession sequence, and Work sequence; behavior and
   the exact allowed path boundary are unchanged.
+- Corrective exact-head CI run 32665361257 rendered the Vera Work and its image
+  successfully in the mobile browser, but the Network IA test queried the
+  retired `canonical-work-presentation-title` section ID. The live DOM and
+  retained Playwright snapshot place canonical media under
+  `canonical-work-media-title`; both stale Work-image selectors now use that
+  public semantic boundary. This is test-only and does not alter runtime code,
+  copy, media, or pixels.

--- a/tests/museum/network-ia-readonly.spec.ts
+++ b/tests/museum/network-ia-readonly.spec.ts
@@ -328,6 +328,28 @@ test.describe("Museum public IA rendered contract @surface @readonly", () => {
       await expectNoDeadLinks(page);
     }
 
+    await openRoute(page, "/museum/network/works/6529NM-W-0029");
+    const veraWorkImage = page.locator(
+      '[aria-labelledby="canonical-work-presentation-title"] img'
+    );
+    await expect(veraWorkImage).toHaveCount(1);
+    await veraWorkImage.scrollIntoViewIfNeeded();
+    await expect
+      .poll(
+        () =>
+          veraWorkImage.evaluate(
+            (image) =>
+              image instanceof HTMLImageElement &&
+              image.complete &&
+              image.naturalWidth > 0
+          ),
+        { timeout: 20_000 }
+      )
+      .toBe(true);
+    await expect(
+      page.getByText("This image is temporarily unavailable.", { exact: true })
+    ).toHaveCount(0);
+
     await openRoute(page, "/museum/network/works/6529NM-W-0001");
     await expect(page.getByText("By", { exact: true })).toBeVisible();
     await expect(page.getByText("Part of", { exact: true })).toBeVisible();

--- a/tests/museum/network-ia-readonly.spec.ts
+++ b/tests/museum/network-ia-readonly.spec.ts
@@ -330,7 +330,7 @@ test.describe("Museum public IA rendered contract @surface @readonly", () => {
 
     await openRoute(page, "/museum/network/works/6529NM-W-0029");
     const veraWorkImage = page.locator(
-      '[aria-labelledby="canonical-work-presentation-title"] img'
+      '[aria-labelledby="canonical-work-media-title"] img'
     );
     await expect(veraWorkImage).toHaveCount(1);
     await veraWorkImage.scrollIntoViewIfNeeded();
@@ -396,7 +396,7 @@ test.describe("Museum public IA rendered contract @surface @readonly", () => {
       })
     ).toHaveCount(1);
     await expect(
-      page.locator('[aria-labelledby="canonical-work-presentation-title"] img')
+      page.locator('[aria-labelledby="canonical-work-media-title"] img')
     ).toHaveCount(1);
     await expect(
       page.getByRole("button", { name: /loads 16\.9 MB/u })

--- a/tests/museum/network-ia-readonly.spec.ts
+++ b/tests/museum/network-ia-readonly.spec.ts
@@ -396,7 +396,7 @@ test.describe("Museum public IA rendered contract @surface @readonly", () => {
       })
     ).toHaveCount(1);
     await expect(
-      page.locator('[aria-labelledby="canonical-work-media-title"] img')
+      page.locator('[aria-labelledby="canonical-work-presentation-title"] img')
     ).toHaveCount(1);
     await expect(
       page.getByRole("button", { name: /loads 16\.9 MB/u })


### PR DESCRIPTION
## Outcome
Restores browser-visible Museum accession derivatives through a strict same-origin delivery route. The canonical publication continues to retain the exact governed CloudFront URI; the endpoint streams the reviewed WebP bytes without re-derivation.

## Root cause
Installed Chrome returned ERR_BLOCKED_BY_ORB for the exact CloudFront derivative even though server GET/HEAD returned valid WebP. Final visual QA therefore showed fallback copy on Vera routes. The same upstream behavior can affect earlier accession derivatives.

## Security and integrity boundary
- exact host allowlist: d3lqz0a4bldqgf.cloudfront.net
- exact accession derivative path grammar and only 640/1280/2400 WebP variants
- HTTPS only; no credentials, query, fragment, alternate port, or arbitrary redirects
- existing DNS-pinned public URL guard
- 8-second timeout, 16 MiB header and streaming-body ceiling, exact image/webp response
- nosniff, same-origin resource policy, immutable cache

## Verification
- 3 focused suites / 10 tests pass
- changed lint and typecheck pass
- optimized production build completed and generated the new route
- installed Chrome decoded all three Vera variants through the same-origin route
- delivered byte hashes match the reviewed source manifest exactly:
  - 640: a53b0dbde5a8a43c8e25b541311f38998a106683901dab95490c1d02083bcbc1
  - 1280: 3e9a68c8d1488592826567430906e5c37b5b304efff556dc8c3c422a04c42555
  - 2400: 0ec810b0e62cdc9c4cfaf2a24553b4feaf57e49a877d519f7dda5300c78dc436
- adversarial invalid URL returns 400
- Museum E2E now requires Vera image complete with naturalWidth greater than zero and no fallback copy

## Release
Corrective follow-up to #3812. After exact-head review and CI, qualify on staging and production with installed-Chrome image decode plus the full Vera route matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Museum accession image delivery so approved images load reliably across standard and responsive displays.
  * Fixed image rendering issues caused by browser blocking of certain image sources.
  * Preserved responsive image variants and existing retry and failure handling.
  * Added safeguards against unsupported or unsafe image URLs.
  * Improved handling of upstream image errors, timeouts, redirects, and oversized responses.

* **Quality Improvements**
  * Added automated coverage for image loading, responsive sources, URL validation, and the Vera Molnár work page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->