### PR TITLE
docs: close out Vera Molnar accession release

### DIFF
--- a/ops/workstreams/vera-molnar-accession/active-context.md
+++ b/ops/workstreams/vera-molnar-accession/active-context.md
@@ -55,5 +55,14 @@ Museum delivery copies, live generator, rights, provenance, and source links.
   the governed source URI and exact bytes while delivering approved accession
   derivatives through a strict same-origin Museum endpoint. Local Chrome
   decodes all 640, 1280, and 2400 variants, and their SHA-256 values match the
-  reviewed presentation manifest. Corrective PR, staging, and production
-  qualification remain to be completed.
+  reviewed presentation manifest. Corrective PR #3813 merged as
+  `d8646201aec183a569b18efe0f061223ed3185ee`. Staging composition
+  `76590cafa3cdefeb73519f53e33b687e1f0f3c21` passed deployment
+  32667636938, automatic Staging E2E 32668149067, and an independent exact-
+  source desktop/mobile Museum route test. Production deployment 32669010834,
+  artifact builder 32669023260, artifact verifier 32669550952, automatic
+  Production E2E 32669902960, and its isolated evidence verifier all passed.
+  Public readback resolved the exact production version three times and found
+  decoded governed media, no fallback, no browser warnings or errors, and no
+  horizontal overflow on the artist, project, acquisition, and Work routes at
+  1440 x 1000 and 390 x 844. The corrected accession is live and qualified.

--- a/ops/workstreams/vera-molnar-accession/run-log.md
+++ b/ops/workstreams/vera-molnar-accession/run-log.md
@@ -174,3 +174,25 @@
   `canonical-work-presentation-title` section. That Magnum selector therefore
   remains presentation-specific. These are test-only corrections and do not
   alter runtime code, copy, media, or pixels.
+- Corrective PR #3813 passed exact-head App PR CI run 32666363626, CodeQL,
+  Sonar, Snyk, secret scan, DCO, trust, debt, and review-thread reconciliation,
+  then merged as `d8646201aec183a569b18efe0f061223ed3185ee`.
+- Staging composition `76590cafa3cdefeb73519f53e33b687e1f0f3c21`
+  passed deploy run 32667636938 and automatic Staging E2E 32668149067. A
+  separate credentialed Chromium run exercised the complete Museum hub,
+  lifecycle, link, overflow, and media-intent contract on desktop and mobile;
+  both projects passed, including decoded Vera media and absence of fallback.
+- Production deploy 32669010834 acquired exact authority, built the immutable
+  artifact in 32669023260, verified it independently in 32669550952, and
+  published exact main `d8646201aec183a569b18efe0f061223ed3185ee`.
+  `/api/version` matched that SHA in three consecutive reads. Automatic
+  Production E2E 32669902960 passed its complete read-only pack and isolated
+  evidence verifier.
+- Final public browser readback covered Vera Molnár's artist record,
+  *Themes and Variations*, the gift acquisition, and Work 6529NM-W-0029 at
+  1440 x 1000 and 390 x 844. Every primary Museum image decoded through the
+  strict same-origin endpoint, the pages showed no temporary-unavailable
+  fallback, all mobile documents reported equal client and scroll widths, and
+  the browser reported no warnings or errors. Representative viewport and
+  full-page captures are retained under the local release evidence directory
+  `vera-molnar-production-d864`.


### PR DESCRIPTION
## Summary
- record exact corrective merge, staging, production, and E2E evidence
- record final desktop/mobile decoded-image and overflow readback
- mark the Vera accession release live and qualified

## Product impact
Documentation only. Production remains qualified at \d8646201aec183a569b18efe0f061223ed3185ee\; this PR does not require redeployment.

## Validation
- \codex-diff-check --cached\`n- staging deploy 32667636938: success
- staging E2E 32668149067: success
- production deploy 32669010834: success
- production E2E 32669902960: success

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Recorded successful staging and production deployment of the Vera Molnár accession correction.
  * Documented independent verification, security checks, and final browser validation.
  * Confirmed the accession is live with decoded media, no fallback or browser errors, and no horizontal overflow across qualified routes and viewports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->