### PR TITLE
Document the Museum homepage release

### DIFF
--- a/ops/workstreams/museum-home-consolidation/active-context.md
+++ b/ops/workstreams/museum-home-consolidation/active-context.md
@@ -1,7 +1,7 @@
 # Museum homepage consolidation
 
-Status: exact production build, deterministic captures, and three-lane visual
-acceptance complete; ready for PR and release
+Status: merged, deployed to staging and production, and qualified by hosted and
+retained browser evidence
 
 ## Release intent
 
@@ -41,3 +41,20 @@ statuses stated plainly.
 
 PR and exact-head bot/CI review, merge, staging deployment and browser E2E,
 then production deployment and live browser readback.
+
+## Release outcome
+
+- PR: `#3815`
+- Exact qualified PR head: `f6337475f96393e1a545d354cebe962b8173ee21`
+- Canonical merge/main: `06ec3e736ea5a8dc131656eef70045916ed5372c`
+- Exact staging composition: `5f3c47ae2b789848d83e6b910f87fbd697f92708`
+- Staging deploy: run `32676652457`, success
+- Automatic staging E2E: run `32677194697`, success
+- Production deploy: run `32678032156`, success
+- Automatic Production E2E: run `32678816271`, success, including the isolated
+  production-evidence verifier
+- Live production version: three consecutive reads returned exact
+  `06ec3e736ea5a8dc131656eef70045916ed5372c` with `stale: false`
+- Live visual readback: one `Acquisitions` section, four acquisition cards, no
+  superseded Collection preview, all nine homepage images decoded, no
+  horizontal overflow, and no browser errors on desktop or 390 px mobile

--- a/ops/workstreams/museum-home-consolidation/run-log.md
+++ b/ops/workstreams/museum-home-consolidation/run-log.md
@@ -61,3 +61,39 @@
   dependency suppression as unnecessary. Removed that suppression and verified
   the file with the exact lint configuration on the current platform; the
   utility's behavior and retained visual evidence are unchanged.
+
+## 2026-08-24
+
+- Exact-head App PR CI run `32675241905` completed successfully across quality,
+  production build, and protected desktop/mobile Museum browser lanes. All
+  external review, security, policy, and analysis checks were green. The sole
+  CodeRabbit thread was resolved on the exact head.
+- PR `#3815` merged at canonical main
+  `06ec3e736ea5a8dc131656eef70045916ed5372c`.
+- Composed the merged main onto the current shared staging ref without a force
+  push. Immediately before the mutation, both the helper and versioned API
+  reported STAGING `OFF` and changeable, the staging lease was free, every
+  staging and production-qualification train was terminal, and the bounded
+  two-repository workflow scan found no staging blocker.
+- Exact staging composition
+  `5f3c47ae2b789848d83e6b910f87fbd697f92708` deployed successfully in run
+  `32676652457`; automatic staging E2E run `32677194697` succeeded against the
+  merged main.
+- Immediately before production dispatch, canonical main remained exact. Both
+  release-control sources reported PRODUCTION `OFF` and changeable, the
+  production lease was free, all production and qualification trains were
+  terminal, and the bounded workflow scan found no competing production actor.
+- Production run `32678032156` built, verified, uploaded, and deployed the exact
+  immutable artifact for main
+  `06ec3e736ea5a8dc131656eef70045916ed5372c`. Three consecutive `/api/version`
+  reads matched that SHA with `stale: false`.
+- Automatic Production E2E run `32678816271` completed successfully. Its
+  read-only pack, isolated production-evidence verifier, and validation
+  notification jobs all succeeded.
+- Retained live production inspection covered the desktop and mobile homepage.
+  The DOM contains exactly one Acquisitions heading and four acquisition
+  articles, with no `In the Collection` or `Current acquisitions` heading. All
+  nine images decoded after mobile lazy loading, document width remained within
+  the viewport, and the browser error log remained empty. The live mobile card
+  composition was also inspected visually at the Keys and Gates and Conflict at
+  Its Edges boundary.


### PR DESCRIPTION
## Summary

- record the exact homepage merge, staging composition, and deployment runs
- record staging and production E2E outcomes
- record the live desktop/mobile production readback

## Scope

Documentation only. No runtime, copy, styling, test, build, or deployment behavior changes. No redeploy is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release records to confirm successful staging and production deployments.
  * Documented end-to-end validation and live homepage checks.
  * Confirmed the Museum homepage displays one Acquisitions heading, four acquisition articles, and nine images without overflow or browser errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->