### PR TITLE
Improve mobile Quick Tag editing on profile Brain pages

### DIFF
--- a/components/user/brain/UserPageBrainActivity.tsx
+++ b/components/user/brain/UserPageBrainActivity.tsx
@@ -18,7 +18,7 @@ function ActivityCardFrame({
 }>) {
   return (
     <section
-      className="tw-relative tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-white/15 tw-bg-black tw-py-4 tw-shadow-2xl md:tw-py-5"
+      className="tw-relative tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-white/15 tw-bg-black tw-py-3 tw-shadow-2xl"
       aria-labelledby="brain-activity-heading"
       data-testid="brain-activity-card"
     >
@@ -37,11 +37,11 @@ function ActivityCardHeader({
   const totalDropsLabel = totalDrops === 0 ? "0" : numberWithCommas(totalDrops);
 
   return (
-    <div className="gap-x-4 tw-mb-4 tw-flex tw-flex-col tw-gap-y-2 tw-px-4 sm:tw-mb-6 sm:tw-flex-row sm:tw-items-center sm:tw-justify-between md:tw-px-5">
+    <div className="gap-x-4 tw-mb-2 tw-flex tw-flex-col tw-gap-y-2 tw-px-4 sm:tw-flex-row sm:tw-items-center sm:tw-justify-between md:tw-px-5">
       <div className="tw-min-w-0">
         <h3
           id="brain-activity-heading"
-          className="tw-mb-0 tw-text-sm tw-font-bold tw-tracking-wide tw-text-iron-50"
+          className="tw-m-0 tw-text-sm tw-font-bold tw-tracking-wide tw-text-iron-50"
         >
           Activity
         </h3>
@@ -83,7 +83,7 @@ export default function UserPageBrainActivity({
     content = <UserPageBrainActivityHeatmapLoading />;
   } else if (activityQuery.status === "error") {
     content = (
-      <p className="tw-px-4 tw-text-sm tw-text-iron-400 md:tw-px-5">
+      <p className="tw-m-0 tw-px-4 tw-text-sm tw-text-iron-400 md:tw-px-5">
         Unable to load activity.
       </p>
     );
@@ -91,7 +91,7 @@ export default function UserPageBrainActivity({
     content = <UserPageBrainActivityHeatmap activity={activity} />;
   } else {
     content = (
-      <p className="tw-px-4 tw-text-sm tw-italic tw-text-iron-500 md:tw-px-5">
+      <p className="tw-m-0 tw-px-4 tw-text-sm tw-italic tw-text-iron-500 md:tw-px-5">
         No activity in last 12 months.
       </p>
     );

--- a/components/user/mention-shortcuts/UserPageMentionShortcuts.tsx
+++ b/components/user/mention-shortcuts/UserPageMentionShortcuts.tsx
@@ -5,459 +5,47 @@ import OverlappingAvatars from "@/components/common/OverlappingAvatars";
 import GroupCreateIdentitySelectedItems from "@/components/groups/page/create/config/GroupCreateIdentitySelectedItems";
 import MobileWrapperDialog from "@/components/mobile-wrapper-dialog/MobileWrapperDialog";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
+import {
+  AliasEditor,
+  getAliasEditorDraft,
+  type AliasEditorDraft,
+} from "@/components/user/mention-shortcuts/UserPageMentionShortcutsEditor";
 import Button from "@/components/utils/button/Button";
-import useKeyboardFocusScroll from "@/components/waves/create-wave/hooks/useKeyboardFocusScroll";
 import {
   QuickTagsBackButton,
   QuickTagsDeleteConfirmation,
   QuickTagsLoadError,
 } from "@/components/user/mention-shortcuts/UserPageMentionShortcutsInlineViews";
-import { getAvailableMentionIdentities } from "@/components/user/mention-shortcuts/userPageMentionShortcuts.helpers";
-import type {
-  MentionAlias,
-  MentionAliasInput,
-  MentionAliasMember,
-} from "@/entities/IMentionAlias";
-import type { CommunityMemberMinimal } from "@/entities/IProfile";
+import type { MentionAlias, MentionAliasInput } from "@/entities/IMentionAlias";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import { getToastErrorDetails } from "@/helpers/toast.helpers";
-import {
-  isReservedMentionAlias,
-  normalizeMentionAlias,
-} from "@/helpers/mentions/mention-aliases.helpers";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
 import { useMentionAliases } from "@/hooks/useMentionAliases";
-import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import useIsMobileScreen from "@/hooks/isMobileScreen";
+import { t } from "@/i18n/messages";
 import {
   createMentionAlias,
   deleteMentionAlias,
   updateMentionAlias,
 } from "@/services/api/mention-aliases-api";
-import { commonApiFetch } from "@/services/api/common-api";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
-  MagnifyingGlassIcon,
   PencilSquareIcon,
   PlusIcon,
   TrashIcon,
 } from "@heroicons/react/24/outline";
-import type { ReactNode, RefObject } from "react";
-import { useContext, useMemo, useRef, useState } from "react";
-import { useBrowserLocale } from "@/hooks/useBrowserLocale";
-import type { SupportedLocale } from "@/i18n/locales";
-import { t } from "@/i18n/messages";
+import type { ReactNode } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 
-const MAX_MEMBERS = 25;
-const MAX_SEARCH_RESULTS = 5;
-const MIN_SEARCH_LENGTH = 3;
 const VISIBLE_QUICK_TAGS = 3;
 const LOADING_MESSAGE_KEY = "user.mentionShortcuts.loading";
 
 type QuickTagsView = "summary" | "manage" | "editor";
 
-type AliasEditorDraft = {
-  readonly alias: string;
-  readonly members: MentionAliasMember[];
-  readonly search: string;
-};
-
 type AliasEditorSaveVariables = {
   readonly aliasId: string | null;
   readonly input: MentionAliasInput;
 };
-
-function getAliasEditorDraft(
-  alias: MentionAlias | null,
-  ownerProfileId: string | null
-): AliasEditorDraft {
-  return {
-    alias: alias?.alias ?? "",
-    members: (alias?.members ?? []).filter(
-      (member) => member.profile_id !== ownerProfileId
-    ),
-    search: "",
-  };
-}
-
-function getAliasErrorDescription(
-  reserved: boolean,
-  aliasIsValid: boolean,
-  hasAlias: boolean
-): string | undefined {
-  if (reserved) return "mention-shortcut-reserved-error";
-  if (!aliasIsValid && hasAlias) return "mention-shortcut-name-error";
-  return undefined;
-}
-
-function getSearchStatus({
-  isFetching,
-  locale,
-  searchIsReady,
-  visibleResultCount,
-}: {
-  readonly isFetching: boolean;
-  readonly locale: SupportedLocale;
-  readonly searchIsReady: boolean;
-  readonly visibleResultCount: number;
-}): string {
-  if (!searchIsReady) {
-    return t(locale, "user.mentionShortcuts.searchPrompt");
-  }
-  if (isFetching) return t(locale, LOADING_MESSAGE_KEY);
-  if (visibleResultCount === 1) {
-    return t(locale, "user.mentionShortcuts.searchResult");
-  }
-  return t(locale, "user.mentionShortcuts.searchResults", {
-    count: visibleResultCount,
-  });
-}
-
-function AliasEditor({
-  backLabel,
-  draft,
-  headingRef,
-  isEditing,
-  isMobileSheet,
-  isSaving,
-  onCancel,
-  onDraftChange,
-  onSave,
-  ownerProfileId,
-}: {
-  readonly backLabel: string;
-  readonly draft: AliasEditorDraft;
-  readonly headingRef: RefObject<HTMLHeadingElement | null>;
-  readonly isEditing: boolean;
-  readonly isMobileSheet: boolean;
-  readonly isSaving: boolean;
-  readonly onCancel: () => void;
-  readonly onDraftChange: (draft: AliasEditorDraft) => void;
-  readonly onSave: (input: MentionAliasInput) => void;
-  readonly ownerProfileId: string | null;
-}) {
-  const locale = useBrowserLocale();
-  const editorContentRef = useRef<HTMLDivElement>(null);
-  useKeyboardFocusScroll(editorContentRef);
-  const { alias, members, search } = draft;
-  const debouncedSearch = useDebouncedValue(search, 200);
-  const profileSearchQuery = useQuery<CommunityMemberMinimal[]>({
-    queryKey: [
-      QueryKey.PROFILE_SEARCH,
-      { param: debouncedSearch, only_profile_owners: "true" },
-    ],
-    queryFn: async () =>
-      await commonApiFetch<CommunityMemberMinimal[]>({
-        endpoint: "community-members",
-        params: {
-          param: debouncedSearch,
-          only_profile_owners: "true",
-        },
-      }),
-    enabled:
-      debouncedSearch.length >= MIN_SEARCH_LENGTH && debouncedSearch === search,
-  });
-  const identities = profileSearchQuery.data ?? [];
-  const normalizedAlias = normalizeMentionAlias(alias);
-  const aliasIsValid = /^\w{3,15}$/.test(normalizedAlias);
-  const reserved = isReservedMentionAlias(normalizedAlias);
-  const aliasHasError = alias.length > 0 && (!aliasIsValid || reserved);
-  const aliasErrorDescription = getAliasErrorDescription(
-    reserved,
-    aliasIsValid,
-    alias.length > 0
-  );
-  const canSave = aliasIsValid && !reserved && members.length > 0;
-
-  const fieldIdPrefix = isMobileSheet ? "quick-tag-sheet" : "mention-shortcut";
-  const nameInputId = `${fieldIdPrefix}-name`;
-  const nameErrorId = `${fieldIdPrefix}-name-error`;
-  const reservedErrorId = `${fieldIdPrefix}-reserved-error`;
-  const searchInputId = `${fieldIdPrefix}-profile-search`;
-  const searchStatusId = `${fieldIdPrefix}-search-status`;
-  let resolvedAliasErrorDescription: string | undefined;
-  if (aliasErrorDescription === "mention-shortcut-name-error") {
-    resolvedAliasErrorDescription = nameErrorId;
-  } else if (aliasErrorDescription === "mention-shortcut-reserved-error") {
-    resolvedAliasErrorDescription = reservedErrorId;
-  }
-
-  const availableIdentities = getAvailableMentionIdentities(
-    identities,
-    members,
-    ownerProfileId
-  );
-  const visibleIdentities = availableIdentities.slice(0, MAX_SEARCH_RESULTS);
-  const searchIsReady =
-    members.length < MAX_MEMBERS &&
-    search.length >= MIN_SEARCH_LENGTH &&
-    debouncedSearch === search;
-  const searchStatus = getSearchStatus({
-    isFetching: profileSearchQuery.isFetching,
-    locale,
-    searchIsReady,
-    visibleResultCount: visibleIdentities.length,
-  });
-
-  const addMember = (identity: CommunityMemberMinimal) => {
-    const { profile_id: profileId, handle } = identity;
-    if (
-      !profileId ||
-      !handle ||
-      profileId === ownerProfileId ||
-      members.length >= MAX_MEMBERS
-    ) {
-      return;
-    }
-    onDraftChange({
-      ...draft,
-      members: [
-        ...members,
-        {
-          profile_id: profileId,
-          handle,
-          pfp: identity.pfp ?? null,
-        },
-      ],
-      search: "",
-    });
-  };
-
-  const save = () => {
-    if (!canSave || isSaving) return;
-    onSave({
-      alias: normalizedAlias,
-      member_profile_ids: [
-        ...new Set(
-          members
-            .map((member) => member.profile_id)
-            .filter((profileId) => profileId !== ownerProfileId)
-        ),
-      ],
-    });
-  };
-
-  const removeMember = (profileId: string) => {
-    onDraftChange({
-      ...draft,
-      members: members.filter((item) => item.profile_id !== profileId),
-    });
-  };
-
-  let searchResultsContent: ReactNode = (
-    <p className="tw-m-0 tw-px-3 tw-py-3 tw-text-sm tw-text-iron-400">
-      {t(locale, "user.mentionShortcuts.searchResults", { count: 0 })}
-    </p>
-  );
-  if (profileSearchQuery.isFetching) {
-    searchResultsContent = (
-      <p className="tw-m-0 tw-px-3 tw-py-3 tw-text-sm tw-text-iron-400">
-        {t(locale, LOADING_MESSAGE_KEY)}
-      </p>
-    );
-  } else if (visibleIdentities.length > 0) {
-    searchResultsContent = (
-      <ul className="tw-m-0 tw-list-none tw-p-0">
-        {visibleIdentities.map((identity) => (
-          <li key={identity.profile_id}>
-            <button
-              type="button"
-              onClick={() => addMember(identity)}
-              className="group tw-flex tw-min-h-11 tw-w-full tw-items-center tw-justify-between tw-gap-3 tw-rounded-lg tw-border-0 tw-bg-transparent tw-px-3 tw-py-2 tw-text-left tw-text-sm tw-font-medium tw-text-iron-200 tw-transition-colors focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 desktop-hover:hover:tw-bg-white/5 desktop-hover:hover:tw-text-white"
-            >
-              <span className="tw-min-w-0 tw-truncate">
-                @{identity.handle}
-                {identity.display && (
-                  <span className="tw-ml-2 tw-text-iron-500">
-                    {identity.display}
-                  </span>
-                )}
-              </span>
-              <PlusIcon
-                aria-hidden="true"
-                className="tw-size-4 tw-flex-none tw-text-iron-600 tw-transition-colors group-hover:tw-text-primary-300"
-              />
-            </button>
-          </li>
-        ))}
-      </ul>
-    );
-  }
-
-  return (
-    <div
-      ref={editorContentRef}
-      aria-labelledby={isMobileSheet ? undefined : "quick-tag-editor-title"}
-    >
-      {!isMobileSheet && (
-        <div className="tw-flex tw-items-center tw-gap-2">
-          <QuickTagsBackButton
-            label={backLabel}
-            onClick={onCancel}
-            disabled={isSaving}
-          />
-          <h3
-            ref={headingRef}
-            id="quick-tag-editor-title"
-            tabIndex={-1}
-            className="tw-m-0 tw-text-sm tw-font-bold tw-tracking-wide tw-text-iron-50 focus:tw-outline-none"
-          >
-            {isEditing
-              ? t(locale, "user.mentionShortcuts.edit")
-              : t(locale, "user.mentionShortcuts.create")}
-          </h3>
-        </div>
-      )}
-      <p className="tw-mb-0 tw-mt-2 tw-max-w-lg tw-text-pretty tw-text-sm tw-leading-5 tw-text-iron-300">
-        {t(locale, "user.mentionShortcuts.editorDescription")}
-      </p>
-
-      <div className="tw-mt-5 tw-space-y-5">
-        <div>
-          <label
-            htmlFor={nameInputId}
-            className="tw-block tw-text-xs tw-font-semibold tw-text-iron-400"
-          >
-            <span>{t(locale, "user.mentionShortcuts.name")}</span>
-            <div
-              className={`tw-mt-1 tw-flex tw-items-center tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-bg-transparent tw-transition-colors focus-within:tw-border-primary-400 ${
-                aliasHasError ? "tw-border-error" : "tw-border-white/10"
-              }`}
-            >
-              <span
-                aria-hidden="true"
-                className="tw-text-sm tw-font-semibold tw-text-iron-500"
-              >
-                @
-              </span>
-              <input
-                id={nameInputId}
-                aria-label={t(locale, "user.mentionShortcuts.name")}
-                aria-invalid={aliasHasError}
-                aria-describedby={resolvedAliasErrorDescription}
-                value={alias}
-                onChange={(event) =>
-                  onDraftChange({ ...draft, alias: event.target.value })
-                }
-                maxLength={15}
-                autoComplete="off"
-                className="tw-min-h-11 tw-w-full tw-border-0 tw-bg-transparent tw-px-1.5 tw-py-2.5 tw-text-sm tw-font-medium tw-text-white tw-outline-none placeholder:tw-text-iron-600"
-              />
-            </div>
-          </label>
-          {!reserved && !aliasIsValid && alias.length > 0 && (
-            <p
-              id={nameErrorId}
-              role="alert"
-              className="tw-mb-0 tw-mt-2 tw-text-xs tw-text-error"
-            >
-              {t(locale, "user.mentionShortcuts.nameError")}
-            </p>
-          )}
-          {reserved && (
-            <p
-              id={reservedErrorId}
-              role="alert"
-              className="tw-mb-0 tw-mt-2 tw-text-xs tw-text-error"
-            >
-              {t(locale, "user.mentionShortcuts.reservedError")}
-            </p>
-          )}
-        </div>
-
-        <div>
-          <label
-            htmlFor={searchInputId}
-            className="tw-block tw-text-xs tw-font-semibold tw-text-iron-400"
-          >
-            {t(locale, "user.mentionShortcuts.addProfiles", {
-              count: members.length,
-              max: MAX_MEMBERS,
-            })}
-          </label>
-
-          <GroupCreateIdentitySelectedItems
-            selectedIdentities={members.map((member) => ({
-              wallet: member.profile_id,
-              handle: member.handle,
-              pfp: member.pfp,
-            }))}
-            onRemove={removeMember}
-            variant="quickTag"
-            handlePrefix="@"
-            getRemoveLabel={(identity) =>
-              t(locale, "user.mentionShortcuts.removeProfile", {
-                handle: identity.handle ?? "",
-              })
-            }
-          />
-
-          <div className="tw-relative tw-mt-2">
-            <div className="tw-flex tw-items-center tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-white/10 tw-transition-colors focus-within:tw-border-primary-400">
-              <MagnifyingGlassIcon
-                aria-hidden="true"
-                className="tw-size-4 tw-flex-none tw-text-iron-600"
-              />
-              <input
-                id={searchInputId}
-                aria-label={t(locale, "user.mentionShortcuts.searchLabel")}
-                aria-describedby={searchStatusId}
-                value={search}
-                onChange={(event) =>
-                  onDraftChange({ ...draft, search: event.target.value })
-                }
-                placeholder={t(
-                  locale,
-                  "user.mentionShortcuts.searchPlaceholder"
-                )}
-                disabled={members.length >= MAX_MEMBERS}
-                autoComplete="off"
-                className="tw-min-h-11 tw-w-full tw-border-0 tw-bg-transparent tw-px-2 tw-py-2.5 tw-text-sm tw-text-white tw-outline-none placeholder:tw-text-iron-600 disabled:tw-cursor-not-allowed disabled:tw-opacity-50"
-              />
-            </div>
-
-            {searchIsReady && (
-              <div
-                className={`tw-z-20 tw-mt-2 tw-max-h-52 tw-overflow-y-auto tw-rounded-xl tw-border tw-border-solid tw-border-white/10 tw-bg-iron-900 tw-p-1.5 tw-shadow-2xl ${
-                  isMobileSheet
-                    ? "tw-relative"
-                    : "tw-absolute tw-left-0 tw-right-0 tw-top-full"
-                }`}
-              >
-                {searchResultsContent}
-              </div>
-            )}
-          </div>
-
-          <p id={searchStatusId} aria-live="polite" className="tw-sr-only">
-            {searchStatus}
-          </p>
-        </div>
-      </div>
-
-      <div className="tw-mt-5 tw-flex tw-flex-col-reverse tw-gap-2 sm:tw-flex-row sm:tw-justify-end">
-        <Button
-          variant="secondary"
-          size="sm"
-          disabled={isSaving}
-          onClick={onCancel}
-        >
-          {t(locale, "user.mentionShortcuts.cancel")}
-        </Button>
-        <Button
-          variant="action"
-          size="sm"
-          disabled={!canSave || isSaving}
-          loading={isSaving}
-          onClick={save}
-        >
-          {isSaving
-            ? t(locale, "user.mentionShortcuts.saving")
-            : t(locale, "user.mentionShortcuts.save")}
-        </Button>
-      </div>
-    </div>
-  );
-}
 
 export default function UserPageMentionShortcuts({
   profile,
@@ -482,10 +70,17 @@ export default function UserPageMentionShortcuts({
     useState<Exclude<QuickTagsView, "editor">>("manage");
   const [aliasToDelete, setAliasToDelete] = useState<MentionAlias | null>(null);
   const viewHeadingRef = useRef<HTMLHeadingElement>(null);
+  const shouldFocusViewHeadingRef = useRef(false);
   const shouldFocusAfterSheetLeaveRef = useRef(false);
 
+  useEffect(() => {
+    if (!shouldFocusViewHeadingRef.current) return;
+    shouldFocusViewHeadingRef.current = false;
+    viewHeadingRef.current?.focus();
+  }, [aliasToDelete, view]);
+
   const requestViewHeadingFocus = () => {
-    requestAnimationFrame(() => viewHeadingRef.current?.focus());
+    shouldFocusViewHeadingRef.current = true;
   };
 
   const changeView = (nextView: QuickTagsView) => {
@@ -915,7 +510,6 @@ export default function UserPageMentionShortcuts({
               key={editorAlias?.id ?? "new"}
               backLabel={t(locale, "user.mentionShortcuts.back")}
               draft={editorDraft}
-              headingRef={viewHeadingRef}
               isEditing={editorAlias !== null}
               isMobileSheet
               isSaving={editorSaveMutation.isPending}

--- a/components/user/mention-shortcuts/UserPageMentionShortcuts.tsx
+++ b/components/user/mention-shortcuts/UserPageMentionShortcuts.tsx
@@ -3,8 +3,10 @@
 import { AuthContext } from "@/components/auth/Auth";
 import OverlappingAvatars from "@/components/common/OverlappingAvatars";
 import GroupCreateIdentitySelectedItems from "@/components/groups/page/create/config/GroupCreateIdentitySelectedItems";
+import MobileWrapperDialog from "@/components/mobile-wrapper-dialog/MobileWrapperDialog";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
 import Button from "@/components/utils/button/Button";
+import useKeyboardFocusScroll from "@/components/waves/create-wave/hooks/useKeyboardFocusScroll";
 import {
   QuickTagsBackButton,
   QuickTagsDeleteConfirmation,
@@ -25,6 +27,7 @@ import {
 } from "@/helpers/mentions/mention-aliases.helpers";
 import { useMentionAliases } from "@/hooks/useMentionAliases";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import useIsMobileScreen from "@/hooks/isMobileScreen";
 import {
   createMentionAlias,
   deleteMentionAlias,
@@ -39,7 +42,7 @@ import {
   TrashIcon,
 } from "@heroicons/react/24/outline";
 import type { ReactNode, RefObject } from "react";
-import { useContext, useEffect, useMemo, useRef, useState } from "react";
+import { useContext, useMemo, useRef, useState } from "react";
 import { useBrowserLocale } from "@/hooks/useBrowserLocale";
 import type { SupportedLocale } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
@@ -51,6 +54,30 @@ const VISIBLE_QUICK_TAGS = 3;
 const LOADING_MESSAGE_KEY = "user.mentionShortcuts.loading";
 
 type QuickTagsView = "summary" | "manage" | "editor";
+
+type AliasEditorDraft = {
+  readonly alias: string;
+  readonly members: MentionAliasMember[];
+  readonly search: string;
+};
+
+type AliasEditorSaveVariables = {
+  readonly aliasId: string | null;
+  readonly input: MentionAliasInput;
+};
+
+function getAliasEditorDraft(
+  alias: MentionAlias | null,
+  ownerProfileId: string | null
+): AliasEditorDraft {
+  return {
+    alias: alias?.alias ?? "",
+    members: (alias?.members ?? []).filter(
+      (member) => member.profile_id !== ownerProfileId
+    ),
+    search: "",
+  };
+}
 
 function getAliasErrorDescription(
   reserved: boolean,
@@ -87,28 +114,31 @@ function getSearchStatus({
 
 function AliasEditor({
   backLabel,
+  draft,
   headingRef,
-  initialAlias,
+  isEditing,
+  isMobileSheet,
+  isSaving,
   onCancel,
-  onSaved,
+  onDraftChange,
+  onSave,
+  ownerProfileId,
 }: {
   readonly backLabel: string;
+  readonly draft: AliasEditorDraft;
   readonly headingRef: RefObject<HTMLHeadingElement | null>;
-  readonly initialAlias: MentionAlias | null;
+  readonly isEditing: boolean;
+  readonly isMobileSheet: boolean;
+  readonly isSaving: boolean;
   readonly onCancel: () => void;
-  readonly onSaved: () => void;
+  readonly onDraftChange: (draft: AliasEditorDraft) => void;
+  readonly onSave: (input: MentionAliasInput) => void;
+  readonly ownerProfileId: string | null;
 }) {
   const locale = useBrowserLocale();
-  const { connectedProfile, setToast } = useContext(AuthContext);
-  const ownerProfileId = connectedProfile?.id ?? null;
-  const queryClient = useQueryClient();
-  const [alias, setAlias] = useState(initialAlias?.alias ?? "");
-  const [members, setMembers] = useState<MentionAliasMember[]>(() =>
-    (initialAlias?.members ?? []).filter(
-      (member) => member.profile_id !== ownerProfileId
-    )
-  );
-  const [search, setSearch] = useState("");
+  const editorContentRef = useRef<HTMLDivElement>(null);
+  useKeyboardFocusScroll(editorContentRef);
+  const { alias, members, search } = draft;
   const debouncedSearch = useDebouncedValue(search, 200);
   const profileSearchQuery = useQuery<CommunityMemberMinimal[]>({
     queryKey: [
@@ -138,34 +168,18 @@ function AliasEditor({
   );
   const canSave = aliasIsValid && !reserved && members.length > 0;
 
-  const mutation = useMutation({
-    mutationFn: async (input: MentionAliasInput) =>
-      initialAlias
-        ? updateMentionAlias(initialAlias.id, input)
-        : createMentionAlias(input),
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: [QueryKey.MENTION_ALIASES],
-      });
-      setToast({
-        type: "success",
-        message: initialAlias
-          ? t(locale, "user.mentionShortcuts.updated")
-          : t(locale, "user.mentionShortcuts.created"),
-      });
-      onSaved();
-    },
-    onError: (error) => {
-      setToast({
-        type: "error",
-        title: t(locale, "user.mentionShortcuts.saveErrorTitle"),
-        details: getToastErrorDetails(
-          error,
-          t(locale, "user.mentionShortcuts.saveErrorDetails")
-        ),
-      });
-    },
-  });
+  const fieldIdPrefix = isMobileSheet ? "quick-tag-sheet" : "mention-shortcut";
+  const nameInputId = `${fieldIdPrefix}-name`;
+  const nameErrorId = `${fieldIdPrefix}-name-error`;
+  const reservedErrorId = `${fieldIdPrefix}-reserved-error`;
+  const searchInputId = `${fieldIdPrefix}-profile-search`;
+  const searchStatusId = `${fieldIdPrefix}-search-status`;
+  let resolvedAliasErrorDescription: string | undefined;
+  if (aliasErrorDescription === "mention-shortcut-name-error") {
+    resolvedAliasErrorDescription = nameErrorId;
+  } else if (aliasErrorDescription === "mention-shortcut-reserved-error") {
+    resolvedAliasErrorDescription = reservedErrorId;
+  }
 
   const availableIdentities = getAvailableMentionIdentities(
     identities,
@@ -194,20 +208,23 @@ function AliasEditor({
     ) {
       return;
     }
-    setMembers((current) => [
-      ...current,
-      {
-        profile_id: profileId,
-        handle,
-        pfp: identity.pfp ?? null,
-      },
-    ]);
-    setSearch("");
+    onDraftChange({
+      ...draft,
+      members: [
+        ...members,
+        {
+          profile_id: profileId,
+          handle,
+          pfp: identity.pfp ?? null,
+        },
+      ],
+      search: "",
+    });
   };
 
   const save = () => {
-    if (!canSave || mutation.isPending) return;
-    mutation.mutate({
+    if (!canSave || isSaving) return;
+    onSave({
       alias: normalizedAlias,
       member_profile_ids: [
         ...new Set(
@@ -220,9 +237,10 @@ function AliasEditor({
   };
 
   const removeMember = (profileId: string) => {
-    setMembers((current) =>
-      current.filter((item) => item.profile_id !== profileId)
-    );
+    onDraftChange({
+      ...draft,
+      members: members.filter((item) => item.profile_id !== profileId),
+    });
   };
 
   let searchResultsContent: ReactNode = (
@@ -266,32 +284,37 @@ function AliasEditor({
   }
 
   return (
-    <div aria-labelledby="quick-tag-editor-title">
-      <div className="tw-flex tw-items-center tw-gap-2">
-        <QuickTagsBackButton
-          label={backLabel}
-          onClick={onCancel}
-          disabled={mutation.isPending}
-        />
-        <h3
-          ref={headingRef}
-          id="quick-tag-editor-title"
-          tabIndex={-1}
-          className="tw-m-0 tw-text-sm tw-font-bold tw-tracking-wide tw-text-iron-50 focus:tw-outline-none"
-        >
-          {initialAlias
-            ? t(locale, "user.mentionShortcuts.edit")
-            : t(locale, "user.mentionShortcuts.create")}
-        </h3>
-      </div>
-      <p className="tw-mb-0 tw-mt-1 tw-text-sm tw-leading-5 tw-text-iron-400">
+    <div
+      ref={editorContentRef}
+      aria-labelledby={isMobileSheet ? undefined : "quick-tag-editor-title"}
+    >
+      {!isMobileSheet && (
+        <div className="tw-flex tw-items-center tw-gap-2">
+          <QuickTagsBackButton
+            label={backLabel}
+            onClick={onCancel}
+            disabled={isSaving}
+          />
+          <h3
+            ref={headingRef}
+            id="quick-tag-editor-title"
+            tabIndex={-1}
+            className="tw-m-0 tw-text-sm tw-font-bold tw-tracking-wide tw-text-iron-50 focus:tw-outline-none"
+          >
+            {isEditing
+              ? t(locale, "user.mentionShortcuts.edit")
+              : t(locale, "user.mentionShortcuts.create")}
+          </h3>
+        </div>
+      )}
+      <p className="tw-mb-0 tw-mt-2 tw-max-w-lg tw-text-pretty tw-text-sm tw-leading-5 tw-text-iron-300">
         {t(locale, "user.mentionShortcuts.editorDescription")}
       </p>
 
       <div className="tw-mt-5 tw-space-y-5">
         <div>
           <label
-            htmlFor="mention-shortcut-name"
+            htmlFor={nameInputId}
             className="tw-block tw-text-xs tw-font-semibold tw-text-iron-400"
           >
             <span>{t(locale, "user.mentionShortcuts.name")}</span>
@@ -307,12 +330,14 @@ function AliasEditor({
                 @
               </span>
               <input
-                id="mention-shortcut-name"
+                id={nameInputId}
                 aria-label={t(locale, "user.mentionShortcuts.name")}
                 aria-invalid={aliasHasError}
-                aria-describedby={aliasErrorDescription}
+                aria-describedby={resolvedAliasErrorDescription}
                 value={alias}
-                onChange={(event) => setAlias(event.target.value)}
+                onChange={(event) =>
+                  onDraftChange({ ...draft, alias: event.target.value })
+                }
                 maxLength={15}
                 autoComplete="off"
                 className="tw-min-h-11 tw-w-full tw-border-0 tw-bg-transparent tw-px-1.5 tw-py-2.5 tw-text-sm tw-font-medium tw-text-white tw-outline-none placeholder:tw-text-iron-600"
@@ -321,7 +346,7 @@ function AliasEditor({
           </label>
           {!reserved && !aliasIsValid && alias.length > 0 && (
             <p
-              id="mention-shortcut-name-error"
+              id={nameErrorId}
               role="alert"
               className="tw-mb-0 tw-mt-2 tw-text-xs tw-text-error"
             >
@@ -330,7 +355,7 @@ function AliasEditor({
           )}
           {reserved && (
             <p
-              id="mention-shortcut-reserved-error"
+              id={reservedErrorId}
               role="alert"
               className="tw-mb-0 tw-mt-2 tw-text-xs tw-text-error"
             >
@@ -341,7 +366,7 @@ function AliasEditor({
 
         <div>
           <label
-            htmlFor="mention-shortcut-profile-search"
+            htmlFor={searchInputId}
             className="tw-block tw-text-xs tw-font-semibold tw-text-iron-400"
           >
             {t(locale, "user.mentionShortcuts.addProfiles", {
@@ -373,11 +398,13 @@ function AliasEditor({
                 className="tw-size-4 tw-flex-none tw-text-iron-600"
               />
               <input
-                id="mention-shortcut-profile-search"
+                id={searchInputId}
                 aria-label={t(locale, "user.mentionShortcuts.searchLabel")}
-                aria-describedby="mention-shortcut-search-status"
+                aria-describedby={searchStatusId}
                 value={search}
-                onChange={(event) => setSearch(event.target.value)}
+                onChange={(event) =>
+                  onDraftChange({ ...draft, search: event.target.value })
+                }
                 placeholder={t(
                   locale,
                   "user.mentionShortcuts.searchPlaceholder"
@@ -389,17 +416,19 @@ function AliasEditor({
             </div>
 
             {searchIsReady && (
-              <div className="tw-absolute tw-left-0 tw-right-0 tw-top-full tw-z-20 tw-mt-2 tw-max-h-52 tw-overflow-y-auto tw-rounded-xl tw-border tw-border-solid tw-border-white/10 tw-bg-iron-900 tw-p-1.5 tw-shadow-2xl">
+              <div
+                className={`tw-z-20 tw-mt-2 tw-max-h-52 tw-overflow-y-auto tw-rounded-xl tw-border tw-border-solid tw-border-white/10 tw-bg-iron-900 tw-p-1.5 tw-shadow-2xl ${
+                  isMobileSheet
+                    ? "tw-relative"
+                    : "tw-absolute tw-left-0 tw-right-0 tw-top-full"
+                }`}
+              >
                 {searchResultsContent}
               </div>
             )}
           </div>
 
-          <p
-            id="mention-shortcut-search-status"
-            aria-live="polite"
-            className="tw-sr-only"
-          >
+          <p id={searchStatusId} aria-live="polite" className="tw-sr-only">
             {searchStatus}
           </p>
         </div>
@@ -409,7 +438,7 @@ function AliasEditor({
         <Button
           variant="secondary"
           size="sm"
-          disabled={mutation.isPending}
+          disabled={isSaving}
           onClick={onCancel}
         >
           {t(locale, "user.mentionShortcuts.cancel")}
@@ -417,11 +446,11 @@ function AliasEditor({
         <Button
           variant="action"
           size="sm"
-          disabled={!canSave}
-          loading={mutation.isPending}
+          disabled={!canSave || isSaving}
+          loading={isSaving}
           onClick={save}
         >
-          {mutation.isPending
+          {isSaving
             ? t(locale, "user.mentionShortcuts.saving")
             : t(locale, "user.mentionShortcuts.save")}
         </Button>
@@ -438,30 +467,25 @@ export default function UserPageMentionShortcuts({
   const locale = useBrowserLocale();
   const { connectedProfile, activeProfileProxy, setToast } =
     useContext(AuthContext);
+  const isMobileScreen = useIsMobileScreen();
+  const ownerProfileId = connectedProfile?.id ?? null;
   const isOwner =
-    !!profile.id &&
-    connectedProfile?.id === profile.id &&
-    !activeProfileProxy;
+    !!profile.id && ownerProfileId === profile.id && !activeProfileProxy;
   const queryClient = useQueryClient();
   const { aliases, isPending, isError, refetch } = useMentionAliases({
     enabled: isOwner,
   });
   const [view, setView] = useState<QuickTagsView>("summary");
   const [editorAlias, setEditorAlias] = useState<MentionAlias | null>(null);
+  const [editorDraft, setEditorDraft] = useState<AliasEditorDraft | null>(null);
   const [editorReturnView, setEditorReturnView] =
     useState<Exclude<QuickTagsView, "editor">>("manage");
   const [aliasToDelete, setAliasToDelete] = useState<MentionAlias | null>(null);
   const viewHeadingRef = useRef<HTMLHeadingElement>(null);
-  const shouldFocusViewHeadingRef = useRef(false);
-
-  useEffect(() => {
-    if (!shouldFocusViewHeadingRef.current) return;
-    shouldFocusViewHeadingRef.current = false;
-    viewHeadingRef.current?.focus();
-  }, [aliasToDelete, view]);
+  const shouldFocusAfterSheetLeaveRef = useRef(false);
 
   const requestViewHeadingFocus = () => {
-    shouldFocusViewHeadingRef.current = true;
+    requestAnimationFrame(() => viewHeadingRef.current?.focus());
   };
 
   const changeView = (nextView: QuickTagsView) => {
@@ -480,6 +504,45 @@ export default function UserPageMentionShortcuts({
     setAliasToDelete(alias);
   };
 
+  const clearEditorState = () => {
+    setEditorAlias(null);
+    setEditorDraft(null);
+  };
+
+  const editorSaveMutation = useMutation({
+    mutationFn: async ({ aliasId, input }: AliasEditorSaveVariables) =>
+      aliasId ? updateMentionAlias(aliasId, input) : createMentionAlias(input),
+    onSuccess: async (_data, { aliasId }) => {
+      await queryClient.invalidateQueries({
+        queryKey: [QueryKey.MENTION_ALIASES],
+      });
+      setToast({
+        type: "success",
+        message: aliasId
+          ? t(locale, "user.mentionShortcuts.updated")
+          : t(locale, "user.mentionShortcuts.created"),
+      });
+
+      if (isMobileScreen) {
+        shouldFocusAfterSheetLeaveRef.current = true;
+      } else {
+        requestViewHeadingFocus();
+        clearEditorState();
+      }
+      setView("manage");
+    },
+    onError: (error) => {
+      setToast({
+        type: "error",
+        title: t(locale, "user.mentionShortcuts.saveErrorTitle"),
+        details: getToastErrorDetails(
+          error,
+          t(locale, "user.mentionShortcuts.saveErrorDetails")
+        ),
+      });
+    },
+  });
+
   const deleteMutation = useMutation({
     mutationFn: deleteMentionAlias,
     onSuccess: async (_data, deletedAliasId) => {
@@ -497,7 +560,7 @@ export default function UserPageMentionShortcuts({
         setView("summary");
       }
       setAliasToDelete(null);
-      setEditorAlias(null);
+      clearEditorState();
     },
     onError: (error) =>
       setToast({
@@ -526,14 +589,49 @@ export default function UserPageMentionShortcuts({
     alias: MentionAlias | null,
     returnView: Exclude<QuickTagsView, "editor">
   ) => {
+    shouldFocusAfterSheetLeaveRef.current = false;
     setEditorAlias(alias);
+    setEditorDraft(getAliasEditorDraft(alias, ownerProfileId));
     setEditorReturnView(returnView);
-    changeView("editor");
+    setAliasToDelete(null);
+    setView("editor");
+    if (!isMobileScreen) {
+      requestViewHeadingFocus();
+    }
+  };
+
+  const cancelEditing = () => {
+    if (editorSaveMutation.isPending) return;
+
+    shouldFocusAfterSheetLeaveRef.current = false;
+    setView(editorReturnView);
+    if (!isMobileScreen) {
+      requestViewHeadingFocus();
+      clearEditorState();
+    }
+  };
+
+  const saveEditor = (input: MentionAliasInput) => {
+    if (editorSaveMutation.isPending) return;
+    editorSaveMutation.mutate({
+      aliasId: editorAlias?.id ?? null,
+      input,
+    });
+  };
+
+  const handleEditorSheetAfterLeave = () => {
+    if (view === "editor") return;
+
+    clearEditorState();
+    if (shouldFocusAfterSheetLeaveRef.current) {
+      shouldFocusAfterSheetLeaveRef.current = false;
+      viewHeadingRef.current?.focus();
+    }
   };
 
   const showSummary = () => {
     setAliasToDelete(null);
-    setEditorAlias(null);
+    clearEditorState();
     changeView("summary");
   };
 
@@ -541,17 +639,20 @@ export default function UserPageMentionShortcuts({
     return null;
   }
 
+  const displayedView =
+    view === "editor" && isMobileScreen ? editorReturnView : view;
+
   let labelledBy = "quick-tags-heading";
-  if (view === "manage" && aliasToDelete) {
+  if (displayedView === "manage" && aliasToDelete) {
     labelledBy = "delete-mention-shortcut-title";
-  } else if (view === "manage") {
+  } else if (displayedView === "manage") {
     labelledBy = "quick-tags-manager-title";
-  } else if (view === "editor") {
+  } else if (displayedView === "editor") {
     labelledBy = "quick-tag-editor-title";
   }
 
   let content: ReactNode;
-  if (view === "manage" && aliasToDelete) {
+  if (displayedView === "manage" && aliasToDelete) {
     content = (
       <QuickTagsDeleteConfirmation
         alias={aliasToDelete}
@@ -561,7 +662,7 @@ export default function UserPageMentionShortcuts({
         onConfirm={() => deleteMutation.mutate(aliasToDelete.id)}
       />
     );
-  } else if (view === "summary") {
+  } else if (displayedView === "summary") {
     content = (
       <div>
         <div className="tw-flex tw-items-start tw-justify-between tw-gap-3">
@@ -606,10 +707,7 @@ export default function UserPageMentionShortcuts({
               onClick={() => startEditing(null, "summary")}
               className="tw-min-h-11 sm:tw-min-h-9"
             >
-              <PlusIcon
-                aria-hidden="true"
-                className="-tw-ml-0.5 tw-size-4"
-              />
+              <PlusIcon aria-hidden="true" className="-tw-ml-0.5 tw-size-4" />
               {t(locale, "user.mentionShortcuts.new")}
             </Button>
           )}
@@ -659,7 +757,7 @@ export default function UserPageMentionShortcuts({
         </div>
       </div>
     );
-  } else if (view === "manage") {
+  } else if (displayedView === "manage") {
     content = (
       <div data-testid="quick-tags-manager">
         <div className="tw-flex tw-items-center tw-justify-between tw-gap-3">
@@ -767,31 +865,68 @@ export default function UserPageMentionShortcuts({
       </div>
     );
   } else {
-    content = (
+    content = editorDraft ? (
       <AliasEditor
         key={editorAlias?.id ?? "new"}
         backLabel={t(locale, "user.mentionShortcuts.back")}
+        draft={editorDraft}
         headingRef={viewHeadingRef}
-        initialAlias={editorAlias}
-        onCancel={() => {
-          setEditorAlias(null);
-          changeView(editorReturnView);
-        }}
-        onSaved={() => {
-          setEditorAlias(null);
-          changeView("manage");
-        }}
+        isEditing={editorAlias !== null}
+        isMobileSheet={false}
+        isSaving={editorSaveMutation.isPending}
+        onCancel={cancelEditing}
+        onDraftChange={setEditorDraft}
+        onSave={saveEditor}
+        ownerProfileId={ownerProfileId}
       />
-    );
+    ) : null;
   }
 
   return (
-    <section
-      aria-labelledby={labelledBy}
-      className="tw-relative tw-rounded-xl tw-border tw-border-solid tw-border-white/15 tw-bg-black tw-px-4 tw-py-3 tw-shadow-2xl"
-      data-testid="quick-tags-section"
-    >
-      {content}
-    </section>
+    <>
+      <section
+        aria-labelledby={labelledBy}
+        className="tw-relative tw-rounded-xl tw-border tw-border-solid tw-border-white/15 tw-bg-black tw-px-4 tw-py-3 tw-shadow-2xl"
+        data-testid="quick-tags-section"
+      >
+        {content}
+      </section>
+
+      <MobileWrapperDialog
+        title={
+          editorAlias
+            ? t(locale, "user.mentionShortcuts.edit")
+            : t(locale, "user.mentionShortcuts.create")
+        }
+        isOpen={isMobileScreen && view === "editor" && editorDraft !== null}
+        onClose={cancelEditing}
+        onBack={cancelEditing}
+        onAfterLeave={handleEditorSheetAfterLeave}
+        backLabel={t(locale, "user.mentionShortcuts.back")}
+        dismissible={!editorSaveMutation.isPending}
+        enableDragToClose
+        showScrollbar
+        tall
+        headerClassName="tw-pb-2"
+      >
+        {editorDraft && (
+          <div className="tw-px-4 sm:tw-px-6">
+            <AliasEditor
+              key={editorAlias?.id ?? "new"}
+              backLabel={t(locale, "user.mentionShortcuts.back")}
+              draft={editorDraft}
+              headingRef={viewHeadingRef}
+              isEditing={editorAlias !== null}
+              isMobileSheet
+              isSaving={editorSaveMutation.isPending}
+              onCancel={cancelEditing}
+              onDraftChange={setEditorDraft}
+              onSave={saveEditor}
+              ownerProfileId={ownerProfileId}
+            />
+          </div>
+        )}
+      </MobileWrapperDialog>
+    </>
   );
 }

--- a/components/user/mention-shortcuts/UserPageMentionShortcuts.tsx
+++ b/components/user/mention-shortcuts/UserPageMentionShortcuts.tsx
@@ -47,6 +47,18 @@ type AliasEditorSaveVariables = {
   readonly input: MentionAliasInput;
 };
 
+function getQuickTagsLabelledBy(
+  displayedView: QuickTagsView,
+  hasDeleteConfirmation: boolean
+) {
+  if (displayedView === "manage" && hasDeleteConfirmation) {
+    return "delete-mention-shortcut-title";
+  }
+  if (displayedView === "manage") return "quick-tags-manager-title";
+  if (displayedView === "editor") return "quick-tag-editor-title";
+  return "quick-tags-heading";
+}
+
 export default function UserPageMentionShortcuts({
   profile,
 }: {
@@ -236,15 +248,7 @@ export default function UserPageMentionShortcuts({
 
   const displayedView =
     view === "editor" && isMobileScreen ? editorReturnView : view;
-
-  let labelledBy = "quick-tags-heading";
-  if (displayedView === "manage" && aliasToDelete) {
-    labelledBy = "delete-mention-shortcut-title";
-  } else if (displayedView === "manage") {
-    labelledBy = "quick-tags-manager-title";
-  } else if (displayedView === "editor") {
-    labelledBy = "quick-tag-editor-title";
-  }
+  const labelledBy = getQuickTagsLabelledBy(displayedView, !!aliasToDelete);
 
   let content: ReactNode;
   if (displayedView === "manage" && aliasToDelete) {

--- a/components/user/mention-shortcuts/UserPageMentionShortcutsEditor.tsx
+++ b/components/user/mention-shortcuts/UserPageMentionShortcutsEditor.tsx
@@ -1,0 +1,431 @@
+import GroupCreateIdentitySelectedItems from "@/components/groups/page/create/config/GroupCreateIdentitySelectedItems";
+import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
+import Button from "@/components/utils/button/Button";
+import useKeyboardFocusScroll from "@/components/waves/create-wave/hooks/useKeyboardFocusScroll";
+import { QuickTagsBackButton } from "@/components/user/mention-shortcuts/UserPageMentionShortcutsInlineViews";
+import { getAvailableMentionIdentities } from "@/components/user/mention-shortcuts/userPageMentionShortcuts.helpers";
+import type {
+  MentionAlias,
+  MentionAliasInput,
+  MentionAliasMember,
+} from "@/entities/IMentionAlias";
+import type { CommunityMemberMinimal } from "@/entities/IProfile";
+import {
+  isReservedMentionAlias,
+  normalizeMentionAlias,
+} from "@/helpers/mentions/mention-aliases.helpers";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import type { SupportedLocale } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
+import { commonApiFetch } from "@/services/api/common-api";
+import { useQuery } from "@tanstack/react-query";
+import {
+  MagnifyingGlassIcon,
+  PlusIcon,
+} from "@heroicons/react/24/outline";
+import { useRef, type ReactNode, type RefObject } from "react";
+
+const MAX_MEMBERS = 25;
+const MAX_SEARCH_RESULTS = 5;
+const MIN_SEARCH_LENGTH = 3;
+const LOADING_MESSAGE_KEY = "user.mentionShortcuts.loading";
+
+export type AliasEditorDraft = {
+  readonly alias: string;
+  readonly members: MentionAliasMember[];
+  readonly search: string;
+};
+
+export function getAliasEditorDraft(
+  alias: MentionAlias | null,
+  ownerProfileId: string | null
+): AliasEditorDraft {
+  return {
+    alias: alias?.alias ?? "",
+    members: (alias?.members ?? []).filter(
+      (member) => member.profile_id !== ownerProfileId
+    ),
+    search: "",
+  };
+}
+
+function getAliasErrorDescription(
+  reserved: boolean,
+  aliasIsValid: boolean,
+  hasAlias: boolean
+): string | undefined {
+  if (reserved) return "mention-shortcut-reserved-error";
+  if (!aliasIsValid && hasAlias) return "mention-shortcut-name-error";
+  return undefined;
+}
+
+function getSearchStatus({
+  isFetching,
+  locale,
+  searchIsReady,
+  visibleResultCount,
+}: {
+  readonly isFetching: boolean;
+  readonly locale: SupportedLocale;
+  readonly searchIsReady: boolean;
+  readonly visibleResultCount: number;
+}): string {
+  if (!searchIsReady) {
+    return t(locale, "user.mentionShortcuts.searchPrompt");
+  }
+  if (isFetching) return t(locale, LOADING_MESSAGE_KEY);
+  if (visibleResultCount === 1) {
+    return t(locale, "user.mentionShortcuts.searchResult");
+  }
+  return t(locale, "user.mentionShortcuts.searchResults", {
+    count: visibleResultCount,
+  });
+}
+
+export function AliasEditor({
+  backLabel,
+  draft,
+  headingRef,
+  isEditing,
+  isMobileSheet,
+  isSaving,
+  onCancel,
+  onDraftChange,
+  onSave,
+  ownerProfileId,
+}: {
+  readonly backLabel: string;
+  readonly draft: AliasEditorDraft;
+  readonly headingRef?: RefObject<HTMLHeadingElement | null> | undefined;
+  readonly isEditing: boolean;
+  readonly isMobileSheet: boolean;
+  readonly isSaving: boolean;
+  readonly onCancel: () => void;
+  readonly onDraftChange: (draft: AliasEditorDraft) => void;
+  readonly onSave: (input: MentionAliasInput) => void;
+  readonly ownerProfileId: string | null;
+}) {
+  const locale = useBrowserLocale();
+  const editorContentRef = useRef<HTMLDivElement>(null);
+  useKeyboardFocusScroll(editorContentRef);
+  const { alias, members, search } = draft;
+  const debouncedSearch = useDebouncedValue(search, 200);
+  const profileSearchQuery = useQuery<CommunityMemberMinimal[]>({
+    queryKey: [
+      QueryKey.PROFILE_SEARCH,
+      { param: debouncedSearch, only_profile_owners: "true" },
+    ],
+    queryFn: async () =>
+      await commonApiFetch<CommunityMemberMinimal[]>({
+        endpoint: "community-members",
+        params: {
+          param: debouncedSearch,
+          only_profile_owners: "true",
+        },
+      }),
+    enabled:
+      debouncedSearch.length >= MIN_SEARCH_LENGTH && debouncedSearch === search,
+  });
+  const identities = profileSearchQuery.data ?? [];
+  const normalizedAlias = normalizeMentionAlias(alias);
+  const aliasIsValid = /^\w{3,15}$/.test(normalizedAlias);
+  const reserved = isReservedMentionAlias(normalizedAlias);
+  const aliasHasError = alias.length > 0 && (!aliasIsValid || reserved);
+  const aliasErrorDescription = getAliasErrorDescription(
+    reserved,
+    aliasIsValid,
+    alias.length > 0
+  );
+  const canSave = aliasIsValid && !reserved && members.length > 0;
+
+  const fieldIdPrefix = isMobileSheet ? "quick-tag-sheet" : "mention-shortcut";
+  const nameInputId = `${fieldIdPrefix}-name`;
+  const nameErrorId = `${fieldIdPrefix}-name-error`;
+  const reservedErrorId = `${fieldIdPrefix}-reserved-error`;
+  const searchInputId = `${fieldIdPrefix}-profile-search`;
+  const searchStatusId = `${fieldIdPrefix}-search-status`;
+  let resolvedAliasErrorDescription: string | undefined;
+  if (aliasErrorDescription === "mention-shortcut-name-error") {
+    resolvedAliasErrorDescription = nameErrorId;
+  } else if (aliasErrorDescription === "mention-shortcut-reserved-error") {
+    resolvedAliasErrorDescription = reservedErrorId;
+  }
+
+  const availableIdentities = getAvailableMentionIdentities(
+    identities,
+    members,
+    ownerProfileId
+  );
+  const visibleIdentities = availableIdentities.slice(0, MAX_SEARCH_RESULTS);
+  const searchIsReady =
+    members.length < MAX_MEMBERS &&
+    search.length >= MIN_SEARCH_LENGTH &&
+    debouncedSearch === search;
+  const searchStatus = getSearchStatus({
+    isFetching: profileSearchQuery.isFetching,
+    locale,
+    searchIsReady,
+    visibleResultCount: visibleIdentities.length,
+  });
+
+  const addMember = (identity: CommunityMemberMinimal) => {
+    const { profile_id: profileId, handle } = identity;
+    if (
+      !profileId ||
+      !handle ||
+      profileId === ownerProfileId ||
+      members.length >= MAX_MEMBERS
+    ) {
+      return;
+    }
+    onDraftChange({
+      ...draft,
+      members: [
+        ...members,
+        {
+          profile_id: profileId,
+          handle,
+          pfp: identity.pfp ?? null,
+        },
+      ],
+      search: "",
+    });
+  };
+
+  const save = () => {
+    if (!canSave || isSaving) return;
+    onSave({
+      alias: normalizedAlias,
+      member_profile_ids: [
+        ...new Set(
+          members
+            .map((member) => member.profile_id)
+            .filter((profileId) => profileId !== ownerProfileId)
+        ),
+      ],
+    });
+  };
+
+  const removeMember = (profileId: string) => {
+    onDraftChange({
+      ...draft,
+      members: members.filter((item) => item.profile_id !== profileId),
+    });
+  };
+
+  let searchResultsContent: ReactNode = (
+    <p className="tw-m-0 tw-px-3 tw-py-3 tw-text-sm tw-text-iron-400">
+      {t(locale, "user.mentionShortcuts.searchResults", { count: 0 })}
+    </p>
+  );
+  if (profileSearchQuery.isFetching) {
+    searchResultsContent = (
+      <p className="tw-m-0 tw-px-3 tw-py-3 tw-text-sm tw-text-iron-400">
+        {t(locale, LOADING_MESSAGE_KEY)}
+      </p>
+    );
+  } else if (visibleIdentities.length > 0) {
+    searchResultsContent = (
+      <ul className="tw-m-0 tw-list-none tw-p-0">
+        {visibleIdentities.map((identity) => (
+          <li key={identity.profile_id}>
+            <button
+              type="button"
+              onClick={() => addMember(identity)}
+              className="group tw-flex tw-min-h-11 tw-w-full tw-items-center tw-justify-between tw-gap-3 tw-rounded-lg tw-border-0 tw-bg-transparent tw-px-3 tw-py-2 tw-text-left tw-text-sm tw-font-medium tw-text-iron-200 tw-transition-colors focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 desktop-hover:hover:tw-bg-white/5 desktop-hover:hover:tw-text-white"
+            >
+              <span className="tw-min-w-0 tw-truncate">
+                @{identity.handle}
+                {identity.display && (
+                  <span className="tw-ml-2 tw-text-iron-500">
+                    {identity.display}
+                  </span>
+                )}
+              </span>
+              <PlusIcon
+                aria-hidden="true"
+                className="tw-size-4 tw-flex-none tw-text-iron-600 tw-transition-colors group-hover:tw-text-primary-300"
+              />
+            </button>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  return (
+    <div
+      ref={editorContentRef}
+      aria-labelledby={isMobileSheet ? undefined : "quick-tag-editor-title"}
+    >
+      {!isMobileSheet && (
+        <div className="tw-flex tw-items-center tw-gap-2">
+          <QuickTagsBackButton
+            label={backLabel}
+            onClick={onCancel}
+            disabled={isSaving}
+          />
+          <h3
+            ref={headingRef}
+            id="quick-tag-editor-title"
+            tabIndex={-1}
+            className="tw-m-0 tw-text-sm tw-font-bold tw-tracking-wide tw-text-iron-50 focus:tw-outline-none"
+          >
+            {isEditing
+              ? t(locale, "user.mentionShortcuts.edit")
+              : t(locale, "user.mentionShortcuts.create")}
+          </h3>
+        </div>
+      )}
+      <p className="tw-mb-0 tw-mt-2 tw-max-w-lg tw-text-pretty tw-text-sm tw-leading-5 tw-text-iron-300">
+        {t(locale, "user.mentionShortcuts.editorDescription")}
+      </p>
+
+      <div className="tw-mt-5 tw-space-y-5">
+        <div>
+          <label
+            htmlFor={nameInputId}
+            className="tw-block tw-text-xs tw-font-semibold tw-text-iron-400"
+          >
+            <span>{t(locale, "user.mentionShortcuts.name")}</span>
+            <div
+              className={`tw-mt-1 tw-flex tw-items-center tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-bg-transparent tw-transition-colors focus-within:tw-border-primary-400 ${
+                aliasHasError ? "tw-border-error" : "tw-border-white/10"
+              }`}
+            >
+              <span
+                aria-hidden="true"
+                className="tw-text-sm tw-font-semibold tw-text-iron-500"
+              >
+                @
+              </span>
+              <input
+                id={nameInputId}
+                aria-label={t(locale, "user.mentionShortcuts.name")}
+                aria-invalid={aliasHasError}
+                aria-describedby={resolvedAliasErrorDescription}
+                value={alias}
+                onChange={(event) =>
+                  onDraftChange({ ...draft, alias: event.target.value })
+                }
+                maxLength={15}
+                autoComplete="off"
+                className="tw-min-h-11 tw-w-full tw-border-0 tw-bg-transparent tw-px-1.5 tw-py-2.5 tw-text-sm tw-font-medium tw-text-white tw-outline-none placeholder:tw-text-iron-600"
+              />
+            </div>
+          </label>
+          {!reserved && !aliasIsValid && alias.length > 0 && (
+            <p
+              id={nameErrorId}
+              role="alert"
+              className="tw-mb-0 tw-mt-2 tw-text-xs tw-text-error"
+            >
+              {t(locale, "user.mentionShortcuts.nameError")}
+            </p>
+          )}
+          {reserved && (
+            <p
+              id={reservedErrorId}
+              role="alert"
+              className="tw-mb-0 tw-mt-2 tw-text-xs tw-text-error"
+            >
+              {t(locale, "user.mentionShortcuts.reservedError")}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label
+            htmlFor={searchInputId}
+            className="tw-block tw-text-xs tw-font-semibold tw-text-iron-400"
+          >
+            {t(locale, "user.mentionShortcuts.addProfiles", {
+              count: members.length,
+              max: MAX_MEMBERS,
+            })}
+          </label>
+
+          <GroupCreateIdentitySelectedItems
+            selectedIdentities={members.map((member) => ({
+              wallet: member.profile_id,
+              handle: member.handle,
+              pfp: member.pfp,
+            }))}
+            onRemove={removeMember}
+            variant="quickTag"
+            handlePrefix="@"
+            getRemoveLabel={(identity) =>
+              t(locale, "user.mentionShortcuts.removeProfile", {
+                handle: identity.handle ?? "",
+              })
+            }
+          />
+
+          <div className="tw-relative tw-mt-2">
+            <div className="tw-flex tw-items-center tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-white/10 tw-transition-colors focus-within:tw-border-primary-400">
+              <MagnifyingGlassIcon
+                aria-hidden="true"
+                className="tw-size-4 tw-flex-none tw-text-iron-600"
+              />
+              <input
+                id={searchInputId}
+                aria-label={t(locale, "user.mentionShortcuts.searchLabel")}
+                aria-describedby={searchStatusId}
+                value={search}
+                onChange={(event) =>
+                  onDraftChange({ ...draft, search: event.target.value })
+                }
+                placeholder={t(
+                  locale,
+                  "user.mentionShortcuts.searchPlaceholder"
+                )}
+                disabled={members.length >= MAX_MEMBERS}
+                autoComplete="off"
+                className="tw-min-h-11 tw-w-full tw-border-0 tw-bg-transparent tw-px-2 tw-py-2.5 tw-text-sm tw-text-white tw-outline-none placeholder:tw-text-iron-600 disabled:tw-cursor-not-allowed disabled:tw-opacity-50"
+              />
+            </div>
+
+            {searchIsReady && (
+              <div
+                className={`tw-z-20 tw-mt-2 tw-max-h-52 tw-overflow-y-auto tw-rounded-xl tw-border tw-border-solid tw-border-white/10 tw-bg-iron-900 tw-p-1.5 tw-shadow-2xl ${
+                  isMobileSheet
+                    ? "tw-relative"
+                    : "tw-absolute tw-left-0 tw-right-0 tw-top-full"
+                }`}
+              >
+                {searchResultsContent}
+              </div>
+            )}
+          </div>
+
+          <p id={searchStatusId} aria-live="polite" className="tw-sr-only">
+            {searchStatus}
+          </p>
+        </div>
+      </div>
+
+      <div className="tw-mt-5 tw-flex tw-flex-col-reverse tw-gap-2 sm:tw-flex-row sm:tw-justify-end">
+        <Button
+          variant="secondary"
+          size="sm"
+          disabled={isSaving}
+          onClick={onCancel}
+        >
+          {t(locale, "user.mentionShortcuts.cancel")}
+        </Button>
+        <Button
+          variant="action"
+          size="sm"
+          disabled={!canSave || isSaving}
+          loading={isSaving}
+          onClick={save}
+        >
+          {isSaving
+            ? t(locale, "user.mentionShortcuts.saving")
+            : t(locale, "user.mentionShortcuts.save")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/ops/docs/profiles/tabs/feature-brain-tab.md
+++ b/ops/docs/profiles/tabs/feature-brain-tab.md
@@ -11,8 +11,8 @@ The companion `Created Waves` and `Most Active In` surfaces inside this tab are
 documented separately in
 [Profile Brain Tab Wave Sidebar](feature-brain-wave-sidebar.md).
 On your own profile, the compact `Quick Tags` section appears beneath
-`Activity` and expands in place for creating and managing personal mention
-shortcuts.
+`Activity`. Its manager stays in the card; create and edit forms use a mobile
+bottom sheet and remain inline on wider screens.
 
 ## Location in the Site
 
@@ -40,7 +40,8 @@ shortcuts.
 5. If the viewed profile exposes a Brain identity, the `Activity` card renders
    above the feed.
 6. On your own profile, use the `Quick Tags` section beneath `Activity` to open
-   the inline Quick Tags manager.
+   the inline manager or a create/edit form. Mobile create and edit forms open
+   in a bottom sheet while the Brain page stays in place.
 7. Select a drop or quote preview to open its thread:
    - public wave drop: `/waves/{waveId}?serialNo={serialNo}`
    - direct-message drop: `/messages/{waveId}?serialNo={serialNo}`
@@ -53,6 +54,9 @@ shortcuts.
 - On your own profile, see up to three Quick Tags in the compact section; the
   controls wrap at narrow widths, and `+N more` indicates additional tags and
   opens the inline manager.
+- On mobile, selecting `New Quick Tag` or a Quick Tag to edit opens a
+  bottom-anchored sheet. Cancelling or dismissing it returns to the preceding
+  compact summary or manager without changing the Brain page.
 - Open a shared `/{user}/brain` link directly and stay on that route while the
   app decides whether Waves is available for the current viewer.
 - If Waves becomes available during that access check, the same

--- a/ops/docs/waves/composer/feature-personal-mention-shortcuts.md
+++ b/ops/docs/waves/composer/feature-personal-mention-shortcuts.md
@@ -13,15 +13,17 @@ Quick Tags let a profile save a private tag for several profiles. For example,
 ## Entry Points
 
 - Open your own profile and select `Brain`.
-- Select `Manage`, a visible Quick Tag, or the `+N more` chip in the compact
-  `Quick Tags` section. The section changes in place instead of opening a
-  separate dialog.
+- Select `Manage` or the `+N more` chip to open the manager inside the compact
+  `Quick Tags` section.
+- Select a visible Quick Tag to edit it. On mobile, create and edit forms open
+  in a bottom sheet; on wider screens, they replace the card content inline.
 
 ## User Journey
 
 1. Open the `Brain` tab on your own profile.
 2. Find the compact `Quick Tags` section beneath `Activity`.
-3. Select `Manage`, then select `New Quick Tag` in the inline manager.
+3. Select `New Quick Tag` in the compact section or open `Manage` and select
+   `New Quick Tag` there.
 4. Create a tag with a 3–15 character name containing letters, numbers, or
    underscores.
 5. Add between 1 and 25 profiles and save.
@@ -54,8 +56,12 @@ case-insensitive.
 - Quick Tags are private to the profile that created them.
 - The compact section shows up to three tags and adds a `+N more` chip when
   more tags exist. Tags wrap at narrow widths so the controls remain visible.
-- Creating, editing, and deleting a Quick Tag stays inside the same Brain-tab
-  card. Back controls return to the preceding Quick Tags view.
+- On mobile, creating or editing a Quick Tag uses a bottom sheet while the
+  preceding summary or manager remains in place underneath it. Back, Cancel,
+  close, backdrop, and drag dismissal return to that preceding view without
+  saving.
+- On wider screens, creating and editing stay inline inside the Brain-tab card.
+  Deletion remains in the inline manager at every width.
 - The section is hidden on other profiles and while acting through a proxy.
 - Quick Tags do not have a dedicated profile tab or route.
 
@@ -65,6 +71,8 @@ case-insensitive.
   show an error with a retry action.
 - If saving or deleting fails, the app shows an error notification and keeps
   the existing Quick Tag state available for another attempt.
+- Closing the mobile create or edit sheet discards unsaved changes and leaves
+  the underlying Brain page and Quick Tags view in place.
 - If a selected profile is no longer eligible, remove it and choose another
   profile before saving.
 

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -1369,7 +1369,8 @@
       "facts": [
         "Quick Tags are managed from the compact owner-only section beneath Activity on the Profile Brain tab.",
         "The section shows up to three tags and uses a +N more chip when additional tags exist; controls wrap at narrow widths.",
-        "Manage, a visible Quick Tag, and +N more open the inline Quick Tags manager inside the same Brain-tab card.",
+        "Manage and +N more open the inline Quick Tags manager inside the same Brain-tab card.",
+        "On mobile, New Quick Tag and existing-tag editing open in a bottom sheet; on wider screens, create and edit forms remain inline.",
         "The section is hidden on other profiles and while acting through a proxy.",
         "Quick Tags do not have a dedicated profile tab or route."
       ],

--- a/public/glossary.json
+++ b/public/glossary.json
@@ -488,7 +488,8 @@
       "facts": [
         "Quick Tags are managed from the compact owner-only section beneath Activity on the Profile Brain tab.",
         "The section shows up to three tags and uses a +N more chip when additional tags exist; controls wrap at narrow widths.",
-        "Manage, a visible Quick Tag, and +N more open the inline Quick Tags manager inside the same Brain-tab card.",
+        "Manage and +N more open the inline Quick Tags manager inside the same Brain-tab card.",
+        "On mobile, New Quick Tag and existing-tag editing open in a bottom sheet; on wider screens, create and edit forms remain inline.",
         "The section is hidden on other profiles and while acting through a proxy.",
         "Quick Tags do not have a dedicated profile tab or route."
       ],

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -1365,7 +1365,8 @@
       "facts": [
         "Quick Tags are managed from the compact owner-only section beneath Activity on the Profile Brain tab.",
         "The section shows up to three tags and uses a +N more chip when additional tags exist; controls wrap at narrow widths.",
-        "Manage, a visible Quick Tag, and +N more open the inline Quick Tags manager inside the same Brain-tab card.",
+        "Manage and +N more open the inline Quick Tags manager inside the same Brain-tab card.",
+        "On mobile, New Quick Tag and existing-tag editing open in a bottom sheet; on wider screens, create and edit forms remain inline.",
         "The section is hidden on other profiles and while acting through a proxy.",
         "Quick Tags do not have a dedicated profile tab or route."
       ],


### PR DESCRIPTION
## Issue

- Quick Tag create and edit forms were compressed inside the Profile Brain card on mobile instead of using the app's established bottom-sheet interaction.
- During review, the empty Brain Activity card also showed excessive vertical padding and title-to-message spacing.

## Fix

- Reuse the shared mobile wrapper dialog for Quick Tag creation and editing at the established mobile breakpoint while retaining the inline editor on wider screens.
- Keep editor drafts and save state owned by the Quick Tags parent so state survives responsive transitions and failed saves.
- Align the Activity card with the compact spacing rhythm used by the neighboring Quick Tags card.

## Changes

- Route every mobile create and edit entry point into the bottom sheet while preserving the summary or manager underneath.
- Preserve Back, Cancel, close, backdrop, Escape, and drag dismissal behavior through the shared dialog.
- Keep save pending state single-submit, retain draft state on errors, and restore focus after the sheet closes.
- Reuse the existing focused-field keyboard scrolling hook used by other mobile sheets.
- Keep search results inside the mobile sheet's scroll flow and retain the desktop anchored dropdown.
- Make form actions full width below `sm` and compact/right-aligned from `sm` upward.
- Remove the Quick Tag sheet's decorative drag handle while retaining its header divider and swipe dismissal.
- Compact the Brain Activity card and remove inherited heading/paragraph margins.
- Update profile, composer, and Help Bot documentation for the responsive workflow.

## Validation

- `./bin/6529 run help-index:sync`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff` — 100/100 with no findings on the source diff before commit
- Browser CRUD pass: created a tag, searched for profiles, added/removed/re-added members, saved, edited, renamed, removed a member, confirmed deletion, and cleaned up test data.
- Browser responsive pass: full-width actions below 640px and compact right-aligned actions at 640px; mobile and desktop Quick Tag layouts visually checked.
- Browser Activity-card pass at narrow and desktop widths; card height reduced from 118px to 74px with an 8px content gap.
- Physical iOS/Android software keyboards were not available in the desktop test environment. The implementation reuses the established keyboard-aware dialog and focused-field scrolling paths; final physical-device confirmation remains appropriate.

## Risk

- Level: Medium
- Why: The change is owner-only and does not alter APIs, validation, permissions, or composer expansion, but it changes responsive editor state and dialog dismissal paths.
- Rollback: Revert the commits in this PR to restore the inline mobile editor and previous Activity-card spacing.

## Review Notes

- Focus review on breakpoint transitions, dismissal/focus restoration, draft preservation on errors, and short-height mobile scrolling.
- The Quick Tags section remains hidden on other profiles and in proxy mode.
- No merge or deployment is requested by this PR; it is being opened for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Quick Tags management with clearer **Manage** and **+N more** entry points.
  - Added responsive editing: mobile users see dismissible bottom sheets, while wider screens use inline forms.
  - Improved focus handling, validation, search, and form feedback during tag creation and editing.
  - Unsaved mobile changes are discarded when dismissed, returning users to the underlying Brain view.

- **Bug Fixes**
  - Streamlined activity card spacing and status message layout.

- **Documentation**
  - Updated Quick Tags guidance to reflect the new management and responsive editing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->