### PR TITLE
Redesign profile owner actions

### DIFF
--- a/__tests__/components/user/user-page-header/UserPageHeader.test.tsx
+++ b/__tests__/components/user/user-page-header/UserPageHeader.test.tsx
@@ -44,12 +44,11 @@ jest.mock(
 jest.mock(
   "@/components/user/user-page-header/UserPageHeaderSubscriptionStatus",
   () =>
-    ({ compact = false }: { readonly compact?: boolean }) => (
-      <div
-        data-testid="subscription-status"
-        data-compact={compact ? "true" : "false"}
-      />
-    )
+    ({
+      layout = "card",
+    }: {
+      readonly layout?: "card" | "subtle" | "wide-row";
+    }) => <div data-testid="subscription-status" data-layout={layout} />
 );
 jest.mock("@/components/user/utils/UserFollowBtn", () => ({
   __esModule: true,
@@ -149,21 +148,36 @@ describe("UserPageHeader", () => {
 
     expect(screen.queryByTestId("follow")).not.toBeInTheDocument();
     const subscriptionStatuses = screen.getAllByTestId("subscription-status");
-    expect(subscriptionStatuses).toHaveLength(3);
+    expect(subscriptionStatuses).toHaveLength(2);
     expect(
       subscriptionStatuses.filter(
-        (subscriptionStatus) => subscriptionStatus.dataset["compact"] === "true"
+        (subscriptionStatus) =>
+          subscriptionStatus.dataset["layout"] === "subtle"
       )
     ).toHaveLength(1);
-    const preferencesButton = screen.getByRole("button", {
+    expect(
+      subscriptionStatuses.filter(
+        (subscriptionStatus) =>
+          subscriptionStatus.dataset["layout"] === "wide-row"
+      )
+    ).toHaveLength(1);
+    const preferencesButtons = screen.getAllByRole("button", {
       name: "Preferences",
     });
-    expect(preferencesButton).toHaveClass(
-      "!tw-border-white/10",
-      "!tw-bg-iron-950",
-      "tw-shadow-md",
-      "tw-shadow-black/40"
+    expect(preferencesButtons).toHaveLength(3);
+    expect(preferencesButtons[0]).toHaveClass(
+      "tw-size-11",
+      "!tw-bg-transparent",
+      "min-[840px]:tw-hidden"
     );
+    preferencesButtons.slice(1).forEach((preferencesButton) => {
+      expect(preferencesButton).toHaveClass(
+        "!tw-border-white/10",
+        "!tw-bg-iron-950",
+        "tw-shadow-md",
+        "tw-shadow-black/40"
+      );
+    });
   });
 
   it("opens preferences from your own profile", async () => {
@@ -184,7 +198,9 @@ describe("UserPageHeader", () => {
       </AuthContext.Provider>
     );
 
-    await user.click(screen.getByRole("button", { name: "Preferences" }));
+    await user.click(
+      screen.getAllByRole("button", { name: "Preferences" })[0]!
+    );
 
     expect(
       screen.getByRole("dialog", { name: "Profile Preferences modal" })

--- a/__tests__/components/user/user-page-header/UserPageHeaderSubscriptionStatus.test.tsx
+++ b/__tests__/components/user/user-page-header/UserPageHeaderSubscriptionStatus.test.tsx
@@ -100,7 +100,7 @@ describe("UserPageHeaderSubscriptionStatus", () => {
     );
   });
 
-  it("renders the wide-header presentation without card chrome", () => {
+  it("renders the subtle presentation without card chrome", () => {
     render(
       <UserPageHeaderSubscriptionStatus
         profile={
@@ -124,6 +124,30 @@ describe("UserPageHeaderSubscriptionStatus", () => {
       "tw-shadow-md"
     );
     expect(screen.getByText("Subscriptions")).toHaveClass("tw-text-iron-500");
+    expect(statusLink).toHaveAttribute(
+      "href",
+      "/sesamenoodles/subscriptions#profile-subscriptions-top-up"
+    );
+  });
+
+  it("renders the wide-row presentation at full width with a divider", () => {
+    render(
+      <UserPageHeaderSubscriptionStatus
+        profile={
+          {
+            consolidation_key: "profile-key",
+            normalised_handle: "sesamenoodles",
+          } as ApiIdentity
+        }
+        layout="wide-row"
+      />
+    );
+
+    const statusLink = screen
+      .getByText("Running low · through The Memes #560, Oct 12, 2026")
+      .closest("a");
+
+    expect(statusLink).toHaveClass("tw-w-full", "tw-border-t");
     expect(statusLink).toHaveAttribute(
       "href",
       "/sesamenoodles/subscriptions#profile-subscriptions-top-up"

--- a/__tests__/components/user/user-page-header/UserPageHeaderSubscriptionStatus.test.tsx
+++ b/__tests__/components/user/user-page-header/UserPageHeaderSubscriptionStatus.test.tsx
@@ -99,4 +99,34 @@ describe("UserPageHeaderSubscriptionStatus", () => {
       "tw-bg-primary-500"
     );
   });
+
+  it("renders the wide-header presentation without card chrome", () => {
+    render(
+      <UserPageHeaderSubscriptionStatus
+        profile={
+          {
+            consolidation_key: "profile-key",
+            normalised_handle: "sesamenoodles",
+          } as ApiIdentity
+        }
+        layout="subtle"
+      />
+    );
+
+    const status = screen.getByText(
+      "Running low · through The Memes #560, Oct 12, 2026"
+    );
+    const statusLink = status.closest("a");
+
+    expect(statusLink).not.toHaveClass(
+      "!tw-border-white/10",
+      "!tw-bg-iron-950",
+      "tw-shadow-md"
+    );
+    expect(screen.getByText("Subscriptions")).toHaveClass("tw-text-iron-500");
+    expect(statusLink).toHaveAttribute(
+      "href",
+      "/sesamenoodles/subscriptions#profile-subscriptions-top-up"
+    );
+  });
 });

--- a/components/mobile-wrapper-dialog/MobileWrapperDialog.tsx
+++ b/components/mobile-wrapper-dialog/MobileWrapperDialog.tsx
@@ -69,6 +69,7 @@ type MobileWrapperDialogProps = {
    * intentional full-bleed surface that requires the shared floating control.
    */
   readonly showHeaderCloseButton?: boolean | undefined;
+  readonly showHeaderDivider?: boolean | undefined;
   readonly headerCloseButtonClassName?: string | undefined;
   readonly surfaceClassName?: string | undefined;
   readonly titleClassName?: string | undefined;
@@ -627,6 +628,7 @@ export default function MobileWrapperDialog({
   showDragHandle,
   enableDragToClose,
   showHeaderCloseButton = true,
+  showHeaderDivider,
   headerCloseButtonClassName,
   surfaceClassName,
   titleClassName,
@@ -752,6 +754,7 @@ export default function MobileWrapperDialog({
                           titleActions={titleActions}
                           headerActions={headerActions}
                           showHeaderCloseButton={showInlineHeaderCloseButton}
+                          showHeaderDivider={showHeaderDivider}
                           headerCloseButtonClassName={
                             headerCloseButtonClassName
                           }

--- a/components/mobile-wrapper-dialog/MobileWrapperDialogHeader.tsx
+++ b/components/mobile-wrapper-dialog/MobileWrapperDialogHeader.tsx
@@ -13,6 +13,7 @@ export default function MobileWrapperDialogHeader({
   titleActions,
   headerActions,
   showHeaderCloseButton,
+  showHeaderDivider,
   headerCloseButtonClassName,
   titleClassName,
   backLabel,
@@ -26,32 +27,32 @@ export default function MobileWrapperDialogHeader({
   readonly titleActions?: ReactNode;
   readonly headerActions?: ReactNode;
   readonly showHeaderCloseButton?: boolean | undefined;
+  readonly showHeaderDivider?: boolean | undefined;
   readonly headerCloseButtonClassName?: string | undefined;
   readonly titleClassName?: string | undefined;
   readonly backLabel: string;
   readonly closeLabel: string;
 }) {
+  const hasHeaderDivider = !!onBack || !!showHeaderDivider;
+
   return (
     <div
       className={clsx(
         "tw-px-4 sm:tw-px-6",
-        onBack && "tw-pb-4",
+        hasHeaderDivider && "tw-pb-4",
         className
       )}
     >
       <div
         className={clsx(
           "tw-flex tw-items-center tw-justify-between tw-gap-3",
-          onBack &&
+          hasHeaderDivider &&
             "-tw-mx-4 tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-white/[0.06] tw-px-4 tw-pb-4 sm:-tw-mx-6 sm:tw-px-6"
         )}
       >
         <div className="tw-flex tw-min-w-0 tw-flex-1 tw-items-center tw-gap-3">
           {onBack && (
-            <MobileWrapperDialogBackButton
-              onClick={onBack}
-              label={backLabel}
-            />
+            <MobileWrapperDialogBackButton onClick={onBack} label={backLabel} />
           )}
           <div className="tw-flex tw-min-w-0 tw-flex-1 tw-items-center tw-gap-3">
             {title && (
@@ -93,7 +94,7 @@ export default function MobileWrapperDialogHeader({
         <div
           className={clsx(
             "tw-flex tw-items-center",
-            onBack ? "tw-pt-4" : "tw-mt-2"
+            hasHeaderDivider ? "tw-pt-4" : "tw-mt-2"
           )}
         >
           {headerActions}

--- a/components/user/user-page-header/UserPageHeaderClient.tsx
+++ b/components/user/user-page-header/UserPageHeaderClient.tsx
@@ -55,6 +55,8 @@ type Props = {
   readonly cmsWebsiteHref?: string | null | undefined;
 };
 
+const PROFILE_PREFERENCES_BUTTON_KEY = "profilePreferences.button";
+
 export default function UserPageHeaderClient({
   profile: initialProfile,
   handleOrWallet,
@@ -154,7 +156,6 @@ export default function UserPageHeaderClient({
     () => aboutStatement !== null || canEdit,
     [aboutStatement, canEdit]
   );
-  const hasVisibleAbout = aboutStatement !== null || canInlineEdit;
 
   const websiteAction =
     cmsWebsiteHref && profile.handle
@@ -166,12 +167,6 @@ export default function UserPageHeaderClient({
       : null;
   const canManageProfilePreferences = isMyProfile && !activeProfileProxy;
   const showSubscriptionStatus = canManageProfilePreferences;
-  let subscriptionStatusVisibilityClass = "";
-  if (canEdit) {
-    subscriptionStatusVisibilityClass = hasTouchScreen
-      ? "tw-hidden"
-      : "tw-hidden sm:tw-block";
-  }
 
   const handleCreateDirectMessage = async (
     primaryWallet: string | undefined
@@ -220,26 +215,45 @@ export default function UserPageHeaderClient({
             canEdit={canInlineEdit}
             profileLabel={profileLabel}
           />
-          {canEdit ? (
+          {canEdit || canManageProfilePreferences ? (
             <div
-              className={`tw-absolute tw-right-4 tw-top-3 tw-z-20 sm:tw-right-6 sm:tw-top-4 md:tw-right-8 ${
+              className={`tw-absolute tw-right-4 tw-top-3 tw-z-20 tw-flex tw-items-center tw-gap-1 sm:tw-right-6 sm:tw-top-4 md:tw-right-8 ${
                 hasTouchScreen ? "" : "sm:tw-hidden"
               }`}
             >
-              <UserPageHeaderEditProfile
-                profile={profile}
-                statement={aboutStatement}
-                defaultBanner1={banner1Color}
-                defaultBanner2={banner2Color}
-              />
+              {canEdit ? (
+                <UserPageHeaderEditProfile
+                  profile={profile}
+                  statement={aboutStatement}
+                  defaultBanner1={banner1Color}
+                  defaultBanner2={banner2Color}
+                />
+              ) : null}
+              {canManageProfilePreferences ? (
+                <Button
+                  variant="tertiary"
+                  size={null}
+                  onClick={() => setIsProfilePreferencesOpen(true)}
+                  aria-label={t(locale, PROFILE_PREFERENCES_BUTTON_KEY)}
+                  title={t(locale, PROFILE_PREFERENCES_BUTTON_KEY)}
+                  className="tw-group tw-size-11 !tw-rounded-full !tw-border-transparent !tw-bg-transparent !tw-p-1 !tw-shadow-none focus-visible:!tw-outline-none active:!tw-bg-transparent desktop-hover:hover:!tw-border-transparent desktop-hover:hover:!tw-bg-transparent sm:tw-size-10 sm:!tw-p-0.5 min-[840px]:tw-hidden"
+                >
+                  <span className="tw-box-border tw-inline-flex tw-size-9 tw-flex-none tw-items-center tw-justify-center tw-rounded-full tw-border tw-border-solid tw-border-white/15 tw-bg-black/75 tw-text-iron-100 tw-shadow-[0_8px_24px_rgba(0,0,0,0.32)] tw-transition-[background-color,border-color,color,transform] tw-duration-200 tw-ease-out group-focus-visible:tw-ring-2 group-focus-visible:tw-ring-primary-400 group-focus-visible:tw-ring-offset-2 group-focus-visible:tw-ring-offset-black group-active:tw-scale-95 group-active:tw-bg-black desktop-hover:group-hover:tw-border-white/25 desktop-hover:group-hover:tw-bg-black/90 desktop-hover:group-hover:tw-text-white motion-reduce:tw-transform-none motion-reduce:tw-transition-none">
+                    <Cog6ToothIcon
+                      className="tw-size-[1.125rem]"
+                      aria-hidden="true"
+                    />
+                  </span>
+                </Button>
+              ) : null}
             </div>
           ) : null}
         </div>
 
         <div className="tw-relative tw-z-20 tw-bg-black md:tw-pointer-events-none md:-tw-mt-[164px] md:tw-bg-transparent">
           <div className="tw-relative tw-z-10 tw-px-4 sm:tw-px-6 md:tw-px-8">
-            <div className="tw-mb-4 tw-flex tw-flex-col tw-items-start tw-gap-5 md:tw-flex-row md:tw-items-end lg:tw-mb-8">
-              <div className="tw-relative -tw-mt-10 tw-flex-shrink-0 sm:-tw-mt-[58px] md:tw-pointer-events-auto md:tw-mt-0">
+            <div className="tw-mb-6 tw-flex tw-flex-col tw-items-start tw-gap-5 md:tw-flex-row md:tw-items-end lg:tw-mb-8 lg:tw-mt-8">
+              <div className="tw-relative -tw-mt-10 tw-flex-shrink-0 sm:-tw-mb-2 sm:-tw-mt-[58px] md:tw-pointer-events-auto md:tw-mb-0 md:tw-mt-0">
                 <UserPageHeaderPfpWrapper
                   profile={profile}
                   canEdit={canInlineEdit}
@@ -254,18 +268,8 @@ export default function UserPageHeaderClient({
                 </UserPageHeaderPfpWrapper>
               </div>
 
-              {canEdit ? (
-                <div
-                  className={`tw-absolute tw-right-4 tw-top-0 sm:tw-right-6 md:tw-pointer-events-auto md:tw-right-8 ${
-                    hasTouchScreen ? "" : "sm:tw-hidden"
-                  }`}
-                >
-                  <UserPageHeaderSubscriptionStatus profile={profile} compact />
-                </div>
-              ) : null}
-
-              <div className="tw-flex tw-w-full tw-min-w-0 tw-flex-col tw-items-start tw-gap-6 md:tw-flex-1 md:tw-flex-row md:tw-items-center md:tw-justify-between">
-                <div className="tw-min-w-0 md:tw-pointer-events-auto">
+              <div className="tw-flex tw-w-full tw-min-w-0 tw-flex-col tw-items-start tw-gap-6 sm:tw-flex-row sm:tw-items-end sm:tw-justify-between md:tw-flex-1 min-[840px]:tw-gap-2 lg:tw-gap-6">
+                <div className="tw-flex tw-min-w-0 tw-flex-col md:tw-pointer-events-auto">
                   <UserPageHeaderName
                     profile={profile}
                     canEdit={canInlineEdit}
@@ -284,31 +288,54 @@ export default function UserPageHeaderClient({
                       variant="meta"
                     />
                   </div>
-                  {canManageProfilePreferences ? (
+                </div>
+
+                {canManageProfilePreferences && !hasTouchScreen ? (
+                  <div className="tw-hidden tw-flex-none sm:tw-block md:tw-pointer-events-auto min-[840px]:tw-hidden">
                     <Button
                       variant="tertiary"
                       size="sm"
                       onClick={() => setIsProfilePreferencesOpen(true)}
-                      aria-label={t(locale, "profilePreferences.button")}
-                      className={`tw-mt-3 ${USER_PAGE_HEADER_SURFACE_CLASS} ${USER_PAGE_HEADER_INTERACTIVE_SURFACE_CLASS}`}
+                      aria-label={t(locale, PROFILE_PREFERENCES_BUTTON_KEY)}
+                      className={`${USER_PAGE_HEADER_SURFACE_CLASS} ${USER_PAGE_HEADER_INTERACTIVE_SURFACE_CLASS}`}
                     >
                       <Cog6ToothIcon className="tw-size-4" aria-hidden="true" />
-                      <span>{t(locale, "profilePreferences.button")}</span>
+                      <span>{t(locale, PROFILE_PREFERENCES_BUTTON_KEY)}</span>
                     </Button>
-                  ) : null}
-                </div>
+                  </div>
+                ) : null}
 
                 {websiteAction || followHandle || showSubscriptionStatus ? (
                   <div
                     className={`tw-w-full tw-flex-shrink-0 tw-flex-col tw-items-stretch tw-gap-2 sm:tw-w-auto sm:tw-flex-row sm:tw-items-center md:tw-pointer-events-auto ${
                       websiteAction || followHandle
                         ? "tw-flex"
-                        : "tw-hidden lg:tw-flex"
+                        : "tw-hidden min-[840px]:tw-flex"
                     }`}
                   >
-                    {showSubscriptionStatus && !(canEdit && hasTouchScreen) ? (
-                      <div className="tw-hidden lg:tw-block">
-                        <UserPageHeaderSubscriptionStatus profile={profile} />
+                    {canManageProfilePreferences ? (
+                      <div className="tw-hidden tw-flex-col tw-items-end tw-gap-4 min-[840px]:tw-flex min-[840px]:tw-w-auto lg:tw-w-[17rem]">
+                        <Button
+                          variant="tertiary"
+                          size="sm"
+                          onClick={() => setIsProfilePreferencesOpen(true)}
+                          aria-label={t(locale, PROFILE_PREFERENCES_BUTTON_KEY)}
+                          className={`${USER_PAGE_HEADER_SURFACE_CLASS} ${USER_PAGE_HEADER_INTERACTIVE_SURFACE_CLASS}`}
+                        >
+                          <Cog6ToothIcon
+                            className="tw-size-4"
+                            aria-hidden="true"
+                          />
+                          <span>
+                            {t(locale, PROFILE_PREFERENCES_BUTTON_KEY)}
+                          </span>
+                        </Button>
+                        <div className="tw-hidden min-[840px]:tw-block">
+                          <UserPageHeaderSubscriptionStatus
+                            profile={profile}
+                            layout="subtle"
+                          />
+                        </div>
                       </div>
                     ) : null}
                     {websiteAction ? (
@@ -342,6 +369,15 @@ export default function UserPageHeaderClient({
               </div>
             </div>
 
+            {showSubscriptionStatus ? (
+              <div className="md:tw-pointer-events-auto min-[840px]:tw-hidden">
+                <UserPageHeaderSubscriptionStatus
+                  profile={profile}
+                  layout="wide-row"
+                />
+              </div>
+            ) : null}
+
             {showAbout ? (
               <div className="md:tw-pointer-events-auto">
                 <UserPageHeaderAbout
@@ -352,17 +388,7 @@ export default function UserPageHeaderClient({
               </div>
             ) : null}
 
-            {showSubscriptionStatus ? (
-              <div
-                className={`md:tw-pointer-events-auto lg:tw-hidden ${
-                  hasVisibleAbout ? "tw-mt-4" : ""
-                } ${subscriptionStatusVisibilityClass}`}
-              >
-                <UserPageHeaderSubscriptionStatus profile={profile} />
-              </div>
-            ) : null}
-
-            <div className="tw-mt-4 tw-flex tw-items-center md:tw-pointer-events-auto md:tw-mt-6">
+            <div className="tw-mt-4 tw-flex tw-items-center md:tw-pointer-events-auto">
               <UserPageHeaderStats
                 profile={profile}
                 handleOrWallet={normalizedHandleOrWallet}

--- a/components/user/user-page-header/UserPageHeaderEditProfile.tsx
+++ b/components/user/user-page-header/UserPageHeaderEditProfile.tsx
@@ -163,11 +163,11 @@ export default function UserPageHeaderEditProfile({
         onAfterLeave={finishDialogLeave}
         tabletModal
         showHeaderCloseButton
+        showHeaderDivider
         enableDragToClose
         showScrollbar={showScrollbar}
         maxWidthClass={maxWidthClass}
         surfaceClassName="tw-bg-iron-950 md:tw-shadow-2xl"
-        headerClassName="-tw-mt-2 tw-pb-4 md:tw-mt-0"
         headerActions={
           activeTarget === "banner" ? (
             <p className="tw-m-0 tw-text-sm tw-font-normal tw-leading-5 tw-text-iron-400">

--- a/components/user/user-page-header/UserPageHeaderSubscriptionStatus.tsx
+++ b/components/user/user-page-header/UserPageHeaderSubscriptionStatus.tsx
@@ -18,6 +18,7 @@ import { ApiSubscriptionCoverageStatus } from "@/generated/models/ApiSubscriptio
 import { useBrowserLocale } from "@/hooks/useBrowserLocale";
 import useCapacitor from "@/hooks/useCapacitor";
 import { formatInteger } from "@/i18n/format";
+import type { SupportedLocale } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
 import {
   ArrowRightIcon,
@@ -59,13 +60,224 @@ const STATUS_ICON_CLASSES: Record<SubscriptionCoverageTone, string> = {
 
 const SUBSCRIPTIONS_TITLE_KEY = "subscriptions.coverage.header.title";
 const MUTED_TEXT_CLASS = "tw-text-iron-400";
+type SubscriptionStatusLayout = "card" | "subtle" | "wide-row";
+
+function getSubtleLayoutClass(layout: SubscriptionStatusLayout) {
+  return layout === "wide-row"
+    ? "tw-min-h-14 tw-border-0 tw-border-t tw-border-solid tw-border-white/[0.08] tw-py-2"
+    : "tw-min-h-10 tw-rounded-lg";
+}
+
+function SubscriptionStatusIcon({
+  tone,
+}: Readonly<{ tone: SubscriptionCoverageTone }>) {
+  const Icon = STATUS_ICONS[tone];
+
+  return (
+    <span
+      aria-hidden="true"
+      className={clsx(
+        "tw-inline-flex tw-size-6 tw-flex-none tw-items-center tw-justify-center tw-rounded-full tw-ring-1",
+        STATUS_ICON_CLASSES[tone]
+      )}
+    >
+      <Icon className="tw-size-3.5" />
+    </span>
+  );
+}
+
+function SubscriptionLoading({
+  layout,
+  locale,
+}: Readonly<{
+  layout: SubscriptionStatusLayout;
+  locale: SupportedLocale;
+}>) {
+  const isSubtle = layout !== "card";
+
+  return (
+    <div
+      aria-label={t(locale, "subscriptions.coverage.loading")}
+      className={clsx(
+        "tw-w-full tw-animate-pulse",
+        isSubtle
+          ? getSubtleLayoutClass(layout)
+          : "tw-min-h-14 tw-rounded-xl tw-p-2.5 sm:tw-w-[22rem]",
+        layout === "subtle" && "tw-flex tw-flex-col tw-justify-center",
+        !isSubtle && USER_PAGE_HEADER_SURFACE_CLASS
+      )}
+    >
+      <div className="tw-h-3.5 tw-w-40 tw-rounded tw-bg-iron-700/80" />
+      <div className="tw-mt-1.5 tw-h-3 tw-w-48 tw-rounded tw-bg-iron-800/90" />
+    </div>
+  );
+}
+
+function SubscriptionUnknown({
+  href,
+  layout,
+  locale,
+}: Readonly<{
+  href: string;
+  layout: SubscriptionStatusLayout;
+  locale: SupportedLocale;
+}>) {
+  const isSubtle = layout !== "card";
+
+  return (
+    <Link
+      href={href}
+      className={clsx(
+        "tw-group tw-flex tw-items-center tw-gap-2 tw-text-left tw-no-underline tw-transition-colors focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400",
+        layout === "subtle"
+          ? "tw-w-fit tw-justify-end"
+          : "tw-w-full tw-justify-between",
+        isSubtle
+          ? `${getSubtleLayoutClass(layout)} desktop-hover:hover:tw-bg-white/[0.025]`
+          : "tw-min-h-14 tw-rounded-xl tw-p-2.5 sm:tw-w-[22rem]",
+        !isSubtle && USER_PAGE_HEADER_SURFACE_CLASS,
+        !isSubtle && USER_PAGE_HEADER_INTERACTIVE_SURFACE_CLASS
+      )}
+    >
+      <span className="tw-min-w-0">
+        <span
+          className={clsx(
+            "tw-block tw-font-medium",
+            isSubtle
+              ? "tw-text-[11px] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-iron-500"
+              : "tw-text-[13px] tw-text-iron-100"
+          )}
+        >
+          {t(locale, SUBSCRIPTIONS_TITLE_KEY)}
+        </span>
+        <span
+          className={clsx(
+            "tw-mt-0.5 tw-block tw-transition-colors",
+            isSubtle
+              ? "tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-400 group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white"
+              : `tw-text-[11px] ${MUTED_TEXT_CLASS}`
+          )}
+        >
+          {t(locale, "subscriptions.coverage.status.unknown")}
+        </span>
+      </span>
+      <ArrowRightIcon
+        className={clsx(
+          "tw-size-4 tw-flex-none tw-transition-colors",
+          isSubtle
+            ? "tw-text-iron-500 group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white"
+            : MUTED_TEXT_CLASS
+        )}
+        aria-hidden="true"
+      />
+    </Link>
+  );
+}
+
+type SubscriptionCoveragePresentationProps = Readonly<{
+  actionLabel: string;
+  href: string;
+  isUrgentTopUp: boolean;
+  locale: SupportedLocale;
+  secondaryLine: string;
+  tone: SubscriptionCoverageTone;
+}>;
+
+function SubscriptionCard({
+  actionLabel,
+  href,
+  isUrgentTopUp,
+  locale,
+  secondaryLine,
+  tone,
+}: SubscriptionCoveragePresentationProps) {
+  return (
+    <div
+      className={clsx(
+        "tw-flex tw-min-h-14 tw-w-full tw-items-center tw-gap-2 tw-rounded-xl tw-p-2.5 focus-within:tw-outline focus-within:tw-outline-2 focus-within:tw-outline-offset-2 focus-within:tw-outline-primary-400 sm:tw-w-[22rem]",
+        USER_PAGE_HEADER_SURFACE_CLASS
+      )}
+    >
+      <SubscriptionStatusIcon tone={tone} />
+      <span className="tw-min-w-0 tw-flex-1">
+        <span className="tw-block tw-truncate tw-text-[13px] tw-font-medium tw-text-iron-100">
+          {t(locale, SUBSCRIPTIONS_TITLE_KEY)}
+        </span>
+        <span className="tw-mt-0.5 tw-block tw-text-[11px] tw-leading-4 tw-text-iron-400">
+          {secondaryLine}
+        </span>
+      </span>
+      <ButtonLink
+        href={href}
+        className={clsx(
+          "tw-inline-flex tw-min-h-10 tw-flex-none tw-items-center tw-gap-1.5 tw-rounded-lg tw-px-2.5 tw-py-2 tw-text-xs tw-font-semibold tw-no-underline tw-transition-colors focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-300",
+          isUrgentTopUp
+            ? "tw-bg-primary-500 tw-text-white desktop-hover:hover:tw-bg-primary-400"
+            : "tw-text-iron-400 desktop-hover:hover:tw-bg-white/[0.05] desktop-hover:hover:tw-text-iron-100"
+        )}
+      >
+        {actionLabel}
+        <ArrowRightIcon className="tw-size-3.5" aria-hidden="true" />
+      </ButtonLink>
+    </div>
+  );
+}
+
+function SubscriptionSubtle({
+  actionLabel,
+  href,
+  isUrgentTopUp,
+  layout,
+  locale,
+  secondaryLine,
+  tone,
+}: SubscriptionCoveragePresentationProps &
+  Readonly<{ layout: Exclude<SubscriptionStatusLayout, "card"> }>) {
+  const isCompact = layout === "subtle";
+
+  return (
+    <Link
+      href={href}
+      className={clsx(
+        "tw-group tw-flex tw-items-center tw-gap-2 tw-text-left tw-no-underline tw-transition-colors focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400",
+        isCompact ? "tw-w-fit tw-justify-end" : "tw-w-full tw-justify-between",
+        `${getSubtleLayoutClass(layout)} desktop-hover:hover:tw-bg-white/[0.025]`
+      )}
+    >
+      <SubscriptionStatusIcon tone={tone} />
+      <span
+        className={clsx("tw-min-w-0", isCompact ? "tw-max-w-40" : "tw-flex-1")}
+      >
+        <span className="tw-block tw-truncate tw-text-[11px] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-iron-500">
+          {t(locale, SUBSCRIPTIONS_TITLE_KEY)}
+        </span>
+        <span className="tw-mt-0.5 tw-flex tw-min-w-0 tw-items-baseline tw-gap-2 tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-400">
+          <span className="tw-min-w-0 tw-truncate tw-transition-colors group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white">
+            {secondaryLine}
+          </span>
+          <span
+            className={clsx(
+              "tw-inline-flex tw-flex-none tw-items-center tw-gap-1 tw-text-xs tw-font-medium tw-transition-colors",
+              isUrgentTopUp
+                ? "group-focus-visible:tw-text-primary-200 desktop-hover:group-hover:tw-text-primary-200 tw-text-primary-300"
+                : "tw-text-iron-500 group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white"
+            )}
+          >
+            {actionLabel}
+            <ArrowRightIcon className="tw-size-3" aria-hidden="true" />
+          </span>
+        </span>
+      </span>
+    </Link>
+  );
+}
 
 export default function UserPageHeaderSubscriptionStatus({
   profile,
   layout = "card",
 }: Readonly<{
   profile: ApiIdentity;
-  layout?: "card" | "subtle" | "wide-row";
+  layout?: SubscriptionStatusLayout;
 }>) {
   const locale = useBrowserLocale();
   const { country } = useCookieConsent();
@@ -80,85 +292,18 @@ export default function UserPageHeaderSubscriptionStatus({
     enabled: !hideSubscriptions,
     profileKey,
   });
-  const isSubtle = layout !== "card";
-  const isWideRow = layout === "wide-row";
-  const isCompactSubtle = layout === "subtle";
-  const subtleLayoutClass = isWideRow
-    ? "tw-min-h-14 tw-border-0 tw-border-t tw-border-solid tw-border-white/[0.08] tw-py-2"
-    : "tw-min-h-10 tw-rounded-lg";
-
   if (hideSubscriptions || !profileKey || !profileHref) {
     return null;
   }
 
   if (coverageQuery.isLoading) {
-    return (
-      <div
-        aria-label={t(locale, "subscriptions.coverage.loading")}
-        className={clsx(
-          "tw-w-full tw-animate-pulse",
-          isSubtle
-            ? subtleLayoutClass
-            : "tw-min-h-14 tw-rounded-xl tw-p-2.5 sm:tw-w-[22rem]",
-          isCompactSubtle && "tw-flex tw-flex-col tw-justify-center",
-          !isSubtle && USER_PAGE_HEADER_SURFACE_CLASS
-        )}
-      >
-        <div className="tw-h-3.5 tw-w-40 tw-rounded tw-bg-iron-700/80" />
-        <div className="tw-mt-1.5 tw-h-3 tw-w-48 tw-rounded tw-bg-iron-800/90" />
-      </div>
-    );
+    return <SubscriptionLoading layout={layout} locale={locale} />;
   }
 
   const coverage = coverageQuery.data;
   if (!coverage) {
     return (
-      <Link
-        href={profileHref}
-        className={clsx(
-          "tw-group tw-flex tw-items-center tw-gap-2 tw-text-left tw-no-underline tw-transition-colors focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400",
-          isCompactSubtle
-            ? "tw-w-fit tw-justify-end"
-            : "tw-w-full tw-justify-between",
-          isSubtle
-            ? `${subtleLayoutClass} desktop-hover:hover:tw-bg-white/[0.025]`
-            : "tw-min-h-14 tw-rounded-xl tw-p-2.5 sm:tw-w-[22rem]",
-          !isSubtle && USER_PAGE_HEADER_SURFACE_CLASS,
-          !isSubtle && USER_PAGE_HEADER_INTERACTIVE_SURFACE_CLASS
-        )}
-      >
-        <span className="tw-min-w-0">
-          <span
-            className={clsx(
-              "tw-block tw-font-medium",
-              isSubtle
-                ? "tw-text-[11px] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-iron-500"
-                : "tw-text-[13px] tw-text-iron-100"
-            )}
-          >
-            {t(locale, SUBSCRIPTIONS_TITLE_KEY)}
-          </span>
-          <span
-            className={clsx(
-              "tw-mt-0.5 tw-block tw-transition-colors",
-              isSubtle
-                ? "tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-400 group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white"
-                : `tw-text-[11px] ${MUTED_TEXT_CLASS}`
-            )}
-          >
-            {t(locale, "subscriptions.coverage.status.unknown")}
-          </span>
-        </span>
-        <ArrowRightIcon
-          className={clsx(
-            "tw-size-4 tw-flex-none tw-transition-colors",
-            isSubtle
-              ? "tw-text-iron-500 group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white"
-              : MUTED_TEXT_CLASS
-          )}
-          aria-hidden="true"
-        />
-      </Link>
+      <SubscriptionUnknown href={profileHref} layout={layout} locale={locale} />
     );
   }
 
@@ -177,7 +322,6 @@ export default function UserPageHeaderSubscriptionStatus({
   const isUrgentTopUp =
     coverage.status === ApiSubscriptionCoverageStatus.RunningLow ||
     coverage.status === ApiSubscriptionCoverageStatus.ActionRequired;
-  const StatusIcon = STATUS_ICONS[presentation.tone];
   const secondaryLine = coverage.funded_through
     ? t(locale, "subscriptions.coverage.header.through", {
         status: presentation.label,
@@ -191,108 +335,18 @@ export default function UserPageHeaderSubscriptionStatus({
         status: presentation.label,
       });
 
-  if (!isSubtle) {
-    return (
-      <div
-        className={clsx(
-          "tw-flex tw-min-h-14 tw-w-full tw-items-center tw-gap-2 tw-rounded-xl tw-p-2.5 focus-within:tw-outline focus-within:tw-outline-2 focus-within:tw-outline-offset-2 focus-within:tw-outline-primary-400 sm:tw-w-[22rem]",
-          USER_PAGE_HEADER_SURFACE_CLASS
-        )}
-      >
-        <span
-          aria-hidden="true"
-          className={clsx(
-            "tw-inline-flex tw-size-6 tw-flex-none tw-items-center tw-justify-center tw-rounded-full tw-ring-1",
-            STATUS_ICON_CLASSES[presentation.tone]
-          )}
-        >
-          <StatusIcon className="tw-size-3.5" />
-        </span>
-        <span className="tw-min-w-0 tw-flex-1">
-          <span className="tw-block tw-truncate tw-text-[13px] tw-font-medium tw-text-iron-100">
-            {t(locale, SUBSCRIPTIONS_TITLE_KEY)}
-          </span>
-          <span className="tw-mt-0.5 tw-block tw-text-[11px] tw-leading-4 tw-text-iron-400">
-            {secondaryLine}
-          </span>
-        </span>
-        <ButtonLink
-          href={href}
-          className={clsx(
-            "tw-inline-flex tw-min-h-10 tw-flex-none tw-items-center tw-gap-1.5 tw-rounded-lg tw-px-2.5 tw-py-2 tw-text-xs tw-font-semibold tw-no-underline tw-transition-colors focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-300",
-            isUrgentTopUp
-              ? "tw-bg-primary-500 tw-text-white desktop-hover:hover:tw-bg-primary-400"
-              : "tw-text-iron-400 desktop-hover:hover:tw-bg-white/[0.05] desktop-hover:hover:tw-text-iron-100"
-          )}
-        >
-          {actionLabel}
-          <ArrowRightIcon className="tw-size-3.5" aria-hidden="true" />
-        </ButtonLink>
-      </div>
-    );
+  const presentationProps = {
+    actionLabel,
+    href,
+    isUrgentTopUp,
+    locale,
+    secondaryLine,
+    tone: presentation.tone,
+  } satisfies SubscriptionCoveragePresentationProps;
+
+  if (layout === "card") {
+    return <SubscriptionCard {...presentationProps} />;
   }
 
-  return (
-    <Link
-      href={href}
-      className={clsx(
-        "tw-group tw-flex tw-items-center tw-gap-2 tw-text-left tw-no-underline tw-transition-colors focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400",
-        isCompactSubtle
-          ? "tw-w-fit tw-justify-end"
-          : "tw-w-full tw-justify-between",
-        `${subtleLayoutClass} desktop-hover:hover:tw-bg-white/[0.025]`
-      )}
-    >
-      <span
-        aria-hidden="true"
-        className={clsx(
-          "tw-inline-flex tw-size-6 tw-flex-none tw-items-center tw-justify-center tw-rounded-full tw-ring-1",
-          STATUS_ICON_CLASSES[presentation.tone]
-        )}
-      >
-        <StatusIcon className="tw-size-3.5" />
-      </span>
-      <span
-        className={clsx(
-          "tw-min-w-0",
-          isCompactSubtle ? "tw-max-w-40" : "tw-flex-1"
-        )}
-      >
-        <span
-          className={clsx(
-            "tw-block tw-truncate tw-font-medium",
-            "tw-text-[11px] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-iron-500"
-          )}
-        >
-          {t(locale, SUBSCRIPTIONS_TITLE_KEY)}
-        </span>
-        <span
-          className={clsx(
-            "tw-mt-0.5 tw-flex tw-min-w-0 tw-items-baseline tw-gap-2",
-            "tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-400"
-          )}
-        >
-          <span
-            className={clsx(
-              "tw-min-w-0 tw-truncate tw-transition-colors",
-              "group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white"
-            )}
-          >
-            {secondaryLine}
-          </span>
-          <span
-            className={clsx(
-              "tw-inline-flex tw-flex-none tw-items-center tw-gap-1 tw-text-xs tw-font-medium tw-transition-colors",
-              isUrgentTopUp
-                ? "group-focus-visible:tw-text-primary-200 desktop-hover:group-hover:tw-text-primary-200 tw-text-primary-300"
-                : "tw-text-iron-500 group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white"
-            )}
-          >
-            {actionLabel}
-            <ArrowRightIcon className="tw-size-3" aria-hidden="true" />
-          </span>
-        </span>
-      </span>
-    </Link>
-  );
+  return <SubscriptionSubtle {...presentationProps} layout={layout} />;
 }

--- a/components/user/user-page-header/UserPageHeaderSubscriptionStatus.tsx
+++ b/components/user/user-page-header/UserPageHeaderSubscriptionStatus.tsx
@@ -58,13 +58,14 @@ const STATUS_ICON_CLASSES: Record<SubscriptionCoverageTone, string> = {
 };
 
 const SUBSCRIPTIONS_TITLE_KEY = "subscriptions.coverage.header.title";
+const MUTED_TEXT_CLASS = "tw-text-iron-400";
 
 export default function UserPageHeaderSubscriptionStatus({
   profile,
-  compact = false,
+  layout = "card",
 }: Readonly<{
   profile: ApiIdentity;
-  compact?: boolean;
+  layout?: "card" | "subtle" | "wide-row";
 }>) {
   const locale = useBrowserLocale();
   const { country } = useCookieConsent();
@@ -76,27 +77,18 @@ export default function UserPageHeaderSubscriptionStatus({
   const profileKey = profile.consolidation_key.trim();
   const profileHref = getProfileSubscriptionsHref(profile);
   const coverageQuery = useSubscriptionCoverage({
-    enabled: !hideSubscriptions && !compact,
+    enabled: !hideSubscriptions,
     profileKey,
   });
+  const isSubtle = layout !== "card";
+  const isWideRow = layout === "wide-row";
+  const isCompactSubtle = layout === "subtle";
+  const subtleLayoutClass = isWideRow
+    ? "tw-min-h-14 tw-border-0 tw-border-t tw-border-solid tw-border-white/[0.08] tw-py-2"
+    : "tw-min-h-10 tw-rounded-lg";
 
   if (hideSubscriptions || !profileKey || !profileHref) {
     return null;
-  }
-
-  if (compact) {
-    return (
-      <ButtonLink
-        href={profileHref}
-        variant="tertiary"
-        size="sm"
-        aria-label={t(locale, SUBSCRIPTIONS_TITLE_KEY)}
-        className={`${USER_PAGE_HEADER_SURFACE_CLASS} ${USER_PAGE_HEADER_INTERACTIVE_SURFACE_CLASS}`}
-      >
-        <span>{t(locale, SUBSCRIPTIONS_TITLE_KEY)}</span>
-        <ArrowRightIcon className="tw-size-3.5" aria-hidden="true" />
-      </ButtonLink>
-    );
   }
 
   if (coverageQuery.isLoading) {
@@ -104,8 +96,12 @@ export default function UserPageHeaderSubscriptionStatus({
       <div
         aria-label={t(locale, "subscriptions.coverage.loading")}
         className={clsx(
-          "tw-min-h-14 tw-w-full tw-animate-pulse tw-rounded-xl tw-p-2.5 sm:tw-w-[22rem]",
-          USER_PAGE_HEADER_SURFACE_CLASS
+          "tw-w-full tw-animate-pulse",
+          isSubtle
+            ? subtleLayoutClass
+            : "tw-min-h-14 tw-rounded-xl tw-p-2.5 sm:tw-w-[22rem]",
+          isCompactSubtle && "tw-flex tw-flex-col tw-justify-center",
+          !isSubtle && USER_PAGE_HEADER_SURFACE_CLASS
         )}
       >
         <div className="tw-h-3.5 tw-w-40 tw-rounded tw-bg-iron-700/80" />
@@ -120,21 +116,46 @@ export default function UserPageHeaderSubscriptionStatus({
       <Link
         href={profileHref}
         className={clsx(
-          "tw-flex tw-min-h-14 tw-w-full tw-items-center tw-justify-between tw-gap-2 tw-rounded-xl tw-p-2.5 tw-text-left tw-no-underline focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 sm:tw-w-[22rem]",
-          USER_PAGE_HEADER_SURFACE_CLASS,
-          USER_PAGE_HEADER_INTERACTIVE_SURFACE_CLASS
+          "tw-group tw-flex tw-items-center tw-gap-2 tw-text-left tw-no-underline tw-transition-colors focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400",
+          isCompactSubtle
+            ? "tw-w-fit tw-justify-end"
+            : "tw-w-full tw-justify-between",
+          isSubtle
+            ? `${subtleLayoutClass} desktop-hover:hover:tw-bg-white/[0.025]`
+            : "tw-min-h-14 tw-rounded-xl tw-p-2.5 sm:tw-w-[22rem]",
+          !isSubtle && USER_PAGE_HEADER_SURFACE_CLASS,
+          !isSubtle && USER_PAGE_HEADER_INTERACTIVE_SURFACE_CLASS
         )}
       >
         <span className="tw-min-w-0">
-          <span className="tw-block tw-text-[13px] tw-font-medium tw-text-iron-100">
+          <span
+            className={clsx(
+              "tw-block tw-font-medium",
+              isSubtle
+                ? "tw-text-[11px] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-iron-500"
+                : "tw-text-[13px] tw-text-iron-100"
+            )}
+          >
             {t(locale, SUBSCRIPTIONS_TITLE_KEY)}
           </span>
-          <span className="tw-mt-0.5 tw-block tw-text-[11px] tw-text-iron-400">
+          <span
+            className={clsx(
+              "tw-mt-0.5 tw-block tw-transition-colors",
+              isSubtle
+                ? "tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-400 group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white"
+                : `tw-text-[11px] ${MUTED_TEXT_CLASS}`
+            )}
+          >
             {t(locale, "subscriptions.coverage.status.unknown")}
           </span>
         </span>
         <ArrowRightIcon
-          className="tw-size-4 tw-flex-none tw-text-iron-400"
+          className={clsx(
+            "tw-size-4 tw-flex-none tw-transition-colors",
+            isSubtle
+              ? "tw-text-iron-500 group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white"
+              : MUTED_TEXT_CLASS
+          )}
           aria-hidden="true"
         />
       </Link>
@@ -170,11 +191,56 @@ export default function UserPageHeaderSubscriptionStatus({
         status: presentation.label,
       });
 
+  if (!isSubtle) {
+    return (
+      <div
+        className={clsx(
+          "tw-flex tw-min-h-14 tw-w-full tw-items-center tw-gap-2 tw-rounded-xl tw-p-2.5 focus-within:tw-outline focus-within:tw-outline-2 focus-within:tw-outline-offset-2 focus-within:tw-outline-primary-400 sm:tw-w-[22rem]",
+          USER_PAGE_HEADER_SURFACE_CLASS
+        )}
+      >
+        <span
+          aria-hidden="true"
+          className={clsx(
+            "tw-inline-flex tw-size-6 tw-flex-none tw-items-center tw-justify-center tw-rounded-full tw-ring-1",
+            STATUS_ICON_CLASSES[presentation.tone]
+          )}
+        >
+          <StatusIcon className="tw-size-3.5" />
+        </span>
+        <span className="tw-min-w-0 tw-flex-1">
+          <span className="tw-block tw-truncate tw-text-[13px] tw-font-medium tw-text-iron-100">
+            {t(locale, SUBSCRIPTIONS_TITLE_KEY)}
+          </span>
+          <span className="tw-mt-0.5 tw-block tw-text-[11px] tw-leading-4 tw-text-iron-400">
+            {secondaryLine}
+          </span>
+        </span>
+        <ButtonLink
+          href={href}
+          className={clsx(
+            "tw-inline-flex tw-min-h-10 tw-flex-none tw-items-center tw-gap-1.5 tw-rounded-lg tw-px-2.5 tw-py-2 tw-text-xs tw-font-semibold tw-no-underline tw-transition-colors focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-300",
+            isUrgentTopUp
+              ? "tw-bg-primary-500 tw-text-white desktop-hover:hover:tw-bg-primary-400"
+              : "tw-text-iron-400 desktop-hover:hover:tw-bg-white/[0.05] desktop-hover:hover:tw-text-iron-100"
+          )}
+        >
+          {actionLabel}
+          <ArrowRightIcon className="tw-size-3.5" aria-hidden="true" />
+        </ButtonLink>
+      </div>
+    );
+  }
+
   return (
-    <div
+    <Link
+      href={href}
       className={clsx(
-        "tw-flex tw-min-h-14 tw-w-full tw-items-center tw-gap-2 tw-rounded-xl tw-p-2.5 focus-within:tw-outline focus-within:tw-outline-2 focus-within:tw-outline-offset-2 focus-within:tw-outline-primary-400 sm:tw-w-[22rem]",
-        USER_PAGE_HEADER_SURFACE_CLASS
+        "tw-group tw-flex tw-items-center tw-gap-2 tw-text-left tw-no-underline tw-transition-colors focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400",
+        isCompactSubtle
+          ? "tw-w-fit tw-justify-end"
+          : "tw-w-full tw-justify-between",
+        `${subtleLayoutClass} desktop-hover:hover:tw-bg-white/[0.025]`
       )}
     >
       <span
@@ -186,26 +252,47 @@ export default function UserPageHeaderSubscriptionStatus({
       >
         <StatusIcon className="tw-size-3.5" />
       </span>
-      <span className="tw-min-w-0 tw-flex-1">
-        <span className="tw-block tw-truncate tw-text-[13px] tw-font-medium tw-text-iron-100">
-          {t(locale, SUBSCRIPTIONS_TITLE_KEY)}
-        </span>
-        <span className="tw-mt-0.5 tw-block tw-text-[11px] tw-leading-4 tw-text-iron-400">
-          {secondaryLine}
-        </span>
-      </span>
-      <Link
-        href={href}
+      <span
         className={clsx(
-          "tw-inline-flex tw-min-h-10 tw-flex-none tw-items-center tw-gap-1.5 tw-rounded-lg tw-px-2.5 tw-py-2 tw-text-xs tw-font-semibold tw-no-underline tw-transition-colors focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-300",
-          isUrgentTopUp
-            ? "tw-bg-primary-500 tw-text-white desktop-hover:hover:tw-bg-primary-400"
-            : "tw-text-iron-400 desktop-hover:hover:tw-bg-white/[0.05] desktop-hover:hover:tw-text-iron-100"
+          "tw-min-w-0",
+          isCompactSubtle ? "tw-max-w-40" : "tw-flex-1"
         )}
       >
-        {actionLabel}
-        <ArrowRightIcon className="tw-size-3.5" aria-hidden="true" />
-      </Link>
-    </div>
+        <span
+          className={clsx(
+            "tw-block tw-truncate tw-font-medium",
+            "tw-text-[11px] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-iron-500"
+          )}
+        >
+          {t(locale, SUBSCRIPTIONS_TITLE_KEY)}
+        </span>
+        <span
+          className={clsx(
+            "tw-mt-0.5 tw-flex tw-min-w-0 tw-items-baseline tw-gap-2",
+            "tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-400"
+          )}
+        >
+          <span
+            className={clsx(
+              "tw-min-w-0 tw-truncate tw-transition-colors",
+              "group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white"
+            )}
+          >
+            {secondaryLine}
+          </span>
+          <span
+            className={clsx(
+              "tw-inline-flex tw-flex-none tw-items-center tw-gap-1 tw-text-xs tw-font-medium tw-transition-colors",
+              isUrgentTopUp
+                ? "group-focus-visible:tw-text-primary-200 desktop-hover:group-hover:tw-text-primary-200 tw-text-primary-300"
+                : "tw-text-iron-500 group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white"
+            )}
+          >
+            {actionLabel}
+            <ArrowRightIcon className="tw-size-3" aria-hidden="true" />
+          </span>
+        </span>
+      </span>
+    </Link>
   );
 }

--- a/components/user/user-page-header/about/UserPageHeaderAbout.tsx
+++ b/components/user/user-page-header/about/UserPageHeaderAbout.tsx
@@ -70,7 +70,7 @@ function UserPageHeaderAboutContent({
                 type="button"
                 onClick={onEditClick}
                 aria-label={editActionLabel}
-                className="tw-pointer-events-none tw-hidden tw-shrink-0 tw-border-none tw-bg-transparent tw-p-0 tw-text-iron-400 tw-opacity-0 tw-transition tw-duration-200 focus-visible:tw-rounded-lg focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 sm:tw-block sm:group-focus-within:tw-pointer-events-auto sm:group-focus-within:tw-opacity-100 desktop-hover:group-hover:tw-pointer-events-auto desktop-hover:group-hover:tw-opacity-100 desktop-hover:hover:tw-text-iron-200"
+                className="tw-pointer-events-none tw-hidden tw-shrink-0 tw-border-none tw-bg-transparent tw-p-0 tw-text-iron-400 tw-opacity-0 tw-transition tw-duration-200 focus-visible:tw-rounded-lg focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 desktop-hover:group-hover:tw-pointer-events-auto desktop-hover:group-hover:tw-opacity-100 desktop-hover:hover:tw-text-iron-200 sm:tw-block sm:group-focus-within:tw-pointer-events-auto sm:group-focus-within:tw-opacity-100"
               >
                 <span aria-hidden="true">
                   <PencilIcon size={PencilIconSize.SMALL} />
@@ -121,7 +121,7 @@ function UserPageHeaderAboutContent({
             onClose={closeEditor}
             tabletModal
             showHeaderCloseButton
-            headerClassName="-tw-mt-2 tw-pb-4 md:tw-mt-0"
+            showHeaderDivider
           >
             <div className="tw-px-4 sm:tw-px-6">
               <UserPageHeaderAboutEdit

--- a/components/user/user-page-header/about/UserPageHeaderAboutEdit.tsx
+++ b/components/user/user-page-header/about/UserPageHeaderAboutEdit.tsx
@@ -34,9 +34,7 @@ export default function UserPageHeaderAboutEdit({
   readonly value?: string | undefined;
   readonly onValueChange?: ((value: string) => void) | undefined;
   readonly errorMsg?: string | null | undefined;
-  readonly onErrorMsgChange?:
-    | ((errorMsg: string | null) => void)
-    | undefined;
+  readonly onErrorMsgChange?: ((errorMsg: string | null) => void) | undefined;
 }) {
   const MAX_STATEMENT_LENGTH = 500;
 
@@ -51,12 +49,9 @@ export default function UserPageHeaderAboutEdit({
   const [internalErrorMsg, setInternalErrorMsg] = useState<string | null>(null);
   const value = controlledValue ?? internalValue;
   const errorMsg =
-    controlledErrorMsg === undefined
-      ? internalErrorMsg
-      : controlledErrorMsg;
+    controlledErrorMsg === undefined ? internalErrorMsg : controlledErrorMsg;
   const onValueChange = controlledOnValueChange ?? setInternalValue;
-  const onErrorMsgChange =
-    controlledOnErrorMsgChange ?? setInternalErrorMsg;
+  const onErrorMsgChange = controlledOnErrorMsgChange ?? setInternalErrorMsg;
   const profileStatementTarget =
     [profile.query, profile.handle, profile.primary_wallet]
       .map((value) => value?.trim() ?? "")
@@ -158,9 +153,9 @@ export default function UserPageHeaderAboutEdit({
   return (
     <div className="tw-w-full tw-max-w-2xl">
       <form onSubmit={onSubmit}>
-        <div className="tw-relative">
+        <div className="tw-overflow-hidden tw-rounded-lg tw-bg-iron-900 tw-shadow-inner tw-ring-1 tw-ring-inset tw-ring-white/10 tw-transition tw-duration-200 tw-ease-out focus-within:tw-ring-2 focus-within:tw-ring-inset focus-within:tw-ring-primary-400/60 hover:tw-ring-white/15">
           <textarea
-            className="tw-block tw-min-h-32 tw-w-full tw-resize-none tw-rounded-lg tw-border-0 tw-bg-iron-900 tw-px-4 tw-pb-10 tw-pt-3.5 tw-text-sm tw-font-normal tw-leading-6 tw-text-iron-50 tw-caret-primary-400 tw-shadow-inner tw-ring-1 tw-ring-inset tw-ring-white/10 tw-transition tw-duration-200 tw-ease-out placeholder:tw-text-iron-600 hover:tw-ring-white/15 focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-inset focus:tw-ring-primary-400/60"
+            className="tw-block tw-min-h-32 tw-w-full tw-resize-none tw-border-0 tw-bg-transparent tw-px-4 tw-pb-2 tw-pt-3.5 tw-text-sm tw-font-normal tw-leading-6 tw-text-iron-50 tw-caret-primary-400 placeholder:tw-text-iron-600 focus:tw-outline-none"
             name="profile-about"
             id="profile-about-input"
             aria-label={getUserProfileHeaderMessage(
@@ -180,11 +175,13 @@ export default function UserPageHeaderAboutEdit({
             onChange={handleInputChange}
             ref={inputRef}
           ></textarea>
-          <div
-            id="profile-about-character-count"
-            className="tw-pointer-events-none tw-absolute tw-bottom-3 tw-right-3 tw-rounded-full tw-bg-black/60 tw-px-2 tw-py-1 tw-text-xs tw-font-medium tw-tabular-nums tw-text-iron-500 tw-ring-1 tw-ring-inset tw-ring-white/10"
-          >
-            {characterCount}
+          <div className="tw-flex tw-justify-end tw-px-3 tw-pb-2">
+            <div
+              id="profile-about-character-count"
+              className="tw-pointer-events-none tw-rounded-full tw-bg-black/60 tw-px-2 tw-py-1 tw-text-xs tw-font-medium tw-tabular-nums tw-text-iron-500 tw-ring-1 tw-ring-inset tw-ring-white/10"
+            >
+              {characterCount}
+            </div>
           </div>
         </div>
         <div className="tw-mt-3 tw-flex tw-w-full tw-flex-col-reverse tw-gap-2 md:tw-ml-auto md:tw-w-auto md:tw-flex-row">

--- a/components/user/user-page-header/banner/UserPageHeaderEditBanner.tsx
+++ b/components/user/user-page-header/banner/UserPageHeaderEditBanner.tsx
@@ -271,9 +271,9 @@ export default function UserPageHeaderEditBanner({
       onAfterLeave={onAfterLeave}
       tabletModal
       showHeaderCloseButton
+      showHeaderDivider
       showScrollbar
       maxWidthClass="md:tw-max-w-2xl"
-      headerClassName="-tw-mt-2 tw-pb-4 md:tw-mt-0"
       headerActions={
         <p className="tw-m-0 tw-text-sm tw-font-normal tw-leading-5 tw-text-iron-400">
           {getUserProfileHeaderMessage(

--- a/components/user/user-page-header/name/UserPageHeaderEditName.tsx
+++ b/components/user/user-page-header/name/UserPageHeaderEditName.tsx
@@ -165,7 +165,7 @@ export default function UserPageHeaderEditName({
       onAfterLeave={onAfterLeave}
       tabletModal
       showHeaderCloseButton
-      headerClassName="-tw-mt-2 tw-pb-4 md:tw-mt-0"
+      showHeaderDivider
       maxWidthClass="md:tw-max-w-xl"
     >
       {form}

--- a/components/user/user-page-header/name/UserPageHeaderNameWrapper.tsx
+++ b/components/user/user-page-header/name/UserPageHeaderNameWrapper.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import PencilIcon from "@/components/utils/icons/PencilIcon";
+import PencilIcon, {
+  PencilIconSize,
+} from "@/components/utils/icons/PencilIcon";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import React, { useState } from "react";
 import UserPageHeaderEditName from "./UserPageHeaderEditName";
@@ -40,7 +42,7 @@ export default function UserPageHeaderNameWrapper({
           className="tw-absolute tw-inset-0 tw-hidden tw-text-iron-400 group-focus-within:tw-block group-hover:tw-block"
         >
           <div className="tw-absolute -tw-left-5 tw-top-1/2 tw-z-10 tw-flex tw-size-5 -tw-translate-y-1/2 tw-items-center tw-justify-center">
-            <PencilIcon />
+            <PencilIcon size={PencilIconSize.SMALL} />
           </div>
         </div>
       </button>

--- a/components/user/user-page-header/name/classification/UserPageClassificationWrapper.tsx
+++ b/components/user/user-page-header/name/classification/UserPageClassificationWrapper.tsx
@@ -35,11 +35,11 @@ export default function UserPageClassificationWrapper({
           "user.profileHeader.classification.edit",
           { name: profileLabel }
         )}
-        className="tw-absolute tw-inset-0 tw-m-0 tw-hidden tw-min-h-6 tw-border-none tw-bg-transparent tw-p-0 tw-transition tw-duration-300 tw-ease-out focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 motion-reduce:tw-transition-none sm:tw-block"
+        className="tw-absolute tw-inset-x-0 tw-top-1/2 tw-m-0 tw-hidden tw-h-6 -tw-translate-y-1/2 tw-border-none tw-bg-transparent tw-p-0 tw-transition tw-duration-300 tw-ease-out focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 motion-reduce:tw-transition-none sm:tw-block"
       >
         <span
           aria-hidden="true"
-          className="tw-absolute -tw-left-5 tw-top-1/2 tw-hidden tw-size-4 -tw-translate-y-1/2 tw-items-center tw-justify-center tw-text-iron-400 group-hover:tw-flex group-focus-within:tw-flex"
+          className="tw-absolute -tw-left-5 tw-top-1/2 tw-hidden tw-size-4 -tw-translate-y-1/2 tw-items-center tw-justify-center tw-text-iron-400 group-focus-within:tw-flex group-hover:tw-flex"
         >
           <PencilIcon size={PencilIconSize.SMALL} />
         </span>

--- a/components/user/user-page-header/name/classification/UserPageHeaderEditClassification.tsx
+++ b/components/user/user-page-header/name/classification/UserPageHeaderEditClassification.tsx
@@ -156,8 +156,8 @@ export default function UserPageHeaderEditClassification({
       onAfterLeave={onAfterLeave}
       tabletModal
       showHeaderCloseButton
+      showHeaderDivider
       maxWidthClass="md:tw-max-w-xl"
-      headerClassName="-tw-mt-2 tw-pb-4 md:tw-mt-0"
     >
       {form}
     </MobileWrapperDialog>

--- a/components/user/user-page-header/pfp/UserPageHeaderEditPfp.tsx
+++ b/components/user/user-page-header/pfp/UserPageHeaderEditPfp.tsx
@@ -257,9 +257,9 @@ export default function UserPageHeaderEditPfp({
       onAfterLeave={onAfterLeave}
       tabletModal
       showHeaderCloseButton
+      showHeaderDivider
       showScrollbar
       maxWidthClass="md:tw-max-w-2xl"
-      headerClassName="-tw-mt-2 tw-pb-4 md:tw-mt-0"
     >
       {form}
     </MobileWrapperDialog>

--- a/ops/docs/notifications/feature-profile-preferences.md
+++ b/ops/docs/notifications/feature-profile-preferences.md
@@ -3,9 +3,13 @@
 ## Overview
 
 Authenticated profiles can open `Profile Preferences` from the app sidebar,
-the desktop profile menu, or the `Preferences` action shown beneath their own
-profile classification to control who may start new direct-message
-conversations and which in-app notifications are created.
+the desktop profile menu, or the `Preferences` action in their own profile
+header to control who may start new direct-message conversations and which
+in-app notifications are created. The action sits in the far-right owner area
+on desktop layouts. Touch-first and phone layouts place an icon-only
+`Preferences` action beside `Edit profile`; smaller fine-pointer layouts place
+the labeled action to the right of the identity. It is hidden while an active
+profile proxy is in use.
 
 ## Direct Messages
 

--- a/ops/docs/profiles/navigation/feature-banner-editing.md
+++ b/ops/docs/profiles/navigation/feature-banner-editing.md
@@ -21,12 +21,15 @@ The editor has two modes:
   - the profile has a handle
   - you are viewing your own profile
   - no active profile proxy context
-- Click the banner edit overlay (`Edit banner`).
+- On smaller and touch-first layouts, use `Edit profile` and choose
+  `Profile cover`.
+- On fine-pointer desktop layouts, use the banner edit overlay.
 
 ## User Journey
 
 1. Open your own profile page.
-2. Click the banner edit overlay to open `Edit profile cover`.
+2. Use the desktop banner edit overlay, or choose `Edit profile` ->
+   `Profile cover` on a smaller layout, to open `Edit profile cover`.
 3. The modal starts in:
    - `Image` mode when the current banner is an image.
    - `Gradient` mode when the current banner is gradient colors.

--- a/ops/docs/profiles/navigation/feature-header-summary.md
+++ b/ops/docs/profiles/navigation/feature-header-summary.md
@@ -51,10 +51,19 @@ The profile header appears on profile routes under `/{user}` and shows:
    - winners-only: opens `Winning Artworks`
    - both: opens `Active Submissions` first
 7. Actions depend on viewer context:
-   - own profile with handle and no active proxy: edit banner, profile picture,
-     name, classification, and About
-   - on editable touch layouts, a compact `Subscriptions` action sits beside
-     `Edit Profile` and opens the profile Subscriptions tab
+   - own profile with handle and no active proxy: fine-pointer desktop layouts
+     expose direct edit controls on the banner, profile picture, name,
+     classification, and About
+   - smaller and touch-first layouts show an `Edit profile` action that opens
+     an editing hub for those same identity fields
+   - `Preferences` remains a distinct owner action for privacy, direct-message,
+     and notification settings; it sits in the far-right owner area on desktop,
+     becomes an icon-only action beside `Edit profile` on touch-first and phone
+     layouts, and sits to the right of the identity on smaller fine-pointer
+     layouts
+   - subscription coverage remains a separate status and navigation surface:
+     a subtle row beneath Preferences on desktop layouts, and a full-width
+     subtle row below the identity block on smaller layouts
    - other profile, signed-in viewer with handle, and target profile with
      handle: follow/unfollow button
    - if that target also has a primary wallet: direct-message button appears
@@ -72,8 +81,12 @@ The profile header appears on profile routes under `/{user}` and shows:
   `See less`; desktop stays expanded.
 - Mobile profile banners show the artwork at full strength. Desktop banners use
   dark gradients where profile content overlaps the artwork.
-- On non-touch layouts, the full subscription status can link directly to the
-  relevant settings, upcoming-drops, or top-up section.
+- The subscription status can link directly to the relevant settings,
+  upcoming-drops, or top-up section. The complete status row is the link, with
+  its current state and contextual action grouped on the second line. It
+  remains a full-width contextual row on smaller layouts.
+- Touch-first layouts use the profile editing hub; fine-pointer desktop layouts
+  retain the field-level editing controls.
 - `Followers` opens a modal list; it does not navigate to a followers tab.
 - On non-touch desktop devices, the artist badge shows a tooltip with activity
   counts.
@@ -94,6 +107,8 @@ The profile header appears on profile routes under `/{user}` and shows:
 - If direct-message creation fails, users get an error toast, the paper-plane
   button returns to its idle state, and they can retry.
 - If profile header edits fail, users get a toast or inline error and can retry.
+- If subscription coverage cannot load, the header shows
+  `Coverage unavailable`; owners can still open Subscriptions and recover there.
 - If the profile cannot be resolved, users see the shared not-found screen:
   - [Route Error and Not-Found Screens](../../shared/feature-route-error-and-not-found.md).
 
@@ -104,6 +119,8 @@ The profile header appears on profile routes under `/{user}` and shows:
   profile with a handle, and a target primary wallet.
 - Artist badge and modal tabs depend on loaded
   `active_main_stage_submission_ids` and `winner_main_stage_drop_ids`.
+- `Edit profile`, `Preferences`, and owner subscription coverage are hidden
+  while an active profile proxy is in use.
 
 ## Related Pages
 

--- a/ops/docs/profiles/navigation/feature-profile-picture-editing.md
+++ b/ops/docs/profiles/navigation/feature-profile-picture-editing.md
@@ -23,11 +23,15 @@ This flow is separate from banner editing.
   - the profile has a handle
   - you are viewing your own profile
   - no active profile proxy context
-- Click the avatar edit control (`Edit profile picture`).
+- On smaller and touch-first layouts, use `Edit profile` and choose
+  `Profile picture`.
+- On fine-pointer desktop layouts, use the avatar edit control
+  (`Edit profile picture`).
 
 ## User Journey
 
-1. Open your own profile and click the avatar edit control.
+1. Open your own profile and use the desktop avatar edit control, or choose
+   `Edit profile` -> `Profile picture` on a smaller layout.
 2. The modal opens. If you already have a profile picture, the upload panel shows its preview.
 3. Choose one source:
    - `Select Meme`: search and click a meme row.

--- a/ops/docs/profiles/tabs/feature-subscriptions-tab.md
+++ b/ops/docs/profiles/tabs/feature-subscriptions-tab.md
@@ -20,10 +20,11 @@ are documented in
 
 - Open `/{user}/subscriptions` directly.
 - Open a profile and choose the `Subscriptions` tab.
-- On your own profile, use the profile-header subscription control. On editable
-  touch layouts it is a compact `Subscriptions` action beside `Edit Profile`;
-  on non-touch layouts the full status can open the relevant settings,
-  upcoming-drops, or top-up section.
+- On your own profile, use the profile-header subscription control. It appears
+  beneath Preferences on desktop layouts, and as a full-width subtle row below
+  the identity block on smaller layouts. The current state and contextual
+  action share the row's second line, and the whole row opens the relevant
+  settings, upcoming-drops, or top-up section.
 - Use the subscription-awareness action on Home or a Meme card.
 - Use `Learn more` in the `Subscription minting` section to open
   `/about/subscriptions`.

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -1180,7 +1180,7 @@
         "Profile pages organize Identity, Curation, Collected, Subscriptions, Proxy, Brain, and xTDH surfaces through tabs.",
         "On their own profile, owners use direct field-level edit controls on fine-pointer desktop layouts; smaller and touch-first layouts provide an Edit profile hub for the profile cover, profile picture, name, classification, and About.",
         "Preferences is a separate owner action in the far-right header area on desktop and an icon-only action beside Edit profile on touch-first and phone layouts; subscription coverage stays a quieter contextual surface beneath Preferences on desktop or across the header below the identity block on smaller screens.",
-        "Editable profile surfaces require the owner or an authorized proxy.",
+        "Editable profile surfaces require the connected profile owner.",
         "Profile editing, profile-header Preferences, and owner subscription coverage are hidden while an active profile proxy is in use."
       ],
       "canonical_path": "/network",

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -1178,14 +1178,18 @@
       "facts": [
         "Profile pages are opened from a real handle or wallet-like route target; use Network, Waves, groups, or a known handle to open the exact profile.",
         "Profile pages organize identity, collected NFTs, waves, groups, subscriptions, proxy, Brain, and xTDH surfaces through tabs.",
-        "Editable profile surfaces require the owner or an authorized proxy."
+        "On their own profile, owners use direct field-level edit controls on fine-pointer desktop layouts; smaller and touch-first layouts provide an Edit profile hub for the profile cover, profile picture, name, classification, and About.",
+        "Preferences is a separate owner action in the far-right header area on desktop and an icon-only action beside Edit profile on touch-first and phone layouts; subscription coverage stays a quieter contextual surface beneath Preferences on desktop or across the header below the identity block on smaller screens.",
+        "Profile editing, profile-header Preferences, and owner subscription coverage are hidden while an active profile proxy is in use."
       ],
       "canonical_path": "/network",
       "related_paths": ["/network"],
       "tags": ["profiles"],
       "source_refs": [
         "ops/docs/profiles/navigation/README.md",
-        "ops/docs/profiles/navigation/feature-tabs.md"
+        "ops/docs/profiles/navigation/feature-tabs.md",
+        "ops/docs/profiles/navigation/feature-header-summary.md",
+        "components/user/user-page-header/UserPageHeaderClient.tsx"
       ]
     },
     {

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -1174,14 +1174,18 @@
       "facts": [
         "Profile pages are opened from a real handle or wallet-like route target; use Network, Waves, groups, or a known handle to open the exact profile.",
         "Profile pages organize identity, collected NFTs, waves, groups, subscriptions, proxy, Brain, and xTDH surfaces through tabs.",
-        "Editable profile surfaces require the owner or an authorized proxy."
+        "On their own profile, owners use direct field-level edit controls on fine-pointer desktop layouts; smaller and touch-first layouts provide an Edit profile hub for the profile cover, profile picture, name, classification, and About.",
+        "Preferences is a separate owner action in the far-right header area on desktop and an icon-only action beside Edit profile on touch-first and phone layouts; subscription coverage stays a quieter contextual surface beneath Preferences on desktop or across the header below the identity block on smaller screens.",
+        "Profile editing, profile-header Preferences, and owner subscription coverage are hidden while an active profile proxy is in use."
       ],
       "canonical_path": "/network",
       "related_paths": ["/network"],
       "tags": ["profiles"],
       "source_refs": [
         "ops/docs/profiles/navigation/README.md",
-        "ops/docs/profiles/navigation/feature-tabs.md"
+        "ops/docs/profiles/navigation/feature-tabs.md",
+        "ops/docs/profiles/navigation/feature-header-summary.md",
+        "components/user/user-page-header/UserPageHeaderClient.tsx"
       ]
     },
     {

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -1176,7 +1176,7 @@
         "Profile pages organize Identity, Curation, Collected, Subscriptions, Proxy, Brain, and xTDH surfaces through tabs.",
         "On their own profile, owners use direct field-level edit controls on fine-pointer desktop layouts; smaller and touch-first layouts provide an Edit profile hub for the profile cover, profile picture, name, classification, and About.",
         "Preferences is a separate owner action in the far-right header area on desktop and an icon-only action beside Edit profile on touch-first and phone layouts; subscription coverage stays a quieter contextual surface beneath Preferences on desktop or across the header below the identity block on smaller screens.",
-        "Editable profile surfaces require the owner or an authorized proxy.",
+        "Editable profile surfaces require the connected profile owner.",
         "Profile editing, profile-header Preferences, and owner subscription coverage are hidden while an active profile proxy is in use."
       ],
       "canonical_path": "/network",


### PR DESCRIPTION
## Issue

Owner profile actions had become visually heavy and inconsistent across breakpoints. Desktop inline editing, preferences, subscription status, and compact-screen controls needed to preserve their existing behavior while aligning cleanly with the profile identity content.

## Fix

Reworked the profile header action layout with responsive Tailwind classes so desktop keeps inline hover editing, compact and touch layouts expose the Edit Profile hub, and preferences and subscription controls adapt without crowding the identity block.

## Notable changes

- Restores desktop inline edit affordances and keeps the Edit Profile hub for compact and touch layouts.
- Aligns Preferences and subscription status with the identity content across breakpoints.
- Makes the subtle subscription row fully clickable while preserving the existing card variant behavior.
- Keeps Follow and direct-message behavior unchanged for other profiles.
- Improves profile edit dialog header spacing and the About editor character-count safe area.
- Updates profile documentation and the generated Help Bot index.
- Adds focused responsive owner-action and subscription-status coverage.

## Validation

- `./bin/6529 run check:changed`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff` (98/100, no errors)
- `./bin/6529 run test __tests__/components/user/user-page-header/UserPageHeader.test.tsx __tests__/components/user/user-page-header/UserPageHeaderSubscriptionStatus.test.tsx --runInBand` (10 tests)
- `./bin/6529 run help-index:sync`
- Docs link validation (300 files)
- Browser QA at desktop and mobile widths, including no horizontal overflow and retained Follow and DM controls for another profile.

## Risk

Medium. This changes responsive presentation and hit targets in a prominent header, but does not change profile APIs, authorization, follow conditions, messaging conditions, or subscription data behavior.

## Review notes

Please focus on breakpoint transitions around 840px, desktop identity/action baseline alignment, and owner versus non-owner action visibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added responsive profile controls, including Preferences access across mobile and desktop layouts.
  - Improved subscription status presentation with card, inline, and full-width row layouts.
  - Added clearer mobile dialog header dividers and refined profile editing interactions.
  - Updated profile editing and subscription navigation for touch-first and desktop experiences.

- **Documentation**
  - Updated help content covering responsive profile editing, Preferences, subscriptions, profile tabs, and proxy-mode behavior.
  - Clarified that profile editing requires the connected profile owner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->