### PR TITLE
Improve subscription and chat card alignment

### DIFF
--- a/__tests__/components/waves/drops/DropItemChat.test.tsx
+++ b/__tests__/components/waves/drops/DropItemChat.test.tsx
@@ -60,7 +60,9 @@ describe("DropItemChat", () => {
     render(<DropItemChat href="https://base.com/p" dropId="d1" />);
     const links = screen.getAllByRole("link");
     expect(links[0]).toHaveAttribute("href", "/p");
-    expect(screen.getByText("Title")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Title" })).toHaveClass(
+      "tw-m-0"
+    );
     expect(screen.getByTestId("position")).toHaveTextContent("2");
     expect(screen.getByTestId("media")).toHaveAttribute("media_url", "img");
     expect(screen.getByTestId("href-buttons")).toHaveTextContent("/p");

--- a/components/user/user-page-header/UserPageHeaderClient.tsx
+++ b/components/user/user-page-header/UserPageHeaderClient.tsx
@@ -314,7 +314,7 @@ export default function UserPageHeaderClient({
                     }`}
                   >
                     {canManageProfilePreferences ? (
-                      <div className="tw-hidden tw-flex-col tw-items-end tw-gap-4 min-[840px]:tw-flex min-[840px]:tw-w-auto lg:tw-w-[17rem]">
+                      <div className="tw-hidden tw-flex-col tw-items-end tw-gap-4 min-[840px]:tw-flex min-[840px]:tw-w-auto">
                         <Button
                           variant="tertiary"
                           size="sm"
@@ -330,7 +330,7 @@ export default function UserPageHeaderClient({
                             {t(locale, PROFILE_PREFERENCES_BUTTON_KEY)}
                           </span>
                         </Button>
-                        <div className="tw-hidden min-[840px]:tw-block">
+                        <div className="tw-hidden lg:tw-block">
                           <UserPageHeaderSubscriptionStatus
                             profile={profile}
                             layout="subtle"
@@ -370,7 +370,7 @@ export default function UserPageHeaderClient({
             </div>
 
             {showSubscriptionStatus ? (
-              <div className="md:tw-pointer-events-auto min-[840px]:tw-hidden">
+              <div className="md:tw-pointer-events-auto lg:tw-hidden">
                 <UserPageHeaderSubscriptionStatus
                   profile={profile}
                   layout="wide-row"

--- a/components/user/user-page-header/UserPageHeaderSubscriptionStatus.tsx
+++ b/components/user/user-page-header/UserPageHeaderSubscriptionStatus.tsx
@@ -240,19 +240,32 @@ function SubscriptionSubtle({
       href={href}
       className={clsx(
         "tw-group tw-flex tw-items-center tw-gap-2 tw-text-left tw-no-underline tw-transition-colors focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400",
-        isCompact ? "tw-w-fit tw-justify-end" : "tw-w-full tw-justify-between",
+        isCompact ? "tw-w-max tw-justify-end" : "tw-w-full tw-justify-between",
         `${getSubtleLayoutClass(layout)} desktop-hover:hover:tw-bg-white/[0.025]`
       )}
     >
       <SubscriptionStatusIcon tone={tone} />
       <span
-        className={clsx("tw-min-w-0", isCompact ? "tw-max-w-40" : "tw-flex-1")}
+        className={clsx(
+          "tw-min-w-0",
+          isCompact ? "tw-whitespace-nowrap" : "tw-flex-1"
+        )}
       >
-        <span className="tw-block tw-truncate tw-text-[11px] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-iron-500">
+        <span
+          className={clsx(
+            "tw-block tw-text-[11px] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-iron-500",
+            !isCompact && "tw-truncate"
+          )}
+        >
           {t(locale, SUBSCRIPTIONS_TITLE_KEY)}
         </span>
         <span className="tw-mt-0.5 tw-flex tw-min-w-0 tw-items-baseline tw-gap-2 tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-400">
-          <span className="tw-min-w-0 tw-truncate tw-transition-colors group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white">
+          <span
+            className={clsx(
+              "tw-min-w-0 tw-transition-colors group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white",
+              !isCompact && "tw-truncate"
+            )}
+          >
             {secondaryLine}
           </span>
           <span

--- a/components/waves/drops/DropItemChat.tsx
+++ b/components/waves/drops/DropItemChat.tsx
@@ -43,7 +43,7 @@ export default function DropItemChat({
                   size="sm"
                 />
               )}
-              <h3 className="tw-mb-0 tw-text-base tw-font-semibold tw-text-iron-100 sm:tw-text-lg">
+              <h3 className="tw-m-0 tw-text-base tw-font-semibold tw-text-iron-100 sm:tw-text-lg">
                 {canOpenDrop ? (
                   <Link className="tw-no-underline" href={relativeLink}>
                     {title}


### PR DESCRIPTION
## Issue

- Subscription status text in the profile header could truncate at desktop widths, while a fixed-width action area created excessive spacing for short labels.
- Embedded drop cards in chat rendered the artwork title lower than the media-type icon and rank badge.

## Fix

- Let the compact subscription row use its natural content width without truncating its status or reserving a fixed action width.
- Move the full-width subscription row below the profile identity until the `lg` breakpoint, where the longest supported status fits safely in the compact layout.
- Remove the drop-card heading's residual default top margin so the title, media-type icon, and rank badge share the same vertical center.

## Changes

- Adjusted the profile header subscription breakpoint and intrinsic-width layout.
- Kept narrow-mobile truncation behavior for genuinely constrained widths.
- Added a focused regression assertion for the chat drop heading margin.
- No wording, icons, colors, state logic, API behavior, or dependencies changed.

## Validation

- Visually checked subscription states including not set up, no upcoming selections, early warning, covered, unavailable, and loading.
- Checked responsive behavior at 320, 390, 840, 1023, 1024, and 1280 px widths with long and short action labels.
- Rendered the affected chat drop card with real API data and confirmed the icon, title, and rank badge have the same measured vertical center.
- `./bin/6529 run typecheck:changed` — passed.
- Focused `DropItemChat` Jest suite — passed.
- `./bin/6529 run react-doctor:diff` — 99/100; only the existing `UserPageHeaderClient` size advisory remains.
- `git diff --check` — passed.
- `./bin/6529 run lint:changed` — attempted locally but exhausted the Node heap while the TypeScript project indexed unrelated nested worktrees; PR CI is the clean lint signal.

## Risk

- Level: Low
- Why: Tailwind-only layout adjustments plus one focused test assertion; no data, auth, or behavior changes.
- Rollback: Revert the single commit to restore the previous layout classes.

## Review Notes

- Focus on the `lg` subscription layout transition and the zero-margin heading in embedded chat drop cards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile header responsiveness across different screen sizes.
  * Updated subscription status layouts to remain compact and prevent unwanted wrapping or overflow.
  * Adjusted drop title spacing for more consistent heading display.

* **Tests**
  * Strengthened coverage to verify drop titles render with the expected heading styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->