### PR TITLE
Keep hidden actions visible on hybrid touch laptops

### DIFF
--- a/__tests__/components/ChatItemHrefButtons.test.tsx
+++ b/__tests__/components/ChatItemHrefButtons.test.tsx
@@ -463,20 +463,23 @@ describe("ChatItemHrefButtons", () => {
     expect(screen.getByRole("button", { name: "Link actions" })).toBeVisible();
   });
 
-  it("keeps the overlay trigger visible when the CSS hover query is unavailable", () => {
+  it("keeps the overlay trigger operable when the CSS hover query is unavailable", async () => {
+    const user = userEvent.setup();
     render(
       <div className="tw-group/link-card tw-relative">
         <ChatItemHrefButtons href="https://a" layout="overlay" />
       </div>
     );
 
-    expect(
-      screen.getByRole("button", { name: "Link actions" }).parentElement
-    ).toHaveClass(
+    const trigger = screen.getByRole("button", { name: "Link actions" });
+    expect(trigger.parentElement).toHaveClass(
       "tw-pointer-events-none",
       "tw-opacity-0",
       "touch-only:tw-pointer-events-auto",
       "touch-only:tw-opacity-100"
     );
+
+    await user.click(trigger);
+    expect(screen.getByRole("button", { name: "Copy link" })).toBeVisible();
   });
 });

--- a/__tests__/components/ChatItemHrefButtons.test.tsx
+++ b/__tests__/components/ChatItemHrefButtons.test.tsx
@@ -462,4 +462,21 @@ describe("ChatItemHrefButtons", () => {
 
     expect(screen.getByRole("button", { name: "Link actions" })).toBeVisible();
   });
+
+  it("keeps the overlay trigger visible when the CSS hover query is unavailable", () => {
+    render(
+      <div className="tw-group/link-card tw-relative">
+        <ChatItemHrefButtons href="https://a" layout="overlay" />
+      </div>
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Link actions" }).parentElement
+    ).toHaveClass(
+      "tw-pointer-events-none",
+      "tw-opacity-0",
+      "touch-only:tw-pointer-events-auto",
+      "touch-only:tw-opacity-100"
+    );
+  });
 });

--- a/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.test.tsx
@@ -131,6 +131,7 @@ describe("BrainLeftSidebarWavePin", () => {
     expect(button).toHaveClass("tw-w-0");
     expect(button).toHaveClass("desktop-hover:group-hover:tw-w-7");
     expect(button).toHaveClass("focus-visible:tw-w-7");
+    expect(button).toHaveClass("touch-only:tw-w-7");
     expect(button).not.toHaveClass("group-focus-within:tw-w-7");
     expect(button).not.toHaveClass("focus:tw-w-7");
     expect(button.querySelector("svg")).toHaveClass("tw-size-3.5");
@@ -143,6 +144,7 @@ describe("BrainLeftSidebarWavePin", () => {
     expect(button).toHaveClass("tw-opacity-0");
     expect(button).toHaveClass("desktop-hover:group-hover:tw-opacity-100");
     expect(button).toHaveClass("focus-visible:tw-opacity-100");
+    expect(button).toHaveClass("touch-only:tw-opacity-100");
     expect(button).not.toHaveClass("group-focus-within:tw-opacity-100");
     expect(button).not.toHaveClass("focus:tw-opacity-100");
   });

--- a/__tests__/components/profile-activity/ProfileActivityLogItemValueWithCopy.test.tsx
+++ b/__tests__/components/profile-activity/ProfileActivityLogItemValueWithCopy.test.tsx
@@ -25,6 +25,7 @@ describe("ProfileActivityLogItemValueWithCopy", () => {
       "focus-visible:tw-opacity-100",
       "touch-only:tw-opacity-100"
     );
+    expect(copyButton).not.toHaveClass("group-hover:tw-opacity-100");
 
     await fireEvent.click(copyButton);
     expect(copy).toHaveBeenCalledWith("0x1");

--- a/__tests__/components/profile-activity/ProfileActivityLogItemValueWithCopy.test.tsx
+++ b/__tests__/components/profile-activity/ProfileActivityLogItemValueWithCopy.test.tsx
@@ -18,7 +18,15 @@ describe("ProfileActivityLogItemValueWithCopy", () => {
     // Initially should show the title
     expect(screen.getByText("Address")).toBeInTheDocument();
 
-    await fireEvent.click(screen.getByRole("button"));
+    const copyButton = screen.getByRole("button", { name: "Copy" });
+    expect(copyButton).toHaveClass(
+      "tw-opacity-0",
+      "desktop-hover:group-hover:tw-opacity-100",
+      "focus-visible:tw-opacity-100",
+      "touch-only:tw-opacity-100"
+    );
+
+    await fireEvent.click(copyButton);
     expect(copy).toHaveBeenCalledWith("0x1");
     expect(screen.getByText("Copied!")).toBeInTheDocument();
   });

--- a/__tests__/components/user/identity/statements/utils/UserPageIdentityDeleteStatementButton.test.tsx
+++ b/__tests__/components/user/identity/statements/utils/UserPageIdentityDeleteStatementButton.test.tsx
@@ -71,4 +71,19 @@ describe("UserPageIdentityDeleteStatementButton", () => {
     const button = screen.getByRole("button", { name: "Delete" });
     expect(button.className).toContain("tw-opacity-100");
   });
+
+  it("shows the desktop-layout button when the CSS hover query is unavailable", () => {
+    render(
+      <UserPageIdentityDeleteStatementButton
+        statement={statement}
+        profile={profile}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Delete" })).toHaveClass(
+      "tw-opacity-0",
+      "desktop-hover:group-hover:tw-opacity-100",
+      "touch-only:tw-opacity-100"
+    );
+  });
 });

--- a/__tests__/components/user/identity/statements/utils/UserPageIdentityDeleteStatementButton.test.tsx
+++ b/__tests__/components/user/identity/statements/utils/UserPageIdentityDeleteStatementButton.test.tsx
@@ -72,7 +72,7 @@ describe("UserPageIdentityDeleteStatementButton", () => {
     expect(button.className).toContain("tw-opacity-100");
   });
 
-  it("shows the desktop-layout button when the CSS hover query is unavailable", () => {
+  it("includes the no-hover CSS fallback on the desktop-layout button", () => {
     render(
       <UserPageIdentityDeleteStatementButton
         statement={statement}

--- a/__tests__/components/user/user-page-header/UserPageHeaderAbout.test.tsx
+++ b/__tests__/components/user/user-page-header/UserPageHeaderAbout.test.tsx
@@ -103,7 +103,10 @@ describe("UserPageHeaderAbout", () => {
     expect(editButton).toHaveClass("tw-hidden", "sm:tw-block");
     expect(editButton).toHaveClass(
       "desktop-hover:group-hover:tw-pointer-events-auto",
-      "desktop-hover:group-hover:tw-opacity-100"
+      "desktop-hover:group-hover:tw-opacity-100",
+      "touch-only:tw-pointer-events-auto",
+      "touch-only:tw-size-11",
+      "touch-only:tw-opacity-100"
     );
   });
 

--- a/__tests__/components/user/user-page-header/banner/UserPageHeaderBanner.test.tsx
+++ b/__tests__/components/user/user-page-header/banner/UserPageHeaderBanner.test.tsx
@@ -59,9 +59,22 @@ describe("UserPageHeaderBanner", () => {
       />
     );
 
-    await userEvent.click(
-      screen.getByRole("button", { name: "Edit alice's profile banner" })
+    const editButton = screen.getByRole("button", {
+      name: "Edit alice's profile banner",
+    });
+    expect(editButton).toHaveClass("tw-hidden", "sm:tw-block");
+    expect(editButton.firstElementChild).toHaveClass(
+      "tw-opacity-0",
+      "desktop-hover:group-hover:tw-opacity-100",
+      "touch-only:tw-opacity-100",
+      "touch-only:tw-bg-transparent"
     );
+    expect(screen.getByTestId("pencil").parentElement).toHaveClass(
+      "touch-only:tw-size-9",
+      "touch-only:tw-bg-iron-950"
+    );
+
+    await userEvent.click(editButton);
     expect(screen.getByTestId("edit")).toBeInTheDocument();
 
     await userEvent.click(screen.getByTestId("edit"));

--- a/__tests__/components/user/user-page-header/banner/UserPageHeaderBanner.test.tsx
+++ b/__tests__/components/user/user-page-header/banner/UserPageHeaderBanner.test.tsx
@@ -69,7 +69,7 @@ describe("UserPageHeaderBanner", () => {
       "touch-only:tw-opacity-100",
       "touch-only:tw-bg-transparent"
     );
-    expect(screen.getByTestId("pencil").parentElement).toHaveClass(
+    expect(editButton.querySelector('[aria-hidden="true"]')).toHaveClass(
       "touch-only:tw-size-9",
       "touch-only:tw-bg-iron-950"
     );

--- a/__tests__/components/user/user-page-header/name/UserPageHeaderNameWrapper.test.tsx
+++ b/__tests__/components/user/user-page-header/name/UserPageHeaderNameWrapper.test.tsx
@@ -43,6 +43,14 @@ describe("UserPageHeaderNameWrapper", () => {
       </UserPageHeaderNameWrapper>
     );
 
+    expect(
+      screen.getByTestId("pencil").parentElement?.parentElement
+    ).toHaveClass(
+      "group-focus-within:tw-block",
+      "desktop-hover:group-hover:tw-block",
+      "touch-only:tw-block"
+    );
+
     await userEvent.click(
       screen.getByRole("button", { name: "Edit Alice's profile name" })
     );

--- a/__tests__/components/waves/drops/WaveDropsScrollControlsUnreadButton.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropsScrollControlsUnreadButton.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { WaveDropsScrollControlsUnreadButton } from "@/components/waves/drops/WaveDropsScrollControlsUnreadButton";
+
+describe("WaveDropsScrollControlsUnreadButton", () => {
+  it("keeps both unread actions visible and operable without hover", async () => {
+    const user = userEvent.setup();
+    const onScrollToUnread = jest.fn();
+    const onDismissUnread = jest.fn();
+
+    render(
+      <WaveDropsScrollControlsUnreadButton
+        unreadDividerSerialNo={42}
+        unreadCount={3}
+        isPointingUp={false}
+        isCombined={false}
+        combinedWidthClassName="tw-w-20"
+        roundedClassName="tw-rounded-full"
+        onScrollToUnread={onScrollToUnread}
+        onDismissUnread={onDismissUnread}
+      />
+    );
+
+    const unreadButton = screen.getByRole("button", {
+      name: "Scroll to first unread message",
+    });
+    expect(unreadButton).toHaveClass(
+      "tw-opacity-50",
+      "desktop-hover:hover:tw-opacity-100",
+      "touch-only:tw-opacity-100"
+    );
+    expect(unreadButton).not.toHaveClass("hover:tw-opacity-100");
+
+    const dismissButton = screen.getByRole("button", { name: "Dismiss" });
+    expect(dismissButton).toHaveClass(
+      "tw-opacity-0",
+      "desktop-hover:group-hover:tw-opacity-50",
+      "touch-only:tw-opacity-100"
+    );
+
+    await user.click(unreadButton);
+    expect(onScrollToUnread).toHaveBeenCalledWith(42);
+
+    await user.click(dismissButton);
+    expect(onDismissUnread).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/components/waves/leaderboard/grid/WaveLeaderboardGridItem.test.tsx
+++ b/__tests__/components/waves/leaderboard/grid/WaveLeaderboardGridItem.test.tsx
@@ -544,7 +544,8 @@ describe("WaveLeaderboardGridItem", () => {
     ).toHaveClass(
       "tw-opacity-0",
       "group-focus-within:tw-opacity-100",
-      "desktop-hover:group-hover:tw-opacity-100"
+      "desktop-hover:group-hover:tw-opacity-100",
+      "touch-only:tw-opacity-100"
     );
     expect(screen.getByTestId("open-action")).toBeInTheDocument();
     expect(screen.getByTestId("vote-button")).toBeInTheDocument();

--- a/__tests__/contracts/hover-revealed-controls.test.ts
+++ b/__tests__/contracts/hover-revealed-controls.test.ts
@@ -1,112 +1,157 @@
 /**
- * Hover may decorate a control. It must never be the only way to reach one.
+ * Hover may decorate a control. It must never be the only way to discover one.
  *
- * `desktop-hover:group-hover:` reveals ride on CSS `:hover`, which tailwind
- * ships wrapped in `(hover: hover) and (pointer: fine)`. Touch devices never
- * match it, and capability-lying hybrids (Surface hardware that reports no
- * hover while a trackpad drives the cursor) do not match it either — so a
- * control whose ONLY reveal is `desktop-hover:group-hover:` cannot be reached
- * by those users. That shipped twice: the wave picture and wave name edit
- * pencils, the latter being the app's only rename entry point.
+ * Tailwind wraps hover rules in `(hover: hover) and (pointer: fine)`. Some
+ * hybrid Windows laptops report the negation of that query while their
+ * trackpad still moves a mouse cursor. Keyboard focus is useful but does not
+ * help that mouse user discover an idle control, and JavaScript touch checks
+ * intentionally classify hybrids as desktop so the layout stays desktop.
  *
- * Two tiers, because the failure modes differ:
- *   - Gating `display`, `visibility` or `pointer-events` removes the hit
- *     target entirely. Unreachable, and a hard failure here.
- *   - Gating `opacity` alone leaves the control clickable but invisible.
- *     Undiscoverable rather than unreachable, so the known set is frozen as a
- *     ratchet instead: existing ones may stay, new ones may not appear.
- *
- * Either tier is satisfied by a second, non-hover way in: `touch-only:` or a
- * focus-driven reveal.
+ * Any class list that pairs an invisible base state with a hover reveal must
+ * therefore include the exact CSS-query complement: `touch-only:`. The scan
+ * covers group hover and self hover, partial opacity reveals, responsive base
+ * gates, and collapsed dimensions. Narrow exemptions below are audited UI
+ * that is decorative or has a separate always-available interaction path.
  */
 import fs from "node:fs";
 import path from "node:path";
 import postcss from "postcss";
 import tailwindcss from "tailwindcss";
 import type { Config } from "tailwindcss";
+import ts from "typescript";
 import tailwindConfig from "@/tailwind.config";
 
 const projectRoot = path.resolve(__dirname, "../..");
 const SCAN_ROOTS = ["components", "app"];
 
-/** States that restore a hit target — without one, nothing can click it. */
-const REACHABLE_STATE =
-  "(?:flex|block|inline-flex|inline-block|inline|grid|table|visible|pointer-events-auto)";
+type RevealKind =
+  | "display"
+  | "visibility"
+  | "pointer-events"
+  | "opacity"
+  | "width"
+  | "height"
+  | "scale";
+
+interface ClassToken {
+  readonly important: boolean;
+  readonly variants: readonly string[];
+  readonly utility: string;
+}
+
+interface GatedLiteral {
+  readonly file: string;
+  readonly literal: string;
+  readonly missingTouchFallbacks: readonly RevealKind[];
+}
+
+interface AuditedRevealExemption {
+  readonly file: string;
+  readonly marker: string;
+  readonly reason: string;
+}
 
 /**
- * Group hover, with or without the `desktop-hover:` capability prefix.
- *
- * The lookbehind keeps `desktop-hover:` itself out of it — that variant is a
- * capability switch, not a cursor state, and applies with no cursor present.
- * Self `hover:` is deliberately excluded too: hovering an element requires it
- * to already occupy space and take pointer events, so it can never be the only
- * way to reach a hidden control. Including it only matched opacity *emphasis*
- * on visible controls.
+ * These are literal-level exemptions, not file-wide suppressions. Each marker
+ * must continue matching a real gated class list or the contract fails.
  */
-const HOVER_VARIANT =
-  "(?:(?<=[\\s\"'`])|(?<=desktop-hover:))group-hover:";
-
-/**
- * Only a class list that starts out hidden is describing a reveal. Without
- * this, every `hover:tw-opacity-100` emphasis on an already-visible control
- * would read as a gate.
- */
-const HIDDEN_BASE =
-  /(?:^|[\s"'`])tw-(?:hidden|invisible|opacity-0|pointer-events-none)(?=[\s"'`]|$)/;
-
-/** A reveal a finger or the keyboard can trigger. */
-const NON_HOVER_VARIANT =
-  "(?:[a-z0-9-]+:)*(?:touch-only|group-focus-within|group-focus-visible|focus-within|focus-visible):";
-
-const HOVER_REACHABILITY_REVEAL = new RegExp(
-  `${HOVER_VARIANT}tw-${REACHABLE_STATE}`
-);
-const HOVER_VISIBILITY_REVEAL = new RegExp(`${HOVER_VARIANT}tw-opacity-100`);
-
-const gatesReachability = (literal: string): boolean =>
-  HIDDEN_BASE.test(literal) && HOVER_REACHABILITY_REVEAL.test(literal);
-
-const gatesVisibilityOnly = (literal: string): boolean =>
-  HIDDEN_BASE.test(literal) &&
-  HOVER_VISIBILITY_REVEAL.test(literal) &&
-  !HOVER_REACHABILITY_REVEAL.test(literal);
-
-/**
- * A hit-target gate needs a hit-target escape: `opacity` alone leaves the
- * control click-dead, so it does not answer a `pointer-events` gate.
- */
-const NON_HOVER_REACHABILITY = new RegExp(
-  `${NON_HOVER_VARIANT}tw-${REACHABLE_STATE}`
-);
-const NON_HOVER_VISIBILITY = new RegExp(
-  `${NON_HOVER_VARIANT}tw-(?:${REACHABLE_STATE}|opacity-100)`
-);
-
-/**
- * Reveals whose non-hover path lives in JS rather than in the class list. Add
- * an entry only with the mechanism named, never to silence an unreachable
- * control.
- */
-const JS_DRIVEN_REVEALS: Readonly<Record<string, string>> = {
-  "components/waves/drops/WaveDropActions.tsx":
-    "WaveDrop.tsx tracks pointerover/out and forces visibility through the forceVisible prop; CSS :hover is only the no-JS fallback.",
-  "components/waves/drops/WaveDrop.helpers.tsx":
-    "Hover-revealed grouped timestamp, not a control: permanently pointer-events-none, and the same forceVisible path drives its opacity.",
-};
-
-/**
- * Controls that go invisible (but stay clickable) without hover. Frozen so the
- * set can only shrink. Do not add to this list — give the control a
- * `touch-only:` or focus reveal instead.
- */
-const VISIBILITY_ONLY_BASELINE: readonly string[] = [
-  "components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx",
-  "components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/WaveAvatar.tsx",
-  "components/brain/left-sidebar/web/WebProfileFeedShortcut.tsx",
-  "components/profile-activity/list/items/utils/ProfileActivityLogItemValueWithCopy.tsx",
-  "components/user/brain/UserPageBrainSidebarWaveItem.tsx",
-  "components/waves/drops/ArtistActiveSubmissionContent.tsx",
-  "components/waves/drops/ArtistWinningArtworksContent.tsx",
+const AUDITED_REVEAL_EXEMPTIONS: readonly AuditedRevealExemption[] = [
+  {
+    file: "components/home/boosted/BoostedDropCompactChatItem.tsx",
+    marker: "tw-items-center tw-overflow-hidden tw-opacity-0",
+    reason:
+      "This pointer-events-none preview replaces already visible summary text as decoration; without hover the original summary remains visible.",
+  },
+  {
+    file: "components/home/now-minting/MemeSubscriptionAwarenessRow.tsx",
+    marker: "tw-bg-primary-400/[0.045] tw-opacity-0",
+    reason:
+      "This aria-hidden, pointer-events-none surface tint is decorative; the row content and actions are always visible.",
+  },
+  {
+    file: "components/profile-cms/CmsArtLightbox.tsx",
+    marker: "tw-uppercase tw-text-white tw-opacity-0",
+    reason:
+      "The Inspect label supplements an already visible and keyboard-focusable artwork control; it is not a separate action.",
+  },
+  {
+    file: "components/drops/view/item/content/media/MediaActionToolbar.tsx",
+    marker: "desktop-hover:group-hover/media:tw-pointer-events-auto",
+    reason:
+      "The inline media toolbar is an enhancement; clicking the visible media opens the expanded viewer with the same actions, and keyboard focus also reveals it.",
+  },
+  {
+    file: "components/user/brain/UserPageBrainSidebarWaveItem.tsx",
+    marker: "-tw-translate-x-1 tw-text-iron-600 tw-opacity-0",
+    reason:
+      "The faded chevron is decorative; the wave link and label remain visible and operable.",
+  },
+  {
+    file: "components/utils/NewVersionToast.tsx",
+    marker: "before:tw-bg-[radial-gradient(circle_at_82%_50%",
+    reason:
+      "This pointer-events-none pseudo-element is a decorative glow on an always visible refresh button.",
+  },
+  {
+    file: "components/waves/drops/ArtistActiveSubmissionContent.tsx",
+    marker: "tw-right-3 tw-top-3 tw-opacity-0",
+    reason:
+      "The eye glyph is decorative feedback on an already visible, fully clickable artwork card.",
+  },
+  {
+    file: "components/waves/drops/ArtistWinningArtworksContent.tsx",
+    marker: "tw-right-3 tw-top-3 tw-opacity-0",
+    reason:
+      "The eye glyph is decorative feedback on an already visible, fully clickable artwork card.",
+  },
+  {
+    file: "components/waves/drops/WaveDropActions.tsx",
+    marker: "desktop-hover:group-hover:tw-pointer-events-auto",
+    reason:
+      "WaveDrop tracks pointerover/out without a hover capability query and passes forceVisible; the CSS hover rule is its no-JS enhancement.",
+  },
+  {
+    file: "components/waves/drops/WaveDrop.helpers.tsx",
+    marker: "tw-opacity-0 desktop-hover:group-hover:tw-opacity-100",
+    reason:
+      "This is a pointer-events-none timestamp, not a control, and WaveDrop's forceVisible pointer path also drives its opacity.",
+  },
+  {
+    file: "components/waves/FilePreview.tsx",
+    marker: "tw-bg-iron-950 tw-opacity-0",
+    reason:
+      "This empty overlay is a decorative shade on a file preview; the preview content and interaction remain visible.",
+  },
+  {
+    file: "components/waves/gallery/WaveGalleryItem.tsx",
+    marker: "tw-bg-gradient-to-t tw-from-black/80",
+    reason:
+      "The gradient is a pointer-events-none visual treatment; the gallery card remains visible and operable.",
+  },
+  {
+    file: "components/waves/gallery/WaveGalleryItem.tsx",
+    marker: "tw-bottom-0 tw-left-0 tw-right-0 tw-translate-y-2",
+    reason:
+      "The title and metadata overlay is pointer-events-none supplementary content; the card and author control have independent visible targets.",
+  },
+  {
+    file: "components/waves/winners/podium/WavePodiumItem.tsx",
+    marker: "tw-size-3 tw-opacity-0 tw-transition-opacity",
+    reason:
+      "The external-link arrow is decorative feedback beside an already visible and fully operable profile link.",
+  },
+  {
+    file: "app/join/FocusSections.tsx",
+    marker: "tw-bg-[linear-gradient(90deg,transparent_0%",
+    reason:
+      "This aria-hidden, pointer-events-none gradient is decorative; the section content remains visible and operable.",
+  },
+  {
+    file: "app/join/JourneyTimelineSection.tsx",
+    marker: "tw-bg-[radial-gradient(circle,rgba(132,173,255",
+    reason:
+      "This empty radial glow is decorative; the timeline icon, copy, and controls remain visible without it.",
+  },
 ];
 
 function sourceFiles(root: string): string[] {
@@ -127,53 +172,255 @@ function sourceFiles(root: string): string[] {
 
 /** Class lists are authored as string literals — check each one on its own. */
 function classStringLiterals(source: string): string[] {
-  return source.match(/"[^"]*"|'[^']*'|`[^`]*`/g) ?? [];
+  const sourceFile = ts.createSourceFile(
+    "hover-audit.tsx",
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  );
+  const literals: string[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+      literals.push(node.getText(sourceFile));
+    } else if (ts.isTemplateExpression(node)) {
+      const staticClasses = [
+        node.head.text,
+        ...node.templateSpans.map((span) => span.literal.text),
+      ].join(" ");
+      literals.push(`\`${staticClasses}\``);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return literals;
 }
 
-function filesWhere(
-  isGated: (literal: string) => boolean,
-  hasEscape: (literal: string) => boolean
-): string[] {
-  const hits = SCAN_ROOTS.flatMap(sourceFiles).flatMap((file) => {
-    const relative = path.relative(projectRoot, file);
-    if (JS_DRIVEN_REVEALS[relative]) {
+function classTokens(literal: string): ClassToken[] {
+  const quote = literal.at(0);
+  const content =
+    (quote === '"' || quote === "'" || quote === "`") &&
+    literal.at(-1) === quote
+      ? literal.slice(1, -1)
+      : literal;
+
+  return content
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((raw) => {
+      const parts = raw.split(":");
+      const utility = parts.at(-1) ?? "";
+      return {
+        important: utility.startsWith("!"),
+        variants: parts.slice(0, -1),
+        utility: utility.replace(/^!/, ""),
+      };
+    });
+}
+
+const hasVariant = (
+  token: ClassToken,
+  matches: (variant: string) => boolean
+): boolean => token.variants.some(matches);
+
+const isHoverToken = (token: ClassToken): boolean =>
+  hasVariant(
+    token,
+    (variant) => variant === "hover" || variant.startsWith("group-hover")
+  );
+
+const isTouchOnlyToken = (token: ClassToken): boolean =>
+  hasVariant(token, (variant) => variant === "touch-only");
+
+const kindForBaseUtility = (utility: string): RevealKind[] => {
+  switch (utility) {
+    case "tw-hidden":
+      return ["display"];
+    case "tw-invisible":
+      return ["visibility"];
+    case "tw-pointer-events-none":
+      return ["pointer-events"];
+    case "tw-opacity-0":
+      return ["opacity"];
+    case "tw-w-0":
+    case "tw-max-w-0":
+      return ["width"];
+    case "tw-h-0":
+    case "tw-max-h-0":
+      return ["height"];
+    case "tw-size-0":
+      return ["width", "height"];
+    case "tw-scale-0":
+      return ["scale"];
+    default:
       return [];
-    }
-    const offending = classStringLiterals(fs.readFileSync(file, "utf8")).some(
-      (literal) => isGated(literal) && !hasEscape(literal)
-    );
-    return offending ? [relative] : [];
-  });
-  return Array.from(new Set(hits)).sort((a, b) => a.localeCompare(b));
+  }
+};
+
+const POSITIVE_DISPLAY = new Set([
+  "tw-block",
+  "tw-flex",
+  "tw-grid",
+  "tw-inline",
+  "tw-inline-block",
+  "tw-inline-flex",
+  "tw-inline-grid",
+  "tw-table",
+]);
+
+const kindForRevealUtility = (utility: string): RevealKind[] => {
+  if (POSITIVE_DISPLAY.has(utility)) return ["display"];
+  if (utility === "tw-visible") return ["visibility"];
+  if (utility === "tw-pointer-events-auto") return ["pointer-events"];
+  if (/^tw-opacity-(?!0(?:$|[/.]))/.test(utility)) return ["opacity"];
+  if (/^tw-(?:w|max-w)-(?!0(?:$|[/.]))/.test(utility)) return ["width"];
+  if (/^tw-(?:h|max-h)-(?!0(?:$|[/.]))/.test(utility)) return ["height"];
+  if (/^tw-size-(?!0(?:$|[/.]))/.test(utility)) {
+    return ["width", "height"];
+  }
+  if (/^tw-scale-(?!0(?:$|[/.]))/.test(utility)) return ["scale"];
+  return [];
+};
+
+function kindsFor(
+  tokens: readonly ClassToken[],
+  tokenMatches: (token: ClassToken) => boolean,
+  utilityKinds: (utility: string) => readonly RevealKind[]
+): Set<RevealKind> {
+  return new Set(
+    tokens.filter(tokenMatches).flatMap((token) => utilityKinds(token.utility))
+  );
 }
 
-describe("hover-revealed controls stay reachable without hover", () => {
-  it("finds no control that only a mouse hover can make clickable", () => {
-    expect(
-      filesWhere(gatesReachability, (literal) =>
-        NON_HOVER_REACHABILITY.test(literal)
-      )
-    ).toEqual([]);
+function missingTouchFallbacks(literal: string): RevealKind[] {
+  const tokens = classTokens(literal);
+  const baseTokens = tokens.filter(
+    (token) => !isHoverToken(token) && !isTouchOnlyToken(token)
+  );
+  const baseKinds = kindsFor(baseTokens, () => true, kindForBaseUtility);
+  const hoverKinds = kindsFor(tokens, isHoverToken, kindForRevealUtility);
+  const touchTokens = tokens.filter(isTouchOnlyToken);
+  const isResponsiveVariant = (variant: string): boolean =>
+    /^(?:sm|md|lg|xl|2xl|min-\[|max-\[|@)/.test(variant);
+  const hasEffectiveTouchFallback = (kind: RevealKind): boolean => {
+    const candidates = touchTokens.filter((token) =>
+      kindForRevealUtility(token.utility).includes(kind)
+    );
+    if (candidates.length === 0) return false;
+
+    const hasResponsiveGate = baseTokens.some(
+      (token) =>
+        kindForBaseUtility(token.utility).includes(kind) &&
+        token.variants.some(isResponsiveVariant)
+    );
+    return !hasResponsiveGate || candidates.some((token) => token.important);
+  };
+
+  return [...baseKinds]
+    .filter((kind) => hoverKinds.has(kind) && !hasEffectiveTouchFallback(kind))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function gatedLiterals(): GatedLiteral[] {
+  return SCAN_ROOTS.flatMap(sourceFiles).flatMap((file) => {
+    const relative = path.relative(projectRoot, file);
+    return classStringLiterals(fs.readFileSync(file, "utf8")).flatMap(
+      (literal) => {
+        const missing = missingTouchFallbacks(literal);
+        return missing.length
+          ? [
+              {
+                file: relative,
+                literal,
+                missingTouchFallbacks: missing,
+              },
+            ]
+          : [];
+      }
+    );
+  });
+}
+
+const exemptionFor = (hit: GatedLiteral): AuditedRevealExemption | undefined =>
+  AUDITED_REVEAL_EXEMPTIONS.find(
+    (exemption) =>
+      exemption.file === hit.file && hit.literal.includes(exemption.marker)
+  );
+
+describe("hover-revealed controls stay visible without hover", () => {
+  const hits = gatedLiterals();
+
+  it("finds no unaudited reveal without the exact touch-only fallback", () => {
+    const unaudited = hits
+      .filter((hit) => !exemptionFor(hit))
+      .map(({ file, missingTouchFallbacks: missing }) => ({ file, missing }));
+
+    expect(unaudited).toEqual([]);
   });
 
-  it("does not grow the set of controls that only a mouse hover makes visible", () => {
-    const current = filesWhere(gatesVisibilityOnly, (literal) =>
-      NON_HOVER_VISIBILITY.test(literal)
-    );
-    const added = current.filter(
-      (file) => !VISIBILITY_ONLY_BASELINE.includes(file)
-    );
-
-    expect(added).toEqual([]);
-    expect(current.length).toBeLessThanOrEqual(
-      VISIBILITY_ONLY_BASELINE.length
-    );
-  });
-
-  it("keeps every JS-driven exemption pointed at a real file", () => {
-    for (const exempt of Object.keys(JS_DRIVEN_REVEALS)) {
-      expect(fs.existsSync(path.join(projectRoot, exempt))).toBe(true);
+  it("keeps every exemption narrow, explained, and attached to a real gate", () => {
+    for (const exemption of AUDITED_REVEAL_EXEMPTIONS) {
+      expect(exemption.reason.length).toBeGreaterThan(40);
+      expect(fs.existsSync(path.join(projectRoot, exemption.file))).toBe(true);
     }
+
+    const detached = AUDITED_REVEAL_EXEMPTIONS.filter(
+      (exemption) =>
+        !hits.some(
+          (hit) =>
+            hit.file === exemption.file &&
+            hit.literal.includes(exemption.marker)
+        )
+    ).map(({ file, marker }) => ({ file, marker }));
+
+    expect(detached).toEqual([]);
+  });
+});
+
+describe("gate detection", () => {
+  it("requires touch-only even when keyboard focus also reveals the control", () => {
+    const literal =
+      "tw-opacity-0 desktop-hover:group-hover:tw-opacity-100 focus-visible:tw-opacity-100";
+
+    expect(missingTouchFallbacks(literal)).toEqual(["opacity"]);
+  });
+
+  it("requires each gated property to be restored", () => {
+    const literal =
+      "tw-pointer-events-none tw-opacity-0 desktop-hover:group-hover:tw-pointer-events-auto desktop-hover:group-hover:tw-opacity-100 touch-only:tw-opacity-100";
+
+    expect(missingTouchFallbacks(literal)).toEqual(["pointer-events"]);
+  });
+
+  it("accepts exact touch-only fallbacks for every gated property", () => {
+    const literal =
+      "tw-pointer-events-none tw-opacity-0 desktop-hover:group-hover:tw-pointer-events-auto desktop-hover:group-hover:tw-opacity-100 touch-only:tw-pointer-events-auto touch-only:tw-opacity-100";
+
+    expect(missingTouchFallbacks(literal)).toEqual([]);
+  });
+
+  it("detects self hover, partial opacity, responsive gates, and collapsed width", () => {
+    expect(
+      missingTouchFallbacks(
+        "lg:tw-opacity-0 tw-w-0 hover:tw-opacity-50 desktop-hover:hover:tw-w-7"
+      )
+    ).toEqual(["opacity", "width"]);
+  });
+
+  it("requires a touch fallback to outrank a responsive visibility gate", () => {
+    const gated =
+      "tw-opacity-100 lg:tw-opacity-0 desktop-hover:group-hover:tw-opacity-100 touch-only:tw-opacity-100";
+    const safe =
+      "tw-opacity-100 lg:tw-opacity-0 desktop-hover:group-hover:tw-opacity-100 touch-only:!tw-opacity-100";
+
+    expect(missingTouchFallbacks(gated)).toEqual(["opacity"]);
+    expect(missingTouchFallbacks(safe)).toEqual([]);
+  });
+
+  it("ignores hover decoration on a control without an invisible base", () => {
+    expect(missingTouchFallbacks("tw-opacity-80 hover:tw-opacity-100")).toEqual(
+      []
+    );
   });
 });
 
@@ -184,44 +431,6 @@ describe("hover-revealed controls stay reachable without hover", () => {
  * `any-hover: hover` from an attached trackpad while its primary pointer is
  * coarse — matching neither the hover reveal nor the touch fallback.
  */
-/** The guard is only worth its green if it separates these cases. */
-describe("gate detection", () => {
-  const gated = (literal: string) => ({
-    reachability: gatesReachability(literal),
-    visibilityOnly: gatesVisibilityOnly(literal),
-  });
-
-  it("rejects an opacity-only escape from a hit-target gate", () => {
-    const literal =
-      "tw-pointer-events-none tw-opacity-0 desktop-hover:group-hover:tw-pointer-events-auto focus-visible:tw-opacity-100";
-
-    expect(gated(literal).reachability).toBe(true);
-    // Opacity cannot restore a hit target, so this must not count as an escape.
-    expect(NON_HOVER_REACHABILITY.test(literal)).toBe(false);
-  });
-
-  it("accepts an escape that restores the hit target", () => {
-    const literal =
-      "tw-pointer-events-none tw-opacity-0 desktop-hover:group-hover:tw-pointer-events-auto touch-only:tw-pointer-events-auto";
-
-    expect(NON_HOVER_REACHABILITY.test(literal)).toBe(true);
-  });
-
-  it("ignores the desktop-hover capability variant on its own", () => {
-    // Applies with no cursor anywhere near the element — not a reveal.
-    expect(gated("tw-hidden desktop-hover:tw-flex")).toEqual({
-      reachability: false,
-      visibilityOnly: false,
-    });
-  });
-
-  it("ignores hover emphasis on an already-visible control", () => {
-    expect(gated("tw-opacity-80 hover:tw-opacity-100")).toEqual({
-      reachability: false,
-      visibilityOnly: false,
-    });
-  });
-});
 
 describe("touch-only complements the hover reveal exactly", () => {
   type VariantValue = string | readonly string[];
@@ -331,5 +540,26 @@ describe("touch-only complements the hover reveal exactly", () => {
     // ...and the fallback sits inside exactly its negation, so no browser can
     // land outside both.
     expect(touchRule).toEqual([[`media ${COMPLEMENT_QUERY}`]]);
+  });
+
+  it("emits an important fallback that can beat responsive base gates", async () => {
+    const markup =
+      '<div class="tw-opacity-100 lg:tw-opacity-0 touch-only:!tw-opacity-100"></div>';
+    const css = await postcss([
+      tailwindcss({
+        ...(tailwindConfig as Config),
+        content: [{ raw: markup, extension: "html" }],
+      }),
+    ]).process("@tailwind utilities;", { from: undefined });
+    const importantDeclarations: boolean[] = [];
+
+    css.root.walkRules((rule) => {
+      if (!rule.selector.includes("touch-only\\:\\!tw-opacity-100")) return;
+      rule.walkDecls("opacity", (declaration) => {
+        importantDeclarations.push(declaration.important);
+      });
+    });
+
+    expect(importantDeclarations).toEqual([true]);
   });
 });

--- a/__tests__/contracts/hover-revealed-controls.test.ts
+++ b/__tests__/contracts/hover-revealed-controls.test.ts
@@ -165,7 +165,7 @@ const AUDITED_REVEAL_EXEMPTIONS: readonly AuditedRevealExemption[] = [
   },
   {
     file: "components/waves/winners/podium/WavePodiumItem.tsx",
-    marker: "tw-size-3 tw-opacity-0 tw-transition-opacity",
+    marker: "tw-top-1/2 tw-ml-2 -tw-translate-y-1/2",
     literalHash:
       "6c495c84006e65e1116ebdac27efe93d03ebbe99b90f05cea1479428974c4c14",
     reason:
@@ -173,7 +173,8 @@ const AUDITED_REVEAL_EXEMPTIONS: readonly AuditedRevealExemption[] = [
   },
   {
     file: "components/waves/winners/podium/WavePodiumItem.tsx",
-    marker: "tw-size-3 tw-opacity-0 tw-transition-opacity",
+    marker:
+      "tw-left-[100%] tw-ml-2 desktop-hover:group-hover/link:tw-opacity-100",
     literalHash:
       "45ab45ab8b895343e261065876d1639d6354954512fa4422ce412a662e945826",
     reason:

--- a/__tests__/contracts/hover-revealed-controls.test.ts
+++ b/__tests__/contracts/hover-revealed-controls.test.ts
@@ -13,6 +13,7 @@
  * gates, and collapsed dimensions. Narrow exemptions below are audited UI
  * that is decorative or has a separate always-available interaction path.
  */
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import postcss from "postcss";
@@ -48,107 +49,149 @@ interface GatedLiteral {
 interface AuditedRevealExemption {
   readonly file: string;
   readonly marker: string;
+  readonly literalHash: string;
   readonly reason: string;
 }
 
 /**
- * These are literal-level exemptions, not file-wide suppressions. Each marker
- * must continue matching a real gated class list or the contract fails.
+ * These are literal-level exemptions, not file-wide suppressions. The marker
+ * keeps reviews readable while the hash pins the entire normalized class
+ * literal; changing or extending that literal invalidates the exemption.
  */
 const AUDITED_REVEAL_EXEMPTIONS: readonly AuditedRevealExemption[] = [
   {
     file: "components/home/boosted/BoostedDropCompactChatItem.tsx",
     marker: "tw-items-center tw-overflow-hidden tw-opacity-0",
+    literalHash:
+      "0f587c25522815d66da60260f1d14df5ea0ad8aadcb8717cde6088300f528df8",
     reason:
       "This pointer-events-none preview replaces already visible summary text as decoration; without hover the original summary remains visible.",
   },
   {
     file: "components/home/now-minting/MemeSubscriptionAwarenessRow.tsx",
     marker: "tw-bg-primary-400/[0.045] tw-opacity-0",
+    literalHash:
+      "0bc7f096adb69984e6ebd6ba6e6dd42070148782c663d14af10ed4401778e31d",
     reason:
       "This aria-hidden, pointer-events-none surface tint is decorative; the row content and actions are always visible.",
   },
   {
     file: "components/profile-cms/CmsArtLightbox.tsx",
     marker: "tw-uppercase tw-text-white tw-opacity-0",
+    literalHash:
+      "4b031231747e41907541a19e6b9515d96c7a9fe1a6bc4e5dc20918134f049cfb",
     reason:
       "The Inspect label supplements an already visible and keyboard-focusable artwork control; it is not a separate action.",
   },
   {
     file: "components/drops/view/item/content/media/MediaActionToolbar.tsx",
     marker: "desktop-hover:group-hover/media:tw-pointer-events-auto",
+    literalHash:
+      "8cdecad1fd55f627ff69f6ef7619a5b3d7ef03bd5a1db6d57408e64563afb848",
     reason:
       "The inline media toolbar is an enhancement; clicking the visible media opens the expanded viewer with the same actions, and keyboard focus also reveals it.",
   },
   {
     file: "components/user/brain/UserPageBrainSidebarWaveItem.tsx",
     marker: "-tw-translate-x-1 tw-text-iron-600 tw-opacity-0",
+    literalHash:
+      "84c3f14d428c46d315170c5f07e9d8378b9181c690a3bdcb800197561aac948e",
     reason:
       "The faded chevron is decorative; the wave link and label remain visible and operable.",
   },
   {
     file: "components/utils/NewVersionToast.tsx",
     marker: "before:tw-bg-[radial-gradient(circle_at_82%_50%",
+    literalHash:
+      "05fb46b70c92b159eb60ee7c479153c5c075347054e0fafb70dc484c4765092e",
     reason:
       "This pointer-events-none pseudo-element is a decorative glow on an always visible refresh button.",
   },
   {
     file: "components/waves/drops/ArtistActiveSubmissionContent.tsx",
     marker: "tw-right-3 tw-top-3 tw-opacity-0",
+    literalHash:
+      "81b51aea26c6c7a7fc1b7df296946a836777339b158ffab0a7d36c051feb5397",
     reason:
       "The eye glyph is decorative feedback on an already visible, fully clickable artwork card.",
   },
   {
     file: "components/waves/drops/ArtistWinningArtworksContent.tsx",
     marker: "tw-right-3 tw-top-3 tw-opacity-0",
+    literalHash:
+      "81b51aea26c6c7a7fc1b7df296946a836777339b158ffab0a7d36c051feb5397",
     reason:
       "The eye glyph is decorative feedback on an already visible, fully clickable artwork card.",
   },
   {
     file: "components/waves/drops/WaveDropActions.tsx",
     marker: "desktop-hover:group-hover:tw-pointer-events-auto",
+    literalHash:
+      "cba6ffbd8f3f64aba6310f2306f8d6e0458f8bbe503330f763f99e1e15bf87a7",
     reason:
       "WaveDrop tracks pointerover/out without a hover capability query and passes forceVisible; the CSS hover rule is its no-JS enhancement.",
   },
   {
     file: "components/waves/drops/WaveDrop.helpers.tsx",
     marker: "tw-opacity-0 desktop-hover:group-hover:tw-opacity-100",
+    literalHash:
+      "dc415d6ed3f1074154a978fff7bea616f299625cfe95d3b0ab2197cefb2768df",
     reason:
       "This is a pointer-events-none timestamp, not a control, and WaveDrop's forceVisible pointer path also drives its opacity.",
   },
   {
     file: "components/waves/FilePreview.tsx",
     marker: "tw-bg-iron-950 tw-opacity-0",
+    literalHash:
+      "bdd312eefbb552edbd175dea4ef9ec973f12695c3397cfa3af018a5c83b0e0b6",
     reason:
       "This empty overlay is a decorative shade on a file preview; the preview content and interaction remain visible.",
   },
   {
     file: "components/waves/gallery/WaveGalleryItem.tsx",
     marker: "tw-bg-gradient-to-t tw-from-black/80",
+    literalHash:
+      "f52aeaa5f9b8f281ec5bea860dbbbc783efbcb5982d965ae6ad1f37ac2f047a0",
     reason:
       "The gradient is a pointer-events-none visual treatment; the gallery card remains visible and operable.",
   },
   {
     file: "components/waves/gallery/WaveGalleryItem.tsx",
     marker: "tw-bottom-0 tw-left-0 tw-right-0 tw-translate-y-2",
+    literalHash:
+      "b635b3b46283c6bb2173c83b6b40e222ba9592626f9cd89b565a21dc6ea57ae1",
     reason:
       "The title and metadata overlay is pointer-events-none supplementary content; the card and author control have independent visible targets.",
   },
   {
     file: "components/waves/winners/podium/WavePodiumItem.tsx",
     marker: "tw-size-3 tw-opacity-0 tw-transition-opacity",
+    literalHash:
+      "6c495c84006e65e1116ebdac27efe93d03ebbe99b90f05cea1479428974c4c14",
+    reason:
+      "The external-link arrow is decorative feedback beside an already visible and fully operable profile link.",
+  },
+  {
+    file: "components/waves/winners/podium/WavePodiumItem.tsx",
+    marker: "tw-size-3 tw-opacity-0 tw-transition-opacity",
+    literalHash:
+      "45ab45ab8b895343e261065876d1639d6354954512fa4422ce412a662e945826",
     reason:
       "The external-link arrow is decorative feedback beside an already visible and fully operable profile link.",
   },
   {
     file: "app/join/FocusSections.tsx",
     marker: "tw-bg-[linear-gradient(90deg,transparent_0%",
+    literalHash:
+      "39d0c8e903fcfd521af6b28b73f571b6666e26e784e31af233a7fddf5f5d6fdb",
     reason:
       "This aria-hidden, pointer-events-none gradient is decorative; the section content remains visible and operable.",
   },
   {
     file: "app/join/JourneyTimelineSection.tsx",
     marker: "tw-bg-[radial-gradient(circle,rgba(132,173,255",
+    literalHash:
+      "8c3c9fa30ca9f143dbf2c6be91ba35659e2099745f7c019e9a09b4be8d6c052b",
     reason:
       "This empty radial glow is decorative; the timeline icon, copy, and controls remain visible without it.",
   },
@@ -196,13 +239,24 @@ function classStringLiterals(source: string): string[] {
   return literals;
 }
 
-function classTokens(literal: string): ClassToken[] {
+function literalContent(literal: string): string {
   const quote = literal.at(0);
-  const content =
+  return (
     (quote === '"' || quote === "'" || quote === "`") &&
     literal.at(-1) === quote
       ? literal.slice(1, -1)
-      : literal;
+      : literal
+  );
+}
+
+const normalizeLiteral = (literal: string): string =>
+  literalContent(literal).trim().split(/\s+/).join(" ");
+
+const literalHash = (literal: string): string =>
+  createHash("sha256").update(normalizeLiteral(literal)).digest("hex");
+
+function classTokens(literal: string): ClassToken[] {
+  const content = literalContent(literal);
 
   return content
     .split(/\s+/)
@@ -344,7 +398,9 @@ function gatedLiterals(): GatedLiteral[] {
 const exemptionFor = (hit: GatedLiteral): AuditedRevealExemption | undefined =>
   AUDITED_REVEAL_EXEMPTIONS.find(
     (exemption) =>
-      exemption.file === hit.file && hit.literal.includes(exemption.marker)
+      exemption.file === hit.file &&
+      hit.literal.includes(exemption.marker) &&
+      literalHash(hit.literal) === exemption.literalHash
   );
 
 describe("hover-revealed controls stay visible without hover", () => {
@@ -364,16 +420,33 @@ describe("hover-revealed controls stay visible without hover", () => {
       expect(fs.existsSync(path.join(projectRoot, exemption.file))).toBe(true);
     }
 
-    const detached = AUDITED_REVEAL_EXEMPTIONS.filter(
-      (exemption) =>
-        !hits.some(
-          (hit) =>
-            hit.file === exemption.file &&
-            hit.literal.includes(exemption.marker)
-        )
-    ).map(({ file, marker }) => ({ file, marker }));
+    const detached = AUDITED_REVEAL_EXEMPTIONS.filter((exemption) => {
+      const matchingHits = hits.filter(
+        (hit) => exemptionFor(hit) === exemption
+      );
+      return matchingHits.length !== 1;
+    }).map(({ file, marker }) => ({ file, marker }));
 
     expect(detached).toEqual([]);
+  });
+
+  it("does not exempt a longer literal that merely contains the marker", () => {
+    const exemption = AUDITED_REVEAL_EXEMPTIONS[0];
+    const auditedHit = hits.find((hit) => exemptionFor(hit) === exemption);
+
+    expect(auditedHit).toBeDefined();
+    if (!auditedHit) {
+      throw new Error("Expected the audited gate to be present");
+    }
+    const closingQuote = auditedHit.literal.at(-1) ?? '"';
+    const longerLiteral = `${auditedHit.literal.slice(0, -1)} tw-sr-only${closingQuote}`;
+
+    expect(
+      exemptionFor({
+        ...auditedHit,
+        literal: longerLiteral,
+      })
+    ).toBeUndefined();
   });
 });
 
@@ -421,6 +494,18 @@ describe("gate detection", () => {
     expect(missingTouchFallbacks("tw-opacity-80 hover:tw-opacity-100")).toEqual(
       []
     );
+  });
+
+  it("detects a gate split around a template interpolation", () => {
+    const [literal] = classStringLiterals(
+      'const classes = `tw-opacity-0 ${variant} desktop-hover:group-hover:tw-opacity-100`;'
+    );
+
+    expect(literal).toBeDefined();
+    if (!literal) {
+      throw new Error("Expected the template class literal to be extracted");
+    }
+    expect(missingTouchFallbacks(literal)).toEqual(["opacity"]);
   });
 });
 

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
@@ -128,7 +128,7 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
   // Desktop rows reveal the pin on row hover or direct keyboard focus.
   const getOpacityClass = () => {
     if (isTouchDevice) return "tw-opacity-100";
-    return "tw-opacity-0 desktop-hover:group-hover:tw-opacity-100 focus-visible:tw-opacity-100";
+    return "tw-opacity-0 desktop-hover:group-hover:tw-opacity-100 focus-visible:tw-opacity-100 touch-only:tw-opacity-100";
   };
   const opacityClass = getOpacityClass();
 
@@ -158,7 +158,7 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
   const getSizeClasses = () => {
     if (!compact) return "tw-size-7 sm:tw-size-6";
     if (isTouchDevice) return "tw-size-7";
-    return "tw-h-7 tw-w-0 desktop-hover:group-hover:tw-w-7 focus-visible:tw-w-7";
+    return "tw-h-7 tw-w-0 desktop-hover:group-hover:tw-w-7 focus-visible:tw-w-7 touch-only:tw-w-7";
   };
   const sizeClasses = getSizeClasses();
   const iconSizeClasses = compact ? "tw-size-3.5" : "tw-size-4";

--- a/components/profile-activity/list/items/utils/ProfileActivityLogItemValueWithCopy.tsx
+++ b/components/profile-activity/list/items/utils/ProfileActivityLogItemValueWithCopy.tsx
@@ -34,12 +34,14 @@ export default function ProfileActivityLogItemValueWithCopy({
       </span>
       <>
         <button
+          type="button"
+          aria-label="Copy"
           onClick={handleCopy}
           className={`${
             isTouchScreen
               ? "tw-block"
-              : "tw-opacity-0 group-hover:tw-opacity-100"
-          } tw-mx-1 tw-cursor-pointer tw-border-0 tw-bg-transparent tw-text-sm tw-font-semibold tw-text-iron-500 tw-transition tw-duration-300 tw-ease-out hover:tw-text-iron-200 focus:tw-outline-none`}
+              : "tw-opacity-0 desktop-hover:group-hover:tw-opacity-100 touch-only:tw-opacity-100"
+          } tw-mx-1 tw-cursor-pointer tw-border-0 tw-bg-transparent tw-text-sm tw-font-semibold tw-text-iron-500 tw-transition tw-duration-300 tw-ease-out focus-visible:tw-opacity-100 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 desktop-hover:hover:tw-text-iron-200`}
           data-tooltip-id={`copy-activity-${value}`}
         >
           <div className="tw-flex tw-h-5 tw-w-5 tw-flex-shrink-0 tw-items-center tw-justify-center lg:tw-h-4 lg:tw-w-4 [&>svg]:tw-h-full [&>svg]:tw-w-full">

--- a/components/user/identity/statements/utils/UserPageIdentityDeleteStatementButton.tsx
+++ b/components/user/identity/statements/utils/UserPageIdentityDeleteStatementButton.tsx
@@ -38,7 +38,7 @@ export default function UserPageIdentityDeleteStatementButton({
         className={`${
           isTouchScreen
             ? "tw-opacity-100"
-            : "tw-opacity-0 group-hover:tw-opacity-100"
+            : "tw-opacity-0 desktop-hover:group-hover:tw-opacity-100 touch-only:tw-opacity-100"
         } tw-inline-flex tw-h-9 tw-w-9 tw-cursor-pointer tw-items-center tw-justify-center tw-rounded-full tw-border-0 tw-bg-transparent tw-p-0 tw-text-rose-400 tw-transition tw-duration-200 tw-ease-out focus-visible:tw-opacity-100 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-rose-400 active:tw-scale-95 desktop-hover:hover:tw-bg-rose-500/10 desktop-hover:hover:tw-text-rose-300 motion-reduce:tw-transform-none motion-reduce:tw-transition-none`}
       >
         <TrashIcon

--- a/components/user/user-page-header/about/UserPageHeaderAbout.tsx
+++ b/components/user/user-page-header/about/UserPageHeaderAbout.tsx
@@ -70,9 +70,12 @@ function UserPageHeaderAboutContent({
                 type="button"
                 onClick={onEditClick}
                 aria-label={editActionLabel}
-                className="tw-pointer-events-none tw-hidden tw-shrink-0 tw-border-none tw-bg-transparent tw-p-0 tw-text-iron-400 tw-opacity-0 tw-transition tw-duration-200 focus-visible:tw-rounded-lg focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 desktop-hover:group-hover:tw-pointer-events-auto desktop-hover:group-hover:tw-opacity-100 desktop-hover:hover:tw-text-iron-200 sm:tw-block sm:group-focus-within:tw-pointer-events-auto sm:group-focus-within:tw-opacity-100"
+                className="tw-pointer-events-none tw-hidden tw-shrink-0 tw-border-none tw-bg-transparent tw-p-0 tw-text-iron-400 tw-opacity-0 tw-transition tw-duration-200 focus-visible:tw-rounded-lg focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 desktop-hover:group-hover:tw-pointer-events-auto desktop-hover:group-hover:tw-opacity-100 desktop-hover:hover:tw-text-iron-200 touch-only:tw-pointer-events-auto touch-only:tw-size-11 touch-only:tw-opacity-100 sm:tw-block sm:group-focus-within:tw-pointer-events-auto sm:group-focus-within:tw-opacity-100"
               >
-                <span aria-hidden="true">
+                <span
+                  aria-hidden="true"
+                  className="tw-flex tw-size-full tw-items-center tw-justify-center"
+                >
                   <PencilIcon size={PencilIconSize.SMALL} />
                 </span>
               </button>

--- a/components/user/user-page-header/banner/UserPageHeaderBanner.tsx
+++ b/components/user/user-page-header/banner/UserPageHeaderBanner.tsx
@@ -59,16 +59,16 @@ export default function UserPageHeaderBanner({
         <button
           type="button"
           onClick={() => setIsEditOpen(true)}
-          className="tw-absolute tw-inset-0 tw-z-10 tw-hidden tw-h-full tw-w-full tw-border-none tw-bg-transparent tw-p-0 sm:tw-block"
+          className="tw-absolute tw-inset-0 tw-z-10 tw-hidden tw-h-full tw-w-full tw-border-none tw-bg-transparent tw-p-0 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-[-2px] focus-visible:tw-outline-primary-400 sm:tw-block"
           aria-label={getUserProfileHeaderMessage(
             "user.profileHeader.banner.edit",
             { name: profileLabel }
           )}
         >
-          <div className="tw-absolute tw-inset-0 tw-bg-black/30 tw-opacity-0 tw-transition-opacity tw-duration-300 tw-ease-out hover:tw-opacity-100">
+          <div className="tw-absolute tw-inset-0 tw-bg-black/30 tw-opacity-0 tw-transition-opacity tw-duration-300 tw-ease-out group-focus-within:tw-opacity-100 desktop-hover:group-hover:tw-opacity-100 touch-only:tw-bg-transparent touch-only:tw-opacity-100 motion-reduce:tw-transition-none">
             <div
               aria-hidden="true"
-              className="tw-absolute tw-right-4 tw-top-4"
+              className="tw-absolute tw-right-4 tw-top-4 touch-only:tw-flex touch-only:tw-size-9 touch-only:tw-items-center touch-only:tw-justify-center touch-only:tw-rounded-full touch-only:tw-border touch-only:tw-border-solid touch-only:tw-border-iron-800/60 touch-only:tw-bg-iron-950 touch-only:tw-shadow-md"
             >
               <PencilIcon />
             </div>

--- a/components/user/user-page-header/name/UserPageHeaderNameWrapper.tsx
+++ b/components/user/user-page-header/name/UserPageHeaderNameWrapper.tsx
@@ -39,7 +39,7 @@ export default function UserPageHeaderNameWrapper({
       >
         <div
           aria-hidden="true"
-          className="tw-absolute tw-inset-0 tw-hidden tw-text-iron-400 group-focus-within:tw-block group-hover:tw-block"
+          className="tw-absolute tw-inset-0 tw-hidden tw-text-iron-400 group-focus-within:tw-block desktop-hover:group-hover:tw-block touch-only:tw-block"
         >
           <div className="tw-absolute -tw-left-5 tw-top-1/2 tw-z-10 tw-flex tw-size-5 -tw-translate-y-1/2 tw-items-center tw-justify-center">
             <PencilIcon size={PencilIconSize.SMALL} />

--- a/components/user/user-page-header/name/classification/UserPageClassificationWrapper.tsx
+++ b/components/user/user-page-header/name/classification/UserPageClassificationWrapper.tsx
@@ -39,7 +39,7 @@ export default function UserPageClassificationWrapper({
       >
         <span
           aria-hidden="true"
-          className="tw-absolute -tw-left-5 tw-top-1/2 tw-hidden tw-size-4 -tw-translate-y-1/2 tw-items-center tw-justify-center tw-text-iron-400 group-focus-within:tw-flex group-hover:tw-flex"
+          className="tw-absolute -tw-left-5 tw-top-1/2 tw-hidden tw-size-4 -tw-translate-y-1/2 tw-items-center tw-justify-center tw-text-iron-400 group-focus-within:tw-flex desktop-hover:group-hover:tw-flex touch-only:tw-flex"
         >
           <PencilIcon size={PencilIconSize.SMALL} />
         </span>

--- a/components/waves/ChatItemHrefButtons.tsx
+++ b/components/waves/ChatItemHrefButtons.tsx
@@ -476,7 +476,7 @@ export default function ChatItemHrefButtons({
           className={`tw-transition-opacity tw-duration-200 ${
             showPersistentOverlayTrigger || isMenuOpen
               ? "tw-pointer-events-auto tw-opacity-100"
-              : "tw-pointer-events-none tw-opacity-0 group-focus-within/link-card:tw-pointer-events-auto group-focus-within/link-card:tw-opacity-100 desktop-hover:group-hover/link-card:tw-pointer-events-auto desktop-hover:group-hover/link-card:tw-opacity-100"
+              : "tw-pointer-events-none tw-opacity-0 group-focus-within/link-card:tw-pointer-events-auto group-focus-within/link-card:tw-opacity-100 desktop-hover:group-hover/link-card:tw-pointer-events-auto desktop-hover:group-hover/link-card:tw-opacity-100 touch-only:tw-pointer-events-auto touch-only:tw-opacity-100"
           }`}
         >
           <button

--- a/components/waves/drops/WaveDropsScrollControlsUnreadButton.tsx
+++ b/components/waves/drops/WaveDropsScrollControlsUnreadButton.tsx
@@ -133,7 +133,7 @@ export function WaveDropsScrollControlsUnreadButton({
           onMouseMove={handlers.onMouseMove}
           onMouseUp={handlers.onMouseUp}
           onMouseLeave={handlers.onMouseLeave}
-          className={`tw-flex tw-h-10 tw-min-w-[2.75rem] tw-items-center tw-justify-center tw-gap-2 tw-border-0 tw-bg-indigo-500 tw-px-4 tw-text-white tw-opacity-50 tw-transition-all tw-duration-300 hover:tw-opacity-100 lg:tw-h-8 ${roundedClassName} ${isCombined ? combinedWidthClassName : ""}`}
+          className={`tw-flex tw-h-10 tw-min-w-[2.75rem] tw-items-center tw-justify-center tw-gap-2 tw-border-0 tw-bg-indigo-500 tw-px-4 tw-text-white tw-opacity-50 tw-transition-all tw-duration-300 desktop-hover:hover:tw-opacity-100 touch-only:tw-opacity-100 lg:tw-h-8 ${roundedClassName} ${isCombined ? combinedWidthClassName : ""}`}
           aria-label="Scroll to first unread message"
         >
           {unreadContent}

--- a/components/waves/drops/WaveDropsScrollControlsUnreadButton.tsx
+++ b/components/waves/drops/WaveDropsScrollControlsUnreadButton.tsx
@@ -104,8 +104,9 @@ export function WaveDropsScrollControlsUnreadButton({
     >
       <div className="tw-group tw-relative">
         <button
+          type="button"
           onClick={handleDismiss}
-          className="tw-absolute -tw-right-2 -tw-top-2 tw-z-50 tw-hidden tw-size-6 tw-items-center tw-justify-center tw-rounded-full tw-border-0 tw-bg-indigo-500 tw-text-white tw-opacity-0 tw-transition-all tw-duration-200 group-hover:tw-opacity-50 hover:!tw-opacity-100 lg:tw-flex"
+          className="tw-absolute -tw-right-2 -tw-top-2 tw-z-50 tw-hidden tw-size-6 tw-items-center tw-justify-center tw-rounded-full tw-border-0 tw-bg-indigo-500 tw-text-white tw-opacity-0 tw-transition-all tw-duration-200 focus-visible:tw-opacity-100 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 desktop-hover:group-hover:tw-opacity-50 desktop-hover:hover:!tw-opacity-100 touch-only:tw-opacity-100 lg:tw-flex"
           aria-label="Dismiss"
         >
           <svg
@@ -123,6 +124,7 @@ export function WaveDropsScrollControlsUnreadButton({
           </svg>
         </button>
         <button
+          type="button"
           onClick={handleUnreadClick}
           onTouchStart={handlers.onTouchStart}
           onTouchMove={handlers.onTouchMove}

--- a/components/waves/gallery/WaveGalleryItem.tsx
+++ b/components/waves/gallery/WaveGalleryItem.tsx
@@ -93,7 +93,7 @@ export const WaveGalleryItem = memo<WaveGalleryItemProps>(
           />
         </div>
         {drop.author.handle && (
-          <div className="tw-absolute tw-bottom-2 tw-left-2 tw-right-2 tw-flex tw-items-center tw-gap-2 tw-opacity-100 tw-transition-opacity tw-duration-300 group-hover:tw-opacity-100 lg:tw-opacity-0">
+          <div className="tw-absolute tw-bottom-2 tw-left-2 tw-right-2 tw-flex tw-items-center tw-gap-2 tw-opacity-100 tw-transition-opacity tw-duration-300 desktop-hover:group-hover:tw-opacity-100 touch-only:!tw-opacity-100 lg:tw-opacity-0">
             <UserProfileTooltipWrapper user={drop.author.handle}>
               <Link
                 onClick={(e) => e.stopPropagation()}

--- a/components/waves/leaderboard/grid/WaveLeaderboardGridItemViewport.tsx
+++ b/components/waves/leaderboard/grid/WaveLeaderboardGridItemViewport.tsx
@@ -220,7 +220,7 @@ export const WaveLeaderboardGridItemViewport: React.FC<
       {showDesktopContentOnlyActions && (
         <div
           data-testid={`wave-leaderboard-grid-item-content-only-actions-${drop.id}`}
-          className="tw-pointer-events-none tw-absolute tw-inset-x-0 tw-bottom-0 tw-z-10 tw-bg-gradient-to-t tw-from-black/90 tw-via-black/65 tw-to-transparent tw-p-2 tw-opacity-0 tw-transition-opacity tw-duration-200 group-focus-within:tw-opacity-100 desktop-hover:group-hover:tw-opacity-100"
+          className="tw-pointer-events-none tw-absolute tw-inset-x-0 tw-bottom-0 tw-z-10 tw-bg-gradient-to-t tw-from-black/90 tw-via-black/65 tw-to-transparent tw-p-2 tw-opacity-0 tw-transition-opacity tw-duration-200 group-focus-within:tw-opacity-100 desktop-hover:group-hover:tw-opacity-100 touch-only:tw-opacity-100"
         >
           <div className="tw-pointer-events-auto tw-flex tw-flex-wrap tw-items-center tw-justify-end tw-gap-2 [&_button]:tw-min-w-11">
             {canOpenDrop && <WaveDropActionsOpen drop={drop} />}


### PR DESCRIPTION
## Issue

- Hybrid Windows touch laptops can keep a desktop layout while reporting that reliable CSS hover is unavailable.
- Controls revealed only by capability-gated hover then remain invisible even though the trackpad still moves the cursor. Reported examples include Wave pinning and profile social-statement deletion.

## Fix

- Use the existing touch-only variant, which is the exact complement of Tailwind's reliable-hover query, to keep affected actions visible when CSS hover cannot fire.
- Preserve the existing hover-reveal design on ordinary mouse desktops and the existing responsive/mobile layouts on phones.
- Strengthen the repository contract so future hover-hidden controls must provide an effective no-hover fallback, including across responsive cascade gates.

## Changes

- Add no-hover fallbacks for Wave pin/unpin, profile statement deletion, activity-log copy, profile About/banner/name/classification editing, link-card actions, leaderboard actions, unread dismissal, and gallery author links.
- Preserve keyboard focus reveals and add missing accessible button semantics where these controls were touched.
- Replace the prior visibility baseline with an AST-based audit covering display, visibility, pointer events, opacity, collapsed dimensions, self-hover, group-hover, partial opacity, responsive gates, and documented literal-level exemptions.

## Validation

- 80 focused component and contract tests passed before the final cascade hardening; the final contract suite passes 11/11.
- Changed-file lint passed.
- Changed-file typecheck passed for 593 TypeScript files.
- Full changed-file quality check passed and confirmed the branch was current with origin/main.
- React Doctor scored 99/100; its two warnings are pre-existing structural observations unrelated to this fix.
- Browser QA against the staging API confirmed desktop mouse reveal, keyboard focus reveal, a successful pin/unpin round trip with state restored, and the 390px phone layout with no horizontal overflow and its existing mobile Edit profile path intact.
- A real Surface device was not available. Exact no-hover coverage is provided by the compiled CSS complement and responsive-cascade contract rather than claimed as real-device evidence.

## Risk

- Level: Low
- Why: CSS visibility and focus behavior only; no API, auth, data-model, dependency, route, or deployment changes. Desktop hover and phone layout behavior remain unchanged.
- Rollback: Revert the single commit to restore the previous per-control visibility classes and contract.

## Review Notes

- Please focus on the touch-only fallback coverage, the documented exemption set, and the responsive opacity override used by the gallery author link.
- The global touch-device classifier was intentionally not changed because hybrids must retain the desktop layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved touch-device usability by keeping key actions, edit controls, pin controls, copy buttons, and overlays visible and interactive without hover.
  * Preserved desktop hover and keyboard-focus behavior while adding clearer focus styling.
  * Improved responsive visibility for wave gallery authors, leaderboard actions, and profile controls.
  * Prevented unintended form submissions from action buttons by explicitly defining their button behavior.

* **Tests**
  * Expanded coverage for responsive touch, hover, focus, visibility, and interaction states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->