### PR TITLE
Replace unhealthy Beanstalk instances from ELB health

### DIFF
--- a/.ebextensions/autoscaling-health.config
+++ b/.ebextensions/autoscaling-health.config
@@ -1,0 +1,6 @@
+Resources:
+  AWSEBAutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      HealthCheckType: ELB
+      HealthCheckGracePeriod: 300


### PR DESCRIPTION
## Issue

- The production Elastic Beanstalk Auto Scaling group used EC2-only health checks, so instances whose application stopped responding were removed from ALB traffic but were not automatically replaced.

## Fix

- Configure the Beanstalk-managed Auto Scaling group to use ELB health checks while retaining the existing homepage (`/`) target health check.
- Give newly launched instances a 300-second grace period before ELB health can trigger replacement.

## Changes

- Add `.ebextensions/autoscaling-health.config` with the AWS-documented `AWSEBAutoScalingGroup` resource override.

## Validation

- Parsed the configuration as YAML and asserted `HealthCheckType: ELB` and `HealthCheckGracePeriod: 300`.
- `./bin/6529 run check:changed`
- Repository-wide lint completed successfully.
- The local optimized Next.js production compilation was started with CI's public production endpoint values but remained nonterminal on the local runner and was stopped; PR CI remains the authoritative production build.

## Risk

- Level: Medium
- Why: This changes production instance-replacement behavior. Persistent homepage health-check failures will now cause Auto Scaling to replace affected instances.
- Rollback: Remove the `.ebextensions` override and deploy a subsequent application version to restore EC2-only health checks.

## Review Notes

- Confirm that the 300-second startup grace period is appropriate for current Beanstalk boot time and that `/` remains the intended ALB health-check path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved deployment reliability by configuring automatic instance health checks through the load balancer.
  * Added a 300-second grace period to allow new instances to initialize before health evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->