### PR TITLE
Gate first wave chat behind guidelines

### DIFF
--- a/__tests__/components/waves/CreateDrop.test.tsx
+++ b/__tests__/components/waves/CreateDrop.test.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/react-query-wrapper/ReactQueryWrapper";
 import { useWave } from "@/hooks/useWave";
 import { commonApiPost } from "@/services/api/common-api";
+import { fetchWaveMetadata } from "@/services/api/waves-v2-api";
 
 const mockSetQueryData = jest.fn();
 const mockInvalidateQueries = jest.fn(() => Promise.resolve());
@@ -40,6 +41,9 @@ jest.mock("@tanstack/react-query", () => ({
 }));
 jest.mock("@/hooks/useWave", () => ({ useWave: jest.fn() }));
 jest.mock("@/services/api/common-api", () => ({ commonApiPost: jest.fn() }));
+jest.mock("@/services/api/waves-v2-api", () => ({
+  fetchWaveMetadata: jest.fn(),
+}));
 jest.mock("@/contexts/wave/MyStreamContext", () => ({
   useMyStream: () => ({
     processDropRemoved: jest.fn(),
@@ -65,6 +69,13 @@ jest.mock("@/components/waves/CreateDropContent", () => (props: any) => (
           drop: {
             wave_id: props.wave.id,
             drop_type: props.isDropMode ? "PARTICIPATORY" : "CHAT",
+            parts: [
+              {
+                content: props.isDropMode ? "Participation drop" : "Chat message",
+                media: [],
+                quoted_drop: null,
+              },
+            ],
           },
           dropId: null,
         } as DropMutationBody)
@@ -126,6 +137,7 @@ jest.mock("@/components/waves/quorum/QuorumProposalDropModal", () => ({
 
 const useWaveMock = useWave as jest.MockedFunction<typeof useWave>;
 const commonApiPostMock = commonApiPost as jest.Mock;
+const fetchWaveMetadataMock = jest.mocked(fetchWaveMetadata);
 
 const wave = {
   id: "1",
@@ -133,6 +145,10 @@ const wave = {
   wave: { authenticated_user_eligible_for_admin: false },
   chat: { authenticated_user_eligible: true },
   participation: { authenticated_user_eligible: true },
+  metrics: {
+    your_drops_count: 0,
+    your_participation_drops_count: 0,
+  },
 } as any;
 
 type PendingPost = {
@@ -160,6 +176,7 @@ describe("CreateDrop", () => {
       isCurationWave: false,
     } as any);
     commonApiPostMock.mockResolvedValue({ id: "server-drop", wave_id: "1" });
+    fetchWaveMetadataMock.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -190,6 +207,72 @@ describe("CreateDrop", () => {
     await waitFor(() => expect(onDropAdded).toHaveBeenCalled());
     await waitFor(() => expect(waitAndInvalidateDrops).toHaveBeenCalled());
     await waitFor(() => expect(commonApiPostMock).toHaveBeenCalled());
+  });
+
+  it("gates a first chat message on guidelines until the user agrees", async () => {
+    fetchWaveMetadataMock.mockResolvedValue([
+      {
+        id: 1,
+        data_key: "wave_display.rules.custom",
+        data_value: "Be thoughtful and stay on topic.",
+      },
+    ]);
+    const guidelinesWave = {
+      ...wave,
+      metrics: {
+        your_drops_count: 0,
+        your_participation_drops_count: 0,
+      },
+    } as any;
+
+    render(
+      <AuthContext.Provider
+        value={
+          {
+            connectedProfile: { id: "profile-1" },
+            setToast: jest.fn(),
+          } as any
+        }
+      >
+        <ReactQueryWrapperContext.Provider
+          value={{ waitAndInvalidateDrops: jest.fn() } as any}
+        >
+          <CreateDrop
+            activeDrop={null}
+            onCancelReplyQuote={() => {}}
+            onDropAddedToQueue={jest.fn()}
+            wave={guidelinesWave}
+            dropId={null}
+            fixedDropMode={"CHAT" as any}
+            privileges={{ chatRestriction: null } as any}
+          />
+        </ReactQueryWrapperContext.Provider>
+      </AuthContext.Provider>
+    );
+
+    await userEvent.click(screen.getByText("submit current mode"));
+    expect(
+      await screen.findByRole("dialog", { name: "Wave guidelines" })
+    ).toBeVisible();
+    expect(commonApiPostMock).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Decline" }));
+    expect(commonApiPostMock).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByText("submit current mode"));
+    expect(
+      await screen.findByRole("dialog", { name: "Wave guidelines" })
+    ).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "Agree" }));
+
+    await waitFor(() => expect(commonApiPostMock).toHaveBeenCalledTimes(1));
+    expect(
+      screen.queryByRole("dialog", { name: "Wave guidelines" })
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("submit current mode"));
+    await waitFor(() => expect(commonApiPostMock).toHaveBeenCalledTimes(2));
+    expect(fetchWaveMetadataMock).toHaveBeenCalledTimes(2);
   });
 
   it("waits for onServerDropCreated before reporting all drops added", async () => {

--- a/__tests__/components/waves/CreateDrop.test.tsx
+++ b/__tests__/components/waves/CreateDrop.test.tsx
@@ -7,7 +7,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { DropMutationBody } from "@/components/waves/CreateDrop";
+import type { DropMutationBody } from "@/components/waves/create-drop-content/drop-submission.types";
 import CreateDrop from "@/components/waves/CreateDrop";
 import { AuthContext } from "@/components/auth/Auth";
 import {
@@ -78,7 +78,7 @@ jest.mock("@/components/waves/CreateDropContent", () => (props: any) => (
             ],
           },
           dropId: null,
-        } as DropMutationBody)
+        } as unknown as DropMutationBody)
       }
     >
       submit current mode

--- a/__tests__/components/waves/CreateDrop.test.tsx
+++ b/__tests__/components/waves/CreateDrop.test.tsx
@@ -69,6 +69,7 @@ jest.mock("@/components/waves/CreateDropContent", () => (props: any) => (
           drop: {
             wave_id: props.wave.id,
             drop_type: props.isDropMode ? "PARTICIPATORY" : "CHAT",
+            title: null,
             parts: [
               {
                 content: props.isDropMode ? "Participation drop" : "Chat message",
@@ -76,9 +77,16 @@ jest.mock("@/components/waves/CreateDropContent", () => (props: any) => (
                 quoted_drop: null,
               },
             ],
+            referenced_nfts: [],
+            mentioned_users: [],
+            mentioned_waves: [],
+            metadata: [],
+            signature: null,
+            is_safe_signature: false,
+            signer_address: "",
           },
           dropId: null,
-        } as unknown as DropMutationBody)
+        } as DropMutationBody)
       }
     >
       submit current mode
@@ -124,7 +132,25 @@ jest.mock("@/components/waves/quorum/QuorumProposalDropModal", () => ({
         <button
           onClick={() =>
             props.submitDrop({
-              drop: { wave_id: props.wave.id, drop_type: "PARTICIPATORY" },
+              drop: {
+                wave_id: props.wave.id,
+                drop_type: "PARTICIPATORY",
+                title: null,
+                parts: [
+                  {
+                    content: "Participation drop",
+                    media: [],
+                    quoted_drop: null,
+                  },
+                ],
+                referenced_nfts: [],
+                mentioned_users: [],
+                mentioned_waves: [],
+                metadata: [],
+                signature: null,
+                is_safe_signature: false,
+                signer_address: "",
+              },
               dropId: null,
             } as DropMutationBody)
           }
@@ -250,7 +276,8 @@ describe("CreateDrop", () => {
       </AuthContext.Provider>
     );
 
-    await userEvent.click(screen.getByText("submit current mode"));
+    fireEvent.click(screen.getByText("submit current mode"));
+    fireEvent.click(screen.getByText("submit current mode"));
     expect(
       await screen.findByRole("dialog", { name: "Wave guidelines" })
     ).toBeVisible();
@@ -273,6 +300,110 @@ describe("CreateDrop", () => {
     await userEvent.click(screen.getByText("submit current mode"));
     await waitFor(() => expect(commonApiPostMock).toHaveBeenCalledTimes(2));
     expect(fetchWaveMetadataMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a first message when current guidelines cannot be loaded", async () => {
+    const setToast = jest.fn();
+    fetchWaveMetadataMock.mockRejectedValue(new Error("network unavailable"));
+
+    render(
+      <AuthContext.Provider
+        value={
+          {
+            connectedProfile: { id: "profile-1" },
+            setToast,
+          } as any
+        }
+      >
+        <ReactQueryWrapperContext.Provider
+          value={{ waitAndInvalidateDrops: jest.fn() } as any}
+        >
+          <CreateDrop
+            activeDrop={null}
+            onCancelReplyQuote={() => {}}
+            onDropAddedToQueue={jest.fn()}
+            wave={wave}
+            dropId={null}
+            fixedDropMode={"CHAT" as any}
+            privileges={{ chatRestriction: null } as any}
+          />
+        </ReactQueryWrapperContext.Provider>
+      </AuthContext.Provider>
+    );
+
+    await userEvent.click(screen.getByText("submit current mode"));
+
+    await waitFor(() =>
+      expect(setToast).toHaveBeenCalledWith({
+        type: "error",
+        title: "Couldn't load the wave guidelines.",
+        description: "Please try again before sending your message.",
+      })
+    );
+    expect(commonApiPostMock).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("asks again when slow mode rejects the enqueue after agreement", async () => {
+    const dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(10_000);
+    const slowWave = {
+      ...wave,
+      chat: {
+        ...wave.chat,
+        slow_mode_cooldown_ms: 30_000,
+      },
+    };
+    const renderComposer = (profileId: string, handle: string) => (
+      <AuthContext.Provider
+        value={
+          {
+            connectedProfile: { id: profileId, handle },
+            setToast: jest.fn(),
+          } as any
+        }
+      >
+        <ReactQueryWrapperContext.Provider
+          value={{ waitAndInvalidateDrops: jest.fn() } as any}
+        >
+          <CreateDrop
+            activeDrop={null}
+            onCancelReplyQuote={() => {}}
+            onDropAddedToQueue={jest.fn()}
+            wave={slowWave}
+            dropId={null}
+            fixedDropMode={"CHAT" as any}
+            privileges={{ chatRestriction: null } as any}
+          />
+        </ReactQueryWrapperContext.Provider>
+      </AuthContext.Provider>
+    );
+
+    const { rerender } = render(renderComposer("profile-a", "viewer-a"));
+    await userEvent.click(screen.getByText("submit current mode"));
+    await waitFor(() => expect(mockSetQueryData).toHaveBeenCalledTimes(1));
+
+    fetchWaveMetadataMock.mockResolvedValue([
+      {
+        id: 1,
+        data_key: "wave_display.rules.custom",
+        data_value: "Be thoughtful and stay on topic.",
+      },
+    ]);
+    rerender(renderComposer("profile-b", "viewer-b"));
+
+    await userEvent.click(screen.getByText("submit current mode"));
+    expect(
+      await screen.findByRole("dialog", { name: "Wave guidelines" })
+    ).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "Agree" }));
+
+    expect(commonApiPostMock).toHaveBeenCalledTimes(1);
+    await userEvent.click(screen.getByText("submit current mode"));
+    expect(
+      await screen.findByRole("dialog", { name: "Wave guidelines" })
+    ).toBeVisible();
+    expect(fetchWaveMetadataMock).toHaveBeenCalledTimes(3);
+    dateNowSpy.mockRestore();
   });
 
   it("waits for onServerDropCreated before reporting all drops added", async () => {

--- a/__tests__/components/waves/create-drop-content/WaveGuidelinesAgreementDialog.test.tsx
+++ b/__tests__/components/waves/create-drop-content/WaveGuidelinesAgreementDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import WaveGuidelinesAgreementDialog from "@/components/waves/create-drop-content/WaveGuidelinesAgreementDialog";
 
@@ -19,9 +19,11 @@ describe("WaveGuidelinesAgreementDialog", () => {
       />
     );
 
-    expect(
-      screen.getByRole("dialog", { name: "Wave guidelines" })
-    ).toBeVisible();
+    const dialog = screen.getByRole("dialog", { name: "Wave guidelines" });
+    expect(dialog).toBeVisible();
+    expect(dialog).toHaveAccessibleDescription(
+      "Review this wave's guidelines before sending your first message."
+    );
     const guidelines = screen.getByText(
       (_content, element) =>
         element?.tagName === "P" &&
@@ -32,10 +34,16 @@ describe("WaveGuidelinesAgreementDialog", () => {
     expect(screen.getByText(/Decline keeps it as a draft/)).toBeVisible();
     expect(container).toBeEmptyDOMElement();
 
-    const guidelinesScroller = guidelines.closest("section")?.parentElement;
+    const guidelinesScroller = screen.getByRole("region", {
+      name: "Guidelines",
+    });
     expect(guidelinesScroller).toHaveClass("tw-overflow-y-auto");
+    expect(guidelinesScroller).toHaveAttribute("tabindex", "0");
 
-    await user.click(screen.getByRole("button", { name: "Agree" }));
+    const agreeButton = screen.getByRole("button", { name: "Agree" });
+    await waitFor(() => expect(agreeButton).toHaveFocus());
+
+    await user.click(agreeButton);
     expect(onAgree).toHaveBeenCalledTimes(1);
     expect(onDecline).not.toHaveBeenCalled();
   });

--- a/__tests__/components/waves/create-drop-content/WaveGuidelinesAgreementDialog.test.tsx
+++ b/__tests__/components/waves/create-drop-content/WaveGuidelinesAgreementDialog.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import WaveGuidelinesAgreementDialog from "@/components/waves/create-drop-content/WaveGuidelinesAgreementDialog";
+
+jest.mock("@/hooks/useBrowserLocale", () => ({
+  useBrowserLocale: () => "en-US",
+}));
+
+describe("WaveGuidelinesAgreementDialog", () => {
+  it("renders an accessible, scroll-contained guidelines decision", async () => {
+    const user = userEvent.setup();
+    const onAgree = jest.fn();
+    const onDecline = jest.fn();
+    const { container } = render(
+      <WaveGuidelinesAgreementDialog
+        guidelines={"Be thoughtful.\nStay on topic."}
+        onAgree={onAgree}
+        onDecline={onDecline}
+      />
+    );
+
+    expect(
+      screen.getByRole("dialog", { name: "Wave guidelines" })
+    ).toBeVisible();
+    const guidelines = screen.getByText(
+      (_content, element) =>
+        element?.tagName === "P" &&
+        element.textContent === "Be thoughtful.\nStay on topic."
+    );
+    expect(guidelines).toBeVisible();
+    expect(screen.getByText("Guidelines")).toBeVisible();
+    expect(screen.getByText(/Decline keeps it as a draft/)).toBeVisible();
+    expect(container).toBeEmptyDOMElement();
+
+    const guidelinesScroller = guidelines.closest("section")?.parentElement;
+    expect(guidelinesScroller).toHaveClass("tw-overflow-y-auto");
+
+    await user.click(screen.getByRole("button", { name: "Agree" }));
+    expect(onAgree).toHaveBeenCalledTimes(1);
+    expect(onDecline).not.toHaveBeenCalled();
+  });
+
+  it("treats Decline and Escape as non-submitting dismissal", async () => {
+    const user = userEvent.setup();
+    const onDecline = jest.fn();
+    const { rerender } = render(
+      <WaveGuidelinesAgreementDialog
+        guidelines="Be kind."
+        onAgree={jest.fn()}
+        onDecline={onDecline}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Decline" }));
+    expect(onDecline).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <WaveGuidelinesAgreementDialog
+        guidelines="Be kind."
+        onAgree={jest.fn()}
+        onDecline={onDecline}
+      />
+    );
+    await user.keyboard("{Escape}");
+    expect(onDecline).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not render when no agreement is pending", () => {
+    render(
+      <WaveGuidelinesAgreementDialog
+        guidelines={null}
+        onAgree={jest.fn()}
+        onDecline={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/create-drop-content/useWaveGuidelinesAgreement.test.tsx
+++ b/__tests__/components/waves/create-drop-content/useWaveGuidelinesAgreement.test.tsx
@@ -1,0 +1,170 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { ApiDropType } from "@/generated/models/ApiDropType";
+import type { ApiWave } from "@/generated/models/ApiWave";
+import { fetchWaveMetadata } from "@/services/api/waves-v2-api";
+import { useWaveGuidelinesAgreement } from "@/components/waves/create-drop-content/useWaveGuidelinesAgreement";
+
+jest.mock("@/services/api/waves-v2-api", () => ({
+  fetchWaveMetadata: jest.fn(),
+}));
+
+const fetchWaveMetadataMock = jest.mocked(fetchWaveMetadata);
+
+const createWave = ({
+  chatDrops = 0,
+  participationDrops = 0,
+  waveId = "wave-1",
+}: {
+  readonly chatDrops?: number;
+  readonly participationDrops?: number;
+  readonly waveId?: string;
+} = {}): ApiWave =>
+  ({
+    id: waveId,
+    metrics: {
+      your_drops_count: chatDrops,
+      your_participation_drops_count: participationDrops,
+    },
+  }) as ApiWave;
+
+const guidelinesMetadata = [
+  {
+    id: 1,
+    data_key: "wave_display.rules.custom",
+    data_value: "Be thoughtful and stay on topic.",
+  },
+];
+
+describe("useWaveGuidelinesAgreement", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchWaveMetadataMock.mockResolvedValue([]);
+  });
+
+  it.each([
+    ["chat message", createWave({ chatDrops: 1 })],
+    ["participation drop", createWave({ participationDrops: 1 })],
+  ])("skips the dialog after an existing %s", async (_label, wave) => {
+    const { result } = renderHook(() =>
+      useWaveGuidelinesAgreement({ profileId: "profile-1", wave })
+    );
+
+    await expect(
+      result.current.requestGuidelinesAgreement(ApiDropType.Chat)
+    ).resolves.toBe("accepted");
+    expect(fetchWaveMetadataMock).not.toHaveBeenCalled();
+    expect(result.current.dialogGuidelines).toBeNull();
+  });
+
+  it("does not gate participation-drop submissions", async () => {
+    const { result } = renderHook(() =>
+      useWaveGuidelinesAgreement({
+        profileId: "profile-1",
+        wave: createWave(),
+      })
+    );
+
+    await expect(
+      result.current.requestGuidelinesAgreement(ApiDropType.Participatory)
+    ).resolves.toBe("accepted");
+    expect(fetchWaveMetadataMock).not.toHaveBeenCalled();
+  });
+
+  it("submits without a dialog when the wave has no guidelines", async () => {
+    const { result } = renderHook(() =>
+      useWaveGuidelinesAgreement({
+        profileId: "profile-1",
+        wave: createWave(),
+      })
+    );
+
+    await expect(
+      result.current.requestGuidelinesAgreement(ApiDropType.Chat)
+    ).resolves.toBe("accepted");
+    expect(fetchWaveMetadataMock).toHaveBeenCalledWith({ waveId: "wave-1" });
+    expect(result.current.dialogGuidelines).toBeNull();
+  });
+
+  it("declines without remembering agreement and opens again on retry", async () => {
+    fetchWaveMetadataMock.mockResolvedValue(guidelinesMetadata);
+    const { result } = renderHook(() =>
+      useWaveGuidelinesAgreement({
+        profileId: "profile-1",
+        wave: createWave(),
+      })
+    );
+
+    let firstRequest!: Promise<string>;
+    act(() => {
+      firstRequest = result.current.requestGuidelinesAgreement(
+        ApiDropType.Chat
+      );
+    });
+    await waitFor(() =>
+      expect(result.current.dialogGuidelines).toBe(
+        "Be thoughtful and stay on topic."
+      )
+    );
+
+    act(() => result.current.declineGuidelines());
+    await expect(firstRequest).resolves.toBe("declined");
+    expect(result.current.dialogGuidelines).toBeNull();
+
+    let secondRequest!: Promise<string>;
+    act(() => {
+      secondRequest = result.current.requestGuidelinesAgreement(
+        ApiDropType.Chat
+      );
+    });
+    await waitFor(() =>
+      expect(result.current.dialogGuidelines).toBe(
+        "Be thoughtful and stay on topic."
+      )
+    );
+
+    act(() => result.current.agreeToGuidelines());
+    await expect(secondRequest).resolves.toBe("accepted");
+    await expect(
+      result.current.requestGuidelinesAgreement(ApiDropType.Chat)
+    ).resolves.toBe("accepted");
+    expect(fetchWaveMetadataMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails closed when the guidelines cannot be loaded", async () => {
+    fetchWaveMetadataMock.mockRejectedValue(new Error("network unavailable"));
+    const { result } = renderHook(() =>
+      useWaveGuidelinesAgreement({
+        profileId: "profile-1",
+        wave: createWave(),
+      })
+    );
+
+    await expect(
+      result.current.requestGuidelinesAgreement(ApiDropType.Chat)
+    ).resolves.toBe("unavailable");
+    expect(result.current.dialogGuidelines).toBeNull();
+  });
+
+  it("cancels a pending decision when the active profile changes", async () => {
+    fetchWaveMetadataMock.mockResolvedValue(guidelinesMetadata);
+    const wave = createWave();
+    const { result, rerender } = renderHook(
+      ({ profileId }: { readonly profileId: string }) =>
+        useWaveGuidelinesAgreement({ profileId, wave }),
+      { initialProps: { profileId: "profile-1" } }
+    );
+
+    let pendingRequest!: Promise<string>;
+    act(() => {
+      pendingRequest = result.current.requestGuidelinesAgreement(
+        ApiDropType.Chat
+      );
+    });
+    await waitFor(() => expect(result.current.dialogGuidelines).not.toBeNull());
+
+    rerender({ profileId: "profile-2" });
+
+    await expect(pendingRequest).resolves.toBe("declined");
+    expect(result.current.dialogGuidelines).toBeNull();
+  });
+});

--- a/__tests__/components/waves/create-drop-content/useWaveGuidelinesAgreement.test.tsx
+++ b/__tests__/components/waves/create-drop-content/useWaveGuidelinesAgreement.test.tsx
@@ -124,6 +124,43 @@ describe("useWaveGuidelinesAgreement", () => {
 
     act(() => result.current.agreeToGuidelines());
     await expect(secondRequest).resolves.toBe("accepted");
+    act(() => result.current.markChatSubmitted());
+    await expect(
+      result.current.requestGuidelinesAgreement(ApiDropType.Chat)
+    ).resolves.toBe("accepted");
+    expect(fetchWaveMetadataMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not remember agreement until the chat is submitted", async () => {
+    fetchWaveMetadataMock.mockResolvedValue(guidelinesMetadata);
+    const { result } = renderHook(() =>
+      useWaveGuidelinesAgreement({
+        profileId: "profile-1",
+        wave: createWave(),
+      })
+    );
+
+    let firstRequest!: Promise<string>;
+    act(() => {
+      firstRequest = result.current.requestGuidelinesAgreement(
+        ApiDropType.Chat
+      );
+    });
+    await waitFor(() => expect(result.current.dialogGuidelines).not.toBeNull());
+    act(() => result.current.agreeToGuidelines());
+    await expect(firstRequest).resolves.toBe("accepted");
+
+    let retryRequest!: Promise<string>;
+    act(() => {
+      retryRequest = result.current.requestGuidelinesAgreement(
+        ApiDropType.Chat
+      );
+    });
+    await waitFor(() => expect(result.current.dialogGuidelines).not.toBeNull());
+    act(() => result.current.declineGuidelines());
+    await expect(retryRequest).resolves.toBe("declined");
+
+    act(() => result.current.markChatSubmitted());
     await expect(
       result.current.requestGuidelinesAgreement(ApiDropType.Chat)
     ).resolves.toBe("accepted");
@@ -165,6 +202,9 @@ describe("useWaveGuidelinesAgreement", () => {
     rerender({ profileId: "profile-2" });
 
     await expect(pendingRequest).resolves.toBe("declined");
+    expect(result.current.dialogGuidelines).toBeNull();
+
+    rerender({ profileId: "profile-1" });
     expect(result.current.dialogGuidelines).toBeNull();
   });
 });

--- a/components/waves/CreateCurationDropContent.tsx
+++ b/components/waves/CreateCurationDropContent.tsx
@@ -24,7 +24,7 @@ import { useSeizeConnectContext } from "../auth/SeizeConnectContext";
 import { ReactQueryWrapperContext } from "../react-query-wrapper/ReactQueryWrapper";
 import { ProcessIncomingDropType } from "@/contexts/wave/hooks/useWaveRealtimeUpdater";
 import { useMyStream } from "@/contexts/wave/MyStreamContext";
-import type { DropMutationBody } from "./CreateDrop";
+import type { DropMutationBody } from "./create-drop-content/drop-submission.types";
 import CreateDropReplyingWrapper from "./CreateDropReplyingWrapper";
 import { CreateDropSubmit } from "./CreateDropSubmit";
 import CreateCurationDropUrlInput from "./CreateCurationDropUrlInput";

--- a/components/waves/CreateDrop.tsx
+++ b/components/waves/CreateDrop.tsx
@@ -38,6 +38,10 @@ import {
   WaveSubmissionExperience,
 } from "@/helpers/waves/wave-submission-experience.helpers";
 import Button from "@/components/utils/button/Button";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import { t } from "@/i18n/messages";
+import WaveGuidelinesAgreementDialog from "./create-drop-content/WaveGuidelinesAgreementDialog";
+import { useWaveGuidelinesAgreement } from "./create-drop-content/useWaveGuidelinesAgreement";
 
 interface CreateDropProps {
   readonly activeDrop: ActiveDropState | null;
@@ -97,6 +101,13 @@ interface SlowModeChatWaveState {
   cooldownMs: number | null;
 }
 
+const isTypedChatMessage = (drop: ApiCreateDropRequest): boolean =>
+  drop.drop_type === ApiDropType.Chat &&
+  drop.parts.some(
+    (part) =>
+      typeof part.content === "string" && part.content.trim().length > 0
+  );
+
 export default function CreateDrop({
   activeDrop,
   onCancelReplyQuote,
@@ -124,6 +135,7 @@ export default function CreateDrop({
   initialMarkdownKey = null,
 }: CreateDropProps) {
   const { setToast, connectedProfile } = useAuth();
+  const locale = useBrowserLocale();
   const { waitAndInvalidateDrops } = useContext(ReactQueryWrapperContext);
   const queryClient = useQueryClient();
   const unreadDividerContext = useUnreadDividerOptional();
@@ -141,6 +153,16 @@ export default function CreateDrop({
   const [dismissedQuorumProposalScope, setDismissedQuorumProposalScope] =
     useState<string | null>(null);
   const { processDropRemoved, processIncomingDrop } = useMyStream();
+  const {
+    agreeToGuidelines,
+    declineGuidelines,
+    dialogGuidelines,
+    markChatSubmitted,
+    requestGuidelinesAgreement,
+  } = useWaveGuidelinesAgreement({
+    profileId: connectedProfile?.id ?? null,
+    wave,
+  });
   const { isMemesWave, isCurationWave, isQuorumWave } = useWave(wave);
   const resolvedSubmissionExperience = resolveWaveSubmissionExperience({
     isMemesWave,
@@ -575,7 +597,7 @@ export default function CreateDrop({
     waitAndInvalidateDrops,
   ]);
 
-  const submitDrop = useCallback(
+  const enqueueDrop = useCallback(
     (dropRequest: DropMutationBody): boolean => {
       const slowModeChatReservation = reserveSlowModeChatQueueSlot(
         dropRequest.drop
@@ -606,6 +628,10 @@ export default function CreateDrop({
       // Trigger UI updates
       onDropAddedToQueue();
 
+      if (dropRequest.drop.drop_type === ApiDropType.Chat) {
+        markChatSubmitted();
+      }
+
       // Explicitly blur any focused input to close keyboard for drop flows.
       if (
         dropRequest.drop.drop_type !== ApiDropType.Chat &&
@@ -617,11 +643,44 @@ export default function CreateDrop({
       return true;
     },
     [
+      markChatSubmitted,
       onDropAddedToQueue,
       processNextDrop,
       reserveSlowModeChatQueueSlot,
       unreadDividerContext,
     ]
+  );
+
+  const submitDrop = useCallback(
+    (dropRequest: DropMutationBody): boolean | Promise<boolean> => {
+      if (!isTypedChatMessage(dropRequest.drop)) {
+        return enqueueDrop(dropRequest);
+      }
+
+      return requestGuidelinesAgreement(dropRequest.drop.drop_type).then(
+        (guidelinesAgreement) => {
+          if (guidelinesAgreement !== "accepted") {
+            if (guidelinesAgreement === "unavailable") {
+              setToast({
+                type: "error",
+                title: t(
+                  locale,
+                  "waves.chat.guidelinesDialog.loadErrorTitle"
+                ),
+                description: t(
+                  locale,
+                  "waves.chat.guidelinesDialog.loadErrorDescription"
+                ),
+              });
+            }
+            return false;
+          }
+
+          return enqueueDrop(dropRequest);
+        }
+      );
+    },
+    [enqueueDrop, locale, requestGuidelinesAgreement, setToast]
   );
 
   const createDropContentProps = useMemo(() => {
@@ -737,5 +796,14 @@ export default function CreateDrop({
     );
   }
 
-  return dropComposerContent;
+  return (
+    <>
+      {dropComposerContent}
+      <WaveGuidelinesAgreementDialog
+        guidelines={dialogGuidelines}
+        onAgree={agreeToGuidelines}
+        onDecline={declineGuidelines}
+      />
+    </>
+  );
 }

--- a/components/waves/CreateDrop.tsx
+++ b/components/waves/CreateDrop.tsx
@@ -42,6 +42,12 @@ import { useBrowserLocale } from "@/hooks/useBrowserLocale";
 import { t } from "@/i18n/messages";
 import WaveGuidelinesAgreementDialog from "./create-drop-content/WaveGuidelinesAgreementDialog";
 import { useWaveGuidelinesAgreement } from "./create-drop-content/useWaveGuidelinesAgreement";
+import type {
+  DropMutationBody,
+  QueuedDropMutationBody,
+  SlowModeChatReservation,
+  SlowModeChatWaveState,
+} from "./create-drop-content/drop-submission.types";
 
 interface CreateDropProps {
   readonly activeDrop: ActiveDropState | null;
@@ -76,29 +82,6 @@ interface CreateDropProps {
   readonly focusOnInitialActiveDrop?: boolean | undefined;
   readonly initialMarkdown?: string | null | undefined;
   readonly initialMarkdownKey?: string | null | undefined;
-}
-
-export interface DropMutationBody {
-  readonly drop: ApiCreateDropRequest;
-  readonly dropId: string | null;
-  readonly onSuccess?: (() => void) | undefined;
-  readonly onError?: ((error: unknown) => boolean | void) | undefined;
-}
-
-interface SlowModeChatReservation {
-  readonly id: number;
-  readonly waveId: string;
-  readonly cooldownMs: number;
-}
-
-interface QueuedDropMutationBody extends DropMutationBody {
-  readonly slowModeChatReservation?: SlowModeChatReservation | undefined;
-}
-
-interface SlowModeChatWaveState {
-  pendingReservationId: number | null;
-  cooldownUntil: number | null;
-  cooldownMs: number | null;
 }
 
 const isTypedChatMessage = (drop: ApiCreateDropRequest): boolean =>

--- a/components/waves/CreateDrop.tsx
+++ b/components/waves/CreateDrop.tsx
@@ -38,10 +38,9 @@ import {
   WaveSubmissionExperience,
 } from "@/helpers/waves/wave-submission-experience.helpers";
 import Button from "@/components/utils/button/Button";
-import { useBrowserLocale } from "@/hooks/useBrowserLocale";
-import { t } from "@/i18n/messages";
 import WaveGuidelinesAgreementDialog from "./create-drop-content/WaveGuidelinesAgreementDialog";
 import { useWaveGuidelinesAgreement } from "./create-drop-content/useWaveGuidelinesAgreement";
+import { useWaveGuidelinesSubmission } from "./create-drop-content/useWaveGuidelinesSubmission";
 import type {
   DropMutationBody,
   QueuedDropMutationBody,
@@ -84,13 +83,6 @@ interface CreateDropProps {
   readonly initialMarkdownKey?: string | null | undefined;
 }
 
-const isTypedChatMessage = (drop: ApiCreateDropRequest): boolean =>
-  drop.drop_type === ApiDropType.Chat &&
-  drop.parts.some(
-    (part) =>
-      typeof part.content === "string" && part.content.trim().length > 0
-  );
-
 export default function CreateDrop({
   activeDrop,
   onCancelReplyQuote,
@@ -118,7 +110,6 @@ export default function CreateDrop({
   initialMarkdownKey = null,
 }: CreateDropProps) {
   const { setToast, connectedProfile } = useAuth();
-  const locale = useBrowserLocale();
   const { waitAndInvalidateDrops } = useContext(ReactQueryWrapperContext);
   const queryClient = useQueryClient();
   const unreadDividerContext = useUnreadDividerOptional();
@@ -634,37 +625,11 @@ export default function CreateDrop({
     ]
   );
 
-  const submitDrop = useCallback(
-    (dropRequest: DropMutationBody): boolean | Promise<boolean> => {
-      if (!isTypedChatMessage(dropRequest.drop)) {
-        return enqueueDrop(dropRequest);
-      }
-
-      return requestGuidelinesAgreement(dropRequest.drop.drop_type).then(
-        (guidelinesAgreement) => {
-          if (guidelinesAgreement !== "accepted") {
-            if (guidelinesAgreement === "unavailable") {
-              setToast({
-                type: "error",
-                title: t(
-                  locale,
-                  "waves.chat.guidelinesDialog.loadErrorTitle"
-                ),
-                description: t(
-                  locale,
-                  "waves.chat.guidelinesDialog.loadErrorDescription"
-                ),
-              });
-            }
-            return false;
-          }
-
-          return enqueueDrop(dropRequest);
-        }
-      );
-    },
-    [enqueueDrop, locale, requestGuidelinesAgreement, setToast]
-  );
+  const submitDrop = useWaveGuidelinesSubmission({
+    enqueueDrop,
+    requestGuidelinesAgreement,
+    setToast,
+  });
 
   const createDropContentProps = useMemo(() => {
     const hasExitFixedDropMode = onExitFixedDropMode !== undefined;

--- a/components/waves/create-drop-content/WaveGuidelinesAgreementDialog.tsx
+++ b/components/waves/create-drop-content/WaveGuidelinesAgreementDialog.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import Button from "@/components/utils/button/Button";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import { t } from "@/i18n/messages";
+import {
+  Dialog,
+  DialogBackdrop,
+  DialogPanel,
+  DialogTitle,
+  Description,
+  Transition,
+  TransitionChild,
+} from "@headlessui/react";
+import { Fragment, useId } from "react";
+import { createPortal } from "react-dom";
+
+interface WaveGuidelinesAgreementDialogProps {
+  readonly guidelines: string | null;
+  readonly onAgree: () => void;
+  readonly onDecline: () => void;
+}
+
+export default function WaveGuidelinesAgreementDialog({
+  guidelines,
+  onAgree,
+  onDecline,
+}: WaveGuidelinesAgreementDialogProps) {
+  const locale = useBrowserLocale();
+  const guidelinesTitleId = useId();
+  const isOpen = guidelines !== null;
+
+  if (!isOpen || typeof document === "undefined") {
+    return null;
+  }
+
+  return createPortal(
+    <Transition show as={Fragment}>
+      <Dialog
+        as="div"
+        className="tailwind-scope tw-fixed tw-inset-0 tw-z-[1000001] tw-cursor-default"
+        onClose={onDecline}
+      >
+        <TransitionChild
+          as={Fragment}
+          enter="tw-duration-200 tw-ease-out"
+          enterFrom="tw-opacity-0"
+          enterTo="tw-opacity-100"
+          leave="tw-duration-150 tw-ease-in"
+          leaveFrom="tw-opacity-100"
+          leaveTo="tw-opacity-0"
+        >
+          <DialogBackdrop className="tw-fixed tw-inset-0 tw-border-0 tw-bg-iron-600/60 tw-p-0 tw-backdrop-blur-[1px]" />
+        </TransitionChild>
+
+        <div className="tw-fixed tw-inset-0 tw-z-[100] tw-flex tw-min-h-0 tw-items-end tw-justify-center tw-overflow-hidden tw-pt-[calc(env(safe-area-inset-top,0px)+1rem)] sm:tw-items-center sm:tw-p-4">
+          <TransitionChild
+            as={Fragment}
+            enter="tw-duration-250 tw-transform tw-transition tw-ease-out"
+            enterFrom="tw-translate-y-full tw-opacity-0 sm:tw-translate-y-2"
+            enterTo="tw-translate-y-0 tw-opacity-100"
+            leave="tw-transform tw-transition tw-duration-150 tw-ease-in"
+            leaveFrom="tw-translate-y-0 tw-opacity-100"
+            leaveTo="tw-translate-y-full tw-opacity-0 sm:tw-translate-y-2"
+          >
+            <DialogPanel
+              data-testid="wave-guidelines-panel"
+              className="tw-flex tw-max-h-full tw-w-full tw-max-w-xl tw-flex-col tw-overflow-hidden tw-rounded-t-xl tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/10 tw-bg-iron-950 tw-shadow-2xl tw-shadow-black/30 sm:tw-max-h-[min(42rem,calc(100dvh-2rem))] sm:tw-rounded-xl sm:tw-border"
+            >
+              <div className="tw-flex-shrink-0 tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-white/5 tw-px-4 tw-py-4 sm:tw-px-6 sm:tw-py-5">
+                <DialogTitle className="tw-m-0 !tw-text-lg !tw-font-semibold !tw-leading-6 !tw-text-iron-50">
+                  {t(locale, "waves.chat.guidelinesDialog.title")}
+                </DialogTitle>
+                <Description className="tw-mb-0 tw-mt-1.5 tw-text-sm tw-leading-5 tw-text-iron-400">
+                  {t(locale, "waves.chat.guidelinesDialog.description")}
+                </Description>
+              </div>
+
+              <div
+                data-testid="wave-guidelines-scroller"
+                className="tw-min-h-0 tw-flex-1 tw-overflow-y-auto tw-overscroll-contain tw-px-4 tw-py-4 tw-scrollbar-thin tw-scrollbar-track-iron-900 tw-scrollbar-thumb-iron-600 sm:tw-px-6 sm:tw-py-5"
+              >
+                <section aria-labelledby={guidelinesTitleId}>
+                  <h3
+                    id={guidelinesTitleId}
+                    className="tw-m-0 !tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.08em] !tw-text-iron-400"
+                  >
+                    {t(locale, "waves.chat.guidelinesDialog.guidelinesLabel")}
+                  </h3>
+                  <div className="tw-mt-3 tw-rounded-lg tw-border tw-border-solid tw-border-white/5 tw-bg-iron-900/70 tw-p-4">
+                    <p className="tw-m-0 tw-whitespace-pre-wrap tw-break-words tw-text-sm tw-font-medium tw-leading-6 tw-text-iron-100">
+                      {guidelines}
+                    </p>
+                  </div>
+                </section>
+              </div>
+
+              <div className="tw-flex-shrink-0 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/5 tw-bg-iron-950 tw-px-4 tw-pb-[calc(env(safe-area-inset-bottom,0px)+1rem)] tw-pt-4 sm:tw-px-6 sm:tw-pb-5 sm:tw-pt-5">
+                <p className="tw-mb-3 tw-mt-0 tw-text-xs tw-leading-4 tw-text-iron-400">
+                  {t(locale, "waves.chat.guidelinesDialog.actionHint")}
+                </p>
+                <div className="tw-grid tw-grid-cols-2 tw-gap-3">
+                  <Button
+                    data-autofocus
+                    variant="secondary"
+                    size="lg"
+                    fullWidth
+                    onClick={onDecline}
+                  >
+                    {t(locale, "waves.chat.guidelinesDialog.decline")}
+                  </Button>
+                  <Button
+                    variant="action"
+                    size="lg"
+                    fullWidth
+                    onClick={onAgree}
+                  >
+                    {t(locale, "waves.chat.guidelinesDialog.agree")}
+                  </Button>
+                </div>
+              </div>
+            </DialogPanel>
+          </TransitionChild>
+        </div>
+      </Dialog>
+    </Transition>,
+    document.body
+  );
+}

--- a/components/waves/create-drop-content/WaveGuidelinesAgreementDialog.tsx
+++ b/components/waves/create-drop-content/WaveGuidelinesAgreementDialog.tsx
@@ -27,6 +27,8 @@ export default function WaveGuidelinesAgreementDialog({
   onDecline,
 }: WaveGuidelinesAgreementDialogProps) {
   const locale = useBrowserLocale();
+  const dialogTitleId = useId();
+  const dialogDescriptionId = useId();
   const guidelinesTitleId = useId();
   const isOpen = guidelines !== null;
 
@@ -64,23 +66,34 @@ export default function WaveGuidelinesAgreementDialog({
             leaveTo="tw-translate-y-full tw-opacity-0 sm:tw-translate-y-2"
           >
             <DialogPanel
+              aria-describedby={dialogDescriptionId}
+              aria-labelledby={dialogTitleId}
               data-testid="wave-guidelines-panel"
               className="tw-flex tw-max-h-full tw-w-full tw-max-w-xl tw-flex-col tw-overflow-hidden tw-rounded-t-xl tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/10 tw-bg-iron-950 tw-shadow-2xl tw-shadow-black/30 sm:tw-max-h-[min(42rem,calc(100dvh-2rem))] sm:tw-rounded-xl sm:tw-border"
             >
               <div className="tw-flex-shrink-0 tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-white/5 tw-px-4 tw-py-4 sm:tw-px-6 sm:tw-py-5">
-                <DialogTitle className="tw-m-0 !tw-text-lg !tw-font-semibold !tw-leading-6 !tw-text-iron-50">
+                <DialogTitle
+                  id={dialogTitleId}
+                  className="tw-m-0 !tw-text-lg !tw-font-semibold !tw-leading-6 !tw-text-iron-50"
+                >
                   {t(locale, "waves.chat.guidelinesDialog.title")}
                 </DialogTitle>
-                <Description className="tw-mb-0 tw-mt-1.5 tw-text-sm tw-leading-5 tw-text-iron-400">
+                <Description
+                  id={dialogDescriptionId}
+                  className="tw-mb-0 tw-mt-1.5 tw-text-sm tw-leading-5 tw-text-iron-400"
+                >
                   {t(locale, "waves.chat.guidelinesDialog.description")}
                 </Description>
               </div>
 
               <div
+                aria-labelledby={guidelinesTitleId}
                 data-testid="wave-guidelines-scroller"
+                role="region"
+                tabIndex={0}
                 className="tw-min-h-0 tw-flex-1 tw-overflow-y-auto tw-overscroll-contain tw-px-4 tw-py-4 tw-scrollbar-thin tw-scrollbar-track-iron-900 tw-scrollbar-thumb-iron-600 sm:tw-px-6 sm:tw-py-5"
               >
-                <section aria-labelledby={guidelinesTitleId}>
+                <section>
                   <h3
                     id={guidelinesTitleId}
                     className="tw-m-0 !tw-text-[0.6875rem] !tw-font-semibold tw-uppercase !tw-leading-4 tw-tracking-[0.08em] !tw-text-iron-400"
@@ -101,7 +114,6 @@ export default function WaveGuidelinesAgreementDialog({
                 </p>
                 <div className="tw-grid tw-grid-cols-2 tw-gap-3">
                   <Button
-                    data-autofocus
                     variant="secondary"
                     size="lg"
                     fullWidth
@@ -110,6 +122,7 @@ export default function WaveGuidelinesAgreementDialog({
                     {t(locale, "waves.chat.guidelinesDialog.decline")}
                   </Button>
                   <Button
+                    data-autofocus
                     variant="action"
                     size="lg"
                     fullWidth

--- a/components/waves/create-drop-content/drop-submission.types.ts
+++ b/components/waves/create-drop-content/drop-submission.types.ts
@@ -1,0 +1,24 @@
+import type { ApiCreateDropRequest } from "@/generated/models/ApiCreateDropRequest";
+
+export interface DropMutationBody {
+  readonly drop: ApiCreateDropRequest;
+  readonly dropId: string | null;
+  readonly onSuccess?: (() => void) | undefined;
+  readonly onError?: ((error: unknown) => boolean | void) | undefined;
+}
+
+export interface SlowModeChatReservation {
+  readonly id: number;
+  readonly waveId: string;
+  readonly cooldownMs: number;
+}
+
+export interface QueuedDropMutationBody extends DropMutationBody {
+  readonly slowModeChatReservation?: SlowModeChatReservation | undefined;
+}
+
+export interface SlowModeChatWaveState {
+  pendingReservationId: number | null;
+  cooldownUntil: number | null;
+  cooldownMs: number | null;
+}

--- a/components/waves/create-drop-content/types.ts
+++ b/components/waves/create-drop-content/types.ts
@@ -1,4 +1,4 @@
-import type { DropMutationBody } from "@/components/waves/CreateDrop";
+import type { DropMutationBody } from "./drop-submission.types";
 import type { useAuth } from "@/components/auth/Auth";
 import type { CreateDropConfig } from "@/entities/IDrop";
 import type { ApiWave } from "@/generated/models/ApiWave";

--- a/components/waves/create-drop-content/types.ts
+++ b/components/waves/create-drop-content/types.ts
@@ -64,7 +64,9 @@ export interface CreateDropContentProps {
   readonly setIsStormMode: React.Dispatch<React.SetStateAction<boolean>>;
   readonly onDropModeChange: (newIsDropMode: boolean) => void;
   readonly onSwitchToDropModeWithUrl: (url: string) => void;
-  readonly submitDrop: (dropRequest: DropMutationBody) => boolean;
+  readonly submitDrop: (
+    dropRequest: DropMutationBody
+  ) => boolean | Promise<boolean>;
   readonly dropModeToggleExitLabel: string | null;
   readonly canExitDropMode: boolean;
   readonly isChatBlockedBySlowMode: boolean;

--- a/components/waves/create-drop-content/useCreateDropSubmission.ts
+++ b/components/waves/create-drop-content/useCreateDropSubmission.ts
@@ -334,7 +334,9 @@ export const useCreateDropSubmission = ({
   readonly requestAuth: () => Promise<{ success: boolean }>;
   readonly setToast: (toast: AppToastInput) => void;
   readonly signDrop: ReturnType<typeof useDropSignature>["signDrop"];
-  readonly submitDrop: (dropRequest: DropMutationBody) => boolean;
+  readonly submitDrop: (
+    dropRequest: DropMutationBody
+  ) => boolean | Promise<boolean>;
   readonly addOptimisticDrop: (params: {
     readonly drop: ApiDrop;
   }) => Promise<void>;
@@ -634,7 +636,7 @@ export const useCreateDropSubmission = ({
         handleDuplicateIdentitySubmissionError,
       });
 
-      const submitAccepted = submitDrop({
+      const submitResult = submitDrop({
         drop: updatedDropRequest,
         dropId: optimisticDrop?.id ?? null,
         onSuccess: dropModeSubmitCallbacks.onSuccess,
@@ -645,6 +647,8 @@ export const useCreateDropSubmission = ({
           return dropModeSubmitCallbacks.onError?.(error);
         },
       });
+      const submitAccepted =
+        typeof submitResult === "boolean" ? submitResult : await submitResult;
       if (!submitAccepted) {
         return;
       }

--- a/components/waves/create-drop-content/useCreateDropSubmission.ts
+++ b/components/waves/create-drop-content/useCreateDropSubmission.ts
@@ -2,7 +2,7 @@
 
 import { containsDisallowedLink } from "@/components/drops/view/part/dropPartMarkdown/linkPreviewDetection";
 import type { AppToastInput } from "@/components/utils/toast/AppToast";
-import type { DropMutationBody } from "@/components/waves/CreateDrop";
+import type { DropMutationBody } from "./drop-submission.types";
 import type { CreateDropInputHandles } from "@/components/waves/CreateDropInput";
 import type { MissingRequirements } from "@/components/waves/utils/getMissingRequirements";
 import { getMissingRequirements } from "@/components/waves/utils/getMissingRequirements";

--- a/components/waves/create-drop-content/useWaveGuidelinesAgreement.ts
+++ b/components/waves/create-drop-content/useWaveGuidelinesAgreement.ts
@@ -1,0 +1,163 @@
+"use client";
+
+import { ApiDropType } from "@/generated/models/ApiDropType";
+import type { ApiWave } from "@/generated/models/ApiWave";
+import { getWaveCustomRulesFromMetadata } from "@/helpers/waves/wave-metadata.helpers";
+import { fetchWaveMetadata } from "@/services/api/waves-v2-api";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type WaveGuidelinesAgreementResult =
+  | "accepted"
+  | "declined"
+  | "unavailable";
+
+interface PendingGuidelinesDecision {
+  readonly scopeKey: string;
+  readonly resolve: (result: WaveGuidelinesAgreementResult) => void;
+}
+
+interface GuidelinesDialogState {
+  readonly guidelines: string;
+  readonly scopeKey: string;
+}
+
+const hasPostedInWave = (wave: ApiWave): boolean =>
+  (wave.metrics.your_drops_count ?? 0) > 0 ||
+  wave.metrics.your_participation_drops_count > 0;
+
+export function useWaveGuidelinesAgreement({
+  profileId,
+  wave,
+}: {
+  readonly profileId: string | null;
+  readonly wave: ApiWave;
+}) {
+  const scopeKey = `${wave.id}:${profileId ?? "anonymous"}`;
+  const activeScopeKeyRef = useRef(scopeKey);
+  const pendingDecisionRef = useRef<PendingGuidelinesDecision | null>(null);
+  const requestRef = useRef<{
+    readonly scopeKey: string;
+    readonly promise: Promise<WaveGuidelinesAgreementResult>;
+  } | null>(null);
+  const satisfiedScopeKeysRef = useRef(new Set<string>());
+  const [dialogState, setDialogState] = useState<GuidelinesDialogState | null>(
+    null
+  );
+
+  const settlePendingDecision = useCallback(
+    (result: WaveGuidelinesAgreementResult) => {
+      const pendingDecision = pendingDecisionRef.current;
+      pendingDecisionRef.current = null;
+      setDialogState(null);
+      pendingDecision?.resolve(result);
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (activeScopeKeyRef.current === scopeKey) {
+      return;
+    }
+
+    activeScopeKeyRef.current = scopeKey;
+    const pendingDecision = pendingDecisionRef.current;
+    if (pendingDecision?.scopeKey !== scopeKey) {
+      pendingDecisionRef.current = null;
+      pendingDecision?.resolve("declined");
+    }
+  }, [scopeKey]);
+
+  useEffect(
+    () => () => {
+      pendingDecisionRef.current?.resolve("declined");
+      pendingDecisionRef.current = null;
+    },
+    []
+  );
+
+  const requestGuidelinesAgreement = useCallback(
+    (
+      dropType: ApiDropType | undefined
+    ): Promise<WaveGuidelinesAgreementResult> => {
+      if (
+        dropType !== ApiDropType.Chat ||
+        hasPostedInWave(wave) ||
+        satisfiedScopeKeysRef.current.has(scopeKey)
+      ) {
+        return Promise.resolve("accepted");
+      }
+
+      const activeRequest = requestRef.current;
+      if (activeRequest?.scopeKey === scopeKey) {
+        return activeRequest.promise;
+      }
+
+      const request = (async (): Promise<WaveGuidelinesAgreementResult> => {
+        const metadata = await fetchWaveMetadata({ waveId: wave.id }).catch(
+          () => null
+        );
+        if (metadata === null) {
+          return "unavailable";
+        }
+
+        if (activeScopeKeyRef.current !== scopeKey) {
+          return "declined";
+        }
+
+        const guidelines = getWaveCustomRulesFromMetadata(metadata);
+        if (!guidelines) {
+          return "accepted";
+        }
+
+        return await new Promise<WaveGuidelinesAgreementResult>((resolve) => {
+          pendingDecisionRef.current = {
+            resolve,
+            scopeKey,
+          };
+          setDialogState({ guidelines, scopeKey });
+        });
+      })();
+
+      requestRef.current = { promise: request, scopeKey };
+      void request.then(
+        () => {
+          if (requestRef.current?.promise === request) {
+            requestRef.current = null;
+          }
+        },
+        () => {
+          if (requestRef.current?.promise === request) {
+            requestRef.current = null;
+          }
+        }
+      );
+      return request;
+    },
+    [scopeKey, wave]
+  );
+
+  const agreeToGuidelines = useCallback(() => {
+    const pendingScopeKey = pendingDecisionRef.current?.scopeKey;
+    if (pendingScopeKey) {
+      satisfiedScopeKeysRef.current.add(pendingScopeKey);
+    }
+    settlePendingDecision("accepted");
+  }, [settlePendingDecision]);
+
+  const declineGuidelines = useCallback(() => {
+    settlePendingDecision("declined");
+  }, [settlePendingDecision]);
+
+  const markChatSubmitted = useCallback(() => {
+    satisfiedScopeKeysRef.current.add(scopeKey);
+  }, [scopeKey]);
+
+  return {
+    agreeToGuidelines,
+    declineGuidelines,
+    dialogGuidelines:
+      dialogState?.scopeKey === scopeKey ? dialogState.guidelines : null,
+    markChatSubmitted,
+    requestGuidelinesAgreement,
+  };
+}

--- a/components/waves/create-drop-content/useWaveGuidelinesAgreement.ts
+++ b/components/waves/create-drop-content/useWaveGuidelinesAgreement.ts
@@ -22,6 +22,7 @@ interface GuidelinesDialogState {
 }
 
 const hasPostedInWave = (wave: ApiWave): boolean =>
+  // Backend dropper metrics count CHAT and PARTICIPATORY drops separately.
   (wave.metrics.your_drops_count ?? 0) > 0 ||
   wave.metrics.your_participation_drops_count > 0;
 
@@ -43,6 +44,9 @@ export function useWaveGuidelinesAgreement({
   const [dialogState, setDialogState] = useState<GuidelinesDialogState | null>(
     null
   );
+  if (dialogState !== null && dialogState.scopeKey !== scopeKey) {
+    setDialogState(null);
+  }
 
   const settlePendingDecision = useCallback(
     (result: WaveGuidelinesAgreementResult) => {
@@ -137,10 +141,6 @@ export function useWaveGuidelinesAgreement({
   );
 
   const agreeToGuidelines = useCallback(() => {
-    const pendingScopeKey = pendingDecisionRef.current?.scopeKey;
-    if (pendingScopeKey) {
-      satisfiedScopeKeysRef.current.add(pendingScopeKey);
-    }
     settlePendingDecision("accepted");
   }, [settlePendingDecision]);
 

--- a/components/waves/create-drop-content/useWaveGuidelinesSubmission.ts
+++ b/components/waves/create-drop-content/useWaveGuidelinesSubmission.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import type { AppToastInput } from "@/components/utils/toast/AppToast";
+import { ApiDropType } from "@/generated/models/ApiDropType";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import { t } from "@/i18n/messages";
+import { useCallback, useRef } from "react";
+import type { DropMutationBody } from "./drop-submission.types";
+import type { WaveGuidelinesAgreementResult } from "./useWaveGuidelinesAgreement";
+
+const isTypedChatMessage = (drop: DropMutationBody["drop"]): boolean =>
+  drop.drop_type === ApiDropType.Chat &&
+  drop.parts.some(
+    (part) =>
+      typeof part.content === "string" && part.content.trim().length > 0
+  );
+
+export function useWaveGuidelinesSubmission({
+  enqueueDrop,
+  requestGuidelinesAgreement,
+  setToast,
+}: {
+  readonly enqueueDrop: (dropRequest: DropMutationBody) => boolean;
+  readonly requestGuidelinesAgreement: (
+    dropType: ApiDropType | undefined
+  ) => Promise<WaveGuidelinesAgreementResult>;
+  readonly setToast: (toast: AppToastInput) => void;
+}) {
+  const locale = useBrowserLocale();
+  const pendingTypedSubmissionRef = useRef<Promise<boolean> | null>(null);
+
+  return useCallback(
+    (dropRequest: DropMutationBody): boolean | Promise<boolean> => {
+      if (!isTypedChatMessage(dropRequest.drop)) {
+        return enqueueDrop(dropRequest);
+      }
+
+      if (pendingTypedSubmissionRef.current !== null) {
+        return false;
+      }
+
+      const submission = requestGuidelinesAgreement(
+        dropRequest.drop.drop_type
+      ).then((guidelinesAgreement) => {
+        if (guidelinesAgreement === "accepted") {
+          return enqueueDrop(dropRequest);
+        }
+        if (guidelinesAgreement === "unavailable") {
+          setToast({
+            type: "error",
+            title: t(locale, "waves.chat.guidelinesDialog.loadErrorTitle"),
+            description: t(
+              locale,
+              "waves.chat.guidelinesDialog.loadErrorDescription"
+            ),
+          });
+        }
+        return false;
+      });
+
+      pendingTypedSubmissionRef.current = submission;
+      void submission.then(() => {
+        if (pendingTypedSubmissionRef.current === submission) {
+          pendingTypedSubmissionRef.current = null;
+        }
+      });
+      return submission;
+    },
+    [enqueueDrop, locale, requestGuidelinesAgreement, setToast]
+  );
+}

--- a/components/waves/quorum/QuorumProposalDropModal.tsx
+++ b/components/waves/quorum/QuorumProposalDropModal.tsx
@@ -6,7 +6,7 @@ import { ReactQueryWrapperContext } from "@/components/react-query-wrapper/React
 import Button from "@/components/utils/button/Button";
 import { trapTabFocus } from "@/components/utils/modal/focusTrap";
 import CreateDropReplyingWrapper from "@/components/waves/CreateDropReplyingWrapper";
-import type { DropMutationBody } from "@/components/waves/CreateDrop";
+import type { DropMutationBody } from "@/components/waves/create-drop-content/drop-submission.types";
 import { ProcessIncomingDropType } from "@/contexts/wave/hooks/useWaveRealtimeUpdater";
 import { useMyStream } from "@/contexts/wave/MyStreamContext";
 import type { ApiCreateDropRequest } from "@/generated/models/ApiCreateDropRequest";

--- a/i18n/messages/de-DE.ts
+++ b/i18n/messages/de-DE.ts
@@ -408,6 +408,18 @@ export const DE_DE_MESSAGES = {
   ...DE_DE_NEW_VERSION_TOAST_MESSAGES,
   "waves.chat.fileUploadAreaAriaLabel":
     "Datei-Upload-Bereich für den Wave-Chat",
+  "waves.chat.guidelinesDialog.title": "Wave-Richtlinien",
+  "waves.chat.guidelinesDialog.description":
+    "Sieh dir die Richtlinien dieser Wave an, bevor du deine erste Nachricht sendest.",
+  "waves.chat.guidelinesDialog.guidelinesLabel": "Richtlinien",
+  "waves.chat.guidelinesDialog.actionHint":
+    "Mit „Zustimmen“ wird deine Nachricht gesendet. Mit „Ablehnen“ bleibt sie als Entwurf erhalten.",
+  "waves.chat.guidelinesDialog.agree": "Zustimmen",
+  "waves.chat.guidelinesDialog.decline": "Ablehnen",
+  "waves.chat.guidelinesDialog.loadErrorTitle":
+    "Wave-Richtlinien konnten nicht geladen werden.",
+  "waves.chat.guidelinesDialog.loadErrorDescription":
+    "Versuche es erneut, bevor du deine Nachricht sendest.",
   ...stormComposerDeMessages,
   "waves.loadingStatus": "Waves werden geladen",
   "waves.gifPicker.open": "GIF hinzufügen",

--- a/i18n/messages/en-GB.ts
+++ b/i18n/messages/en-GB.ts
@@ -391,6 +391,18 @@ export const EN_GB_MESSAGES = {
   ...EN_GB_QR_SCANNER_MESSAGES,
   ...EN_GB_NEW_VERSION_TOAST_MESSAGES,
   "waves.chat.fileUploadAreaAriaLabel": "Wave chat file upload area",
+  "waves.chat.guidelinesDialog.title": "Wave guidelines",
+  "waves.chat.guidelinesDialog.description":
+    "Review this wave's guidelines before sending your first message.",
+  "waves.chat.guidelinesDialog.guidelinesLabel": "Guidelines",
+  "waves.chat.guidelinesDialog.actionHint":
+    "Agree sends your message. Decline keeps it as a draft.",
+  "waves.chat.guidelinesDialog.agree": "Agree",
+  "waves.chat.guidelinesDialog.decline": "Decline",
+  "waves.chat.guidelinesDialog.loadErrorTitle":
+    "Couldn't load the wave guidelines.",
+  "waves.chat.guidelinesDialog.loadErrorDescription":
+    "Please try again before sending your message.",
   "waves.loadingStatus": "Loading waves",
   "waves.gifPicker.open": "Add GIF",
   "waves.gifPicker.dialogTitle": "GIF search",

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -1619,6 +1619,17 @@ const GROUP_NFT_OWNERSHIP_MESSAGES = objectMessages("groups.nftOwnership", {
 
 const WAVE_CHAT_MESSAGES = objectMessages("waves.chat", {
   fileUploadAreaAriaLabel: "Wave chat file upload area",
+  "guidelinesDialog.title": "Wave guidelines",
+  "guidelinesDialog.description":
+    "Review this wave's guidelines before sending your first message.",
+  "guidelinesDialog.guidelinesLabel": "Guidelines",
+  "guidelinesDialog.actionHint":
+    "Agree sends your message. Decline keeps it as a draft.",
+  "guidelinesDialog.agree": "Agree",
+  "guidelinesDialog.decline": "Decline",
+  "guidelinesDialog.loadErrorTitle": "Couldn't load the wave guidelines.",
+  "guidelinesDialog.loadErrorDescription":
+    "Please try again before sending your message.",
   "replyTargetDeletedToast.title": "Reply removed.",
   "replyTargetDeletedToast.description":
     "The message you were replying to was deleted. Your draft is still here.",

--- a/i18n/messages/es-ES.ts
+++ b/i18n/messages/es-ES.ts
@@ -408,6 +408,18 @@ export const ES_ES_MESSAGES = {
   ...ES_ES_NEW_VERSION_TOAST_MESSAGES,
   "waves.chat.fileUploadAreaAriaLabel":
     "Área de carga de archivos del chat de wave",
+  "waves.chat.guidelinesDialog.title": "Directrices de la wave",
+  "waves.chat.guidelinesDialog.description":
+    "Revisa las directrices de esta wave antes de enviar tu primer mensaje.",
+  "waves.chat.guidelinesDialog.guidelinesLabel": "Directrices",
+  "waves.chat.guidelinesDialog.actionHint":
+    "Aceptar envía tu mensaje. Rechazar lo conserva como borrador.",
+  "waves.chat.guidelinesDialog.agree": "Aceptar",
+  "waves.chat.guidelinesDialog.decline": "Rechazar",
+  "waves.chat.guidelinesDialog.loadErrorTitle":
+    "No se pudieron cargar las directrices de la wave.",
+  "waves.chat.guidelinesDialog.loadErrorDescription":
+    "Inténtalo de nuevo antes de enviar tu mensaje.",
   ...stormComposerEsMessages,
   "waves.loadingStatus": "Cargando waves",
   "waves.gifPicker.open": "Añadir GIF",

--- a/i18n/messages/fr-FR.ts
+++ b/i18n/messages/fr-FR.ts
@@ -414,6 +414,18 @@ export const FR_FR_MESSAGES = {
   ...FR_FR_NEW_VERSION_TOAST_MESSAGES,
   "waves.chat.fileUploadAreaAriaLabel":
     "Zone d'envoi de fichiers du chat de wave",
+  "waves.chat.guidelinesDialog.title": "Directives de la wave",
+  "waves.chat.guidelinesDialog.description":
+    "Consultez les directives de cette wave avant d’envoyer votre premier message.",
+  "waves.chat.guidelinesDialog.guidelinesLabel": "Directives",
+  "waves.chat.guidelinesDialog.actionHint":
+    "Accepter envoie votre message. Refuser le conserve comme brouillon.",
+  "waves.chat.guidelinesDialog.agree": "Accepter",
+  "waves.chat.guidelinesDialog.decline": "Refuser",
+  "waves.chat.guidelinesDialog.loadErrorTitle":
+    "Impossible de charger les directives de la wave.",
+  "waves.chat.guidelinesDialog.loadErrorDescription":
+    "Réessayez avant d’envoyer votre message.",
   ...stormComposerFrMessages,
   "waves.loadingStatus": "Chargement des waves",
   "waves.gifPicker.open": "Ajouter un GIF",

--- a/ops/docs/waves/composer/README.md
+++ b/ops/docs/waves/composer/README.md
@@ -28,6 +28,7 @@ Use this area when you need behavior for:
 
 ### Submission and Content
 
+- [First-Message Wave Guidelines](feature-first-message-guidelines.md)
 - [Storm Composer](feature-storm-composer.md)
 - [Wave Drop Composer Enter-Key Behavior](feature-enter-key-behavior.md)
 - [Wave Drop Composer Body Length Limits and Storm Rules](feature-wave-drop-body-length-limits.md)

--- a/ops/docs/waves/composer/feature-first-message-guidelines.md
+++ b/ops/docs/waves/composer/feature-first-message-guidelines.md
@@ -50,8 +50,8 @@ participation drop in the wave.
 
 - Pressing Escape or dismissing the dialog has the same result as
   **Decline**: the message is not sent and the draft remains available.
-- Declining does not record agreement. Submitting the draft again opens the
-  guidelines again while the profile still has no posts in the wave.
+- Declining does not record agreement. If the profile still has no posts in the
+  wave, submitting the draft opens the guidelines again.
 - The dialog keeps its header and actions visible while long guidelines scroll
   inside the available height. Its mobile layout respects the viewport and
   device safe areas.

--- a/ops/docs/waves/composer/feature-first-message-guidelines.md
+++ b/ops/docs/waves/composer/feature-first-message-guidelines.md
@@ -1,0 +1,82 @@
+# First-Message Wave Guidelines
+
+## Overview
+
+Wave guidelines are display-only creator guidance. When a wave has guidelines,
+the composer asks a profile to review them before sending its first chat
+message in that wave. This review is separate from participation rules that
+require a wallet signature.
+
+## Location in the Site
+
+- Standard wave threads: `/waves/{waveId}`
+- Direct-message threads: `/messages/{waveId}` when that wave has guidelines
+- The review opens from the wave composer immediately before the first chat
+  message is sent.
+
+## Entry Points
+
+- Write and submit a new chat message in a wave with guidelines.
+- Submit a reply or chat post with typed, non-whitespace text as the first post
+  from that profile in the wave. Poll-only and attachment-only submissions keep
+  their normal flow.
+
+The review opens only when the profile has posted neither a chat message nor a
+participation drop in the wave.
+
+## User Journey
+
+1. Write a message in the wave composer and submit it.
+2. If the wave has guidelines and this is the profile's first post in the
+   wave, a **Wave guidelines** dialog opens before the message is sent.
+3. Read the creator-provided guidelines in the scrollable dialog.
+4. Choose one of the two actions:
+   - **Agree** closes the dialog and sends the pending message.
+   - **Decline** closes the dialog without sending and keeps the draft.
+5. After agreeing, the guidelines dialog does not interrupt later messages
+   from that profile in the same wave.
+
+## Common Scenarios
+
+- If the profile has already sent a chat message, the composer submits later
+  messages normally.
+- If the profile has already posted a participation drop, its first later chat
+  message is also submitted normally.
+- If the wave has no guidelines, no review dialog appears.
+- Participation-drop submission continues to use its normal flow. Guidelines
+  do not introduce a signature or an extra dialog for that submission.
+
+## Edge Cases
+
+- Pressing Escape or dismissing the dialog has the same result as
+  **Decline**: the message is not sent and the draft remains available.
+- Declining does not record agreement. Submitting the draft again opens the
+  guidelines again while the profile still has no posts in the wave.
+- The dialog keeps its header and actions visible while long guidelines scroll
+  inside the available height. Its mobile layout respects the viewport and
+  device safe areas.
+- Guidelines are plain creator-provided text and retain their line breaks.
+
+## Failure and Recovery
+
+- The composer checks the current wave guidelines before the first message. If
+  they cannot be loaded, the message is not sent and an error toast asks the
+  user to try again.
+- The draft remains in the composer after a load failure or decline, so the
+  user can retry without recreating it.
+- Normal message submission errors continue to use the composer's existing
+  error and draft-recovery behavior after the user agrees.
+
+## Limitations / Notes
+
+- Guidelines are not signed with a wallet. Participation rules that require
+  acceptance remain a separate signed flow for eligible participation drops.
+- The first-post check combines the profile's chat-message count and
+  participation-drop count for the active wave.
+
+## Related Pages
+
+- [Wave Composer Index](README.md)
+- [Wave Participation Flow](../flow-wave-participation.md)
+- [Wave Creation Rules Step](../create/feature-rules-step.md)
+- [Wave Chat Composer Availability](../chat/feature-chat-composer-availability.md)

--- a/ops/docs/waves/flow-wave-participation.md
+++ b/ops/docs/waves/flow-wave-participation.md
@@ -64,6 +64,10 @@ same context.
    and drop eligibility. In memes-wave contexts, quick vote can also appear
    from dedicated footer triggers when unrated memes remain.
 8. Submit new content when participation is allowed.
+   - When the profile has never posted in the wave and the wave has
+     guidelines, submitting a first chat message opens the guidelines review.
+     **Agree** sends the pending message; **Decline** keeps the draft without
+     sending it.
 9. Share links so others can reopen the same wave or target drop.
 
 ## Common Scenarios
@@ -77,6 +81,9 @@ same context.
   wave guidelines, and any rules that require acceptance. Acceptance-required
   rules are enforced by the existing submit terms/signature modal.
 - `Chat` rules show generated chat/access rules and optional wave guidelines.
+- Wave guidelines are display-only, but a profile with no prior chat messages
+  or participation drops reviews them before its first chat message is sent.
+  Declining keeps the draft and shows the review again on the next attempt.
 - When posting is blocked, thread content stays readable and the composer area
   shows blocked states (for example
   `Connect your wallet to participate in this wave`,
@@ -123,6 +130,7 @@ same context.
 - [Wave Drop Actions Index](drop-actions/README.md)
 - [Wave Creation Index](create/README.md)
 - [Wave Creation Rules Step](create/feature-rules-step.md)
+- [First-Message Wave Guidelines](composer/feature-first-message-guidelines.md)
 - [Public Wave Preview](feature-public-wave-preview.md)
 - [Wave Winners Tab](leaderboard/feature-winners-tab.md)
 - [Wave Outcome Lists](feature-outcome-lists.md)

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -2522,6 +2522,7 @@
         "All wave creation includes a Rules step. Chat enters Rules after Groups and then goes to Description; Rank and Approve enter Rules after Drops and then go to Voting.",
         "Generated rules summarize the wave setup. Chat rules focus on wave type, access, and chat settings; Rank and Approve rules also include timing, submissions, voting, approval, and outcome visibility.",
         "Creators can add Wave guidelines that are saved as wave metadata and shown under Guidelines in the wave rules panel.",
+        "When a wave has guidelines, a profile with no prior chat messages or participation drops in that wave reviews them before its first chat message is sent. Agree sends the pending message; Decline keeps the draft and shows the guidelines again on the next attempt.",
         "For Rank and Approve waves, creators can add rules that require acceptance; those use the existing participation terms and wallet-signature submit flow.",
         "Wave admins can edit Wave guidelines later from Configuration. For Rank and Approve waves, admins can also edit acceptance-required rules there.",
         "Participants can review rules in Configuration in the desktop wave right sidebar or from the mobile About information path."
@@ -2531,6 +2532,7 @@
       "tags": ["waves", "rules", "chat", "rank", "approve"],
       "source_refs": [
         "ops/docs/waves/create/feature-rules-step.md",
+        "ops/docs/waves/composer/feature-first-message-guidelines.md",
         "ops/docs/waves/flow-wave-participation.md",
         "ops/docs/waves/sidebars/feature-right-sidebar-tabs.md"
       ]
@@ -2583,6 +2585,8 @@
       ],
       "facts": [
         "The wave composer is where users post drops and replies inside a wave.",
+        "If a wave has guidelines and the profile has posted neither a chat message nor a participation drop there, submitting its first chat message opens a Wave guidelines dialog before the message is sent.",
+        "Agree sends the pending first message and prevents repeat prompts in that wave. Decline or dismissing the dialog does not send the message, keeps the draft, and shows the guidelines again on the next submit attempt.",
         "Composer docs cover markdown, mentions, NFT hashtag references, curation URLs, media uploads, and Enter-key behavior.",
         "Composer availability depends on the wave, groups, permissions, and current state.",
         "If an authenticated wallet has no profile handle yet, public wave content can stay readable while the composer prompts the user to create a profile before participating."
@@ -2592,6 +2596,7 @@
       "tags": ["waves", "composer", "drops"],
       "source_refs": [
         "ops/docs/waves/composer/README.md",
+        "ops/docs/waves/composer/feature-first-message-guidelines.md",
         "ops/docs/waves/chat/feature-chat-composer-availability.md"
       ]
     },

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -2518,6 +2518,7 @@
         "All wave creation includes a Rules step. Chat enters Rules after Groups and then goes to Description; Rank and Approve enter Rules after Drops and then go to Voting.",
         "Generated rules summarize the wave setup. Chat rules focus on wave type, access, and chat settings; Rank and Approve rules also include timing, submissions, voting, approval, and outcome visibility.",
         "Creators can add Wave guidelines that are saved as wave metadata and shown under Guidelines in the wave rules panel.",
+        "When a wave has guidelines, a profile with no prior chat messages or participation drops in that wave reviews them before its first chat message is sent. Agree sends the pending message; Decline keeps the draft and shows the guidelines again on the next attempt.",
         "For Rank and Approve waves, creators can add rules that require acceptance; those use the existing participation terms and wallet-signature submit flow.",
         "Wave admins can edit Wave guidelines later from Configuration. For Rank and Approve waves, admins can also edit acceptance-required rules there.",
         "Participants can review rules in Configuration in the desktop wave right sidebar or from the mobile About information path."
@@ -2527,6 +2528,7 @@
       "tags": ["waves", "rules", "chat", "rank", "approve"],
       "source_refs": [
         "ops/docs/waves/create/feature-rules-step.md",
+        "ops/docs/waves/composer/feature-first-message-guidelines.md",
         "ops/docs/waves/flow-wave-participation.md",
         "ops/docs/waves/sidebars/feature-right-sidebar-tabs.md"
       ]
@@ -2579,6 +2581,8 @@
       ],
       "facts": [
         "The wave composer is where users post drops and replies inside a wave.",
+        "If a wave has guidelines and the profile has posted neither a chat message nor a participation drop there, submitting its first chat message opens a Wave guidelines dialog before the message is sent.",
+        "Agree sends the pending first message and prevents repeat prompts in that wave. Decline or dismissing the dialog does not send the message, keeps the draft, and shows the guidelines again on the next submit attempt.",
         "Composer docs cover markdown, mentions, NFT hashtag references, curation URLs, media uploads, and Enter-key behavior.",
         "Composer availability depends on the wave, groups, permissions, and current state.",
         "If an authenticated wallet has no profile handle yet, public wave content can stay readable while the composer prompts the user to create a profile before participating."
@@ -2588,6 +2592,7 @@
       "tags": ["waves", "composer", "drops"],
       "source_refs": [
         "ops/docs/waves/composer/README.md",
+        "ops/docs/waves/composer/feature-first-message-guidelines.md",
         "ops/docs/waves/chat/feature-chat-composer-availability.md"
       ]
     },

--- a/tests/social/waves-composer-sandbox.spec.ts
+++ b/tests/social/waves-composer-sandbox.spec.ts
@@ -8,6 +8,7 @@ import {
 } from "../testHelpers";
 import {
   dismissNextDevTools,
+  enableSandboxWaveGuidelines,
   expectNoUnsafeSandboxMutations,
   fetchSandboxRequests,
   getSandboxApiOrigin,
@@ -22,6 +23,8 @@ const PREVIEW_URL = "https://example.com/6529-composer-preview";
 const PREVIEW_TITLE = "Sandbox Preview Title";
 const PREVIEW_DESCRIPTION = "Deterministic local preview served by Playwright.";
 const SANDBOX_CHAT_DROP_CONTENT = "Local-only chat drop from Playwright.";
+const SANDBOX_GUIDELINES_FIRST_LINE =
+  "1. Keep discussions constructive and stay on topic in this local sandbox wave.";
 const SANDBOX_FIRST_POLL_OPTION =
   "A longer poll option that stays readable on a phone";
 const SANDBOX_SECOND_POLL_OPTION = "A second poll option";
@@ -304,6 +307,90 @@ test.describe("Waves composer local sandbox @auth @medium @local-only", () => {
       requests.some((request) => request.path.startsWith("/api/attachments"))
     ).toBe(false);
     await expectNoHorizontalOverflow(page);
+    await expectNoUnsafeSandboxMutations(baseURL);
+  });
+
+  test("gates a first chat message with scroll-contained guidelines", async ({
+    baseURL,
+    page,
+  }) => {
+    await enableSandboxWaveGuidelines(baseURL);
+    await gotoSandboxWave(page);
+
+    const composer = page
+      .getByRole("textbox", { name: "Write a chat message" })
+      .last();
+    const postButton = page.getByRole("button", { name: "Post" }).last();
+    await composer.fill(SANDBOX_CHAT_DROP_CONTENT);
+    await postButton.click();
+
+    const dialog = page.getByRole("dialog", { name: "Wave guidelines" });
+    await expect(dialog).toBeVisible({
+      timeout: LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
+    });
+    await expect(dialog).toContainText(SANDBOX_GUIDELINES_FIRST_LINE);
+    await expect(page.getByRole("button", { name: "Decline" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Agree" })).toBeVisible();
+
+    const dropRequestsBeforeDecision = (
+      await fetchSandboxRequests(baseURL)
+    ).filter(
+      (request) => request.method === "POST" && request.path === "/api/drops"
+    );
+    expect(dropRequestsBeforeDecision).toEqual([]);
+
+    const viewport = page.viewportSize();
+    expect(viewport).not.toBeNull();
+    const panelBounds = await page
+      .getByTestId("wave-guidelines-panel")
+      .boundingBox();
+    expect(panelBounds).not.toBeNull();
+    expect(panelBounds!.x).toBeGreaterThanOrEqual(0);
+    expect(panelBounds!.y).toBeGreaterThanOrEqual(0);
+    expect(panelBounds!.x + panelBounds!.width).toBeLessThanOrEqual(
+      viewport!.width
+    );
+    expect(panelBounds!.y + panelBounds!.height).toBeLessThanOrEqual(
+      viewport!.height
+    );
+
+    const scroller = page.getByTestId("wave-guidelines-scroller");
+    const scrollMetrics = await scroller.evaluate((element) => ({
+      clientHeight: element.clientHeight,
+      scrollHeight: element.scrollHeight,
+    }));
+    expect(scrollMetrics.scrollHeight).toBeGreaterThan(
+      scrollMetrics.clientHeight
+    );
+    await expectNoHorizontalOverflow(page);
+
+    await page.getByRole("button", { name: "Decline" }).click();
+    await expect(dialog).toBeHidden();
+    await expect(composer).toContainText(SANDBOX_CHAT_DROP_CONTENT);
+    expect(
+      (await fetchSandboxRequests(baseURL)).filter(
+        (request) => request.method === "POST" && request.path === "/api/drops"
+      )
+    ).toEqual([]);
+
+    await postButton.click();
+    await expect(dialog).toBeVisible();
+    await page.getByRole("button", { name: "Agree" }).click();
+
+    await expect
+      .poll(
+        async () =>
+          (await fetchSandboxRequests(baseURL)).filter(
+            (request) =>
+              request.method === "POST" && request.path === "/api/drops"
+          ).length,
+        {
+          timeout: LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
+          message: "Expected Agree to release the pending chat submission.",
+        }
+      )
+      .toBe(1);
+    await expect(dialog).toBeHidden();
     await expectNoUnsafeSandboxMutations(baseURL);
   });
 

--- a/tests/support/composerSandboxServer.cjs
+++ b/tests/support/composerSandboxServer.cjs
@@ -56,6 +56,11 @@ const SANDBOX_SCHEDULED_WAVE_DESCRIPTION =
   "Local-only scheduled rank wave description for Playwright.";
 const SANDBOX_SCHEDULED_OUTCOME_TITLE = "Sandbox manual outcome";
 const SANDBOX_CHAT_DROP_CONTENT = "Local-only chat drop from Playwright.";
+const SANDBOX_WAVE_GUIDELINES = Array.from(
+  { length: 24 },
+  (_, index) =>
+    `${index + 1}. Keep discussions constructive and stay on topic in this local sandbox wave.`
+).join("\n");
 const SANDBOX_POLL_OPTIONS = [
   "A longer poll option that stays readable on a phone",
   "A second poll option",
@@ -86,6 +91,7 @@ const requests = [];
 // Keep created groups for the lifetime of the local sandbox process so saved
 // wave drafts remain resolvable after the request log is reset between tests.
 let sandboxDropReaction = null;
+let sandboxWaveGuidelinesEnabled = false;
 let sandboxRuleGroupSequence = 0;
 const sandboxRuleGroups = new Map();
 const MAX_REQUEST_BODY_BYTES = 16 * 1024;
@@ -2443,6 +2449,12 @@ function handleDiagnostics(method, pathname, res) {
   if (pathname === "/__composer-sandbox/reset" && method === "POST") {
     requests.length = 0;
     sandboxDropReaction = null;
+    sandboxWaveGuidelinesEnabled = false;
+    writeJson(res, 200, { ok: true });
+    return true;
+  }
+  if (pathname === "/__composer-sandbox/guidelines" && method === "POST") {
+    sandboxWaveGuidelinesEnabled = true;
     writeJson(res, 200, { ok: true });
     return true;
   }
@@ -2474,6 +2486,19 @@ const mockApiExactReadRoutes = new Map([
     () => ({ data: [localWaveOverview], page: 1, next: false }),
   ],
   ["/api/v2/official-waves", () => [localWaveOverview]],
+  [
+    `/api/v2/waves/${SANDBOX_WAVE_ID}/metadata`,
+    () =>
+      sandboxWaveGuidelinesEnabled
+        ? [
+            {
+              id: 1,
+              data_key: "wave_display.rules.custom",
+              data_value: SANDBOX_WAVE_GUIDELINES,
+            },
+          ]
+        : [],
+  ],
   [`/api/waves/${SANDBOX_DM_WAVE_ID}`, () => dmWave],
   [
     `/api/v2/waves/${SANDBOX_DM_WAVE_ID}/drops`,

--- a/tests/support/localSandbox.ts
+++ b/tests/support/localSandbox.ts
@@ -179,6 +179,16 @@ export async function resetSandboxRequests(baseURL: string | undefined) {
   expect(response.ok).toBe(true);
 }
 
+export async function enableSandboxWaveGuidelines(
+  baseURL: string | undefined
+) {
+  const response = await fetch(
+    `${getSandboxApiOrigin(baseURL)}/__composer-sandbox/guidelines`,
+    { method: "POST" }
+  );
+  expect(response.ok).toBe(true);
+}
+
 export async function expectNoUnsafeSandboxMutations(
   baseURL: string | undefined
 ) {


### PR DESCRIPTION
## Issue

First-time posters can currently send a chat message without reviewing a wave's display-only guidelines. Unlike participation rules, these guidelines do not require a wallet signature, but they should still be shown before the first typed chat message is sent.

## Fix

Intercept the first typed chat submission when the active profile has neither prior chat messages nor participation drops. Fetch the current wave metadata, show an accessible guidelines decision dialog, and release the pending submission only after **Agree**.

## Changes

- Gate typed first-chat submissions by the wave's existing per-profile metrics and `wave_display.rules.custom` metadata.
- Keep the draft and show the dialog again after **Decline**; remember **Agree** for the active profile/wave scope.
- Fail closed with a retryable toast when current metadata cannot be loaded.
- Preserve normal synchronous submission for polls, attachment-only posts, and participation drops.
- Add a viewport-contained mobile bottom sheet / desktop dialog with fixed actions and an internally scrolling guidelines body.
- Add all supported locale strings, focused unit/integration coverage, deterministic desktop/mobile Playwright coverage, and user-facing help documentation.

## Validation

- Focused Jest: 3 suites, 33 tests passed.
- `lint:changed`: passed with zero warnings.
- Production TypeScript check: passed.
- Jest TypeScript ratchet: passed (2,079 existing diagnostics in 848 files).
- React Doctor: no findings.
- Production frontend build: passed.
- Focused Playwright: guidelines flow passed on desktop Chromium and Pixel 7/mobile Chromium; panel bounds, internal scrolling, decline/retry, draft retention, and single submission after agree are asserted.
- Full composer sandbox surfaced the existing poll newline-shape failure; the identical focused poll test was reproduced on clean current `main`.

## Risk

**Medium.** This adds a pre-submit branch to the shared wave chat composer. The path is frontend-only, uses existing metrics and metadata APIs, and leaves signed participation rules unchanged. Rollback is a frontend revert; there are no database, backend, dependency, or migration changes.

## Review Notes

- The no-prior-post check uses `your_drops_count` plus `your_participation_drops_count`.
- Only non-whitespace typed chat content is gated; poll-only, attachment-only, and participation submissions keep their existing flows.
- Agreement is intentionally in-memory because a successful/queued first chat makes the server metrics authoritative for later visits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added first-message guideline review for Wave chat submissions.
  * Users can review, accept, decline, or dismiss guidelines before sending their first chat message.
  * Draft messages remain preserved when guidelines are declined or unavailable.
  * Participation submissions are not blocked by guideline review.
  * Added localized dialog text in English, German, Spanish, and French.

* **Documentation**
  * Added guidance covering first-message Wave guidelines and submission behavior.

* **Tests**
  * Added coverage for dialog accessibility, agreement flows, error handling, draft preservation, and successful submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->