### PR TITLE
Show all default snapshot collections

### DIFF
--- a/__tests__/components/distribution-plan-tool/create-snapshots/form/CreateSnapshotFormSearchCollectionDropdown.test.tsx
+++ b/__tests__/components/distribution-plan-tool/create-snapshots/form/CreateSnapshotFormSearchCollectionDropdown.test.tsx
@@ -54,7 +54,7 @@ describe('CreateSnapshotFormSearchCollectionDropdown', () => {
   });
 
   it('renders only default collections when collections list is empty', () => {
-    render(
+    const { container } = render(
       <CreateSnapshotFormSearchCollectionDropdown
         collections={[]}
         defaultCollections={[sampleDefault] as any}
@@ -63,6 +63,9 @@ describe('CreateSnapshotFormSearchCollectionDropdown', () => {
     );
     expect(screen.getAllByTestId('table')).toHaveLength(1);
     expect(tableMock).toHaveBeenCalledWith(expect.objectContaining({ collections: [sampleDefault] }));
+    expect(container.querySelector('.tw-overflow-y-auto')).toHaveClass(
+      'tw-max-h-96'
+    );
   });
 
   it('renders no table when both lists are empty', () => {

--- a/components/distribution-plan-tool/create-snapshots/form/CreateSnapshotFormSearchCollectionDropdown.tsx
+++ b/components/distribution-plan-tool/create-snapshots/form/CreateSnapshotFormSearchCollectionDropdown.tsx
@@ -16,7 +16,7 @@ export default function CreateSnapshotFormSearchCollectionDropdown({
 }) {
   return (
     <div className="tw-absolute tw-z-10 tw-mt-1 tw-w-full tw-overflow-hidden tw-rounded-md tw-bg-iron-800 tw-shadow-lg tw-ring-1 tw-ring-white/10">
-      <div className="tw-py-1 tw-flow-root tw-max-h-[calc(240px+_-5vh)] tw-overflow-x-hidden tw-overflow-y-auto">
+      <div className="tw-flow-root tw-max-h-96 tw-overflow-y-auto tw-overflow-x-hidden tw-py-1">
         {!!collections.length && (
           <CreateSnapshotFormSearchCollectionDropdownTable
             collections={collections}


### PR DESCRIPTION
## Issue

- The snapshot collection dropdown is capped too low, so only about three of the five default collections are visible without scrolling.

## Fix

- Increase the dropdown maximum height to the existing Tailwind 24rem size while retaining vertical overflow for longer search result lists.

## Changes

- Replace the legacy viewport-reducing height calculation with `tw-max-h-96`.
- Add a focused regression assertion for the expanded dropdown cap.
- No API, backend, copy, workflow, or help-corpus changes are required.

## Validation

- `6529 run lint:changed`
- `6529 run typecheck:ci`
- `6529 run react-doctor:diff` (100/100)
- `6529 run test --testPathPatterns=CreateSnapshotFormSearchCollectionDropdown.test.tsx` (3 tests passed)
- `git diff --check`
- Browser verification at 1280x720 and 390x844: all five defaults are visible, dropdown client height equals scroll height, and no page-level horizontal overflow was introduced.

## Risk

- Level: Low
- Why: One Tailwind maximum-height utility changes; data loading, selection behavior, and overflow behavior are unchanged.
- Rollback: Revert the height utility and its regression assertion.

## Review Notes

- Please focus on the dropdown height cap and retention of overflow for longer search results.