### PR TITLE
Improve hybrid-touch controls and winner podium UI

### DIFF
--- a/__tests__/components/waves/drops/WaveDropActionsOpen.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropActionsOpen.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import WaveDropActionsOpen from "@/components/waves/drops/WaveDropActionsOpen";
 import { ApiDropType } from "@/generated/models/ApiDropType";
+import { TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 // Mock ResizeObserver
@@ -51,7 +52,7 @@ test("pushes route on click", async () => {
   render(<WaveDropActionsOpen drop={drop} />);
   expect(screen.getByTestId("tooltip-open-2")).toHaveAttribute(
     "data-z-index",
-    "10000"
+    String(TOOLTIP_STYLES.zIndex)
   );
   await user.click(screen.getByRole("button"));
   expect(push).toHaveBeenCalled();

--- a/__tests__/contracts/hover-revealed-controls.test.ts
+++ b/__tests__/contracts/hover-revealed-controls.test.ts
@@ -164,23 +164,6 @@ const AUDITED_REVEAL_EXEMPTIONS: readonly AuditedRevealExemption[] = [
       "The title and metadata overlay is pointer-events-none supplementary content; the card and author control have independent visible targets.",
   },
   {
-    file: "components/waves/winners/podium/WavePodiumItem.tsx",
-    marker: "tw-top-1/2 tw-ml-2 -tw-translate-y-1/2",
-    literalHash:
-      "6c495c84006e65e1116ebdac27efe93d03ebbe99b90f05cea1479428974c4c14",
-    reason:
-      "The external-link arrow is decorative feedback beside an already visible and fully operable profile link.",
-  },
-  {
-    file: "components/waves/winners/podium/WavePodiumItem.tsx",
-    marker:
-      "tw-left-[100%] tw-ml-2 desktop-hover:group-hover/link:tw-opacity-100",
-    literalHash:
-      "45ab45ab8b895343e261065876d1639d6354954512fa4422ce412a662e945826",
-    reason:
-      "The external-link arrow is decorative feedback beside an already visible and fully operable profile link.",
-  },
-  {
     file: "app/join/FocusSections.tsx",
     marker: "tw-bg-[linear-gradient(90deg,transparent_0%",
     literalHash:

--- a/components/waves/drops/WaveDropActionsCopyLink.tsx
+++ b/components/waves/drops/WaveDropActionsCopyLink.tsx
@@ -71,8 +71,8 @@ const WaveDropActionsCopyLink: React.FC<WaveDropActionsCopyLinkProps> = ({
   const iconSizeClass = size === "compact" ? "tw-h-4 tw-w-4" : "tw-h-5 tw-w-5";
   const buttonSizeClass =
     size === "compact"
-      ? "tw-w-full tw-justify-center tw-px-0 desktop-hover:hover:tw-bg-iron-800 desktop-hover:hover:tw-text-iron-200"
-      : "tw-px-2";
+      ? "tw-h-full tw-w-full tw-justify-center tw-px-0 desktop-hover:hover:tw-bg-iron-800 desktop-hover:hover:tw-text-iron-200"
+      : "tw-size-7 tw-justify-center tw-p-0 desktop-hover:hover:tw-bg-iron-800 desktop-hover:hover:tw-text-iron-200";
 
   const getLinkText = () => {
     if (isDisabled) return "Unavailable";
@@ -113,7 +113,7 @@ const WaveDropActionsCopyLink: React.FC<WaveDropActionsCopyLinkProps> = ({
   return (
     <>
       <button
-        className={`icon tw-group tw-flex tw-h-full tw-flex-shrink-0 tw-items-center tw-justify-center tw-gap-x-2 tw-rounded-full tw-border-0 tw-bg-transparent tw-text-[0.8125rem] tw-font-medium tw-leading-5 tw-text-iron-500 tw-transition tw-duration-300 tw-ease-out focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 ${buttonSizeClass} ${
+        className={`icon tw-group tw-flex tw-flex-shrink-0 tw-items-center tw-justify-center tw-gap-x-2 tw-rounded-full tw-border-0 tw-bg-transparent tw-text-[0.8125rem] tw-font-medium tw-leading-5 tw-text-iron-500 tw-transition tw-duration-300 tw-ease-out focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 ${buttonSizeClass} ${
           isDisabled ? "tw-cursor-default tw-opacity-50" : "tw-cursor-pointer"
         }`}
         onClick={copyToClipboard}

--- a/components/waves/drops/WaveDropActionsOpen.tsx
+++ b/components/waves/drops/WaveDropActionsOpen.tsx
@@ -2,9 +2,10 @@
 
 import React from "react";
 import { ApiDropType } from "@/generated/models/ApiDropType";
-import { Tooltip } from "react-tooltip";
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
+import { TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { Tooltip } from "react-tooltip";
 import ProposalCardReadFullButton from "./proposal/ProposalCardReadFullButton";
 
 interface WaveDropActionsOpenProps {
@@ -104,21 +105,10 @@ const WaveDropActionsOpen: React.FC<WaveDropActionsOpenProps> = ({
       </button>
       <Tooltip
         id={`open-${drop.id}`}
-        place="top-end"
+        place="top"
         offset={8}
         opacity={1}
-        positionStrategy="fixed"
-        style={{
-          padding: "4px 8px",
-          background: "#1F2937",
-          color: "white",
-          fontSize: "13px",
-          fontWeight: 500,
-          borderRadius: "6px",
-          boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
-          zIndex: 10000,
-          pointerEvents: "none",
-        }}
+        style={TOOLTIP_STYLES}
       >
         <span className="tw-text-xs">Open</span>
       </Tooltip>

--- a/components/waves/drops/participation/EndedParticipationDrop.tsx
+++ b/components/waves/drops/participation/EndedParticipationDrop.tsx
@@ -217,13 +217,13 @@ function EndedParticipationDropInner({
             )}
 
             {!isStackedTimestamp && (
-              <p className="tw-mb-0 tw-whitespace-nowrap tw-text-xs tw-font-normal tw-leading-none tw-text-iron-500">
+              <p className="tw-m-0 tw-whitespace-nowrap tw-text-xs tw-font-normal tw-leading-none tw-text-iron-500">
                 {getTimeAgoShort(drop.created_at)}
               </p>
             )}
           </div>
           {isStackedTimestamp && (
-            <p className="tw-mb-0 tw-whitespace-nowrap tw-text-xs tw-font-normal tw-leading-none tw-text-iron-500">
+            <p className="tw-m-0 tw-whitespace-nowrap tw-text-xs tw-font-normal tw-leading-none tw-text-iron-500">
               {getTimeAgoShort(drop.created_at)}
             </p>
           )}

--- a/components/waves/winners/podium/WavePodiumItem.tsx
+++ b/components/waves/winners/podium/WavePodiumItem.tsx
@@ -50,7 +50,6 @@ const positionStyles = {
     ring: "tw-ring-[#fbbf24]",
     shadow: "tw-shadow-[0_0_20px_rgba(251,191,36,0.3)]",
     autorFontSize: "tw-text-sm sm:tw-text-base md:tw-text-xl",
-    ratingFontSize: "tw-text-sm sm:tw-text-base md:tw-text-2xl",
     positionText: "1st",
     bgGradient:
       "tw-bg-gradient-to-b tw-from-[#fbbf24]/20 tw-to-transparent tw-blur-2xl tw-scale-150",
@@ -73,7 +72,6 @@ const positionStyles = {
     ring: "tw-ring-[#94a3b8]",
     shadow: "tw-shadow-[0_0_20px_rgba(148,163,184,0.3)]",
     autorFontSize: "tw-text-sm sm:tw-text-base",
-    ratingFontSize: "tw-text-sm sm:tw-text-base",
     positionText: "2nd",
     bgGradient:
       "tw-bg-gradient-to-b tw-from-[#94a3b8]/20 tw-to-transparent tw-blur-2xl tw-scale-150",
@@ -96,7 +94,6 @@ const positionStyles = {
     ring: "tw-ring-[#CD7F32]",
     shadow: "tw-shadow-[0_0_20px_rgba(205,127,50,0.3)]",
     autorFontSize: "tw-text-sm sm:tw-text-base",
-    ratingFontSize: "tw-text-base",
     positionText: "3rd",
     bgGradient:
       "tw-bg-gradient-to-b tw-from-[#CD7F32]/20 tw-to-transparent tw-blur-2xl tw-scale-150",
@@ -382,7 +379,7 @@ export const WavePodiumItem: React.FC<WavePodiumItemProps> = ({
                           viewBox="0 0 24 24"
                           strokeWidth="1.5"
                           stroke="currentColor"
-                          className={`tw-size-3 tw-opacity-0 tw-transition-opacity ${styles.textColor} tw-absolute tw-left-[100%] tw-top-1/2 tw-ml-2 -tw-translate-y-1/2 desktop-hover:group-hover/link:tw-opacity-100`}
+                          className={`tw-size-3 tw-opacity-0 tw-transition-opacity ${styles.textColor} tw-absolute tw-left-[100%] tw-top-1/2 tw-ml-2 -tw-translate-y-1/2 group-focus-visible/link:tw-opacity-100 desktop-hover:group-hover/link:tw-opacity-100 touch-only:tw-opacity-100`}
                         >
                           <path
                             strokeLinecap="round"
@@ -449,7 +446,7 @@ export const WavePodiumItem: React.FC<WavePodiumItemProps> = ({
                       viewBox="0 0 24 24"
                       strokeWidth="1.5"
                       stroke="currentColor"
-                      className={`tw-size-3 tw-opacity-0 tw-transition-opacity ${styles.textColor} tw-absolute tw-left-[100%] tw-ml-2 desktop-hover:group-hover/link:tw-opacity-100`}
+                      className={`tw-size-3 tw-opacity-0 tw-transition-opacity ${styles.textColor} tw-absolute tw-left-[100%] tw-top-1/2 tw-ml-2 -tw-translate-y-1/2 group-focus-visible/link:tw-opacity-100 desktop-hover:group-hover/link:tw-opacity-100 touch-only:tw-opacity-100`}
                     >
                       <path
                         strokeLinecap="round"
@@ -462,11 +459,11 @@ export const WavePodiumItem: React.FC<WavePodiumItemProps> = ({
               )}
 
               <div className="tw-relative tw-flex tw-flex-col tw-items-center tw-gap-y-2">
-                <div className="tw-flex tw-items-center tw-gap-x-1">
+                <div className="tw-flex tw-items-baseline tw-gap-x-1">
                   <span
                     className={`${
                       drop.rating >= 0 ? styles.textColor : "tw-text-[#ff4466]"
-                    } tw-font-semibold ${styles.ratingFontSize}`}
+                    } tw-text-sm tw-font-semibold sm:tw-text-base`}
                   >
                     {formatNumberWithCommas(drop.rating)}
                   </span>

--- a/components/waves/winners/podium/WavePodiumItemContentOutcomes.tsx
+++ b/components/waves/winners/podium/WavePodiumItemContentOutcomes.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useMemo } from "react";
+import React, { useMemo, useSyncExternalStore } from "react";
+import { createPortal } from "react-dom";
 import { Tooltip } from "react-tooltip";
 import type { ApiWaveDecisionWinner } from "@/generated/models/ApiWaveDecisionWinner";
 import { ApiWaveOutcomeCredit } from "@/generated/models/ApiWaveOutcomeCredit";
@@ -13,9 +14,19 @@ interface WavePodiumItemContentOutcomesProps {
   readonly outcomesVisible?: boolean | undefined;
 }
 
+const subscribeToClientRender = () => () => undefined;
+const getClientRenderSnapshot = () => true;
+const getServerRenderSnapshot = () => false;
+
 export const WavePodiumItemContentOutcomes: React.FC<
   WavePodiumItemContentOutcomesProps
 > = ({ winner, outcomesVisible = true }) => {
+  const canRenderTooltip = useSyncExternalStore(
+    subscribeToClientRender,
+    getClientRenderSnapshot,
+    getServerRenderSnapshot
+  );
+
   // Transform awards into the same format that useDropOutcomes provided
   const { nicOutcomes, repOutcomes, manualOutcomes, haveOutcomes } =
     useMemo(() => {
@@ -140,16 +151,24 @@ export const WavePodiumItemContentOutcomes: React.FC<
           Outcome
         </span>
       </button>
-      <Tooltip
-        id={tooltipId}
-        place="top"
-        offset={8}
-        opacity={1}
-        positionStrategy="fixed"
-        style={TOOLTIP_STYLES}
-      >
-        {tooltipContent}
-      </Tooltip>
+      {canRenderTooltip &&
+        createPortal(
+          <Tooltip
+            id={tooltipId}
+            place="top"
+            offset={8}
+            opacity={1}
+            positionStrategy="fixed"
+            style={{
+              ...TOOLTIP_STYLES,
+              maxWidth: "min(360px, calc(100vw - 32px))",
+              whiteSpace: "normal",
+            }}
+          >
+            <div className="tailwind-scope">{tooltipContent}</div>
+          </Tooltip>,
+          document.body
+        )}
     </>
   );
 };


### PR DESCRIPTION
## Issue

- Winner profile arrows relied on fine-pointer hover, which made the existing profile links less discoverable on hybrid touch laptops and for keyboard users.
- Follow-up review found inconsistent podium value sizing and alignment, a vertically offset participation timestamp, clipped Outcome tooltips, and inconsistent Chat action sizing and tooltip styling.

## Fix

- Preserve the existing profile-name navigation and mouse-hover behavior while exposing the arrow on touch input and keyboard focus.
- Apply narrowly scoped layout and overlay fixes using existing Tailwind and tooltip patterns.

## Changes

- Show podium profile arrows for touch input and visible keyboard focus, and remove their obsolete hover-control contract exemptions.
- Align fallback arrows beside names, standardize podium total font sizes, and baseline totals with their voting-credit labels.
- Remove inherited top margins from participation timestamps so they center with the identity row.
- Make the Chat Copy Link action an explicit 28 by 28 pixel control and reuse the shared tooltip styles for Open Drop.
- Portal podium Outcome tooltips outside clipped cards, cap them at 360 pixels, and wrap long outcome text within the viewport.

## Validation

- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff` — 98/100; three reported warnings are pre-existing patterns in touched components and are not introduced here.
- `./bin/6529 run test --testPathPatterns=__tests__/contracts/hover-revealed-controls.test.ts --runInBand`
- `git diff --check`
- Browser QA on a representative Winners view verified touch/focus arrow visibility, name/arrow and timestamp centering, consistent podium total sizing and baselines, a 28 by 28 pixel Chat copy action, shared Open Drop tooltip styling, and unclipped Outcome tooltips for all three rank cards.

## Risk

- Level: Low
- Why: The change is limited to visibility, sizing, alignment, and tooltip rendering. Navigation, outcome data, voting behavior, and API calls are unchanged.
- Rollback: Revert the single commit to restore the previous presentation.

## Review Notes

- The profile-name link was already operable; reviewers should treat the arrow change as hybrid-input and keyboard discoverability, not a navigation repair.
- Please focus on the `touch-only` and focus-visible behavior and the SSR-safe tooltip portal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved copy-link button sizing, alignment, and hover states.
  * Standardized podium rating text sizing and alignment.
  * Refined spacing for ended participation timestamps.

* **Bug Fixes**
  * Improved tooltip placement, layering, and responsive rendering.
  * Ensured podium external-link controls are visible when focused or used on touch devices.
  * Improved vertical alignment for podium external-link icons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->