### PR TITLE
Rank site and group identity searches consistently

### DIFF
--- a/__tests__/components/groups/GroupCreateWallets.test.tsx
+++ b/__tests__/components/groups/GroupCreateWallets.test.tsx
@@ -119,6 +119,15 @@ describe("GroupCreateWallets", () => {
     );
   });
 
+  it.each([GroupCreateWalletsType.INCLUDE, GroupCreateWalletsType.EXCLUDE])(
+    "requests level-ranked identity results for %s",
+    (type) => {
+      renderComp({ type, walletsLimit: 5 });
+
+      expect(identitiesProps.sort).toBe("level");
+    }
+  );
+
   it("removes wallets when remove button clicked", async () => {
     const user = userEvent.setup();
     const { setWallets } = renderComp({ walletsLimit: 5 });

--- a/__tests__/components/header/HeaderSearchModal.test.tsx
+++ b/__tests__/components/header/HeaderSearchModal.test.tsx
@@ -3,6 +3,7 @@ import type { HeaderSearchModalItemType } from "@/components/header/header-searc
 import type { SidebarSection } from "@/components/navigation/navTypes";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
 import type { ApiWave } from "@/generated/models/ApiWave";
+import { commonApiFetch } from "@/services/api/common-api";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import { DEFAULT_DROP_FORGE_PERMISSIONS } from "../../helpers/dropForgePermissions";
@@ -97,6 +98,9 @@ jest.mock("@tanstack/react-query", () => ({
     isFetchingNextPage: false,
   }),
   keepPreviousData: (prev: unknown) => prev,
+}));
+jest.mock("@/services/api/common-api", () => ({
+  commonApiFetch: jest.fn(),
 }));
 jest.mock("next/navigation", () => ({
   useRouter: () => useRouter(),
@@ -497,6 +501,20 @@ describe("HeaderSearchModal", () => {
     waveItemCall?.[0].onWaveSelect(wave);
     expect(activeWaveSet).toHaveBeenCalledWith(wave.id, {
       isDirectMessage: false,
+    });
+  });
+
+  it("requests only non-direct-message waves for site search", () => {
+    setup();
+
+    fireEvent.change(getSearchInput(), { target: { value: "wave" } });
+
+    expect(useWaves).toHaveBeenLastCalledWith({
+      identity: null,
+      waveName: "wave",
+      limit: 20,
+      enabled: true,
+      directMessage: false,
     });
   });
 
@@ -989,6 +1007,28 @@ describe("HeaderSearchModal", () => {
       "Profiles",
       "Waves",
     ]);
+  });
+
+  it("requests server-ranked profile results", async () => {
+    setup({ selectedCategory: "PROFILES" });
+
+    fireEvent.change(getSearchInput(), { target: { value: "gelato" } });
+
+    const profileQueryOptions = [...useQueryMock.mock.calls]
+      .reverse()
+      .find(
+        ([options]) =>
+          options.queryKey[0] === QueryKey.PROFILE_SEARCH &&
+          options.queryKey[1] === "gelato"
+      )?.[0];
+    expect(profileQueryOptions).toBeDefined();
+
+    await profileQueryOptions?.queryFn();
+
+    expect(commonApiFetch).toHaveBeenCalledWith({
+      endpoint: "community-members",
+      params: { param: "gelato", sort: "level" },
+    });
   });
 
   it("triggers onClose on click away", () => {

--- a/__tests__/components/waves/create-wave/groups/CreateWaveInlineGroupIdentities.test.tsx
+++ b/__tests__/components/waves/create-wave/groups/CreateWaveInlineGroupIdentities.test.tsx
@@ -12,11 +12,13 @@ jest.mock(
     function MockGroupCreateIdentitiesSearch(props: {
       readonly selectedWallets: string[];
       readonly resultsLayout?: string;
+      readonly sort?: string;
     }) {
       return (
         <div
           data-testid="identities-search"
           data-results-layout={props.resultsLayout}
+          data-sort={props.sort}
         >
           {props.selectedWallets.join(",")}
         </div>
@@ -138,6 +140,10 @@ describe("CreateWaveInlineGroupIdentities", () => {
     expect(screen.getByTestId("identities-search")).toHaveAttribute(
       "data-results-layout",
       "popover"
+    );
+    expect(screen.getByTestId("identities-search")).toHaveAttribute(
+      "data-sort",
+      "level"
     );
   });
 

--- a/components/groups/page/create/config/wallets/GroupCreateWallets.tsx
+++ b/components/groups/page/create/config/wallets/GroupCreateWallets.tsx
@@ -168,6 +168,7 @@ export default function GroupCreateWallets({
           selectedIdentities={sources.selectedIdentities}
           selectedWallets={selectedWallets}
           onRemove={onRemove}
+          sort="level"
         />
         <CreateGroupWalletsEmma
           setWallets={onEmmaWalletsChange}

--- a/components/header/header-search/header-search-modal/HeaderSearchModalContent.tsx
+++ b/components/header/header-search/header-search-modal/HeaderSearchModalContent.tsx
@@ -286,7 +286,6 @@ function ScopedHeaderSearchModal({
   const isQuerySettled = trimmedSearchValue === trimmedDebouncedValue;
   const isAwaitingDebouncedSearch = isLiveSearchEligible && !isQuerySettled;
   const formattedInputMinLength = formatInteger(locale, MIN_SEARCH_LENGTH);
-
   const { appWalletsSupported } = useAppWallets();
   const { country } = useCookieConsent();
   const capacitor = useCapacitor();
@@ -411,7 +410,7 @@ function ScopedHeaderSearchModal({
     queryFn: async () =>
       await commonApiFetch<CommunityMemberMinimal[]>({
         endpoint: "community-members",
-        params: { param: trimmedDebouncedValue },
+        params: { param: trimmedDebouncedValue, sort: "level" },
       }),
     enabled: shouldSearchDefault,
   });
@@ -441,6 +440,7 @@ function ScopedHeaderSearchModal({
     waveName: shouldSearchDefault ? trimmedDebouncedValue : null,
     limit: 20,
     enabled: shouldSearchDefault,
+    directMessage: false,
   });
 
   const pageResults = useMemo(

--- a/components/waves/create-wave/groups/CreateWaveInlineGroupIdentities.tsx
+++ b/components/waves/create-wave/groups/CreateWaveInlineGroupIdentities.tsx
@@ -73,6 +73,7 @@ export default function CreateWaveInlineGroupIdentities({
               inputClassName="tw-border-white/10 tw-bg-iron-950 tw-ring-white/10 desktop-hover:hover:tw-ring-white/15 desktop-hover:hover:focus:tw-ring-primary-400 focus:tw-border-primary-400 focus:tw-bg-iron-950 focus:tw-ring-primary-400"
               iconClassName="tw-text-iron-500"
               resultsLayout={resultsLayout}
+              sort="level"
             />
           </div>
           {onCancel && (

--- a/ops/docs/groups/feature-group-create-and-edit.md
+++ b/ops/docs/groups/feature-group-create-and-edit.md
@@ -57,6 +57,9 @@ then run `Test` or `Create`.
   - `Include Identities`
   - `Exclude Identities`
   - Sources: identity search, EMMA list import, CSV upload
+  - Identity search shows exact, prefix, and substring profile-handle matches
+    in that order before ENS-only matches, and orders each match group by
+    profile level, highest first.
   - Combined wallets are deduplicated and normalized to lowercase.
 - `Include me` behavior:
   - Turning on adds the connected profile primary wallet (if present) to

--- a/ops/docs/navigation/feature-header-search-modal.md
+++ b/ops/docs/navigation/feature-header-search-modal.md
@@ -40,6 +40,15 @@ The search control opens one of two clearly scoped experiences:
 - Site-wide browse:
   - In `All`, each category shows a 3-result preview.
   - `View all <Category>` opens the full list for that category.
+- Profile results:
+  - Exact, prefix, and substring profile-handle matches appear in that order,
+    before results that match only by ENS.
+  - Within each match group, profiles are ordered by level from highest to
+    lowest.
+  - Profiles at the same level keep the order supplied by search.
+- Wave results:
+  - The `Waves` category includes only non-direct-message Waves.
+  - Direct-message conversations remain available through `DMs` navigation.
 - Pages catalog:
   - Page results can include top-level navigation destinations such as
     `NFTs`, `Museum`, `Waves`, `DMs`, `Join 6529`, and `About`, secondary

--- a/ops/docs/waves/create/feature-groups-step.md
+++ b/ops/docs/waves/create/feature-groups-step.md
@@ -54,6 +54,9 @@ step is user-reachable for `Chat`, `Rank`, and `Approve`.
 criteria` opens the criteria editor, where `Add identity` appears alongside
   the rule choices instead of as a separate row-level action. The identity
   search uses `Back to criteria` to return to those choices.
+- Inline identity search shows exact, prefix, and substring profile-handle
+  matches in that order before ENS-only matches, and orders each match group by
+  profile level, highest first.
 - Opening `Replace criteria` starts a pending replacement for that row. `Next`
   remains disabled until the user applies it with `Create and use new group`,
   abandons it with `Discard draft`, or selects a saved group with `Choose

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -1049,6 +1049,8 @@
       ],
       "facts": [
         "Search 6529 finds Pages, NFTs, Profiles, and Waves, with an always-visible result-type selector and a result count tied to the visible query.",
+        "Search 6529 ranks exact, prefix, and substring profile-handle matches before ENS-only matches, then orders each match group by level from highest to lowest.",
+        "Wave results in Search 6529 exclude direct-message conversations.",
         "The search control in an active Wave opens Search messages for that Wave; use Search all 6529 in the dialog to switch to site search.",
         "In Search messages, open Filters to limit results to one author who has posted in the Wave, an After date, a Before date, or a combination of those filters.",
         "Arrow keys move through site results and Enter opens the selected result.",
@@ -2326,6 +2328,7 @@
         "The Groups step shows all access and moderation rows immediately, organized from Visibility through Admins without an Advanced settings disclosure.",
         "In Groups, Visibility controls wave access; followers who can view the wave may get a notification when it is created.",
         "Each Groups access row offers Replace criteria and Choose group; Replace criteria contains Add identity and the rule choices, Back to criteria returns from identity search, and Next stays disabled until the pending replacement is created, discarded, or replaced by a saved group.",
+        "Inline group identity search ranks exact, prefix, and substring profile-handle matches before ENS-only matches, then orders each match group by profile level, highest first.",
         "An empty Visibility, drop, vote, or chat scope is labeled Public without a Current group heading; after a group is selected, the heading and its current eligible identity count are shown.",
         "A selected saved access group shows its current eligible identity count; View members opens a paginated, searchable member browser without leaving wave creation.",
         "A valid unsaved inline group offers Preview matches, which evaluates current membership without saving the group or applying it to the Wave.",
@@ -2991,6 +2994,7 @@
         "For full-collection xTDH grants, group membership requires ownership of at least one collection token.",
         "Group creation requires the relevant connected profile permissions.",
         "Groups can be used later in workflows such as wave access or participation settings.",
+        "Include and exclude identity search ranks exact, prefix, and substring profile-handle matches before ENS-only matches, then orders each match group by profile level, highest first.",
         "Publishing a replacement for a group used by a Wave is rejected if it would leave any active Drop, Vote, Chat, or Admins group member outside that Wave's Visibility group."
       ],
       "canonical_path": "/network/groups",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -1045,6 +1045,8 @@
       ],
       "facts": [
         "Search 6529 finds Pages, NFTs, Profiles, and Waves, with an always-visible result-type selector and a result count tied to the visible query.",
+        "Search 6529 ranks exact, prefix, and substring profile-handle matches before ENS-only matches, then orders each match group by level from highest to lowest.",
+        "Wave results in Search 6529 exclude direct-message conversations.",
         "The search control in an active Wave opens Search messages for that Wave; use Search all 6529 in the dialog to switch to site search.",
         "In Search messages, open Filters to limit results to one author who has posted in the Wave, an After date, a Before date, or a combination of those filters.",
         "Arrow keys move through site results and Enter opens the selected result.",
@@ -2322,6 +2324,7 @@
         "The Groups step shows all access and moderation rows immediately, organized from Visibility through Admins without an Advanced settings disclosure.",
         "In Groups, Visibility controls wave access; followers who can view the wave may get a notification when it is created.",
         "Each Groups access row offers Replace criteria and Choose group; Replace criteria contains Add identity and the rule choices, Back to criteria returns from identity search, and Next stays disabled until the pending replacement is created, discarded, or replaced by a saved group.",
+        "Inline group identity search ranks exact, prefix, and substring profile-handle matches before ENS-only matches, then orders each match group by profile level, highest first.",
         "An empty Visibility, drop, vote, or chat scope is labeled Public without a Current group heading; after a group is selected, the heading and its current eligible identity count are shown.",
         "A selected saved access group shows its current eligible identity count; View members opens a paginated, searchable member browser without leaving wave creation.",
         "A valid unsaved inline group offers Preview matches, which evaluates current membership without saving the group or applying it to the Wave.",
@@ -2987,6 +2990,7 @@
         "For full-collection xTDH grants, group membership requires ownership of at least one collection token.",
         "Group creation requires the relevant connected profile permissions.",
         "Groups can be used later in workflows such as wave access or participation settings.",
+        "Include and exclude identity search ranks exact, prefix, and substring profile-handle matches before ENS-only matches, then orders each match group by profile level, highest first.",
         "Publishing a replacement for a group used by a Wave is rejected if it would leave any active Drop, Vote, Chat, or Admins group member outside that Wave's Visibility group."
       ],
       "canonical_path": "/network/groups",


### PR DESCRIPTION
## Issue

- Search 6529 profile results were not ordered by profile level and could place ENS-only matches ahead of matching profiles.
- Site-wide Wave results could include direct-message conversations.
- Include/Exclude identity search in group creation and inline Wave group creators did not opt into the same identity ranking used by direct-message creation.

## Fix

- Request the backend's level-ranked community-member search contract wherever consistent identity ranking is required.
- Keep direct-message Waves out of site-wide Wave search.

## Changes

- Search 6529 requests `sort=level` for Profiles and limits Waves to non-DM results.
- Include and Exclude identity selectors request level-ranked results.
- Inline Wave group identity selectors request level-ranked results.
- Added regression coverage for the API parameters and both group-creation surfaces.
- Updated product documentation and the Help 6529 knowledge index.

## Validation

- `./bin/6529 run test:no-coverage __tests__/components/header/HeaderSearchModal.test.tsx __tests__/components/groups/page/create/config/identities/select/GroupCreateIdentitiesSearchItems.test.tsx __tests__/components/groups/GroupCreateWallets.test.tsx __tests__/components/waves/create-wave/groups/CreateWaveInlineGroupIdentities.test.tsx --runInBand` — 58 tests passed.
- `./bin/6529 run check:changed` — passed.
- `./bin/6529 run typecheck:ci` — passed.
- `./bin/6529 run react-doctor:diff` — 98/100; only existing advisories in touched legacy components.
- `./bin/6529 run help-index:sync` — passed.
- Live local browser verification covered global search, Include identities, Exclude identities, and an inline Visibility-group picker with no browser-console errors.
- The full docs-link validator still reports the pre-existing missing `ops/docs/content-moderation.md` target referenced by `ops/docs/shared/feature-ios-eula-consent.md`; this PR does not touch that link.

## Risk

- Level: Low
- Why: The change only adds supported query options to existing search calls and narrows site-wide Wave search to non-DM results.
- Rollback: Revert this frontend commit; no data or schema rollback is required.

## Review Notes

- The backend `sort=level` API contract is already merged and present on the backend staging branch. It ranks exact, prefix, and substring profile-handle matches before ENS/auto-wallet matches, then sorts each bucket by level.
- No backend Lambda deployment is introduced by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved profile and identity search ranking: exact, prefix, and partial handle matches appear before ENS-only matches, ordered by profile level.
  * Group identity searches now use level-based sorting for more relevant results.
  * Wave search results now exclude direct-message conversations; direct messages remain available in the dedicated navigation.

* **Documentation**
  * Updated help content to describe the new search ranking and filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->