### PR TITLE
Update identity search API contract

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4367,15 +4367,21 @@ paths:
     get:
       tags:
         - Identities
-      summary: Search for identities
+      summary: Search or list identities
+      description: >-
+        When handle is supplied, exact and prefix matches are ranked before
+        other substring matches, with higher raw profile level first within each
+        match bucket. Without handle, identities are ordered by raw profile
+        level descending.
       operationId: searchIdentities
       parameters:
         - name: handle
-          description: At least 3 characters of a handle
+          description: At least 3 characters of a handle when supplied
           in: query
-          required: true
+          required: false
           schema:
             type: string
+            minLength: 3
         - name: wave_id
           description: Search only users who can view given wave
           in: query
@@ -4403,6 +4409,20 @@ paths:
           required: false
           schema:
             type: boolean
+        - name: classification
+          description: Filter by profile classification
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/ApiProfileClassification"
+        - name: subclassification
+          description: Filter by exact profile subclassification
+          in: query
+          required: false
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 255
       responses:
         "200":
           description: successful operation
@@ -4412,6 +4432,8 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/ApiIdentity"
+        "400":
+          description: Invalid handle, limit, classification, or subclassification
   /identities/{identity_key}:
     get:
       tags:


### PR DESCRIPTION
## Issue

- The frontend-owned public OpenAPI contract must stay synchronized with the backend identity-search API.

## Fix

- Publish the updated `GET /identities` contract after the backend makes `handle` optional and adds profile filters.

## Changes

- Mark `handle` optional with a three-character minimum when supplied.
- Add optional `classification` enum and exact `subclassification` query parameters.
- Document ordering with and without a handle.
- No frontend runtime or visible UI behavior changes.

## Validation

- `./bin/6529 run generate`
- `./bin/6529 run check:changed`
- Frontend and backend OpenAPI inputs are byte-for-byte identical.

## Risk

- Level: Low
- Why: Contract-only synchronization; generated output does not change for these query parameters.
- Rollback: Revert this PR and redeploy the previous frontend artifact.

## Deployment

1. Deploy backend PR #1952 service `api`.
2. Deploy this frontend `WEB` candidate.

## Review Notes

- Coupled backend prerequisite: https://github.com/6529-Collections/6529seize-backend/pull/1952

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional classification and subclassification filters to identity searches.
  - Identity searches can now omit the handle and document ranking behavior.
  - Added validation requiring supplied handles to contain at least three characters.

- **Bug Fixes**
  - Documented `400` error responses for invalid handles, limits, classifications, or subclassifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->