### PR TITLE
Restore authenticated mutations across wallet chains

### DIFF
--- a/__tests__/components/auth/Auth.test.tsx
+++ b/__tests__/components/auth/Auth.test.tsx
@@ -2509,6 +2509,49 @@ describe("Auth component", () => {
       expect(mockSignMessage).not.toHaveBeenCalled();
     });
 
+    it("does not continue a session upgrade if the chain becomes unsupported", async () => {
+      const validAddress = "0x1111111111111111111111111111111111111111";
+      walletAddress = validAddress;
+      const sessionV2 = require("@/services/auth/session-v2.utils");
+      const nonce = createDeferredPromise<{
+        readonly signable_message: string;
+        readonly server_signature: string;
+      }>();
+      sessionV2.getSessionNonce.mockReturnValueOnce(nonce.promise);
+
+      render(
+        <ReactQueryWrapperContext.Provider
+          value={{ invalidateAll: jest.fn() } as any}
+        >
+          <Auth>
+            <SessionUpgradeProbe />
+          </Auth>
+        </ReactQueryWrapperContext.Provider>
+      );
+
+      fireEvent.click(screen.getByTestId("request-session-upgrade"));
+      await waitFor(() => {
+        expect(sessionV2.getSessionNonce).toHaveBeenCalledWith({
+          signerAddress: validAddress,
+        });
+      });
+
+      mockActiveChainId = 137;
+      nonce.resolve({
+        signable_message: "sign this message exactly",
+        server_signature: "server-signature",
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("session-upgrade-result")).toHaveTextContent(
+          "false"
+        );
+      });
+      expect(mockSignMessage).not.toHaveBeenCalled();
+      expect(sessionV2.loginWithSessionV2).not.toHaveBeenCalled();
+      expect(mockSeizeDisconnect).not.toHaveBeenCalled();
+    });
+
     it("tracks a connected reauth prompt once for a visible auth incident", async () => {
       mockUsePathname.mockReturnValue("/waves/wave-1");
       const mockValidateAuthImmediate =

--- a/__tests__/components/auth/Auth.test.tsx
+++ b/__tests__/components/auth/Auth.test.tsx
@@ -349,6 +349,28 @@ function RequestAuthButton() {
   );
 }
 
+function RequestAuthResultButton() {
+  const { requestAuth } = useAuth();
+  const [result, setResult] = React.useState("pending");
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() =>
+          void requestAuth().then(({ success }) => {
+            setResult(String(success));
+          })
+        }
+        data-testid="request-auth-result"
+      >
+        request auth
+      </button>
+      <span data-testid="request-auth-success">{result}</span>
+    </>
+  );
+}
+
 function SessionUpgradeProbe() {
   const {
     ensureActiveSessionV2WebSession,
@@ -621,6 +643,109 @@ describe("Auth component", () => {
       expect(mockValidateJwt).not.toHaveBeenCalled();
       expect(mockSignMessage).not.toHaveBeenCalled();
     });
+
+    it.each([
+      {
+        chainId: undefined,
+        chainState: "unknown",
+        canSign: false,
+        wagmiConnected: false,
+      },
+      {
+        chainId: 137,
+        chainState: "unsupported",
+        canSign: true,
+        wagmiConnected: true,
+      },
+    ])(
+      "allows an authorized session request when the active chain is $chainState",
+      async ({ chainId, canSign, wagmiConnected }) => {
+        const validAddress = "0x1111111111111111111111111111111111111111";
+        walletAddress = validAddress;
+        canSignActiveWallet = canSign;
+        mockActiveChainId = chainId;
+        mockWagmiIsConnected = wagmiConnected;
+        const authUtils = require("@/services/auth/auth.utils");
+        const sessionV2 = require("@/services/auth/session-v2.utils");
+        const mockValidateJwt =
+          require("@/services/auth/jwt-validation.utils").validateJwt;
+        authUtils.getAuthJwt.mockReturnValue("valid-jwt");
+
+        render(
+          <ReactQueryWrapperContext.Provider
+            value={{ invalidateAll: jest.fn() } as any}
+          >
+            <Auth>
+              <RequestAuthResultButton />
+            </Auth>
+          </ReactQueryWrapperContext.Provider>
+        );
+
+        await userEvent.click(screen.getByTestId("request-auth-result"));
+
+        await waitFor(() => {
+          expect(screen.getByTestId("request-auth-success")).toHaveTextContent(
+            "true"
+          );
+        });
+        expect(mockValidateJwt).toHaveBeenCalledWith(
+          expect.objectContaining({
+            jwt: "valid-jwt",
+            wallet: validAddress,
+          })
+        );
+        expect(sessionV2.getSessionNonce).not.toHaveBeenCalled();
+        expect(mockSignMessage).not.toHaveBeenCalled();
+        expect(sessionV2.loginWithSessionV2).not.toHaveBeenCalled();
+        expect(mockSeizeDisconnect).not.toHaveBeenCalled();
+        expect(mockSeizeDisconnectAndLogout).not.toHaveBeenCalled();
+      }
+    );
+
+    it.each([
+      { chainId: undefined, chainState: "unknown" },
+      { chainId: 137, chainState: "unsupported" },
+    ])(
+      "does not begin authorized-session reauthentication when the active chain is $chainState",
+      async ({ chainId }) => {
+        const validAddress = "0x1111111111111111111111111111111111111111";
+        walletAddress = validAddress;
+        mockActiveChainId = chainId;
+        mockWagmiIsConnected = chainId !== undefined;
+        const authUtils = require("@/services/auth/auth.utils");
+        const sessionV2 = require("@/services/auth/session-v2.utils");
+        const mockValidateJwt =
+          require("@/services/auth/jwt-validation.utils").validateJwt;
+        authUtils.getAuthJwt.mockReturnValue("expired-jwt");
+        mockValidateJwt.mockResolvedValue({
+          isValid: false,
+          wasCancelled: false,
+        });
+
+        render(
+          <ReactQueryWrapperContext.Provider
+            value={{ invalidateAll: jest.fn() } as any}
+          >
+            <Auth>
+              <RequestAuthResultButton />
+            </Auth>
+          </ReactQueryWrapperContext.Provider>
+        );
+
+        await userEvent.click(screen.getByTestId("request-auth-result"));
+
+        await waitFor(() => {
+          expect(screen.getByTestId("request-auth-success")).toHaveTextContent(
+            "false"
+          );
+        });
+        expect(mockValidateJwt).toHaveBeenCalled();
+        expect(authUtils.removeAuthJwt).not.toHaveBeenCalled();
+        expect(sessionV2.getSessionNonce).not.toHaveBeenCalled();
+        expect(mockSignMessage).not.toHaveBeenCalled();
+        expect(mockSeizeDisconnect).not.toHaveBeenCalled();
+      }
+    );
 
     it("force-validates an authorized session after the server rejects it", async () => {
       const validAddress = "0x1111111111111111111111111111111111111111";

--- a/components/auth/authActions.ts
+++ b/components/auth/authActions.ts
@@ -296,6 +296,20 @@ export function createAuthRequestActions({
     setToast,
   });
 
+  const createSigningAuthRequestGuard = (
+    authRequestGuard: AuthRequestGuard
+  ): AuthRequestGuard => ({
+    isCurrent: () => isActiveChainSupported() && authRequestGuard.isCurrent(),
+    acceptCurrentState: (walletAddress: string) => {
+      if (!isActiveChainSupported()) {
+        return false;
+      }
+
+      const accepted = authRequestGuard.acceptCurrentState(walletAddress);
+      return accepted && isActiveChainSupported();
+    },
+  });
+
   const ensureConnectedWalletAddress = (): string | null => {
     if (address) {
       return address;
@@ -312,13 +326,19 @@ export function createAuthRequestActions({
     walletAddress: string,
     authRequestGuard: AuthRequestGuard
   ): Promise<boolean> => {
+    const signingAuthRequestGuard =
+      createSigningAuthRequestGuard(authRequestGuard);
+    if (!signingAuthRequestGuard.isCurrent()) {
+      return false;
+    }
+
     const { success } = await requestSignIn({
       signerAddress: walletAddress,
       role: null,
-      authRequestGuard,
+      authRequestGuard: signingAuthRequestGuard,
     });
 
-    if (!authRequestGuard.isCurrent()) {
+    if (!signingAuthRequestGuard.isCurrent()) {
       return false;
     }
     if (!success) {
@@ -457,21 +477,27 @@ export function createAuthRequestActions({
     readonly validationResult: AuthorizedWalletValidationResult;
     readonly walletAddress: string;
   }): Promise<boolean> => {
+    const signingAuthRequestGuard =
+      createSigningAuthRequestGuard(authRequestGuard);
+    if (!signingAuthRequestGuard.isCurrent()) {
+      return false;
+    }
+
     const canReauthenticate = await prepareAuthorizedWalletReauthentication({
       serverRejected,
       walletAddress,
       validationResult,
     });
-    if (!canReauthenticate || !authRequestGuard.isCurrent()) {
+    if (!canReauthenticate || !signingAuthRequestGuard.isCurrent()) {
       return false;
     }
 
     const { success } = await requestSignIn({
       signerAddress: walletAddress,
       role,
-      authRequestGuard,
+      authRequestGuard: signingAuthRequestGuard,
     });
-    if (!authRequestGuard.isCurrent()) {
+    if (!signingAuthRequestGuard.isCurrent()) {
       return false;
     }
     if (!success) {
@@ -555,14 +581,7 @@ export function createAuthRequestActions({
       return { success: false };
     }
 
-    if (!isActiveChainSupported()) {
-      return { success: false };
-    }
-
-    const authRequestGuard = createAuthRequestGuard(
-      options ?? {},
-      isActiveChainSupported
-    );
+    const authRequestGuard = createAuthRequestGuard(options ?? {});
     if (!authRequestGuard.isCurrent()) {
       return { success: false };
     }
@@ -586,9 +605,7 @@ export function createAuthRequestActions({
           );
       return { success };
     } finally {
-      // A chain change makes the request guard stale, but must still release
-      // the signing state so authentication can resume after switching back.
-      if (authRequestGuard.isCurrent() || !isActiveChainSupported()) {
+      if (authRequestGuard.isCurrent()) {
         setAuthLoadingState("idle");
       }
     }

--- a/components/auth/authActions.ts
+++ b/components/auth/authActions.ts
@@ -651,11 +651,10 @@ export function createAuthRequestActions({
         return { success: false };
       }
 
-      const authRequestGuard = createAuthRequestGuard(
-        {},
-        isActiveChainSupported
+      const signingAuthRequestGuard = createSigningAuthRequestGuard(
+        createAuthRequestGuard({})
       );
-      if (!authRequestGuard.isCurrent()) {
+      if (!signingAuthRequestGuard.isCurrent()) {
         return { success: false };
       }
 
@@ -665,10 +664,10 @@ export function createAuthRequestActions({
       const { success } = await requestSignIn({
         signerAddress: upgradeAddress,
         role,
-        authRequestGuard,
+        authRequestGuard: signingAuthRequestGuard,
       });
 
-      if (!authRequestGuard.isCurrent()) {
+      if (!signingAuthRequestGuard.isCurrent()) {
         return { success: false };
       }
 
@@ -709,10 +708,12 @@ export function createAuthRequestActions({
       return;
     }
 
-    const authRequestGuard = createAuthRequestGuard({}, isActiveChainSupported);
+    const signingAuthRequestGuard = createSigningAuthRequestGuard(
+      createAuthRequestGuard({})
+    );
 
     await removeAuthJwt();
-    if (!authRequestGuard.isCurrent()) {
+    if (!signingAuthRequestGuard.isCurrent()) {
       setToast({
         message:
           "Network changed. Switch to a supported network to continue signing in.",
@@ -724,9 +725,9 @@ export function createAuthRequestActions({
       const { success } = await requestSignIn({
         signerAddress: address,
         role: profileProxy ? validateRoleForAuthentication(profileProxy) : null,
-        authRequestGuard,
+        authRequestGuard: signingAuthRequestGuard,
       });
-      if (success && authRequestGuard.isCurrent()) {
+      if (success && signingAuthRequestGuard.isCurrent()) {
         setActiveProfileProxy(profileProxy);
         dispatchProfileSwitchedEvent(profileProxy);
       }


### PR DESCRIPTION
## Issue

- PR #3833 made active-chain support a prerequisite for every requestAuth() call. Valid stored sessions could therefore read content and receive notifications but silently fail all authenticated mutations when Wagmi had no active chain or reported an unsupported chain.

## Fix

- Restore the previous validation-first behavior for existing authorized sessions.
- Apply the supported-chain guard only when authentication actually needs to enter a wallet-signing flow.
- Preserve the latest-chain checks throughout nonce, signature, login, and persistence so unsupported-chain races still cannot authenticate.

## Changes

- Compose the existing auth-state guard with chain support only for unauthorized sign-in and authorized reauthentication.
- Keep valid JWT-backed mutations working when the live chain is unknown or unsupported.
- Keep existing connections and stored sessions intact: no disconnect, logout, JWT removal, nonce request, or signature is triggered solely because the active chain is unavailable.
- Add regression coverage for unknown and unsupported chains across valid-session and reauthentication-required paths.

## Validation

- Focused Auth test suite: 80 tests passed.
- Changed-file lint passed.
- Changed-file and full TypeScript checks passed.
- React Doctor diff scan passed at 100/100 with no findings.
- No deployment or browser E2E was run; this is a non-visual auth-control-flow fix covered at the integration-test level.

## Risk

- Level: Medium
- Why: requestAuth() guards many mutation paths, but the change is limited to restoring valid-session behavior while retaining chain enforcement around every signing path.
- Rollback: revert this PR to restore the current chain-wide requestAuth() gate.

## Review Notes

- Please focus on the separation between JWT validation and signing guards, especially chain changes between nonce retrieval, signing, login, and session persistence.
- Follow-up to #3833.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication handling on unsupported blockchain networks.
  - Prevented reauthentication attempts when sessions are expired or the active network is unsupported.
  - Prevented unnecessary wallet signing, session login, nonce retrieval, and disconnection actions when authentication cannot proceed.
  - Improved validation of authenticated sessions and authorization results across supported and unsupported network scenarios.
  - Improved session upgrades and profile changes by consistently validating network support before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->