### PR TITLE
Fix profile Brain sidebar scrolling

### DIFF
--- a/__tests__/components/user/brain/UserPageBrainSidebar.test.tsx
+++ b/__tests__/components/user/brain/UserPageBrainSidebar.test.tsx
@@ -120,6 +120,52 @@ describe("UserPageBrainSidebar", () => {
     });
   });
 
+  it("exposes the desktop lists as one keyboard-scrollable region", () => {
+    createdState = makeState({ waves: [makeWave()] });
+    recentState = makeState({
+      waves: [makeWave({ id: "wave-2", name: "Recent Wave" })],
+    });
+
+    render(<UserPageBrainSidebar profile={baseProfile} />);
+
+    const scrollRegion = screen.getByRole("region", {
+      name: "Created Waves Recently Active In",
+    });
+
+    expect(scrollRegion).toBe(screen.getByTestId("brain-sidebar-desktop"));
+    expect(scrollRegion).toHaveAttribute("tabindex", "0");
+    expect(scrollRegion).toHaveClass(
+      "lg:tw-max-h-[calc(100dvh-4rem)]",
+      "lg:tw-overflow-y-auto",
+      "lg:tw-overscroll-y-contain"
+    );
+    expect(
+      screen.getByTestId("brain-sidebar-mobile-strip")
+    ).not.toHaveAttribute("tabindex");
+
+    Object.defineProperties(scrollRegion, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 200 },
+    });
+    scrollRegion.scrollTop = 100;
+
+    expect(
+      fireEvent.wheel(scrollRegion, { cancelable: true, deltaY: 40 })
+    ).toBe(false);
+    expect(
+      fireEvent.keyDown(scrollRegion, { cancelable: true, key: "PageDown" })
+    ).toBe(false);
+
+    scrollRegion.scrollTop = 50;
+    expect(
+      fireEvent.wheel(scrollRegion, { cancelable: true, deltaY: 40 })
+    ).toBe(true);
+    expect(
+      fireEvent.keyDown(scrollRegion, { cancelable: true, key: "PageDown" })
+    ).toBe(false);
+    expect(scrollRegion.scrollTop).toBe(100);
+  });
+
   it("keeps a successful recent section when created waves fail", () => {
     createdState = makeState({
       status: "error",
@@ -199,6 +245,7 @@ describe("UserPageBrainSidebar", () => {
     const toggle = within(createdSection).getByRole("button", {
       name: "Show more",
     });
+    toggle.scrollIntoView = jest.fn();
     toggle.focus();
 
     fireEvent.click(toggle);
@@ -206,6 +253,10 @@ describe("UserPageBrainSidebar", () => {
       within(createdSection).getByRole("button", { name: "Show less" })
     ).toBe(toggle);
     expect(globalThis.document.activeElement).toBe(toggle);
+    expect(toggle.scrollIntoView).toHaveBeenLastCalledWith({
+      block: "nearest",
+      inline: "nearest",
+    });
     expect(within(createdSection).getByText("Hidden Wave")).toBeInTheDocument();
 
     fireEvent.click(toggle);
@@ -213,7 +264,52 @@ describe("UserPageBrainSidebar", () => {
       within(createdSection).getByRole("button", { name: "Show more" })
     ).toBe(toggle);
     expect(globalThis.document.activeElement).toBe(toggle);
+    expect(toggle.scrollIntoView).toHaveBeenCalledTimes(2);
     expect(within(createdSection).queryByText("Hidden Wave")).toBeNull();
+  });
+
+  it("keeps a focused load-more control visible after a non-final page", () => {
+    recentState = makeState({
+      waves: [makeWave({ id: "wave-2", name: "Recent Wave" })],
+      hasNextPage: true,
+    });
+
+    const { rerender } = render(<UserPageBrainSidebar profile={baseProfile} />);
+    const recentSection = screen.getByRole("region", {
+      name: "Recently Active In",
+    });
+    const loadMore = within(recentSection).getByRole("button", {
+      name: "Load more",
+    });
+    loadMore.scrollIntoView = jest.fn();
+    loadMore.focus();
+
+    recentState = makeState({
+      waves: [makeWave({ id: "wave-2", name: "Recent Wave" })],
+      hasNextPage: true,
+      isFetchingNextPage: true,
+    });
+    rerender(<UserPageBrainSidebar profile={baseProfile} />);
+
+    expect(loadMore).toHaveAttribute("aria-busy", "true");
+    expect(loadMore).toHaveAttribute("aria-disabled", "true");
+    expect(loadMore).not.toBeDisabled();
+    expect(globalThis.document.activeElement).toBe(loadMore);
+
+    recentState = makeState({
+      waves: [
+        makeWave({ id: "wave-2", name: "Recent Wave" }),
+        makeWave({ id: "wave-3", name: "Another Recent Wave" }),
+      ],
+      hasNextPage: true,
+    });
+    rerender(<UserPageBrainSidebar profile={baseProfile} />);
+
+    expect(globalThis.document.activeElement).toBe(loadMore);
+    expect(loadMore.scrollIntoView).toHaveBeenCalledWith({
+      block: "nearest",
+      inline: "nearest",
+    });
   });
 
   it("uses truthful mobile and modal copy while more created pages exist", () => {
@@ -275,6 +371,8 @@ describe("UserPageBrainSidebar", () => {
     const loadMore = within(recentSection).getByRole("button", {
       name: "Load more",
     });
+    const scrollRegion = screen.getByTestId("brain-sidebar-desktop");
+    scrollRegion.scrollTop = 64;
     loadMore.focus();
     fireEvent.click(loadMore);
 
@@ -293,6 +391,7 @@ describe("UserPageBrainSidebar", () => {
     });
 
     const completion = within(recentSection).getByRole("status");
+    expect(scrollRegion.scrollTop).toBe(64);
     expect(completion).toHaveTextContent("All waves loaded.");
     expect(globalThis.document.activeElement).toBe(completion);
     expect(

--- a/__tests__/components/user/brain/UserPageBrainSidebar.test.tsx
+++ b/__tests__/components/user/brain/UserPageBrainSidebar.test.tsx
@@ -128,11 +128,10 @@ describe("UserPageBrainSidebar", () => {
 
     render(<UserPageBrainSidebar profile={baseProfile} />);
 
-    const scrollRegion = screen.getByRole("region", {
-      name: "Created Waves Recently Active In",
-    });
+    const scrollRegion = screen.getByTestId("brain-sidebar-desktop");
 
-    expect(scrollRegion).toBe(screen.getByTestId("brain-sidebar-desktop"));
+    expect(scrollRegion).toHaveAccessibleName("Brain waves");
+    expect(scrollRegion.tagName).toBe("SECTION");
     expect(scrollRegion).toHaveAttribute("tabindex", "0");
     expect(scrollRegion).toHaveClass(
       "lg:tw-max-h-[calc(100dvh-4rem)]",
@@ -310,6 +309,41 @@ describe("UserPageBrainSidebar", () => {
       block: "nearest",
       inline: "nearest",
     });
+  });
+
+  it("blocks repeated load-more activations until the request settles", async () => {
+    let resolveNextPage:
+      | ((result: { readonly isComplete: boolean }) => void)
+      | undefined;
+    const fetchNextPage = jest.fn(
+      async () =>
+        await new Promise<{ readonly isComplete: boolean }>((resolve) => {
+          resolveNextPage = resolve;
+        })
+    );
+    recentState = makeState({
+      waves: [makeWave({ id: "wave-2", name: "Recent Wave" })],
+      hasNextPage: true,
+      fetchNextPage,
+    });
+
+    render(<UserPageBrainSidebar profile={baseProfile} />);
+    const loadMore = within(
+      screen.getByRole("region", { name: "Recently Active In" })
+    ).getByRole("button", { name: "Load more" });
+
+    fireEvent.click(loadMore);
+    fireEvent.click(loadMore);
+
+    expect(fetchNextPage).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveNextPage?.({ isComplete: false });
+      await Promise.resolve();
+    });
+
+    fireEvent.click(loadMore);
+    expect(fetchNextPage).toHaveBeenCalledTimes(2);
   });
 
   it("uses truthful mobile and modal copy while more created pages exist", () => {

--- a/components/user/brain/UserPageBrainSidebar.module.css
+++ b/components/user/brain/UserPageBrainSidebar.module.css
@@ -1,0 +1,4 @@
+.desktopScrollRegion {
+  overflow-anchor: none;
+  scrollbar-gutter: stable;
+}

--- a/components/user/brain/UserPageBrainSidebar.tsx
+++ b/components/user/brain/UserPageBrainSidebar.tsx
@@ -6,15 +6,67 @@ import { shortenAddress } from "@/helpers/address.helpers";
 import { useBrowserLocale } from "@/hooks/useBrowserLocale";
 import { useProfileWaveActivityWaves } from "@/hooks/useProfileWaveActivityWaves";
 import { useWaveCreatorPreviewModal } from "@/hooks/useWaveCreatorPreviewModal";
+import { useEffect, useRef, type KeyboardEvent } from "react";
 import UserPageBrainSidebarCreated from "./UserPageBrainSidebarCreated";
 import UserPageBrainSidebarCreatedModal from "./UserPageBrainSidebarCreatedModal";
 import UserPageBrainSidebarMobileStrip from "./UserPageBrainSidebarMobileStrip";
 import UserPageBrainSidebarRecentlyActive from "./UserPageBrainSidebarRecentlyActive";
+import styles from "./UserPageBrainSidebar.module.css";
 import { getProfileWaveIdentity } from "./userPageBrainSidebar.helpers";
 import { getUserPageBrainSidebarMessage } from "./userPageBrainSidebar.messages";
 
 const CREATED_PAGE_SIZE = 20;
 const RECENT_PAGE_SIZE = 5;
+const SCROLL_BOUNDARY_TOLERANCE_PX = 1;
+const KEYBOARD_SCROLL_STEP_PX = 40;
+
+const canScrollVertically = (element: HTMLDivElement): boolean =>
+  element.scrollHeight - element.clientHeight > SCROLL_BOUNDARY_TOLERANCE_PX;
+
+const isAtVerticalScrollBoundary = (
+  element: HTMLDivElement,
+  direction: -1 | 1
+): boolean => {
+  if (direction < 0) {
+    return element.scrollTop <= SCROLL_BOUNDARY_TOLERANCE_PX;
+  }
+
+  const remainingScroll =
+    element.scrollHeight - element.clientHeight - element.scrollTop;
+  return remainingScroll <= SCROLL_BOUNDARY_TOLERANCE_PX;
+};
+
+const getKeyboardScrollTop = (
+  event: KeyboardEvent<HTMLDivElement>
+): number | null => {
+  const sidebar = event.currentTarget;
+  const pageScrollDistance = sidebar.clientHeight * 0.8;
+
+  switch (event.key) {
+    case "ArrowUp":
+      return sidebar.scrollTop - KEYBOARD_SCROLL_STEP_PX;
+    case "ArrowDown":
+      return sidebar.scrollTop + KEYBOARD_SCROLL_STEP_PX;
+    case "PageUp":
+      return sidebar.scrollTop - pageScrollDistance;
+    case "PageDown":
+      return sidebar.scrollTop + pageScrollDistance;
+    case "Home":
+      return 0;
+    case "End":
+      return sidebar.scrollHeight - sidebar.clientHeight;
+    case " ":
+      if (event.target === sidebar) {
+        return (
+          sidebar.scrollTop +
+          (event.shiftKey ? -pageScrollDistance : pageScrollDistance)
+        );
+      }
+      return null;
+    default:
+      return null;
+  }
+};
 
 export default function UserPageBrainSidebar({
   profile,
@@ -22,6 +74,7 @@ export default function UserPageBrainSidebar({
   readonly profile: ApiIdentity;
 }) {
   const locale = useBrowserLocale();
+  const desktopSidebarRef = useRef<HTMLDivElement>(null);
   const identity = getProfileWaveIdentity(profile).trim();
   const hasIdentity = identity.length > 0;
   const createdState = useProfileWaveActivityWaves({
@@ -55,6 +108,43 @@ export default function UserPageBrainSidebar({
     );
   }
 
+  useEffect(() => {
+    const sidebar = desktopSidebarRef.current;
+    if (!sidebar) {
+      return;
+    }
+
+    // React delegates wheel events passively, so the boundary guard needs a
+    // native listener to keep Chromium from handing the gesture to the feed.
+    const handleWheel = (event: WheelEvent) => {
+      if (!canScrollVertically(sidebar) || event.deltaY === 0) {
+        return;
+      }
+
+      const direction = event.deltaY < 0 ? -1 : 1;
+      if (isAtVerticalScrollBoundary(sidebar, direction)) {
+        event.preventDefault();
+      }
+    };
+
+    sidebar.addEventListener("wheel", handleWheel, { passive: false });
+    return () => sidebar.removeEventListener("wheel", handleWheel);
+  }, [hasIdentity]);
+
+  const handleDesktopSidebarKeyDown = (
+    event: KeyboardEvent<HTMLDivElement>
+  ) => {
+    const sidebar = event.currentTarget;
+    const nextScrollTop = getKeyboardScrollTop(event);
+    if (nextScrollTop === null || !canScrollVertically(sidebar)) {
+      return;
+    }
+
+    const maxScrollTop = sidebar.scrollHeight - sidebar.clientHeight;
+    event.preventDefault();
+    sidebar.scrollTop = Math.min(Math.max(nextScrollTop, 0), maxScrollTop);
+  };
+
   if (!hasIdentity) {
     return null;
   }
@@ -75,8 +165,13 @@ export default function UserPageBrainSidebar({
       />
 
       <div
-        className="tw-hidden tw-space-y-6 lg:tw-block"
+        aria-labelledby="brain-created-waves-heading brain-recent-waves-heading"
+        className={`${styles["desktopScrollRegion"] ?? ""} tw-hidden tw-space-y-6 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-primary-400 lg:tw-block lg:tw-max-h-[calc(100dvh-4rem)] lg:tw-overflow-y-auto lg:tw-overflow-x-hidden lg:tw-overscroll-y-contain lg:tw-pb-1 lg:tw-pr-1 lg:tw-scrollbar-thin lg:tw-scrollbar-track-transparent lg:tw-scrollbar-thumb-iron-700/70 desktop-hover:hover:lg:tw-scrollbar-thumb-iron-500`}
         data-testid="brain-sidebar-desktop"
+        onKeyDown={handleDesktopSidebarKeyDown}
+        ref={desktopSidebarRef}
+        role="region"
+        tabIndex={0}
       >
         <UserPageBrainSidebarCreated identity={identity} state={createdState} />
         <UserPageBrainSidebarRecentlyActive state={recentState} />

--- a/components/user/brain/UserPageBrainSidebar.tsx
+++ b/components/user/brain/UserPageBrainSidebar.tsx
@@ -164,18 +164,20 @@ export default function UserPageBrainSidebar({
         onOpenCreatedWaves={handleBadgeClick}
       />
 
-      <div
-        aria-labelledby="brain-created-waves-heading brain-recent-waves-heading"
+      <section
+        aria-label={getUserPageBrainSidebarMessage(
+          locale,
+          "user.brain.sidebar.mobileStripLabel"
+        )}
         className={`${styles["desktopScrollRegion"] ?? ""} tw-hidden tw-space-y-6 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-primary-400 lg:tw-block lg:tw-max-h-[calc(100dvh-4rem)] lg:tw-overflow-y-auto lg:tw-overflow-x-hidden lg:tw-overscroll-y-contain lg:tw-pb-1 lg:tw-pr-1 lg:tw-scrollbar-thin lg:tw-scrollbar-track-transparent lg:tw-scrollbar-thumb-iron-700/70 desktop-hover:hover:lg:tw-scrollbar-thumb-iron-500`}
         data-testid="brain-sidebar-desktop"
         onKeyDown={handleDesktopSidebarKeyDown}
         ref={desktopSidebarRef}
-        role="region"
         tabIndex={0}
       >
         <UserPageBrainSidebarCreated identity={identity} state={createdState} />
         <UserPageBrainSidebarRecentlyActive state={recentState} />
-      </div>
+      </section>
 
       <UserPageBrainSidebarCreatedModal
         isOpen={isModalOpen}

--- a/components/user/brain/UserPageBrainSidebar.tsx
+++ b/components/user/brain/UserPageBrainSidebar.tsx
@@ -167,7 +167,7 @@ export default function UserPageBrainSidebar({
       <section
         aria-label={getUserPageBrainSidebarMessage(
           locale,
-          "user.brain.sidebar.mobileStripLabel"
+          "user.brain.sidebar.desktopScrollRegionLabel"
         )}
         className={`${styles["desktopScrollRegion"] ?? ""} tw-hidden tw-space-y-6 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-primary-400 lg:tw-block lg:tw-max-h-[calc(100dvh-4rem)] lg:tw-overflow-y-auto lg:tw-overflow-x-hidden lg:tw-overscroll-y-contain lg:tw-pb-1 lg:tw-pr-1 lg:tw-scrollbar-thin lg:tw-scrollbar-track-transparent lg:tw-scrollbar-thumb-iron-700/70 desktop-hover:hover:lg:tw-scrollbar-thumb-iron-500`}
         data-testid="brain-sidebar-desktop"

--- a/components/user/brain/UserPageBrainSidebarCreated.tsx
+++ b/components/user/brain/UserPageBrainSidebarCreated.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import { useBrowserLocale } from "@/hooks/useBrowserLocale";
 import type { ProfileWaveActivityQueryState } from "@/hooks/useProfileWaveActivityWaves";
 import { getUserPageBrainSidebarMessage } from "./userPageBrainSidebar.messages";
@@ -24,6 +24,7 @@ export default function UserPageBrainSidebarCreated({
   state,
 }: UserPageBrainSidebarCreatedProps) {
   const locale = useBrowserLocale();
+  const toggleButtonRef = useRef<HTMLButtonElement>(null);
   const [expandedIdentity, setExpandedIdentity] = useState<string | null>(null);
   const isExpanded = expandedIdentity === identity;
   const visibleWaves = isExpanded
@@ -31,6 +32,13 @@ export default function UserPageBrainSidebarCreated({
     : state.waves.slice(0, DEFAULT_VISIBLE_CREATED_WAVES);
   const canRevealMore =
     state.waves.length > DEFAULT_VISIBLE_CREATED_WAVES || state.hasNextPage;
+
+  useLayoutEffect(() => {
+    const button = toggleButtonRef.current;
+    if (button && globalThis.document.activeElement === button) {
+      button.scrollIntoView({ block: "nearest", inline: "nearest" });
+    }
+  }, [isExpanded]);
 
   return (
     <section aria-labelledby="brain-created-waves-heading">
@@ -65,6 +73,7 @@ export default function UserPageBrainSidebarCreated({
           {(canRevealMore || isExpanded) && (
             <div className="tw-mt-2 tw-flex tw-flex-wrap tw-items-center tw-gap-x-3 tw-gap-y-1">
               <button
+                ref={toggleButtonRef}
                 type="button"
                 onClick={() =>
                   setExpandedIdentity(isExpanded ? null : identity)

--- a/components/user/brain/UserPageBrainSidebarLoadMore.tsx
+++ b/components/user/brain/UserPageBrainSidebarLoadMore.tsx
@@ -24,6 +24,7 @@ export default function UserPageBrainSidebarLoadMore({
 }: UserPageBrainSidebarLoadMoreProps) {
   const locale = useBrowserLocale();
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const fetchInFlightRef = useRef(false);
   const pendingCompletionFocusRef = useRef(false);
   const [showCompletion, setShowCompletion] = useState(false);
   const shouldShowCompletion =
@@ -75,9 +76,10 @@ export default function UserPageBrainSidebarLoadMore({
             pendingCompletionFocusRef.current = false;
           }}
           onClick={() => {
-            if (state.isFetchingNextPage) {
+            if (state.isFetchingNextPage || fetchInFlightRef.current) {
               return;
             }
+            fetchInFlightRef.current = true;
             pendingCompletionFocusRef.current =
               globalThis.document.activeElement === buttonRef.current;
             setShowCompletion(false);
@@ -92,6 +94,9 @@ export default function UserPageBrainSidebarLoadMore({
               })
               .catch(() => {
                 pendingCompletionFocusRef.current = false;
+              })
+              .finally(() => {
+                fetchInFlightRef.current = false;
               });
           }}
           aria-busy={state.isFetchingNextPage}

--- a/components/user/brain/UserPageBrainSidebarLoadMore.tsx
+++ b/components/user/brain/UserPageBrainSidebarLoadMore.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import { useBrowserLocale } from "@/hooks/useBrowserLocale";
 import type { ProfileWaveActivityQueryState } from "@/hooks/useProfileWaveActivityWaves";
 import { getUserPageBrainSidebarMessage } from "./userPageBrainSidebar.messages";
@@ -28,6 +28,13 @@ export default function UserPageBrainSidebarLoadMore({
   const [showCompletion, setShowCompletion] = useState(false);
   const shouldShowCompletion =
     showCompletion && !state.hasNextPage && !state.isFetchNextPageError;
+
+  useLayoutEffect(() => {
+    const button = buttonRef.current;
+    if (button && globalThis.document.activeElement === button) {
+      button.scrollIntoView({ block: "nearest", inline: "nearest" });
+    }
+  }, [state.waves.length]);
 
   const focusCompletion = useCallback((element: HTMLOutputElement | null) => {
     if (!element || !pendingCompletionFocusRef.current) {
@@ -68,6 +75,9 @@ export default function UserPageBrainSidebarLoadMore({
             pendingCompletionFocusRef.current = false;
           }}
           onClick={() => {
+            if (state.isFetchingNextPage) {
+              return;
+            }
             pendingCompletionFocusRef.current =
               globalThis.document.activeElement === buttonRef.current;
             setShowCompletion(false);
@@ -84,7 +94,8 @@ export default function UserPageBrainSidebarLoadMore({
                 pendingCompletionFocusRef.current = false;
               });
           }}
-          disabled={state.isFetchingNextPage}
+          aria-busy={state.isFetchingNextPage}
+          aria-disabled={state.isFetchingNextPage}
           className={buttonClassName}
         >
           {getUserPageBrainSidebarMessage(locale, buttonMessageKey)}

--- a/components/user/brain/UserPageBrainSidebarSectionState.tsx
+++ b/components/user/brain/UserPageBrainSidebarSectionState.tsx
@@ -5,7 +5,7 @@ import type { ProfileWaveActivityQueryState } from "@/hooks/useProfileWaveActivi
 import { getUserPageBrainSidebarMessage } from "./userPageBrainSidebar.messages";
 
 export const BRAIN_SIDEBAR_ACTION_BUTTON_CLASS =
-  "tw-cursor-pointer tw-rounded-sm tw-border-none tw-bg-transparent tw-px-1 tw-py-1 tw-text-xs tw-font-semibold tw-text-iron-500 tw-transition-colors focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 disabled:tw-cursor-wait disabled:tw-opacity-60 desktop-hover:hover:tw-text-iron-300 motion-reduce:tw-transition-none";
+  "tw-cursor-pointer tw-rounded-sm tw-border-none tw-bg-transparent tw-px-1 tw-py-1 tw-text-xs tw-font-semibold tw-text-iron-500 tw-transition-colors aria-disabled:tw-cursor-wait aria-disabled:tw-opacity-60 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 disabled:tw-cursor-wait disabled:tw-opacity-60 desktop-hover:hover:tw-text-iron-300 motion-reduce:tw-transition-none";
 
 export const BRAIN_SIDEBAR_COMPLETION_CLASS =
   "tw-m-0 tw-block tw-rounded-sm tw-px-1 tw-py-1 tw-text-xs tw-font-semibold tw-text-iron-500 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400";

--- a/i18n/messages/de-DE.ts
+++ b/i18n/messages/de-DE.ts
@@ -25,6 +25,7 @@ export const DE_DE_MESSAGES = {
     "Wave-Aktivität des Profils wird geladen",
   "user.brain.sidebar.loadingMoreWaveActivity":
     "Weitere Wave-Aktivität des Profils wird geladen",
+  "user.brain.sidebar.desktopScrollRegionLabel": "Brain-Waves",
   "user.brain.sidebar.mobileStripLabel": "Brain-Waves",
   "user.brain.sidebar.createdEmpty": "Keine zugänglichen erstellten Waves.",
   "user.brain.sidebar.recentEmpty": "Keine kürzlichen Wave-Beiträge.",

--- a/i18n/messages/en-GB.ts
+++ b/i18n/messages/en-GB.ts
@@ -17,6 +17,7 @@ export const EN_GB_MESSAGES = {
   "user.brain.sidebar.loadingWaveActivity": "Loading profile wave activity",
   "user.brain.sidebar.loadingMoreWaveActivity":
     "Loading more profile wave activity",
+  "user.brain.sidebar.desktopScrollRegionLabel": "Brain waves",
   "user.brain.sidebar.mobileStripLabel": "Brain waves",
   "user.brain.sidebar.createdEmpty": "No accessible created waves.",
   "user.brain.sidebar.recentEmpty": "No recent wave posts.",

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -136,6 +136,7 @@ const USER_BRAIN_SIDEBAR_MESSAGES = objectMessages("user.brain.sidebar", {
   privateWave: "Private wave",
   loadingWaveActivity: "Loading profile wave activity",
   loadingMoreWaveActivity: "Loading more profile wave activity",
+  desktopScrollRegionLabel: "Brain waves",
   mobileStripLabel: "Brain waves",
   createdEmpty: "No accessible created waves.",
   recentEmpty: "No recent wave posts.",

--- a/i18n/messages/es-ES.ts
+++ b/i18n/messages/es-ES.ts
@@ -23,6 +23,7 @@ export const ES_ES_MESSAGES = {
     "Cargando la actividad del perfil en Waves",
   "user.brain.sidebar.loadingMoreWaveActivity":
     "Cargando más actividad del perfil en Waves",
+  "user.brain.sidebar.desktopScrollRegionLabel": "Waves del Brain",
   "user.brain.sidebar.mobileStripLabel": "Waves del Brain",
   "user.brain.sidebar.createdEmpty": "No hay Waves creadas accesibles.",
   "user.brain.sidebar.recentEmpty": "No hay publicaciones recientes en Waves.",

--- a/i18n/messages/fr-FR.ts
+++ b/i18n/messages/fr-FR.ts
@@ -23,6 +23,7 @@ export const FR_FR_MESSAGES = {
     "Chargement de l’activité du profil dans les Waves",
   "user.brain.sidebar.loadingMoreWaveActivity":
     "Chargement d’autres activités du profil dans les Waves",
+  "user.brain.sidebar.desktopScrollRegionLabel": "Waves du Brain",
   "user.brain.sidebar.mobileStripLabel": "Waves du Brain",
   "user.brain.sidebar.createdEmpty": "Aucune Wave créée accessible.",
   "user.brain.sidebar.recentEmpty":

--- a/ops/docs/profiles/tabs/feature-brain-wave-sidebar.md
+++ b/ops/docs/profiles/tabs/feature-brain-wave-sidebar.md
@@ -31,12 +31,15 @@ The same wave can appear in both lists. Direct-message waves are excluded.
    page when one is available. `Show less` restores the compact view.
 4. Desktop shows the first page of recent activity. Select `Load more` to
    append the next page.
-5. Small screens show the first created-wave pill and recent-activity pills in
+5. On desktop, scroll anywhere inside the right sidebar to move through both
+   lists without moving the Brain feed. The sidebar remains one scroll area,
+   and keyboard focus moves it as controls come into view.
+6. Small screens show the first created-wave pill and recent-activity pills in
    a horizontally scrollable strip.
-6. If more created results are loaded or another created page is available,
+7. If more created results are loaded or another created page is available,
    select `More` to open the created-waves modal. The modal uses the same
    ordering and supports `Load more` until every created result is reachable.
-7. Select a wave row or pill to open `/waves/{waveId}`.
+8. Select a wave row or pill to open `/waves/{waveId}`.
 
 When the final cursor page finishes loading from a focused `Load more` control,
 focus moves to the visible `All waves loaded.` status instead of falling back to
@@ -71,6 +74,9 @@ the document.
   visibility from the preceding viewer is not reused.
 - The compact created view remains limited to five visible rows, but cursor
   pagination keeps all results reachable.
+- On desktop, the sidebar becomes independently scrollable only when its
+  content is taller than the available viewport. Short, loading, empty, and
+  error states keep their natural height.
 
 ## Failure and Recovery
 

--- a/ops/docs/profiles/tabs/feature-brain-wave-sidebar.md
+++ b/ops/docs/profiles/tabs/feature-brain-wave-sidebar.md
@@ -32,8 +32,9 @@ The same wave can appear in both lists. Direct-message waves are excluded.
 4. Desktop shows the first page of recent activity. Select `Load more` to
    append the next page.
 5. On desktop, scroll anywhere inside the right sidebar to move through both
-   lists without moving the Brain feed. The sidebar remains one scroll area,
-   and keyboard focus moves it as controls come into view.
+   lists without moving the Brain feed. The sidebar remains one scroll area.
+   Keyboard users can focus the region and use navigation keys to scroll it;
+   focused controls remain visible after content updates.
 6. Small screens show the first created-wave pill and recent-activity pills in
    a horizontally scrollable strip.
 7. If more created results are loaded or another created page is available,

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -1391,6 +1391,7 @@
         "Recently Active In lists accessible non-direct-message root waves and subwaves ordered by the profile's latest post, whether or not the profile created them; a wave can appear in both sections.",
         "Each row labels the profile-specific time as Last post. Created Waves also labels its separate total wave posts count, which includes retained CHAT posts by all authors; Recently Active In does not show that wave-wide total.",
         "Created Waves initially shows five rows on desktop, and both lists provide Load more controls so cursor pages remain reachable.",
+        "On desktop, Created Waves and Recently Active In share one independently scrollable sidebar, so scrolling it does not advance the Brain feed.",
         "On small screens, More opens the Created waves modal with the same profile-specific ordering and Load more pagination; it does not show a partial page count as a total.",
         "When a focused Load more control retrieves the final cursor page, focus moves to an All waves loaded status so keyboard focus is preserved.",
         "Created Waves and Recently Active In load and recover independently, and results refresh for a connected-viewer change so private-wave access is not reused across viewers.",

--- a/public/glossary.json
+++ b/public/glossary.json
@@ -394,6 +394,7 @@
         "Recently Active In lists accessible non-direct-message root waves and subwaves ordered by the profile's latest post, whether or not the profile created them; a wave can appear in both sections.",
         "Each row labels the profile-specific time as Last post. Created Waves also labels its separate total wave posts count, which includes retained CHAT posts by all authors; Recently Active In does not show that wave-wide total.",
         "Created Waves initially shows five rows on desktop, and both lists provide Load more controls so cursor pages remain reachable.",
+        "On desktop, Created Waves and Recently Active In share one independently scrollable sidebar, so scrolling it does not advance the Brain feed.",
         "On small screens, More opens the Created waves modal with the same profile-specific ordering and Load more pagination; it does not show a partial page count as a total.",
         "When a focused Load more control retrieves the final cursor page, focus moves to an All waves loaded status so keyboard focus is preserved.",
         "Created Waves and Recently Active In load and recover independently, and results refresh for a connected-viewer change so private-wave access is not reused across viewers.",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -1387,6 +1387,7 @@
         "Recently Active In lists accessible non-direct-message root waves and subwaves ordered by the profile's latest post, whether or not the profile created them; a wave can appear in both sections.",
         "Each row labels the profile-specific time as Last post. Created Waves also labels its separate total wave posts count, which includes retained CHAT posts by all authors; Recently Active In does not show that wave-wide total.",
         "Created Waves initially shows five rows on desktop, and both lists provide Load more controls so cursor pages remain reachable.",
+        "On desktop, Created Waves and Recently Active In share one independently scrollable sidebar, so scrolling it does not advance the Brain feed.",
         "On small screens, More opens the Created waves modal with the same profile-specific ordering and Load more pagination; it does not show a partial page count as a total.",
         "When a focused Load more control retrieves the final cursor page, focus moves to an All waves loaded status so keyboard focus is preserved.",
         "Created Waves and Recently Active In load and recover independently, and results refresh for a connected-viewer change so private-wave access is not reused across viewers.",


### PR DESCRIPTION
## Issue

- On desktop profile Brain pages, wheel, trackpad, keyboard, and touch scrolling over the right sidebar advanced the document instead of the sidebar. That could repeatedly trigger the main post feed's infinite loader and keep the `Recently Active In` pagination control out of reach.

## Fix

- Keep the existing sticky desktop sidebar, but make its complete `Created Waves` and `Recently Active In` contents one viewport-bounded, independently scrollable region.
- Contain boundary gestures so scrolling inside the sidebar does not transfer to the document, while preserving normal document scrolling over the main feed.
- Add explicit keyboard scrolling and accessible region semantics, and preserve focused pagination controls and scroll position as sidebar content changes.

## Changes

- Add the desktop sidebar scroll container, viewport-relative height, overscroll containment, stable scrollbar gutter, scroll-anchor isolation, and focused-region styling.
- Prevent Chromium wheel chaining only at the sidebar's top and bottom boundaries with a scoped non-passive listener.
- Keep `Show more` and `Load more` controls visible after expansion; retain focus while sidebar pagination is loading.
- Expand focused unit coverage for scrolling, keyboard interaction, accessibility attributes, pagination, loading, completion, empty, and error behavior.
- Document the profile Brain sidebar behavior and update the help index.

## Validation

- `./bin/6529 run check:changed`
- `./bin/6529 run test:no-coverage __tests__/components/user/brain/UserPageBrainSidebar.test.tsx --runInBand` (11 tests passed)
- `./bin/6529 run react-doctor:diff` (99/100; the sole warning is the intentional non-passive boundary wheel listener)
- `./bin/6529 run help-index:sync`
- `./bin/6529 run agent-files:sync`
- `./bin/6529 run test:no-coverage __tests__/scripts/sync-agent-files.test.ts --runInBand` (12 tests passed)
- Production-API local validation on `/RegularDad/brain`: wheel/trackpad-equivalent input, keyboard navigation, trusted touch swipes, `Show more`, `Load more`, focus retention, sidebar pagination, main-feed scrolling, and main-feed infinite loading.
- Staging-API local validation on `/punk6529/brain`, plus a production-backed empty profile state.
- Responsive validation at desktop short/tall heights, the 1024 px breakpoint boundary, and a 390 px mobile viewport; confirmed no horizontal overflow and the mobile sidebar flow remains unchanged.
- Restarted the local application after the final fixes, repeated the affected desktop and mobile flows, and shut it down cleanly.
- The broader docs link validator still reports one pre-existing unrelated broken link in `ops/docs/shared/feature-ios-eula-consent.md`; the touched Brain documentation adds no links.

## Risk

- Level: Low
- Why: The change is scoped to the desktop profile Brain sidebar and its existing controls. Mobile rendering and the main feed's infinite-loading implementation are unchanged.
- Rollback: Revert this PR to restore the prior document-scrolling behavior; there are no data, API, schema, dependency, or migration changes.

## Review Notes

- Please focus on sidebar boundary gesture behavior and accessibility. CSS overscroll containment alone did not stop Chromium from handing an already-boundary wheel gesture to the document, so the native listener is deliberately non-passive and cancels only when the sidebar cannot scroll farther in the requested direction.
- The loading control uses `aria-disabled` rather than native `disabled` during an in-flight request because Chromium otherwise drops focus, preventing the control from being kept visible as results append.
