### PR TITLE
fix: Implemented the narrow production telemetry fix for Sentry issue 6529-FRONTEND-D3. No commit, push, deplo

### DIFF
--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -1846,9 +1846,13 @@ describe("instrumentation-client", () => {
     expect(result).toBeNull();
   });
 
-  it.each([3, 7])(
-    "drops the observed raw anonymous EvalError wrapper at line %i",
-    (wrapperLine) => {
+  it.each([
+    { wrapperFunction: "n", wrapperLine: 3, wrapperColumn: 4853 },
+    { wrapperFunction: "n", wrapperLine: 7, wrapperColumn: 4853 },
+    { wrapperFunction: "r", wrapperLine: 7, wrapperColumn: 6173 },
+  ])(
+    "drops the observed raw anonymous EvalError wrapper $wrapperFunction at $wrapperLine:$wrapperColumn",
+    ({ wrapperFunction, wrapperLine, wrapperColumn }) => {
       const beforeSend = loadBeforeSend();
       const event = {
         transaction: "/waves/:wave",
@@ -1866,10 +1870,10 @@ describe("instrumentation-client", () => {
                   {
                     filename: "app:///_next/static/chunks/0example-chunk.js",
                     abs_path: "app:///_next/static/chunks/0example-chunk.js",
-                    function: "n",
+                    function: wrapperFunction,
                     in_app: true,
                     lineno: wrapperLine,
-                    colno: 4853,
+                    colno: wrapperColumn,
                   },
                   {
                     filename: "<anonymous>",
@@ -1910,7 +1914,7 @@ describe("instrumentation-client", () => {
         "    at eval (<anonymous>)",
         "    at predicate (<anonymous>:234:30)",
         "    at next (<anonymous>:234:30)",
-        `    at n (app:///_next/static/chunks/0example-chunk.js:${wrapperLine}:4853)`,
+        `    at ${wrapperFunction} (app:///_next/static/chunks/0example-chunk.js:${wrapperLine}:${wrapperColumn})`,
       ].join("\n");
 
       const result = beforeSend(event, { originalException: error });

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -1157,14 +1157,16 @@ describe("sentry-client-filters", () => {
   });
 
   const createObservedRawAnonymousUnsafeEvalStack = (
-    wrapperLine: number
+    wrapperFunction: string,
+    wrapperLine: number,
+    wrapperColumn: number
   ): string =>
     [
       `EvalError: ${anonymousUnsafeEvalCspMessage}`,
       "    at eval (<anonymous>)",
       "    at predicate (<anonymous>:234:30)",
       "    at next (<anonymous>:234:30)",
-      `    at n (app:///_next/static/chunks/0example-chunk.js:${wrapperLine}:4853)`,
+      `    at ${wrapperFunction} (app:///_next/static/chunks/0example-chunk.js:${wrapperLine}:${wrapperColumn})`,
     ].join("\n");
 
   const createObservedSentryE7WasmCspUnsafeEvalEvent = (
@@ -8914,16 +8916,26 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(true);
   });
 
-  it.each([3, 7])(
-    "filters the observed raw anonymous EvalError wrapper at line %i",
-    (wrapperLine) => {
+  it.each([
+    { wrapperFunction: "n", wrapperLine: 3, wrapperColumn: 4853 },
+    { wrapperFunction: "n", wrapperLine: 7, wrapperColumn: 4853 },
+    { wrapperFunction: "r", wrapperLine: 7, wrapperColumn: 6173 },
+  ])(
+    "filters the observed raw anonymous EvalError wrapper $wrapperFunction at $wrapperLine:$wrapperColumn",
+    ({ wrapperFunction, wrapperLine, wrapperColumn }) => {
       // Arrange
       const frames = createObservedRawAnonymousUnsafeEvalFrames({
+        function: wrapperFunction,
         lineno: wrapperLine,
+        colno: wrapperColumn,
       });
       const event = createObservedRawAnonymousUnsafeEvalCspEvent({ frames });
       const error = new EvalError(anonymousUnsafeEvalCspMessage);
-      error.stack = createObservedRawAnonymousUnsafeEvalStack(wrapperLine);
+      error.stack = createObservedRawAnonymousUnsafeEvalStack(
+        wrapperFunction,
+        wrapperLine,
+        wrapperColumn
+      );
 
       // Act
       const result = shouldFilterAnonymousUnsafeEvalCspError(event, {
@@ -10875,16 +10887,57 @@ describe("sentry-client-filters", () => {
 
   it.each([
     [
-      "wrapper function",
+      "a changed wrapper function",
       createObservedRawAnonymousUnsafeEvalFrames({ function: "runTemplate" }),
     ],
-    ["wrapper line", createObservedRawAnonymousUnsafeEvalFrames({ lineno: 8 })],
     [
-      "wrapper column",
+      "a changed wrapper line",
+      createObservedRawAnonymousUnsafeEvalFrames({ lineno: 8 }),
+    ],
+    [
+      "a changed wrapper column",
       createObservedRawAnonymousUnsafeEvalFrames({ colno: 4854 }),
     ],
+    [
+      "the new function with the previous column",
+      createObservedRawAnonymousUnsafeEvalFrames({ function: "r" }),
+    ],
+    [
+      "the previous function with the new column",
+      createObservedRawAnonymousUnsafeEvalFrames({ colno: 6173 }),
+    ],
+    [
+      "the new function at an unobserved line",
+      createObservedRawAnonymousUnsafeEvalFrames({
+        function: "r",
+        lineno: 3,
+        colno: 6173,
+      }),
+    ],
+    [
+      "an unrecognized function at the new coordinates",
+      createObservedRawAnonymousUnsafeEvalFrames({
+        function: "s",
+        colno: 6173,
+      }),
+    ],
+    [
+      "a changed column on the new function",
+      createObservedRawAnonymousUnsafeEvalFrames({
+        function: "r",
+        colno: 6174,
+      }),
+    ],
+    [
+      "a conflicting application path on the new wrapper",
+      createObservedRawAnonymousUnsafeEvalFrames({
+        abs_path: "app:///utils/eval-template.ts",
+        function: "r",
+        colno: 6173,
+      }),
+    ],
   ])(
-    "does not filter raw unsafe-eval frames with a changed %s",
+    "does not filter raw unsafe-eval frames with %s",
     (_, frames) => {
       // Arrange
       const event = createObservedRawAnonymousUnsafeEvalCspEvent({ frames });

--- a/utils/sentry-client-filters/errors.ts
+++ b/utils/sentry-client-filters/errors.ts
@@ -61,6 +61,11 @@ const sentryBrowserPathTokens = ["@sentry/browser", "@sentry+browser"];
 const anonymousUnsafeEvalRawChunkPathPattern =
   /^app:\/\/\/_next\/static\/chunks\/[a-z0-9._~-]+\.js$/i;
 const anonymousUnsafeEvalRawWrapperLineNumbers = new Set([3, 7]);
+const anonymousUnsafeEvalRawWrapperSignatures = [
+  { functionName: "n", lineNumber: 3, columnNumber: 4853 },
+  { functionName: "n", lineNumber: 7, columnNumber: 4853 },
+  { functionName: "r", lineNumber: 7, columnNumber: 6173 },
+] as const;
 const twitterUserAgentPattern =
   /(?:^|[\s;(])twitter(?:android| for iphone)?\//i;
 const twitterConfigAddEventListenerMechanism =
@@ -340,11 +345,17 @@ function isAnonymousUnsafeEvalRawWrapperFrame(
   }
 
   const paths = getFramePaths(frame);
+  const functionName = frame.function?.trim();
+  const hasKnownWrapperSignature =
+    anonymousUnsafeEvalRawWrapperSignatures.some(
+      (signature) =>
+        signature.functionName === functionName &&
+        signature.lineNumber === frame.lineno &&
+        signature.columnNumber === frame.colno
+    );
+
   return (
-    frame.function?.trim() === "n" &&
-    frame.lineno !== undefined &&
-    anonymousUnsafeEvalRawWrapperLineNumbers.has(frame.lineno) &&
-    frame.colno === 4853 &&
+    hasKnownWrapperSignature &&
     paths.length > 0 &&
     paths.every((path) =>
       anonymousUnsafeEvalRawChunkPathPattern.test(path.trim())


### PR DESCRIPTION
<!-- sentry-fix-job:70 issue:7542319908 -->
## Issue

- Sentry: [6529-FRONTEND-D3](https://seize-ff.sentry.io/issues/7542319908/)
- First seen: 2026-06-10T17:06:16.104Z
- Latest occurrence: 2026-08-27T19:29:58.000Z
- Automatic triage confidence: 99%

Extend the existing D3 telemetry filter for a new production raw-stack variant. The August events source-map to the same Sentry wrapper as the already-filtered July variant, but their minified function and column no longer match the repository's exact predicate.

## Fix

The filter recognized only the older raw Sentry wrapper signatures using function n at column 4853. Four August events used the source-mapped equivalent wrapper r at line 7, column 6173, so beforeSend reported the third-party CSP error.

## Changes

- Added r at 7:6173 as an explicit accepted wrapper tuple while preserving the existing n tuples.
- Kept the exact chunk path, four-frame sequence, CSP message, mechanism, handled-state, and application-evidence guards unchanged.
- Added positive predicate and beforeSend coverage for the new tuple.
- Added negative coverage for mixed tuples, changed coordinates or functions, and conflicting application paths.
- Left the production CSP unchanged.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Focused Jest suites passed: 2 suites, 715 tests.
- ./bin/6529 run lint:changed passed.
- ./bin/6529 run typecheck:changed passed.
- git diff --check passed.
- Final Sonar-sensitive diff review passed.

## Risk

- Assessed risk: low
- Changed files: 3
- Changed lines: 108
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

Backpack attribution is strongly corroborated, but the exact extension code path invoking eval was not located. Unrecognized future wrapper tuples intentionally remain reportable.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
