### PR TITLE
Fix Network group filter E2E coverage

### DIFF
--- a/tests/public-groups-tools/public-groups-tools-readonly.spec.ts
+++ b/tests/public-groups-tools/public-groups-tools-readonly.spec.ts
@@ -138,10 +138,15 @@ test.describe("Public groups, tools, and calendar read-only coverage @surface @m
     // sets. The criteria builder opens by default, so the request starts only
     // after switching to Choose group and focusing its search field.
     const groupsResponsePromise = page.waitForResponse(
-      (response) =>
-        response.request().method() === "GET" &&
-        /\/groups(\?|$)/.test(response.url()) &&
-        response.ok(),
+      (response) => {
+        const responseUrl = new URL(response.url());
+        return (
+          response.request().method() === "GET" &&
+          /\/groups\/?$/.test(responseUrl.pathname) &&
+          !responseUrl.searchParams.has("group_name") &&
+          response.ok()
+        );
+      },
       { timeout: 30000 }
     );
     await groupSearch.focus();
@@ -156,7 +161,9 @@ test.describe("Public groups, tools, and calendar read-only coverage @surface @m
       0
     );
     const groupId = groups[0]?.id;
-    expect(typeof groupId).toBe("string");
+    if (typeof groupId !== "string") {
+      throw new Error("Expected the first public group to have an id");
+    }
 
     // Deep-link the group: the URL param hydrates the active-group state.
     await gotoReady(page, `/network?group=${groupId}`);

--- a/tests/public-groups-tools/public-groups-tools-readonly.spec.ts
+++ b/tests/public-groups-tools/public-groups-tools-readonly.spec.ts
@@ -121,9 +121,22 @@ test.describe("Public groups, tools, and calendar read-only coverage @surface @m
   }) => {
     await gotoReady(page, "/network");
 
-    // Resolve a real group id from the app's own unfiltered groups request
-    // (fired when the filter panel opens) so the test stays portable across
-    // local, staging, and production data sets.
+    await openGroupFilters(page);
+    const chooseGroupButton = page
+      .getByRole("button", { name: "Choose group" })
+      .filter({ visible: true });
+    await expect(chooseGroupButton).toBeVisible({ timeout: 30000 });
+    await chooseGroupButton.click();
+
+    const groupSearch = page
+      .getByRole("combobox", { name: /Search groups/i })
+      .filter({ visible: true });
+    await expect(groupSearch).toBeVisible();
+
+    // Resolve a real group id from the saved-group search's unfiltered request
+    // so the test stays portable across local, staging, and production data
+    // sets. The criteria builder opens by default, so the request starts only
+    // after switching to Choose group and focusing its search field.
     const groupsResponsePromise = page.waitForResponse(
       (response) =>
         response.request().method() === "GET" &&
@@ -131,10 +144,7 @@ test.describe("Public groups, tools, and calendar read-only coverage @surface @m
         response.ok(),
       { timeout: 30000 }
     );
-    await openGroupFilters(page);
-    await expect(page.getByLabel(/^(By )?Group [Nn]ame$/).first()).toBeVisible({
-      timeout: 30000,
-    });
+    await groupSearch.focus();
     const groupsResponse = await groupsResponsePromise;
     const groupsPayload = (await groupsResponse.json()) as
       | { readonly id?: string; readonly name?: string }[]
@@ -153,19 +163,23 @@ test.describe("Public groups, tools, and calendar read-only coverage @surface @m
     await expect(page).toHaveURL(
       (url) => url.searchParams.get("group") === groupId
     );
-    await openGroupFilters(page);
 
-    // The active-group block is required: "Members:" in the desktop sidebar,
-    // "Active filter" in the mobile sheet.
-    await expect(page.getByText(/Members:|Active filter/).first()).toBeVisible({
-      timeout: 30000,
-    });
+    // The current Network UI exposes the active state in the filter trigger and
+    // the selected-group summary on both desktop and mobile layouts.
+    await expect(
+      page.getByRole("button", { name: "Open group filters (active)" })
+    ).toBeVisible({ timeout: 30000 });
+    await expect(page.getByText("Selected group", { exact: true })).toBeVisible(
+      {
+        timeout: 30000,
+      }
+    );
 
     // Clearing the group exercises the state transition back to null and
     // must drop the URL param.
     const clearButton = page
-      .getByRole("button", { name: /remove|clear group/i })
-      .first();
+      .getByRole("button", { name: "Clear selected group" })
+      .filter({ visible: true });
     await expect(clearButton).toBeVisible({ timeout: 15000 });
     await clearButton.click();
     await expect(page).toHaveURL(


### PR DESCRIPTION
## Summary
- update the Network active-group E2E to open the new criteria builder
- switch to Choose group before waiting for the saved-group request
- assert and clear the current selected-group UI across desktop and mobile

## Verification
- `./bin/6529 exec pnpm run typecheck:playwright`
- `./bin/6529 exec pnpm run lint:uncommitted:tight`
- full public-groups/tools Playwright pack: 10 passed across desktop and mobile Chromium

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated network group filter coverage to follow the current search and selection flow.
  * Improved validation of active group filters and clearing selected groups.
  * Refined request timing checks to match when group data is loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->