### PR TITLE
fix: Implemented a narrowly bounded telemetry filter for the verified browser-extension sendMessage events.

### DIFF
--- a/__tests__/fixtures/sentry-noise-filter-hardening.json
+++ b/__tests__/fixtures/sentry-noise-filter-hardening.json
@@ -122,9 +122,9 @@
     }
   },
   "threeV": {
-    "transaction": "/waves/:wave",
+    "transaction": "/about/:section",
     "request": {
-      "url": "https://6529.io/waves/00000000-0000-4000-8000-000000000003"
+      "url": "https://6529.io/about/example-section"
     },
     "exception": {
       "values": [
@@ -138,13 +138,19 @@
           "stacktrace": {
             "frames": [
               {
-                "filename": "node_modules/.pnpm/@sentry+browser@10.45.0/node_modules/@sentry/browser/src/helpers.ts",
-                "function": "n",
-                "in_app": false
+                "filename": "app:///_next/static/chunks/3b-aes9pb81yl.js",
+                "abs_path": "app:///_next/static/chunks/3b-aes9pb81yl.js",
+                "function": "r",
+                "lineno": 7,
+                "colno": 6173,
+                "in_app": true
               },
               {
                 "filename": "app:///injectedScript.bundle.js",
+                "abs_path": "app:///injectedScript.bundle.js",
                 "function": "n",
+                "lineno": 2,
+                "colno": 84147,
                 "in_app": true
               }
             ]

--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -2871,12 +2871,36 @@ describe("instrumentation-client", () => {
     expect(result).toBeNull();
   });
 
-  it("drops the raw 3V injected sendMessage event with a Sentry helper frame", () => {
+  it("drops the raw 3V injected sendMessage event with a minified Sentry wrapper", () => {
     const beforeSend = loadBeforeSend();
 
     const result = beforeSend(noiseFilterFixtures.threeV);
 
     expect(result).toBeNull();
+  });
+
+  it("keeps a 3V-shaped event with changed wrapper coordinates", () => {
+    const beforeSend = loadBeforeSend();
+    const fixtureValue = noiseFilterFixtures.threeV.exception.values[0];
+    const event = {
+      ...noiseFilterFixtures.threeV,
+      exception: {
+        values: [
+          {
+            ...fixtureValue,
+            stacktrace: {
+              frames: fixtureValue.stacktrace.frames.map((frame, index) =>
+                index === 0 ? { ...frame, colno: 6174 } : frame
+              ),
+            },
+          },
+        ],
+      },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result).not.toBeNull();
   });
 
   it("drops the exact browser-extension wallet rejection bridge stack", () => {

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -1,3 +1,4 @@
+import noiseFilterFixtures from "@/__tests__/fixtures/sentry-noise-filter-hardening.json";
 import {
   createLatestReactDomRawFrames,
   createObservedReactDomRawInsertBeforeFrames,
@@ -388,6 +389,36 @@ describe("sentry-client-filters", () => {
     "Network request failed. Please check your connection and try again. (/api/dm-drops/unread)";
   const webkitExtensionMessagingTabNotFoundMessage =
     "Invalid call to runtime.sendMessage(). Tab not found.";
+  const browserExtensionSendMessageErrorMessage =
+    "Cannot read properties of undefined (reading 'sendMessage')";
+  const browserExtensionSendMessageFixtureValue =
+    noiseFilterFixtures.threeV.exception.values[0];
+  const browserExtensionSendMessageRawFrames: SentryStackFrame[] =
+    browserExtensionSendMessageFixtureValue.stacktrace.frames;
+
+  const createBrowserExtensionSendMessageEvent = (
+    valueOverrides: Partial<SentryExceptionValue> = {},
+    eventOverrides: TestSentryClientEventOverrides = {}
+  ): TestSentryClientEvent => ({
+    ...noiseFilterFixtures.threeV,
+    ...eventOverrides,
+    exception: {
+      values: [
+        {
+          ...browserExtensionSendMessageFixtureValue,
+          ...valueOverrides,
+        },
+      ],
+    },
+  });
+
+  const overrideBrowserExtensionSendMessageFrame = (
+    frameIndex: number,
+    frameOverrides: Partial<SentryStackFrame>
+  ): SentryStackFrame[] =>
+    browserExtensionSendMessageRawFrames.map((frame, index) =>
+      index === frameIndex ? { ...frame, ...frameOverrides } : frame
+    );
 
   const buildSpan = (
     overrides: TestSentryTransactionSpanOverrides = {}
@@ -10004,6 +10035,248 @@ describe("sentry-client-filters", () => {
         },
       ],
     };
+
+    // Act
+    const result = shouldFilterBrowserExtensionSendMessageError(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("filters the exact pre-symbolication browser-extension sendMessage stack", () => {
+    // Arrange
+    const event = createBrowserExtensionSendMessageEvent();
+
+    // Act
+    const result = shouldFilterBrowserExtensionSendMessageError(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it.each([
+    ["the older three-line wrapper", 3],
+    ["the older seven-line wrapper", 7],
+  ])("filters %s from the verified cohort", (_, wrapperLine) => {
+    // Arrange
+    const [wrapperFrame, injectedFrame] = browserExtensionSendMessageRawFrames;
+    const event = createBrowserExtensionSendMessageEvent({
+      stacktrace: {
+        frames: [
+          {
+            ...wrapperFrame,
+            function: "n",
+            lineno: wrapperLine,
+            colno: 4853,
+          },
+          {
+            ...injectedFrame,
+            colno: 84027,
+          },
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterBrowserExtensionSendMessageError(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("continues filtering the server-symbolicated sendMessage stack", () => {
+    // Arrange
+    const [, injectedFrame] = browserExtensionSendMessageRawFrames;
+    const event = createBrowserExtensionSendMessageEvent({
+      stacktrace: {
+        frames: [
+          {
+            filename:
+              "node_modules/.pnpm/@sentry+browser@10.45.0/node_modules/@sentry/browser/src/helpers.ts",
+            function: "n",
+            lineno: 111,
+            colno: 58,
+            in_app: false,
+          },
+          injectedFrame,
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterBrowserExtensionSendMessageError(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it.each([
+    [
+      "an extra frame",
+      [
+        ...browserExtensionSendMessageRawFrames,
+        {
+          filename: "app:///services/messaging/sendMessage.ts",
+          function: "sendMessage",
+          in_app: true,
+        },
+      ],
+    ],
+    [
+      "reversed frame order",
+      [...browserExtensionSendMessageRawFrames].reverse(),
+    ],
+    [
+      "a changed wrapper function",
+      overrideBrowserExtensionSendMessageFrame(0, { function: "x" }),
+    ],
+    [
+      "a changed wrapper line",
+      overrideBrowserExtensionSendMessageFrame(0, { lineno: 8 }),
+    ],
+    [
+      "a changed wrapper column",
+      overrideBrowserExtensionSendMessageFrame(0, { colno: 6174 }),
+    ],
+    [
+      "an app-owned wrapper path",
+      overrideBrowserExtensionSendMessageFrame(0, {
+        filename: "app:///services/messaging/sendMessage.ts",
+        abs_path: "app:///services/messaging/sendMessage.ts",
+      }),
+    ],
+    [
+      "a changed injected function",
+      overrideBrowserExtensionSendMessageFrame(1, { function: "sendMessage" }),
+    ],
+    [
+      "a changed injected line",
+      overrideBrowserExtensionSendMessageFrame(1, { lineno: 3 }),
+    ],
+    [
+      "a changed injected column",
+      overrideBrowserExtensionSendMessageFrame(1, { colno: 84148 }),
+    ],
+    [
+      "a changed injected path",
+      overrideBrowserExtensionSendMessageFrame(1, {
+        filename: "app:///injectedScript.bundle-copy.js",
+        abs_path: "app:///injectedScript.bundle-copy.js",
+      }),
+    ],
+  ])("does not filter the raw sendMessage near miss with %s", (_, frames) => {
+    // Arrange
+    const event = createBrowserExtensionSendMessageEvent({
+      stacktrace: { frames },
+    });
+
+    // Act
+    const result = shouldFilterBrowserExtensionSendMessageError(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it.each([
+    [
+      "a changed message",
+      { value: "Cannot read properties of undefined (reading 'sendMessages')" },
+    ],
+    [
+      "a different mechanism",
+      {
+        mechanism: {
+          type: "auto.browser.global_handlers.onerror",
+          handled: false,
+        },
+      },
+    ],
+    [
+      "a handled mechanism",
+      {
+        mechanism: {
+          type: "auto.browser.global_handlers.onunhandledrejection",
+          handled: true,
+        },
+      },
+    ],
+  ])(
+    "does not filter the raw sendMessage near miss with %s",
+    (_, overrides) => {
+      // Arrange
+      const event = createBrowserExtensionSendMessageEvent(overrides);
+
+      // Act
+      const result = shouldFilterBrowserExtensionSendMessageError(event);
+
+      // Assert
+      expect(result).toBe(false);
+    }
+  );
+
+  it("does not filter a raw sendMessage event with another exception", () => {
+    // Arrange
+    const event = createBrowserExtensionSendMessageEvent();
+    event.exception = {
+      values: [
+        ...(event.exception?.values ?? []),
+        {
+          type: "TypeError",
+          value: "App-owned failure",
+          stacktrace: {
+            frames: [
+              {
+                filename: "app:///services/messaging/sendMessage.ts",
+                function: "sendMessage",
+                in_app: true,
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    // Act
+    const result = shouldFilterBrowserExtensionSendMessageError(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter raw sendMessage events with app-owned original stacks", () => {
+    // Arrange
+    const event = createBrowserExtensionSendMessageEvent();
+    const error = new Error(browserExtensionSendMessageErrorMessage);
+    error.stack = [
+      `Error: ${browserExtensionSendMessageErrorMessage}`,
+      "    at sendMessage (app:///services/messaging/sendMessage.ts:10:1)",
+    ].join("\n");
+
+    // Act
+    const result = shouldFilterBrowserExtensionSendMessageError(event, {
+      originalException: error,
+    });
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter raw sendMessage events with app-owned serialized stacks", () => {
+    // Arrange
+    const event = createBrowserExtensionSendMessageEvent(
+      {},
+      {
+        extra: {
+          __serialized__: {
+            message: browserExtensionSendMessageErrorMessage,
+            stack: [
+              `Error: ${browserExtensionSendMessageErrorMessage}`,
+              "    at sendMessage (app:///services/messaging/sendMessage.ts:10:1)",
+            ].join("\n"),
+          },
+        },
+      }
+    );
 
     // Act
     const result = shouldFilterBrowserExtensionSendMessageError(event);

--- a/utils/sentry-client-filters/extension-messaging.ts
+++ b/utils/sentry-client-filters/extension-messaging.ts
@@ -24,6 +24,33 @@ import {
 
 const browserExtensionWalletRejectionMessage = "User rejected the request.";
 const browserExtensionWalletBridgePath = "app:///content-scripts/bridge.js";
+const browserExtensionSendMessageNextChunkPrefix =
+  "app:///_next/static/chunks/";
+const browserExtensionSendMessageInjectedPath =
+  "app:///injectedScript.bundle.js";
+// beforeSend receives Sentry's minified wrapper before server-side source maps
+// reveal helpers.ts. Keep each cohort-backed wrapper/injected tuple exact so
+// nearby application failures and future bundle drift fail open.
+const browserExtensionSendMessageRawFrameSignatures = [
+  {
+    wrapperFunction: "n",
+    wrapperLine: 3,
+    wrapperColumn: 4853,
+    injectedColumn: 84027,
+  },
+  {
+    wrapperFunction: "n",
+    wrapperLine: 7,
+    wrapperColumn: 4853,
+    injectedColumn: 84027,
+  },
+  {
+    wrapperFunction: "r",
+    wrapperLine: 7,
+    wrapperColumn: 6173,
+    injectedColumn: 84147,
+  },
+] as const;
 // Keep the complete pre-symbolication stack exact so extension bundle drift
 // fails open and nearby application failures remain visible.
 const browserExtensionWalletBridgeFrameSignatures = [
@@ -66,6 +93,56 @@ function hasOnlyInjectedSendMessageFrames(
       (frame) =>
         isExtensionMessagingFrame(frame) || isSentryBrowserHelperFrame(frame)
     )
+  );
+}
+
+function hasOnlyMatchingFramePaths(
+  frame: SentryStackFrame,
+  predicate: (path: string) => boolean
+): boolean {
+  const framePaths = getFramePaths(frame);
+  return framePaths.length > 0 && framePaths.every(predicate);
+}
+
+function hasExactBrowserExtensionSendMessageRawFrames(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  if (!Array.isArray(frames) || frames.length !== 2) {
+    return false;
+  }
+
+  const [wrapperFrame, injectedFrame] = frames;
+  if (!wrapperFrame || !injectedFrame) {
+    return false;
+  }
+
+  const hasExpectedWrapperPath = hasOnlyMatchingFramePaths(
+    wrapperFrame,
+    (path) =>
+      path.startsWith(browserExtensionSendMessageNextChunkPrefix) &&
+      path.endsWith(".js")
+  );
+  const hasExpectedInjectedPath = hasOnlyMatchingFramePaths(
+    injectedFrame,
+    (path) => path === browserExtensionSendMessageInjectedPath
+  );
+  if (
+    !hasExpectedWrapperPath ||
+    !hasExpectedInjectedPath ||
+    wrapperFrame.in_app !== true ||
+    injectedFrame.function !== "n" ||
+    injectedFrame.in_app !== true ||
+    injectedFrame.lineno !== 2
+  ) {
+    return false;
+  }
+
+  return browserExtensionSendMessageRawFrameSignatures.some(
+    (signature) =>
+      wrapperFrame.function === signature.wrapperFunction &&
+      wrapperFrame.lineno === signature.wrapperLine &&
+      wrapperFrame.colno === signature.wrapperColumn &&
+      injectedFrame.colno === signature.injectedColumn
   );
 }
 
@@ -177,7 +254,12 @@ export function shouldFilterBrowserExtensionSendMessageError(
   event: SentryClientEvent,
   hint?: SentryEventHint
 ): boolean {
-  const value = event.exception?.values?.[0];
+  const values = event.exception?.values;
+  if (!Array.isArray(values) || values.length !== 1) {
+    return false;
+  }
+
+  const [value] = values;
   const normalizedMessage = normalizeErrorPrefix(value?.value ?? "");
   const isWebKitExtensionTabNotFoundError =
     normalizedMessage === webkitExtensionMessagingTabNotFoundMessage;
@@ -189,17 +271,29 @@ export function shouldFilterBrowserExtensionSendMessageError(
     return false;
   }
 
+  const frames = value.stacktrace?.frames;
+  const hasVerifiedRawFrames =
+    normalizedMessage === injectedScriptSendMessageError &&
+    hasExactBrowserExtensionSendMessageRawFrames(frames);
+  const ownershipValue = hasVerifiedRawFrames
+    ? {
+        ...value,
+        stacktrace: {
+          frames: frames?.slice(1),
+        },
+      }
+    : value;
   if (
     value.mechanism?.type !== browserUnhandledRejectionMechanism ||
     value.mechanism.handled !== false ||
-    hasAppOwnedSourceEvidence(event, value, hint)
+    hasAppOwnedSourceEvidence(event, ownershipValue, hint)
   ) {
     return false;
   }
 
   if (isWebKitExtensionTabNotFoundError) {
-    return event.exception?.values?.length === 1;
+    return true;
   }
 
-  return hasOnlyInjectedSendMessageFrames(value.stacktrace?.frames);
+  return hasVerifiedRawFrames || hasOnlyInjectedSendMessageFrames(frames);
 }


### PR DESCRIPTION
<!-- sentry-fix-job:72 issue:7097361904 -->
## Issue

- Sentry: [6529-FRONTEND-3V](https://seize-ff.sentry.io/issues/7097361904/)
- First seen: 2025-12-09T02:57:57.308Z
- Latest occurrence: 2026-08-31T13:14:49.000Z
- Automatic triage confidence: 99%

A useful narrow telemetry fix is available. The repository already filters this extension error, but its regression fixture represents the server-symbolicated stack rather than the pre-symbolication stack seen by beforeSend. The production event therefore escapes the filter.

## Fix

Sentry 10.45.0 exposes its minified wrapper as an application-owned Next.js frame before source mapping, matching [Sentry issue #20687](https://github.com/getsentry/sentry-javascript/issues/20687). The existing ownership guard therefore preserved the extension error.

## Changes

- Matched only the three observed raw wrapper/injected frame signatures.
- Ignored only the verified Sentry wrapper during ownership checks; genuine app-owned frames and stacks remain reportable.
- Updated the 3V fixture to the pre-symbolication event shape.
- Added positive and negative helper and beforeSend regression tests.

## Validation

- [x] git diff --check
- [x] ESLint changed files

- Focused Jest suites: 728 tests passed.
- lint:changed passed.
- typecheck:ci passed.
- git diff --check passed.
- quality:changed was infrastructure-blocked because its mandatory fetch could not update shared worktree metadata; relevant checks were run separately.

## Risk

- Assessed risk: low
- Changed files: 4
- Changed lines: 417
- This PR is intentionally kept as a draft.
- No merge, deployment, or Sentry resolution is performed by this automation.

## Review notes

The matcher intentionally fails open if the minified signature changes. Post-release recurrence monitoring and a later Sentry upgrade remain outside this job.

The automation will wait for every GitHub check and recognized review bot, send actionable machine and human feedback to the repair agent, push a new commit, and repeat until the latest head is clean.
