### PR TITLE
Show DM access criteria to eligible participants

### DIFF
--- a/__tests__/components/waves/specs/groups/group/WaveGroupMembersScope.test.tsx
+++ b/__tests__/components/waves/specs/groups/group/WaveGroupMembersScope.test.tsx
@@ -44,6 +44,24 @@ describe("WaveGroupMembersScope", () => {
     );
   });
 
+  it("renders the member count and criteria for an available direct-message group", () => {
+    render(
+      <WaveGroupMembersScope
+        group={{
+          id: "dm-1",
+          name: "Direct message group",
+          is_hidden: false,
+          is_direct_message: true,
+        }}
+      />
+    );
+
+    const summary = screen.getByTestId("members-summary");
+    expect(summary).toHaveAttribute("href", "/network?page=1&group=dm-1");
+    expect(summary).toHaveAttribute("data-group-id", "dm-1");
+    expect(screen.queryByTestId("fallback-scope")).not.toBeInTheDocument();
+  });
+
   it("preserves the private and unavailable scope fallbacks", () => {
     render(<WaveGroupMembersScope group={{ is_hidden: true }} />);
 

--- a/__tests__/components/waves/specs/groups/group/WaveGroupMembersScope.test.tsx
+++ b/__tests__/components/waves/specs/groups/group/WaveGroupMembersScope.test.tsx
@@ -62,6 +62,20 @@ describe("WaveGroupMembersScope", () => {
     expect(screen.queryByTestId("fallback-scope")).not.toBeInTheDocument();
   });
 
+  it("preserves the private fallback for a hidden direct-message group", () => {
+    render(
+      <WaveGroupMembersScope
+        group={{
+          is_hidden: true,
+          is_direct_message: true,
+        }}
+      />
+    );
+
+    expect(screen.getByTestId("fallback-scope")).toBeInTheDocument();
+    expect(screen.queryByTestId("members-summary")).not.toBeInTheDocument();
+  });
+
   it("preserves the private and unavailable scope fallbacks", () => {
     render(<WaveGroupMembersScope group={{ is_hidden: true }} />);
 

--- a/components/waves/specs/groups/group/WaveGroupMembersScope.tsx
+++ b/components/waves/specs/groups/group/WaveGroupMembersScope.tsx
@@ -12,7 +12,7 @@ export default function WaveGroupMembersScope({
   const groupId = group.id?.trim();
   const groupName = group.name?.trim();
 
-  if (group.is_hidden || group.is_direct_message || !groupId || !groupName) {
+  if (group.is_hidden || !groupId || !groupName) {
     return <WaveGroupScope group={group} />;
   }
 

--- a/components/waves/specs/groups/group/WaveGroupMembersScope.tsx
+++ b/components/waves/specs/groups/group/WaveGroupMembersScope.tsx
@@ -12,6 +12,8 @@ export default function WaveGroupMembersScope({
   const groupId = group.id?.trim();
   const groupName = group.name?.trim();
 
+  // The waves API viewer-scopes private groups: unauthorized viewers receive
+  // only an is_hidden stub, while eligible DM participants receive the group.
   if (group.is_hidden || !groupId || !groupName) {
     return <WaveGroupScope group={group} />;
   }

--- a/ops/docs/waves/sidebars/feature-right-sidebar-group-management.md
+++ b/ops/docs/waves/sidebars/feature-right-sidebar-group-management.md
@@ -98,6 +98,9 @@ Users can:
   not depend on wave edit permission. An authenticated private-group member or
   creator can inspect that group's criteria and members. Configuration shows
   the current `1 user` or `X users` count instead of the generated group name.
+- Eligible direct-message participants get the same member count and criteria
+  summary for their DM access groups. The generated direct-message group name
+  is not used as the visible value.
 - Scope stubs hidden from the current viewer never render a link, group
   identity, or group metadata.
 - If multiple access rows currently share a group, changing identities or

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -2869,7 +2869,7 @@
         "Rank and Approve wave Configuration shows Chat status as Enabled or Disabled, and wave admins can edit that row with a gear to enable or disable chat.",
         "The Access row uses Chat access wording; `Anyone` means no chat access group is attached, independently of whether chat is enabled.",
         "Rank and Approve Configuration shows Chat status separately from Chat access, so disabled chat does not look like the same thing as an unrestricted chat access group.",
-        "Access groups available to the current viewer—including authorized private groups for their authenticated members or creators—link from Configuration to a filtered Network view that shows both the group criteria and current members; Configuration displays a live eligible-member count instead of the generated group name.",
+        "Access groups available to the current viewer—including authorized private groups and direct-message groups for their eligible authenticated members or creators—link from Configuration to a filtered Network view that shows both the group criteria and current members; Configuration displays a live eligible-member count instead of the generated group name.",
         "Use the Clear selected group button in Network to close the group summary and return to the default member view.",
         "A scoped group hidden from the current viewer is labeled `Private group` without a link, name, id, author, criteria, or membership details.",
         "Network does not reuse a selected group's cached criteria or members after the authenticated viewer changes, or while opening a different group.",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -2865,7 +2865,7 @@
         "Rank and Approve wave Configuration shows Chat status as Enabled or Disabled, and wave admins can edit that row with a gear to enable or disable chat.",
         "The Access row uses Chat access wording; `Anyone` means no chat access group is attached, independently of whether chat is enabled.",
         "Rank and Approve Configuration shows Chat status separately from Chat access, so disabled chat does not look like the same thing as an unrestricted chat access group.",
-        "Access groups available to the current viewer—including authorized private groups for their authenticated members or creators—link from Configuration to a filtered Network view that shows both the group criteria and current members; Configuration displays a live eligible-member count instead of the generated group name.",
+        "Access groups available to the current viewer—including authorized private groups and direct-message groups for their eligible authenticated members or creators—link from Configuration to a filtered Network view that shows both the group criteria and current members; Configuration displays a live eligible-member count instead of the generated group name.",
         "Use the Clear selected group button in Network to close the group summary and return to the default member view.",
         "A scoped group hidden from the current viewer is labeled `Private group` without a link, name, id, author, criteria, or membership details.",
         "Network does not reuse a selected group's cached criteria or members after the authenticated viewer changes, or while opening a different group.",


### PR DESCRIPTION
## Issue

- Eligible participants in direct-message waves see `Private group` for Visibility, Chat access, and Admins instead of the participant count and criteria shown in ordinary waves.

## Fix

- Allow available direct-message access groups to use the existing member-count and criteria-summary presentation.
- Preserve the private fallback for hidden group stubs, so ineligible viewers receive no group identity or membership details.

## Changes

- Remove the direct-message-only presentation block from the Configuration access-row member summary.
- Add a regression test covering an available direct-message group.
- Document the eligible-DM behavior and synchronize the Help Bot index.

## Validation

- `6529 run test --testPathPatterns='(__tests__/components/waves/specs/groups/group/WaveGroupMembersScope|__tests__/components/waves/specs/WaveRulesGroupMembersLink)\.test\.tsx$'` — 2 suites, 5 tests passed.
- `6529 run typecheck` — passed.
- `6529 run check:changed` — passed.
- `6529 run react-doctor:diff` — 100/100, no issues.
- `6529 run help-index:sync` — passed.
- Browser visual validation was not completed because the local app runtime was unavailable; the DM-specific conditional and the reused count/criteria renderer are covered by focused component tests.

## Risk

- Level: Low
- Why: frontend-only conditional rendering change; no API, data shape, permission, or deployment-order changes.
- Rollback: revert this PR to restore the direct-message `Private group` fallback.

## Review Notes

- Confirm that `is_hidden` remains the privacy boundary while `is_direct_message` no longer suppresses details already authorized by the API.
- Frontend-only release candidate; no backend dependency or deploy unit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Direct-message access groups now display member counts and eligibility summaries.
  * Eligible participants can open a filtered Network view to review group members.
  * Direct-message group names are not shown as visible access-group labels.

* **Documentation**
  * Updated help content to explain direct-message access groups and their availability to eligible members or creators.
  * Added guidance for direct-message edge cases in group management documentation.

* **Tests**
  * Added coverage confirming the member-summary link and filtered Network destination for direct-message groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->