### PR TITLE
Keep profile owner actions aligned below the banner

### DIFF
--- a/__tests__/components/user/user-page-header/UserPageHeader.test.tsx
+++ b/__tests__/components/user/user-page-header/UserPageHeader.test.tsx
@@ -6,6 +6,7 @@ import { AuthContext } from "@/components/auth/Auth";
 import { useQuery } from "@tanstack/react-query";
 import { useParams, useRouter } from "next/navigation";
 import { useSeizeConnectContext } from "@/components/auth/SeizeConnectContext";
+import useDeviceInfo from "@/hooks/useDeviceInfo";
 import { useIdentity } from "@/hooks/useIdentity";
 
 jest.mock("next/dynamic", () => () => () => <div />);
@@ -18,7 +19,10 @@ jest.mock("@/components/header/ProfilePreferencesSettings", () => ({
 }));
 jest.mock(
   "@/components/user/user-page-header/banner/UserPageHeaderBanner",
-  () => () => <div data-testid="banner" />
+  () =>
+    ({ canEdit }: { readonly canEdit: boolean }) => (
+      <div data-testid="banner" data-can-edit={canEdit} />
+    )
 );
 jest.mock(
   "@/components/user/user-page-header/pfp/UserPageHeaderPfp",
@@ -44,11 +48,9 @@ jest.mock(
 jest.mock(
   "@/components/user/user-page-header/UserPageHeaderSubscriptionStatus",
   () =>
-    ({
-      layout = "card",
-    }: {
-      readonly layout?: "card" | "subtle" | "wide-row";
-    }) => <div data-testid="subscription-status" data-layout={layout} />
+    ({ layout = "card" }: { readonly layout?: "card" | "header" }) => (
+      <div data-testid="subscription-status" data-layout={layout} />
+    )
 );
 jest.mock("@/components/user/utils/UserFollowBtn", () => ({
   __esModule: true,
@@ -61,6 +63,10 @@ jest.mock("@/components/auth/SeizeConnectContext", () => ({
   useSeizeConnectContext: jest.fn(),
 }));
 jest.mock("@tanstack/react-query", () => ({ useQuery: jest.fn() }));
+jest.mock("@/hooks/useDeviceInfo", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
 jest.mock("@/hooks/useIdentity", () => ({ useIdentity: jest.fn() }));
 jest.mock("next/navigation", () => ({
   useParams: jest.fn(),
@@ -92,6 +98,10 @@ const proxiedOwnProfileAuth = {
 
 describe("UserPageHeader", () => {
   beforeEach(() => {
+    (useDeviceInfo as jest.Mock).mockReturnValue({
+      hasTouchScreen: false,
+      isApp: false,
+    });
     (useQuery as jest.Mock).mockReturnValue({
       isFetched: true,
       data: [{ statement_type: "BIO", statement_group: "GENERAL" }],
@@ -147,37 +157,60 @@ describe("UserPageHeader", () => {
     );
 
     expect(screen.queryByTestId("follow")).not.toBeInTheDocument();
-    const subscriptionStatuses = screen.getAllByTestId("subscription-status");
-    expect(subscriptionStatuses).toHaveLength(2);
-    expect(
-      subscriptionStatuses.filter(
-        (subscriptionStatus) =>
-          subscriptionStatus.dataset["layout"] === "subtle"
-      )
-    ).toHaveLength(1);
-    expect(
-      subscriptionStatuses.filter(
-        (subscriptionStatus) =>
-          subscriptionStatus.dataset["layout"] === "wide-row"
-      )
-    ).toHaveLength(1);
+    expect(screen.getAllByTestId("subscription-status")).toHaveLength(1);
+    expect(screen.getByTestId("subscription-status")).toHaveAttribute(
+      "data-layout",
+      "header"
+    );
     const preferencesButtons = screen.getAllByRole("button", {
       name: "Preferences",
     });
-    expect(preferencesButtons).toHaveLength(3);
+    expect(preferencesButtons).toHaveLength(1);
     expect(preferencesButtons[0]).toHaveClass(
       "tw-size-11",
-      "!tw-bg-transparent",
-      "min-[840px]:tw-hidden"
+      "!tw-border-white/10",
+      "!tw-bg-iron-950",
+      "tw-shadow-md",
+      "tw-shadow-black/40"
     );
-    preferencesButtons.slice(1).forEach((preferencesButton) => {
-      expect(preferencesButton).toHaveClass(
-        "!tw-border-white/10",
-        "!tw-bg-iron-950",
-        "tw-shadow-md",
-        "tw-shadow-black/40"
-      );
+    expect(
+      screen.getAllByRole("button", { name: "Edit profile" })
+    ).toHaveLength(1);
+  });
+
+  it("keeps the single owner action cluster available on touch screens", () => {
+    (useDeviceInfo as jest.Mock).mockReturnValue({
+      hasTouchScreen: true,
+      isApp: false,
     });
+
+    render(
+      <AuthContext.Provider value={ownProfileAuth}>
+        <UserPageHeaderClient
+          profile={profile}
+          handleOrWallet="bob"
+          fallbackMainAddress="0x1"
+          defaultBanner1="#000000"
+          defaultBanner2="#111111"
+          initialStatements={[]}
+          profileEnabledAt="2024-01-01T00:00:00Z"
+          followersCount={5}
+          cmsWebsiteHref={null}
+        />
+      </AuthContext.Provider>
+    );
+
+    expect(screen.getByTestId("banner")).toHaveAttribute(
+      "data-can-edit",
+      "false"
+    );
+    expect(
+      screen.getAllByRole("button", { name: "Edit profile" })
+    ).toHaveLength(1);
+    expect(screen.getAllByRole("button", { name: "Preferences" })).toHaveLength(
+      1
+    );
+    expect(screen.getAllByTestId("subscription-status")).toHaveLength(1);
   });
 
   it("opens preferences from your own profile", async () => {
@@ -198,9 +231,7 @@ describe("UserPageHeader", () => {
       </AuthContext.Provider>
     );
 
-    await user.click(
-      screen.getAllByRole("button", { name: "Preferences" })[0]!
-    );
+    await user.click(screen.getByRole("button", { name: "Preferences" }));
 
     expect(
       screen.getByRole("dialog", { name: "Profile Preferences modal" })

--- a/__tests__/components/user/user-page-header/UserPageHeaderSubscriptionStatus.test.tsx
+++ b/__tests__/components/user/user-page-header/UserPageHeaderSubscriptionStatus.test.tsx
@@ -100,7 +100,7 @@ describe("UserPageHeaderSubscriptionStatus", () => {
     );
   });
 
-  it("renders the subtle presentation without card chrome", () => {
+  it("renders the header presentation as a compact stacked block", () => {
     render(
       <UserPageHeaderSubscriptionStatus
         profile={
@@ -109,7 +109,7 @@ describe("UserPageHeaderSubscriptionStatus", () => {
             normalised_handle: "sesamenoodles",
           } as ApiIdentity
         }
-        layout="subtle"
+        layout="header"
       />
     );
 
@@ -123,14 +123,29 @@ describe("UserPageHeaderSubscriptionStatus", () => {
       "!tw-bg-iron-950",
       "tw-shadow-md"
     );
-    expect(screen.getByText("Subscriptions")).toHaveClass("tw-text-iron-500");
+    expect(screen.getByText("Subscriptions")).toHaveClass(
+      "tw-block",
+      "tw-leading-3",
+      "tw-text-iron-500"
+    );
+    expect(status.parentElement).toHaveClass(
+      "tw-mt-1",
+      "tw-flex",
+      "tw-flex-wrap"
+    );
+    expect(statusLink).toHaveClass("tw-min-h-11", "tw-flex-col");
     expect(statusLink).toHaveAttribute(
       "href",
       "/sesamenoodles/subscriptions#profile-subscriptions-top-up"
     );
   });
 
-  it("renders the wide-row presentation at full width with a divider", () => {
+  it("keeps the header loading state in the same two-line footprint", () => {
+    useSubscriptionCoverageMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as ReturnType<typeof useSubscriptionCoverage>);
+
     render(
       <UserPageHeaderSubscriptionStatus
         profile={
@@ -139,18 +154,36 @@ describe("UserPageHeaderSubscriptionStatus", () => {
             normalised_handle: "sesamenoodles",
           } as ApiIdentity
         }
-        layout="wide-row"
+        layout="header"
       />
     );
 
-    const statusLink = screen
-      .getByText("Running low · through The Memes #560, Oct 12, 2026")
-      .closest("a");
-
-    expect(statusLink).toHaveClass("tw-w-full", "tw-border-t");
-    expect(statusLink).toHaveAttribute(
-      "href",
-      "/sesamenoodles/subscriptions#profile-subscriptions-top-up"
+    expect(screen.getByLabelText("Loading subscription coverage")).toHaveClass(
+      "tw-min-h-11",
+      "tw-flex-col"
     );
+  });
+
+  it("keeps unavailable coverage actionable in the stacked header layout", () => {
+    useSubscriptionCoverageMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    } as ReturnType<typeof useSubscriptionCoverage>);
+
+    render(
+      <UserPageHeaderSubscriptionStatus
+        profile={
+          {
+            consolidation_key: "profile-key",
+            normalised_handle: "sesamenoodles",
+          } as ApiIdentity
+        }
+        layout="header"
+      />
+    );
+
+    const statusLink = screen.getByText("Coverage unavailable").closest("a");
+    expect(statusLink).toHaveClass("tw-min-h-11", "tw-flex-col");
+    expect(statusLink).toHaveAttribute("href", "/sesamenoodles/subscriptions");
   });
 });

--- a/components/user/user-page-header/UserPageHeaderClient.tsx
+++ b/components/user/user-page-header/UserPageHeaderClient.tsx
@@ -81,90 +81,22 @@ function ProfilePreferencesButton({
   return (
     <Button
       variant="tertiary"
-      size="sm"
+      size={null}
       onClick={onClick}
       aria-label={t(DEFAULT_LOCALE, PROFILE_PREFERENCES_BUTTON_KEY)}
-      className={`${USER_PAGE_HEADER_SURFACE_CLASS} ${USER_PAGE_HEADER_INTERACTIVE_SURFACE_CLASS}`}
+      title={t(DEFAULT_LOCALE, PROFILE_PREFERENCES_BUTTON_KEY)}
+      className={`tw-size-11 !tw-rounded-full !tw-p-0 ${USER_PAGE_HEADER_SURFACE_CLASS} ${USER_PAGE_HEADER_INTERACTIVE_SURFACE_CLASS}`}
     >
-      <Cog6ToothIcon className="tw-size-4" aria-hidden="true" />
-      <span>{t(DEFAULT_LOCALE, PROFILE_PREFERENCES_BUTTON_KEY)}</span>
+      <Cog6ToothIcon className="tw-size-5" aria-hidden="true" />
     </Button>
   );
 }
 
-type MobileHeaderControlsProps = Readonly<{
+type ProfileHeaderActionColumnProps = Readonly<{
   aboutStatement: CicStatement | null;
   banner1Color: string;
   banner2Color: string;
   canEdit: boolean;
-  canManageProfilePreferences: boolean;
-  hasTouchScreen: boolean;
-  onOpenPreferences: () => void;
-  profile: ApiIdentity;
-}>;
-
-function MobileHeaderControls({
-  aboutStatement,
-  banner1Color,
-  banner2Color,
-  canEdit,
-  canManageProfilePreferences,
-  hasTouchScreen,
-  onOpenPreferences,
-  profile,
-}: MobileHeaderControlsProps) {
-  if (!canEdit && !canManageProfilePreferences) {
-    return null;
-  }
-
-  return (
-    <div
-      className={`tw-absolute tw-right-4 tw-top-3 tw-z-20 tw-flex tw-items-center tw-gap-1 sm:tw-right-6 sm:tw-top-4 md:tw-right-8 ${
-        hasTouchScreen ? "" : "sm:tw-hidden"
-      }`}
-    >
-      {canEdit ? (
-        <UserPageHeaderEditProfile
-          profile={profile}
-          statement={aboutStatement}
-          defaultBanner1={banner1Color}
-          defaultBanner2={banner2Color}
-        />
-      ) : null}
-      {canManageProfilePreferences ? (
-        <Button
-          variant="tertiary"
-          size={null}
-          onClick={onOpenPreferences}
-          aria-label={t(DEFAULT_LOCALE, PROFILE_PREFERENCES_BUTTON_KEY)}
-          title={t(DEFAULT_LOCALE, PROFILE_PREFERENCES_BUTTON_KEY)}
-          className="tw-group tw-size-11 !tw-rounded-full !tw-border-transparent !tw-bg-transparent !tw-p-1 !tw-shadow-none focus-visible:!tw-outline-none active:!tw-bg-transparent desktop-hover:hover:!tw-border-transparent desktop-hover:hover:!tw-bg-transparent sm:tw-size-10 sm:!tw-p-0.5 min-[840px]:tw-hidden"
-        >
-          <span className="tw-box-border tw-inline-flex tw-size-9 tw-flex-none tw-items-center tw-justify-center tw-rounded-full tw-border tw-border-solid tw-border-white/15 tw-bg-black/75 tw-text-iron-100 tw-shadow-[0_8px_24px_rgba(0,0,0,0.32)] tw-transition-[background-color,border-color,color,transform] tw-duration-200 tw-ease-out group-focus-visible:tw-ring-2 group-focus-visible:tw-ring-primary-400 group-focus-visible:tw-ring-offset-2 group-focus-visible:tw-ring-offset-black group-active:tw-scale-95 group-active:tw-bg-black desktop-hover:group-hover:tw-border-white/25 desktop-hover:group-hover:tw-bg-black/90 desktop-hover:group-hover:tw-text-white motion-reduce:tw-transform-none motion-reduce:tw-transition-none">
-            <Cog6ToothIcon className="tw-size-[1.125rem]" aria-hidden="true" />
-          </span>
-        </Button>
-      ) : null}
-    </div>
-  );
-}
-
-function SmallScreenPreferencesButton({
-  onClick,
-  show,
-}: Readonly<{ onClick: () => void; show: boolean }>) {
-  if (!show) {
-    return null;
-  }
-
-  return (
-    <div className="tw-hidden tw-flex-none sm:tw-absolute sm:tw-right-0 sm:tw-top-6 sm:tw-block min-[840px]:tw-hidden">
-      <ProfilePreferencesButton onClick={onClick} />
-    </div>
-  );
-}
-
-type ProfileHeaderActionColumnProps = Readonly<{
   canManageProfilePreferences: boolean;
   directMessageLoading: boolean;
   followHandle: string | null;
@@ -176,6 +108,10 @@ type ProfileHeaderActionColumnProps = Readonly<{
 }>;
 
 function ProfileHeaderActionColumn({
+  aboutStatement,
+  banner1Color,
+  banner2Color,
+  canEdit,
   canManageProfilePreferences,
   directMessageLoading,
   followHandle,
@@ -185,28 +121,32 @@ function ProfileHeaderActionColumn({
   showSubscriptionStatus,
   websiteAction,
 }: ProfileHeaderActionColumnProps) {
-  if (!canManageProfilePreferences && !websiteAction && !followHandle) {
+  if (
+    !canEdit &&
+    !canManageProfilePreferences &&
+    !websiteAction &&
+    !followHandle
+  ) {
     return null;
   }
 
-  const topPaddingClass = canManageProfilePreferences
-    ? "md:tw-pt-0"
-    : "md:tw-pt-5";
-  const visibilityClass =
-    websiteAction || followHandle ? "tw-flex" : "tw-hidden min-[840px]:tw-flex";
   const directMessageAction = profile.primary_wallet
     ? () => onCreateDirectMessage(profile.primary_wallet)
     : undefined;
 
   return (
-    <div
-      className={`tw-w-full tw-flex-col tw-items-start tw-gap-3 md:tw-w-auto md:tw-flex-none md:tw-items-end md:tw-pb-2 lg:tw-col-start-2 lg:tw-row-span-2 lg:tw-row-start-1 lg:tw-self-start lg:tw-pt-0 ${topPaddingClass} ${visibilityClass}`}
-    >
-      <div className="tw-flex tw-w-full tw-flex-wrap tw-items-end tw-gap-2 md:tw-w-auto md:tw-justify-end">
+    <div className="tw-flex tw-w-full tw-min-w-0 tw-flex-col tw-gap-2 sm:tw-flex-row sm:tw-items-start lg:tw-w-auto lg:tw-max-w-[36rem] lg:tw-justify-self-end">
+      <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-2 lg:tw-flex-none">
+        {canEdit ? (
+          <UserPageHeaderEditProfile
+            profile={profile}
+            statement={aboutStatement}
+            defaultBanner1={banner1Color}
+            defaultBanner2={banner2Color}
+          />
+        ) : null}
         {canManageProfilePreferences ? (
-          <div className="tw-hidden min-[840px]:tw-block">
-            <ProfilePreferencesButton onClick={onOpenPreferences} />
-          </div>
+          <ProfilePreferencesButton onClick={onOpenPreferences} />
         ) : null}
         {websiteAction ? (
           <ButtonLink
@@ -229,8 +169,8 @@ function ProfileHeaderActionColumn({
         ) : null}
       </div>
       {showSubscriptionStatus ? (
-        <div className="tw-hidden min-[840px]:tw-block">
-          <UserPageHeaderSubscriptionStatus profile={profile} layout="subtle" />
+        <div className="tw-min-w-0 tw-flex-1 lg:tw-flex-none lg:tw-pt-3">
+          <UserPageHeaderSubscriptionStatus profile={profile} layout="header" />
         </div>
       ) : null}
     </div>
@@ -241,12 +181,12 @@ type ProfileHeaderContentProps = Readonly<{
   aboutStatement: CicStatement | null;
   banner1Color: string;
   banner2Color: string;
+  canEdit: boolean;
   canInlineEdit: boolean;
   canManageProfilePreferences: boolean;
   directMessageLoading: boolean;
   followHandle: string | null;
   followersCount: number | null;
-  hasTouchScreen: boolean;
   mainAddress: string;
   normalizedHandleOrWallet: string;
   onCreateDirectMessage: (primaryWallet: string | undefined) => void;
@@ -263,12 +203,12 @@ function ProfileHeaderContent({
   aboutStatement,
   banner1Color,
   banner2Color,
+  canEdit,
   canInlineEdit,
   canManageProfilePreferences,
   directMessageLoading,
   followHandle,
   followersCount,
-  hasTouchScreen,
   mainAddress,
   normalizedHandleOrWallet,
   onCreateDirectMessage,
@@ -280,34 +220,27 @@ function ProfileHeaderContent({
   showSubscriptionStatus,
   websiteAction,
 }: ProfileHeaderContentProps) {
-  const identityPaddingClass =
-    canManageProfilePreferences && !hasTouchScreen
-      ? "sm:tw-pr-36 min-[840px]:tw-pr-0"
-      : "";
-
   return (
     <div className="tw-relative tw-z-20 tw-bg-black">
-      <div className="tw-relative tw-z-10 tw-px-4 sm:tw-px-6 md:tw-px-8 lg:tw-grid lg:tw-grid-cols-[minmax(0,1fr)_auto] lg:tw-gap-x-6">
-        <div className="tw-relative tw-mb-6 tw-flex tw-flex-col tw-items-start tw-gap-4 sm:tw-mb-4 md:tw-flex-row md:tw-justify-between md:tw-gap-6 lg:tw-contents">
-          <div
-            className={`tw-flex tw-w-full tw-min-w-0 tw-flex-col tw-items-start tw-gap-3 sm:tw-relative sm:tw-min-h-16 sm:tw-flex-row sm:tw-items-end sm:tw-gap-4 sm:tw-pt-16 md:tw-flex-1 md:tw-gap-5 lg:tw-col-start-1 lg:tw-row-start-1 lg:tw-pl-[132px] lg:tw-pt-0 ${identityPaddingClass}`}
-          >
-            <div className="tw-relative -tw-mt-10 tw-flex-shrink-0 sm:tw-absolute sm:-tw-top-14 sm:tw-left-0 sm:tw-mt-0">
-              <UserPageHeaderPfpWrapper
+      <div className="tw-relative tw-z-10 tw-px-4 sm:tw-px-6 md:tw-px-8">
+        <div className="tw-relative tw-mb-6 tw-flex tw-flex-col tw-gap-3 sm:tw-mb-4 sm:tw-block sm:tw-pt-16 lg:tw-pl-[132px] lg:tw-pt-0">
+          <div className="tw-relative -tw-mt-10 tw-flex-shrink-0 sm:tw-absolute sm:-tw-top-14 sm:tw-left-0 sm:tw-mt-0">
+            <UserPageHeaderPfpWrapper
+              profile={profile}
+              canEdit={canInlineEdit}
+              profileLabel={profileLabel}
+            >
+              <UserPageHeaderPfp
                 profile={profile}
-                canEdit={canInlineEdit}
                 profileLabel={profileLabel}
-              >
-                <UserPageHeaderPfp
-                  profile={profile}
-                  profileLabel={profileLabel}
-                  defaultBanner1={banner1Color}
-                  defaultBanner2={banner2Color}
-                />
-              </UserPageHeaderPfpWrapper>
-            </div>
+                defaultBanner1={banner1Color}
+                defaultBanner2={banner2Color}
+              />
+            </UserPageHeaderPfpWrapper>
+          </div>
 
-            <div className="tw-min-w-0 tw-flex-1 tw-pb-1 sm:tw-pb-2 sm:tw-pt-2 lg:tw-pt-1">
+          <div className="tw-grid tw-min-w-0 tw-gap-4 sm:tw-pt-2 lg:tw-grid-cols-[minmax(0,1fr)_auto] lg:tw-gap-x-6 lg:tw-pt-1">
+            <div className="tw-min-w-0 tw-pb-1 sm:tw-pb-2">
               <UserPageHeaderName
                 profile={profile}
                 canEdit={canInlineEdit}
@@ -317,36 +250,26 @@ function ProfileHeaderContent({
                 variant="full"
               />
             </div>
-          </div>
 
-          <SmallScreenPreferencesButton
-            onClick={onOpenPreferences}
-            show={canManageProfilePreferences && !hasTouchScreen}
-          />
-
-          <ProfileHeaderActionColumn
-            canManageProfilePreferences={canManageProfilePreferences}
-            directMessageLoading={directMessageLoading}
-            followHandle={followHandle}
-            onCreateDirectMessage={onCreateDirectMessage}
-            onOpenPreferences={onOpenPreferences}
-            profile={profile}
-            showSubscriptionStatus={showSubscriptionStatus}
-            websiteAction={websiteAction}
-          />
-        </div>
-
-        {showSubscriptionStatus ? (
-          <div className="min-[840px]:tw-hidden">
-            <UserPageHeaderSubscriptionStatus
+            <ProfileHeaderActionColumn
+              aboutStatement={aboutStatement}
+              banner1Color={banner1Color}
+              banner2Color={banner2Color}
+              canEdit={canEdit}
+              canManageProfilePreferences={canManageProfilePreferences}
+              directMessageLoading={directMessageLoading}
+              followHandle={followHandle}
+              onCreateDirectMessage={onCreateDirectMessage}
+              onOpenPreferences={onOpenPreferences}
               profile={profile}
-              layout="wide-row"
+              showSubscriptionStatus={showSubscriptionStatus}
+              websiteAction={websiteAction}
             />
           </div>
-        ) : null}
+        </div>
 
         {showAbout ? (
-          <div className="lg:tw-col-start-1 lg:tw-row-start-2 lg:tw-self-start lg:tw-pt-4">
+          <div className="lg:tw-pt-4">
             <UserPageHeaderAbout
               profile={profile}
               statement={aboutStatement}
@@ -355,7 +278,7 @@ function ProfileHeaderContent({
           </div>
         ) : null}
 
-        <div className="tw-mt-4 tw-flex tw-items-center sm:tw-mt-6 lg:tw-col-span-2 lg:tw-col-start-1 lg:tw-row-start-3 lg:tw-mt-4">
+        <div className="tw-mt-4 tw-flex tw-items-center sm:tw-mt-6 lg:tw-mt-4">
           <UserPageHeaderStats
             profile={profile}
             handleOrWallet={normalizedHandleOrWallet}
@@ -506,36 +429,24 @@ export default function UserPageHeaderClient({
         aria-labelledby="profile-heading"
         className="tw-relative tw-bg-black tw-pb-4 md:tw-pb-8"
       >
-        <div className="tw-relative tw-w-full">
-          <UserPageHeaderBanner
-            profile={profile}
-            defaultBanner1={banner1Color}
-            defaultBanner2={banner2Color}
-            canEdit={canInlineEdit}
-            profileLabel={profileLabel}
-          />
-          <MobileHeaderControls
-            aboutStatement={aboutStatement}
-            banner1Color={banner1Color}
-            banner2Color={banner2Color}
-            canEdit={canEdit}
-            canManageProfilePreferences={canManageProfilePreferences}
-            hasTouchScreen={hasTouchScreen}
-            onOpenPreferences={() => setIsProfilePreferencesOpen(true)}
-            profile={profile}
-          />
-        </div>
+        <UserPageHeaderBanner
+          profile={profile}
+          defaultBanner1={banner1Color}
+          defaultBanner2={banner2Color}
+          canEdit={canInlineEdit}
+          profileLabel={profileLabel}
+        />
 
         <ProfileHeaderContent
           aboutStatement={aboutStatement}
           banner1Color={banner1Color}
           banner2Color={banner2Color}
+          canEdit={canEdit}
           canInlineEdit={canInlineEdit}
           canManageProfilePreferences={canManageProfilePreferences}
           directMessageLoading={directMessageLoading}
           followHandle={followHandle}
           followersCount={followersCount}
-          hasTouchScreen={hasTouchScreen}
           mainAddress={mainAddress}
           normalizedHandleOrWallet={normalizedHandleOrWallet}
           onCreateDirectMessage={handleCreateDirectMessage}

--- a/components/user/user-page-header/UserPageHeaderEditProfile.tsx
+++ b/components/user/user-page-header/UserPageHeaderEditProfile.tsx
@@ -18,6 +18,10 @@ import UserPageHeaderEditBanner from "./banner/UserPageHeaderEditBanner";
 import UserPageHeaderEditName from "./name/UserPageHeaderEditName";
 import UserPageHeaderEditClassification from "./name/classification/UserPageHeaderEditClassification";
 import UserPageHeaderEditPfp from "./pfp/UserPageHeaderEditPfp";
+import {
+  USER_PAGE_HEADER_INTERACTIVE_SURFACE_CLASS,
+  USER_PAGE_HEADER_SURFACE_CLASS,
+} from "./user-page-header-surface";
 import { getUserProfileHeaderMessage } from "./user-page-header.messages";
 
 type EditTarget = "banner" | "pfp" | "name" | "classification" | "about";
@@ -142,11 +146,9 @@ export default function UserPageHeaderEditProfile({
         onClick={openMenu}
         aria-label={getUserProfileHeaderMessage("user.profileHeader.edit.open")}
         title={getUserProfileHeaderMessage("user.profileHeader.edit.open")}
-        className="tw-group tw-size-11 !tw-rounded-full !tw-border-transparent !tw-bg-transparent !tw-p-1 !tw-shadow-none focus-visible:!tw-outline-none active:!tw-bg-transparent desktop-hover:hover:!tw-border-transparent desktop-hover:hover:!tw-bg-transparent sm:tw-size-10 sm:!tw-p-0.5"
+        className={`tw-size-11 !tw-rounded-full !tw-p-0 ${USER_PAGE_HEADER_SURFACE_CLASS} ${USER_PAGE_HEADER_INTERACTIVE_SURFACE_CLASS}`}
       >
-        <span className="tw-box-border tw-inline-flex tw-size-9 tw-flex-none tw-items-center tw-justify-center tw-rounded-full tw-border tw-border-solid tw-border-white/15 tw-bg-black/75 tw-text-iron-100 tw-shadow-[0_8px_24px_rgba(0,0,0,0.32)] tw-transition-[background-color,border-color,color,transform] tw-duration-200 tw-ease-out group-focus-visible:tw-ring-2 group-focus-visible:tw-ring-primary-400 group-focus-visible:tw-ring-offset-2 group-focus-visible:tw-ring-offset-black group-active:tw-scale-95 group-active:tw-bg-black desktop-hover:group-hover:tw-border-white/25 desktop-hover:group-hover:tw-bg-black/90 desktop-hover:group-hover:tw-text-white motion-reduce:tw-transform-none motion-reduce:tw-transition-none">
-          <PencilIcon className="tw-size-[1.125rem]" aria-hidden="true" />
-        </span>
+        <PencilIcon className="tw-size-5" aria-hidden="true" />
       </Button>
 
       <MobileWrapperDialog

--- a/components/user/user-page-header/UserPageHeaderSubscriptionStatus.tsx
+++ b/components/user/user-page-header/UserPageHeaderSubscriptionStatus.tsx
@@ -58,15 +58,16 @@ const STATUS_ICON_CLASSES: Record<SubscriptionCoverageTone, string> = {
   neutral: "tw-bg-iron-800 tw-text-iron-300 tw-ring-iron-700",
 };
 
+const HEADER_STATUS_CLASSES: Record<SubscriptionCoverageTone, string> = {
+  positive: "tw-text-emerald-200",
+  caution: "tw-text-amber-200",
+  danger: "tw-text-red-200",
+  neutral: "tw-text-iron-200",
+};
+
 const SUBSCRIPTIONS_TITLE_KEY = "subscriptions.coverage.header.title";
 const MUTED_TEXT_CLASS = "tw-text-iron-400";
-type SubscriptionStatusLayout = "card" | "subtle" | "wide-row";
-
-function getSubtleLayoutClass(layout: SubscriptionStatusLayout) {
-  return layout === "wide-row"
-    ? "tw-min-h-14 tw-border-0 tw-border-t tw-border-solid tw-border-white/[0.08] tw-py-2"
-    : "tw-min-h-10 tw-rounded-lg";
-}
+type SubscriptionStatusLayout = "card" | "header";
 
 function SubscriptionStatusIcon({
   tone,
@@ -93,22 +94,21 @@ function SubscriptionLoading({
   layout: SubscriptionStatusLayout;
   locale: SupportedLocale;
 }>) {
-  const isSubtle = layout !== "card";
+  const isHeader = layout === "header";
 
   return (
     <div
       aria-label={t(locale, "subscriptions.coverage.loading")}
       className={clsx(
         "tw-w-full tw-animate-pulse",
-        isSubtle
-          ? getSubtleLayoutClass(layout)
+        isHeader
+          ? "tw-flex tw-min-h-11 tw-min-w-0 tw-flex-col tw-justify-center tw-rounded-lg"
           : "tw-min-h-14 tw-rounded-xl tw-p-2.5 sm:tw-w-[22rem]",
-        layout === "subtle" && "tw-flex tw-flex-col tw-justify-center",
-        !isSubtle && USER_PAGE_HEADER_SURFACE_CLASS
+        !isHeader && USER_PAGE_HEADER_SURFACE_CLASS
       )}
     >
-      <div className="tw-h-3.5 tw-w-40 tw-rounded tw-bg-iron-700/80" />
-      <div className="tw-mt-1.5 tw-h-3 tw-w-48 tw-rounded tw-bg-iron-800/90" />
+      <div className="tw-h-3 tw-w-24 tw-max-w-full tw-rounded tw-bg-iron-700/80" />
+      <div className="tw-mt-1 tw-h-4 tw-w-48 tw-max-w-full tw-rounded tw-bg-iron-800/90" />
     </div>
   );
 }
@@ -122,61 +122,49 @@ function SubscriptionUnknown({
   layout: SubscriptionStatusLayout;
   locale: SupportedLocale;
 }>) {
-  const isSubtle = layout !== "card";
+  if (layout === "header") {
+    return (
+      <Link
+        href={href}
+        className="tw-group tw-flex tw-min-h-11 tw-w-full tw-min-w-0 tw-flex-col tw-justify-center tw-rounded-lg tw-text-left tw-no-underline tw-transition-colors focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 desktop-hover:hover:tw-bg-white/[0.025]"
+      >
+        <span className="tw-block tw-text-[11px] tw-font-semibold tw-uppercase tw-leading-3 tw-tracking-[0.06em] tw-text-iron-500">
+          {t(locale, SUBSCRIPTIONS_TITLE_KEY)}
+        </span>
+        <span className="tw-mt-1 tw-flex tw-min-w-0 tw-flex-wrap tw-items-baseline tw-gap-x-1.5 tw-gap-y-0.5 tw-text-[13px] tw-font-medium tw-leading-4 tw-text-iron-200">
+          <span className="tw-transition-colors group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white">
+            {t(locale, "subscriptions.coverage.status.unknown")}
+          </span>
+          <ArrowRightIcon
+            className="tw-size-3 tw-flex-none tw-text-iron-500 tw-transition-colors group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white"
+            aria-hidden="true"
+          />
+        </span>
+      </Link>
+    );
+  }
 
   return (
     <Link
       href={href}
       className={clsx(
-        "tw-group tw-flex tw-gap-2 tw-text-left tw-no-underline tw-transition-colors focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400",
-        layout === "subtle"
-          ? "tw-w-fit tw-items-start tw-justify-end"
-          : "tw-w-full tw-items-center tw-justify-between",
-        isSubtle
-          ? `${getSubtleLayoutClass(layout)} desktop-hover:hover:tw-bg-white/[0.025]`
-          : "tw-min-h-14 tw-rounded-xl tw-p-2.5 sm:tw-w-[22rem]",
-        !isSubtle && USER_PAGE_HEADER_SURFACE_CLASS,
-        !isSubtle && USER_PAGE_HEADER_INTERACTIVE_SURFACE_CLASS
+        "tw-group tw-flex tw-min-h-14 tw-w-full tw-items-center tw-justify-between tw-gap-2 tw-rounded-xl tw-p-2.5 tw-text-left tw-no-underline tw-transition-colors focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 sm:tw-w-[22rem]",
+        USER_PAGE_HEADER_SURFACE_CLASS,
+        USER_PAGE_HEADER_INTERACTIVE_SURFACE_CLASS
       )}
     >
-      <span
-        className={clsx(
-          "tw-min-w-0",
-          isSubtle && "tw-flex tw-items-baseline",
-          layout === "subtle" && "tw-gap-2 tw-whitespace-nowrap",
-          layout === "wide-row" && "tw-flex-1 tw-flex-wrap tw-gap-1"
-        )}
-      >
-        <span
-          className={clsx(
-            "tw-font-medium",
-            isSubtle
-              ? "tw-text-[11px] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-iron-500"
-              : "tw-text-[13px] tw-text-iron-100",
-            isSubtle ? "tw-inline-block" : "tw-block"
-          )}
-        >
+      <span className="tw-min-w-0">
+        <span className="tw-block tw-text-[13px] tw-font-medium tw-text-iron-100">
           {t(locale, SUBSCRIPTIONS_TITLE_KEY)}
         </span>
         <span
-          className={clsx(
-            "tw-block tw-transition-colors",
-            isSubtle
-              ? "tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-200 group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white"
-              : `tw-text-[11px] ${MUTED_TEXT_CLASS}`,
-            isSubtle ? "tw-mt-0" : "tw-mt-0.5"
-          )}
+          className={`tw-mt-0.5 tw-block tw-text-[11px] ${MUTED_TEXT_CLASS}`}
         >
           {t(locale, "subscriptions.coverage.status.unknown")}
         </span>
       </span>
       <ArrowRightIcon
-        className={clsx(
-          "tw-size-4 tw-flex-none tw-transition-colors",
-          isSubtle
-            ? "tw-text-iron-500 group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white"
-            : MUTED_TEXT_CLASS
-        )}
+        className={`tw-size-4 tw-flex-none tw-transition-colors ${MUTED_TEXT_CLASS}`}
         aria-hidden="true"
       />
     </Link>
@@ -232,61 +220,41 @@ function SubscriptionCard({
   );
 }
 
-function SubscriptionSubtle({
+function SubscriptionHeader({
   actionLabel,
   href,
   isUrgentTopUp,
-  layout,
   locale,
   secondaryLine,
   tone,
-}: SubscriptionCoveragePresentationProps &
-  Readonly<{ layout: Exclude<SubscriptionStatusLayout, "card"> }>) {
-  const isCompact = layout === "subtle";
-
+}: SubscriptionCoveragePresentationProps) {
   return (
     <Link
       href={href}
-      className={clsx(
-        "tw-group tw-flex tw-gap-2 tw-text-left tw-no-underline tw-transition-colors focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400",
-        isCompact
-          ? "tw-w-max tw-items-start tw-justify-end"
-          : "tw-w-full tw-items-center tw-justify-between",
-        `${getSubtleLayoutClass(layout)} desktop-hover:hover:tw-bg-white/[0.025]`
-      )}
+      className="tw-group tw-flex tw-min-h-11 tw-w-full tw-min-w-0 tw-flex-col tw-justify-center tw-rounded-lg tw-text-left tw-no-underline tw-transition-colors focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 desktop-hover:hover:tw-bg-white/[0.025]"
     >
-      <SubscriptionStatusIcon tone={tone} />
-      <span
-        className={clsx(
-          "tw-flex tw-min-w-0 tw-items-baseline",
-          isCompact
-            ? "tw-gap-x-2 tw-whitespace-nowrap"
-            : "tw-flex-1 tw-flex-wrap tw-gap-x-1"
-        )}
-      >
-        <span className="tw-inline-block tw-text-[11px] tw-font-semibold tw-uppercase tw-tracking-[0.06em] tw-text-iron-500">
-          {t(locale, SUBSCRIPTIONS_TITLE_KEY)}
+      <span className="tw-block tw-text-[11px] tw-font-semibold tw-uppercase tw-leading-3 tw-tracking-[0.06em] tw-text-iron-500">
+        {t(locale, SUBSCRIPTIONS_TITLE_KEY)}
+      </span>
+      <span className="tw-mt-1 tw-flex tw-min-w-0 tw-flex-wrap tw-items-baseline tw-gap-x-2 tw-gap-y-0.5 tw-text-[13px] tw-font-medium tw-leading-4">
+        <span
+          className={clsx(
+            "tw-min-w-0 tw-transition-colors group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white",
+            HEADER_STATUS_CLASSES[tone]
+          )}
+        >
+          {secondaryLine}
         </span>
-        <span className="tw-flex tw-min-w-0 tw-items-baseline tw-gap-2 tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-200">
-          <span
-            className={clsx(
-              "tw-min-w-0 tw-transition-colors group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white",
-              !isCompact && "tw-truncate"
-            )}
-          >
-            {secondaryLine}
-          </span>
-          <span
-            className={clsx(
-              "tw-inline-flex tw-flex-none tw-items-center tw-gap-1 tw-text-xs tw-font-medium tw-transition-colors",
-              isUrgentTopUp
-                ? "group-focus-visible:tw-text-primary-200 desktop-hover:group-hover:tw-text-primary-200 tw-text-primary-300"
-                : "tw-text-iron-500 group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white"
-            )}
-          >
-            {actionLabel}
-            <ArrowRightIcon className="tw-size-3" aria-hidden="true" />
-          </span>
+        <span
+          className={clsx(
+            "tw-inline-flex tw-flex-none tw-items-center tw-gap-1 tw-text-xs tw-font-medium tw-transition-colors",
+            isUrgentTopUp
+              ? "group-focus-visible:tw-text-primary-200 desktop-hover:group-hover:tw-text-primary-200 tw-text-primary-300"
+              : "tw-text-iron-500 group-focus-visible:tw-text-white desktop-hover:group-hover:tw-text-white"
+          )}
+        >
+          {actionLabel}
+          <ArrowRightIcon className="tw-size-3" aria-hidden="true" />
         </span>
       </span>
     </Link>
@@ -369,5 +337,5 @@ export default function UserPageHeaderSubscriptionStatus({
     return <SubscriptionCard {...presentationProps} />;
   }
 
-  return <SubscriptionSubtle {...presentationProps} layout={layout} />;
+  return <SubscriptionHeader {...presentationProps} />;
 }

--- a/ops/docs/notifications/feature-profile-preferences.md
+++ b/ops/docs/notifications/feature-profile-preferences.md
@@ -5,11 +5,10 @@
 Authenticated profiles can open `Profile Preferences` from the app sidebar,
 the desktop profile menu, or the `Preferences` action in their own profile
 header to control who may start new direct-message conversations and which
-in-app notifications are created. The action sits in the far-right owner area
-on desktop layouts. Touch-first and phone layouts place an icon-only
-`Preferences` action beside `Edit profile`; smaller fine-pointer layouts place
-the labeled action to the right of the identity. It is hidden while an active
-profile proxy is in use.
+in-app notifications are created. In the profile header, the icon-only action
+sits beside `Edit profile` in the owner action cluster below the banner. The
+cluster follows the identity on smaller layouts and aligns to its right on
+larger layouts. It is hidden while an active profile proxy is in use.
 
 ## Direct Messages
 

--- a/ops/docs/profiles/navigation/feature-banner-editing.md
+++ b/ops/docs/profiles/navigation/feature-banner-editing.md
@@ -21,15 +21,15 @@ The editor has two modes:
   - the profile has a handle
   - you are viewing your own profile
   - no active profile proxy context
-- On smaller and touch-first layouts, use `Edit profile` and choose
-  `Profile cover`.
+- On any layout, use `Edit profile` in the owner action cluster below the
+  banner and choose `Profile cover`.
 - On fine-pointer desktop layouts, use the banner edit overlay.
 
 ## User Journey
 
 1. Open your own profile page.
-2. Use the desktop banner edit overlay, or choose `Edit profile` ->
-   `Profile cover` on a smaller layout, to open `Edit profile cover`.
+2. Choose `Edit profile` -> `Profile cover`, or use the fine-pointer desktop
+   banner edit overlay, to open `Edit profile cover`.
 3. The modal starts in:
    - `Image` mode when the current banner is an image.
    - `Gradient` mode when the current banner is gradient colors.

--- a/ops/docs/profiles/navigation/feature-header-summary.md
+++ b/ops/docs/profiles/navigation/feature-header-summary.md
@@ -53,19 +53,20 @@ The profile header appears on profile routes under `/{user}` and shows:
    - winners-only: opens `Winning Artworks`
    - both: opens `Active Submissions` first
 7. Actions depend on viewer context:
-   - own profile with handle and no active proxy: fine-pointer desktop layouts
-     expose direct edit controls on the banner, profile picture, name,
-     classification, and About
-   - smaller and touch-first layouts show an `Edit profile` action that opens
-     an editing hub for those same identity fields
+   - own profile with handle and no active proxy: one owner action cluster below
+     the banner contains `Edit profile`, `Preferences`, and subscription
+     coverage
+   - `Edit profile` opens an editing hub for the profile cover, profile picture,
+     name, classification, and About on every layout
+   - fine-pointer layouts also expose direct edit controls on those individual
+     fields
    - `Preferences` remains a distinct owner action for privacy, direct-message,
-     and notification settings; it sits in the right-side action area below the
-     banner on desktop, remains an icon-only action beside `Edit profile` in the
-     banner's top-right corner on touch-first and phone layouts, and sits to the
-     right of the identity on smaller fine-pointer layouts
-   - subscription coverage remains a separate status and navigation surface:
-     a subtle row beneath Preferences on desktop layouts, and a full-width
-     subtle row below the identity block on smaller layouts
+     and notification settings
+   - subscription coverage remains a separate navigation surface in the same
+     cluster, with its label on the first line and current state plus contextual
+     action on the second
+   - the owner action cluster follows the identity block on smaller layouts and
+     aligns to its right on larger layouts
    - other profile, signed-in viewer with handle, and target profile with
      handle: follow/unfollow button
    - if that target also has a primary wallet: direct-message button appears
@@ -81,15 +82,15 @@ The profile header appears on profile routes under `/{user}` and shows:
   value.
 - Long About text (`>240` chars) is clamped on mobile with `See more` /
   `See less`; desktop stays expanded.
-- Mobile profile banners retain their existing full-strength artwork and
-  top-right owner controls. Desktop banners fade into the content surface at
-  the bottom; only the profile picture crosses that boundary.
+- Mobile profile banners retain their existing full-strength artwork. Desktop
+  banners fade into the content surface at the bottom. Owner actions remain on
+  the content surface below the banner, and only the profile picture crosses
+  the banner boundary.
 - The subscription status can link directly to the relevant settings,
-  upcoming-drops, or top-up section. The complete status row is the link, with
-  its label, current state, and contextual action kept inline when space allows.
-  It remains a full-width contextual row on smaller layouts and can wrap when
+  upcoming-drops, or top-up section. The complete status surface is the link,
+  with its label above the current state and contextual action. It can wrap when
   translated or dynamic content cannot fit.
-- Touch-first layouts use the profile editing hub; fine-pointer desktop layouts
+- Touch-first layouts use the profile editing hub; fine-pointer layouts also
   retain the field-level editing controls.
 - `Followers` opens a modal list; it does not navigate to a followers tab.
 - On non-touch desktop devices, the artist badge shows a tooltip with activity

--- a/ops/docs/profiles/navigation/feature-profile-picture-editing.md
+++ b/ops/docs/profiles/navigation/feature-profile-picture-editing.md
@@ -23,15 +23,15 @@ This flow is separate from banner editing.
   - the profile has a handle
   - you are viewing your own profile
   - no active profile proxy context
-- On smaller and touch-first layouts, use `Edit profile` and choose
-  `Profile picture`.
+- On any layout, use `Edit profile` in the owner action cluster below the
+  banner and choose `Profile picture`.
 - On fine-pointer desktop layouts, use the avatar edit control
   (`Edit profile picture`).
 
 ## User Journey
 
-1. Open your own profile and use the desktop avatar edit control, or choose
-   `Edit profile` -> `Profile picture` on a smaller layout.
+1. Open your own profile and choose `Edit profile` -> `Profile picture`, or use
+   the fine-pointer desktop avatar edit control.
 2. The modal opens. If you already have a profile picture, the upload panel shows its preview.
 3. Choose one source:
    - `Select Meme`: search and click a meme row.

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -1180,8 +1180,8 @@
       "facts": [
         "Profile pages are opened from a real handle or wallet-like route target; use Network, Waves, groups, or a known handle to open the exact profile.",
         "Profile pages organize Identity, Curation, Collected, Subscriptions, Proxy, Brain, and xTDH surfaces through tabs.",
-        "On their own profile, owners use direct field-level edit controls on fine-pointer desktop layouts; smaller and touch-first layouts provide an Edit profile hub for the profile cover, profile picture, name, classification, and About.",
-        "Preferences is a separate owner action in the right-side area below the banner on desktop and an icon-only action beside Edit profile in the banner's top-right corner on touch-first and phone layouts; subscription coverage stays a quieter contextual surface beneath Preferences on desktop or across the header below the identity block on smaller screens.",
+        "On their own profile, owners can use the Edit profile hub for the profile cover, profile picture, name, classification, and About on every layout; fine-pointer layouts also provide direct field-level edit controls.",
+        "Edit profile, Preferences, and subscription coverage share one owner action cluster on the content surface below the banner. It follows the identity on smaller layouts and aligns to its right on larger layouts; subscription coverage places its label above the current state and contextual action.",
         "Editable profile surfaces require the connected profile owner.",
         "Profile editing, profile-header Preferences, and owner subscription coverage are hidden while an active profile proxy is in use."
       ],

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -1176,8 +1176,8 @@
       "facts": [
         "Profile pages are opened from a real handle or wallet-like route target; use Network, Waves, groups, or a known handle to open the exact profile.",
         "Profile pages organize Identity, Curation, Collected, Subscriptions, Proxy, Brain, and xTDH surfaces through tabs.",
-        "On their own profile, owners use direct field-level edit controls on fine-pointer desktop layouts; smaller and touch-first layouts provide an Edit profile hub for the profile cover, profile picture, name, classification, and About.",
-        "Preferences is a separate owner action in the right-side area below the banner on desktop and an icon-only action beside Edit profile in the banner's top-right corner on touch-first and phone layouts; subscription coverage stays a quieter contextual surface beneath Preferences on desktop or across the header below the identity block on smaller screens.",
+        "On their own profile, owners can use the Edit profile hub for the profile cover, profile picture, name, classification, and About on every layout; fine-pointer layouts also provide direct field-level edit controls.",
+        "Edit profile, Preferences, and subscription coverage share one owner action cluster on the content surface below the banner. It follows the identity on smaller layouts and aligns to its right on larger layouts; subscription coverage places its label above the current state and contextual action.",
         "Editable profile surfaces require the connected profile owner.",
         "Profile editing, profile-header Preferences, and owner subscription coverage are hidden while an active profile proxy is in use."
       ],


### PR DESCRIPTION
## Issue

Profile owners could see duplicated Edit Profile, Preferences, and subscription controls across several responsive regimes. Some variants were positioned over the banner, which made the action area vulnerable to overlap and inconsistent alignment around intermediate widths.

## Fix

Use one flow-anchored action cluster on the content surface below the banner. The cluster follows the identity on smaller layouts and aligns to its right on larger layouts, so the responsive behavior no longer depends on separate phone, touch, 840px, and desktop copies.

## Notable changes

- Render exactly one Edit Profile action, one Preferences action, and one owner subscription status.
- Give Edit Profile and Preferences consistent 44×44 icon-button surfaces and accessible names.
- Stack the subscription label above its current state and contextual action.
- Keep field-level edit controls on fine-pointer layouts while preserving the Edit Profile hub for touch-first layouts.
- Update profile and preferences documentation plus the generated Help Bot corpus.
- Add regression coverage for owner, visitor, proxy, loading, unavailable-coverage, and touch-screen states.

## Validation

- `./bin/6529 run check:changed`
- `./bin/6529 run test --testPathPatterns='user-page-header/(UserPageHeader|UserPageHeaderSubscriptionStatus)\.test\.tsx' --runInBand` — 13 tests passed
- `./bin/6529 run react-doctor:diff` — 100/100, no issues
- `./bin/6529 run help-index:sync`
- `git diff --check`
- Authenticated responsive browser QA at 320, 406, 494, 564, 639/640, 714, 767/768, 839/840, 879/880, 1023/1024, 1342, and 2560px
- Verified one instance of each owner control, 44×44 targets, normal-flow positioning, zero horizontal overflow, correct dialog launches, DOM focus order, and no browser or Next.js runtime errors

The repo-wide docs-link validator remains blocked by an unrelated broken link already present on `main`: `ops/docs/shared/feature-ios-eula-consent.md` points to a missing `ops/docs/content-moderation.md` file.

Native simulator evidence was not collected because the sibling mobile-shell checkout is not on the workflow branch required by the mobile-testing skill. The touch-specific component path is covered by Jest and responsive browser QA.

## Risk

Low to moderate. The change is isolated to the profile header action layout and subscription-header presentation. The main review focus is long dynamic subscription copy near the large-layout transition.

## Rollback

Revert commit `73a881c5b9b715853baf8f9ef4029f6644f993a4`.

## Review notes

Please focus on the action cluster around the 640, 768, and 1024px transitions and on whether the desktop status baseline feels balanced beside the profile name.
