### PR TITLE
Resolve production artifact metadata without build secrets

### DIFF
--- a/.github/workflows/app-pr-ci.yml
+++ b/.github/workflows/app-pr-ci.yml
@@ -536,6 +536,7 @@ jobs:
             __tests__/scripts/museum-surface-registry.test.ts \
             __tests__/scripts/package-public-review-artifacts.test.ts \
             __tests__/scripts/production-build-artifact.test.ts \
+            __tests__/scripts/production-artifact-metadata.test.ts \
             __tests__/scripts/production-artifact-verifier.test.ts \
             __tests__/scripts/deployment-e2e-workflows.test.ts \
             __tests__/scripts/public-review-artifact-workflows.test.ts \

--- a/.github/workflows/build-upload-deploy-prod.yml
+++ b/.github/workflows/build-upload-deploy-prod.yml
@@ -45,25 +45,35 @@ jobs:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
+  resolve-production-artifact:
+    name: Resolve production artifact metadata
+    needs: build-production-artifact
+    uses: ./.github/workflows/production-artifact-metadata.yml
+
   verify-production-artifact:
     name: Verify exact production artifact
     permissions:
       actions: read
       contents: read
-    needs: build-production-artifact
+    needs: resolve-production-artifact
     uses: ./.github/workflows/production-artifact-verifier.yml
     with:
       target_sha: ${{ github.sha }}
-      artifact_run_id: ${{ needs.build-production-artifact.outputs.producer_run_id }}
-      artifact_run_attempt: ${{ needs.build-production-artifact.outputs.producer_run_attempt }}
-      artifact_id: ${{ needs.build-production-artifact.outputs.artifact_id }}
-      artifact_digest: ${{ needs.build-production-artifact.outputs.artifact_digest }}
-      artifact_name: ${{ needs.build-production-artifact.outputs.artifact_name }}
-      artifact_workflow_sha: ${{ needs.build-production-artifact.outputs.workflow_sha }}
+      artifact_run_id: ${{ github.run_id }}
+      artifact_run_attempt: ${{ needs.resolve-production-artifact.outputs.producer_run_attempt }}
+      artifact_id: ${{ needs.resolve-production-artifact.outputs.artifact_id }}
+      artifact_digest: ${{ needs.resolve-production-artifact.outputs.artifact_digest }}
+      artifact_name: production-frontend-${{ github.sha }}-${{ github.run_id }}
+      artifact_workflow_sha: ${{ github.sha }}
 
   build-upload-deploy:
     name: Deploy verified production artifact
-    needs: [build-production-artifact, verify-production-artifact]
+    needs:
+      [
+        build-production-artifact,
+        resolve-production-artifact,
+        verify-production-artifact,
+      ]
     runs-on: ubuntu-latest
     timeout-minutes: 75
     permissions:
@@ -90,17 +100,16 @@ jobs:
       - name: Download exact production artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: ${{ needs.build-production-artifact.outputs.artifact_name }}
+          name: production-frontend-${{ github.sha }}-${{ github.run_id }}
           path: production-artifact
 
       - name: Independently verify selected production bytes
         env:
-          ARTIFACT_NAME: ${{ needs.build-production-artifact.outputs.artifact_name }}
-          BUILDER_PACKAGE_SHA256: ${{ needs.build-production-artifact.outputs.package_sha256 }}
-          PRODUCER_RUN_ATTEMPT: ${{ needs.build-production-artifact.outputs.producer_run_attempt }}
-          PRODUCER_RUN_ID: ${{ needs.build-production-artifact.outputs.producer_run_id }}
+          ARTIFACT_NAME: production-frontend-${{ github.sha }}-${{ github.run_id }}
+          PRODUCER_RUN_ATTEMPT: ${{ needs.resolve-production-artifact.outputs.producer_run_attempt }}
+          PRODUCER_RUN_ID: ${{ github.run_id }}
           VERIFIER_PACKAGE_SHA256: ${{ needs.verify-production-artifact.outputs.package_sha256 }}
-          WORKFLOW_SHA: ${{ needs.build-production-artifact.outputs.workflow_sha }}
+          WORKFLOW_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           (cd production-artifact && sha256sum -c SHA256SUMS)
@@ -125,7 +134,6 @@ jobs:
               (.package_sha256 | test("^[a-f0-9]{64}$"))
             ' production-artifact/manifest.json >/dev/null
           package_digest="$(sha256sum production-artifact/target/package.zip | cut -d' ' -f1)"
-          test "$package_digest" = "$BUILDER_PACKAGE_SHA256"
           test "$package_digest" = "$VERIFIER_PACKAGE_SHA256"
           test "$package_digest" = "$(jq -r .package_sha256 production-artifact/manifest.json)"
           jq -e \
@@ -342,6 +350,7 @@ jobs:
     if: always()
     needs:
       - build-production-artifact
+      - resolve-production-artifact
       - verify-production-artifact
       - build-upload-deploy
     runs-on: ubuntu-latest
@@ -361,6 +370,7 @@ jobs:
       - name: Notify CI wave about failure
         if: >-
           (needs.build-production-artifact.result != 'success' ||
+          needs.resolve-production-artifact.result != 'success' ||
           needs.verify-production-artifact.result != 'success' ||
           needs.build-upload-deploy.result != 'success') &&
           hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''
@@ -381,6 +391,7 @@ jobs:
       - name: Notify CI wave about success
         if: >-
           needs.build-production-artifact.result == 'success' &&
+          needs.resolve-production-artifact.result == 'success' &&
           needs.verify-production-artifact.result == 'success' &&
           needs.build-upload-deploy.result == 'success' &&
           hashFiles('.ci-wave-notifier/scripts/notify-ci-wave.mjs') != ''

--- a/.github/workflows/production-artifact-metadata.yml
+++ b/.github/workflows/production-artifact-metadata.yml
@@ -1,0 +1,90 @@
+name: Resolve Production Artifact Metadata
+
+on:
+  workflow_call:
+    outputs:
+      artifact_id:
+        description: Exact artifact uploaded by this run's successful builder.
+        value: ${{ jobs.resolve.outputs.artifact_id }}
+      artifact_digest:
+        description: GitHub's digest of the uploaded artifact archive.
+        value: ${{ jobs.resolve.outputs.artifact_digest }}
+      producer_run_attempt:
+        description: Successful builder attempt that uploaded this artifact.
+        value: ${{ jobs.resolve.outputs.producer_run_attempt }}
+
+permissions:
+  actions: read
+
+jobs:
+  resolve:
+    name: Resolve uploaded production artifact
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      artifact_id: ${{ steps.resolve.outputs.artifact_id }}
+      artifact_digest: ${{ steps.resolve.outputs.artifact_digest }}
+      producer_run_attempt: ${{ steps.resolve.outputs.producer_run_attempt }}
+    steps:
+      # No build secrets enter this reusable workflow. Short secret values can
+      # otherwise cause GitHub to redact ordinary SHA, digest, and ID outputs.
+      - name: Resolve artifact from the successful builder
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = refs/heads/main
+          [[ "$GITHUB_SHA" =~ ^[a-f0-9]{40}$ ]]
+          [[ "$GITHUB_RUN_ID" =~ ^[1-9][0-9]{0,19}$ ]]
+          [[ "$GITHUB_RUN_ATTEMPT" =~ ^[1-9][0-9]{0,8}$ ]]
+          metadata_root="$RUNNER_TEMP/production-artifact-metadata"
+          mkdir -p "$metadata_root"
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts?per_page=100" \
+            --jq '.artifacts' | jq -s 'add' > "$metadata_root/artifacts.json"
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?filter=all&per_page=100" \
+            --jq '.jobs' | jq -s 'add' > "$metadata_root/jobs.json"
+          jq -e \
+            --arg name "production-frontend-${GITHUB_SHA}-${GITHUB_RUN_ID}" \
+            --arg sha "$GITHUB_SHA" \
+            --arg run_id "$GITHUB_RUN_ID" '
+              [.[] | select(.name == $name)] |
+              if length != 1 then error("Expected one exact production artifact") else .[0] end |
+              select(
+                .expired == false and
+                (.id | tostring | test("^[1-9][0-9]{0,19}$")) and
+                (.digest | test("^sha256:[a-f0-9]{64}$")) and
+                (.created_at | type) == "string" and
+                (.workflow_run.id | tostring) == $run_id and
+                .workflow_run.head_branch == "main" and
+                .workflow_run.head_sha == $sha
+              )
+            ' "$metadata_root/artifacts.json" > "$metadata_root/artifact.json"
+          # Failed-job reruns retain the earlier successful builder and its
+          # artifact. Bind the artifact to that attempt, not the current one.
+          producer_attempt="$(jq -er \
+            --slurpfile artifact "$metadata_root/artifact.json" \
+            --arg sha "$GITHUB_SHA" \
+            --arg run_id "$GITHUB_RUN_ID" \
+            --argjson current_attempt "$GITHUB_RUN_ATTEMPT" '
+              [.[] | select(
+                .name == "Build exact production artifact / Build exact production artifact" and
+                (.run_id | tostring) == $run_id and .head_sha == $sha and
+                .status == "completed" and .conclusion == "success" and
+                (.run_attempt | type) == "number" and
+                .run_attempt >= 1 and .run_attempt <= $current_attempt and
+                (.started_at | type) == "string" and
+                (.completed_at | type) == "string" and
+                .started_at <= $artifact[0].created_at and
+                .completed_at >= $artifact[0].created_at
+              )] |
+              if length != 1 then error("Expected one successful artifact producer") else .[0].run_attempt end
+            ' "$metadata_root/jobs.json")"
+          [[ "$producer_attempt" =~ ^[1-9][0-9]{0,8}$ ]]
+          {
+            echo "artifact_id=$(jq -r .id "$metadata_root/artifact.json")"
+            echo "artifact_digest=$(jq -r .digest "$metadata_root/artifact.json")"
+            echo "producer_run_attempt=$producer_attempt"
+          } >> "$GITHUB_OUTPUT"

--- a/__tests__/scripts/ci-wave-web-validation.test.ts
+++ b/__tests__/scripts/ci-wave-web-validation.test.ts
@@ -78,6 +78,7 @@ describe("frontend CI wave WEB E2E lifecycle", () => {
 
     expect(deployment.needs).toEqual([
       "build-production-artifact",
+      "resolve-production-artifact",
       "verify-production-artifact",
       "build-upload-deploy",
     ]);

--- a/__tests__/scripts/frontend-deployment-workflows.test.ts
+++ b/__tests__/scripts/frontend-deployment-workflows.test.ts
@@ -37,6 +37,7 @@ describe("frontend deployment workflow contract", () => {
       "build-upload-deploy-prod.yml",
       "deploy-staging.yml",
       "production-artifact-verifier.yml",
+      "production-artifact-metadata.yml",
       "production-build-artifact.yml",
       "production-e2e.yml",
       "staging-e2e.yml",
@@ -153,6 +154,7 @@ describe("frontend deployment workflow contract", () => {
 
     expect(deployment.needs).toEqual([
       "build-production-artifact",
+      "resolve-production-artifact",
       "verify-production-artifact",
       "build-upload-deploy",
     ]);

--- a/__tests__/scripts/production-artifact-metadata.test.ts
+++ b/__tests__/scripts/production-artifact-metadata.test.ts
@@ -1,0 +1,179 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import YAML from "yaml";
+
+const readWorkflow = (name: string) =>
+  YAML.parse(
+    fs.readFileSync(path.join(process.cwd(), ".github/workflows", name), "utf8")
+  );
+const metadata = readWorkflow("production-artifact-metadata.yml");
+const deployment = readWorkflow("build-upload-deploy-prod.yml");
+const sha = "a1".repeat(20);
+const digest = `sha256:${"b1".repeat(32)}`;
+const artifact = () => ({
+  id: 123,
+  name: `production-frontend-${sha}-456`,
+  digest,
+  expired: false,
+  created_at: "2026-09-03T12:05:00Z",
+  workflow_run: { id: 456, head_branch: "main", head_sha: sha },
+});
+const builder = () => ({
+  name: "Build exact production artifact / Build exact production artifact",
+  run_id: 456,
+  run_attempt: 1,
+  head_sha: sha,
+  status: "completed",
+  conclusion: "success",
+  started_at: "2026-09-03T12:00:00Z",
+  completed_at: "2026-09-03T12:06:00Z",
+});
+
+function resolve({
+  artifacts = [artifact()],
+  jobs = [builder()],
+  attempt = "1",
+  ref = "refs/heads/main",
+}: {
+  artifacts?: ReturnType<typeof artifact>[];
+  jobs?: ReturnType<typeof builder>[];
+  attempt?: string;
+  ref?: string;
+} = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "production-metadata-"));
+  try {
+    fs.writeFileSync(
+      path.join(root, "artifacts.json"),
+      JSON.stringify(artifacts)
+    );
+    fs.writeFileSync(path.join(root, "jobs.json"), JSON.stringify(jobs));
+    fs.writeFileSync(
+      path.join(root, "gh"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  *"/456/artifacts?per_page=100"*) cat "$RUNNER_TEMP/artifacts.json" ;;
+  *"/456/jobs?filter=all&per_page=100"*) cat "$RUNNER_TEMP/jobs.json" ;;
+  *) exit 2 ;;
+esac
+`,
+      { mode: 0o755 }
+    );
+    const output = path.join(root, "output");
+    const result = spawnSync(
+      "bash",
+      ["-c", metadata.jobs.resolve.steps[0].run],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${root}:${process.env["PATH"]}`,
+          RUNNER_TEMP: root,
+          GITHUB_OUTPUT: output,
+          GITHUB_REF: ref,
+          GITHUB_SHA: sha,
+          GITHUB_RUN_ID: "456",
+          GITHUB_RUN_ATTEMPT: attempt,
+          GITHUB_REPOSITORY: "6529-Collections/6529seize-frontend",
+        },
+      }
+    );
+    return {
+      status: result.status,
+      stderr: result.stderr,
+      output: fs.existsSync(output) ? fs.readFileSync(output, "utf8") : "",
+    };
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe("production artifact metadata without build secrets", () => {
+  it("does not depend on outputs redacted by the secret-bearing builder", () => {
+    expect(metadata.on.workflow_call.secrets).toBeUndefined();
+    expect(metadata.permissions).toEqual({ actions: "read" });
+    expect(JSON.stringify(metadata.jobs)).not.toContain("${{ secrets.");
+    expect(
+      deployment.jobs["resolve-production-artifact"].secrets
+    ).toBeUndefined();
+    expect(JSON.stringify(deployment.jobs)).not.toContain(
+      "needs.build-production-artifact.outputs."
+    );
+    expect(deployment.jobs["verify-production-artifact"].needs).toBe(
+      "resolve-production-artifact"
+    );
+    const result = resolve();
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+    expect(result.output).toBe(
+      `artifact_id=123\nartifact_digest=${digest}\nproducer_run_attempt=1\n`
+    );
+  });
+
+  it("retains the successful producer attempt when only failed jobs rerun", () => {
+    const result = resolve({ attempt: "2" });
+    expect(result.status).toBe(0);
+    expect(result.output).toContain("producer_run_attempt=1\n");
+  });
+
+  it("uses the builder that uploaded the selected artifact across attempts", () => {
+    const earlier = {
+      ...builder(),
+      started_at: "2026-09-03T11:00:00Z",
+      completed_at: "2026-09-03T11:06:00Z",
+    };
+    const result = resolve({
+      attempt: "2",
+      jobs: [earlier, { ...builder(), run_attempt: 2 }],
+    });
+    expect(result.status).toBe(0);
+    expect(result.output).toContain("producer_run_attempt=2\n");
+  });
+
+  it.each([
+    ["missing artifact", { artifacts: [] }],
+    ["duplicate artifact", { artifacts: [artifact(), artifact()] }],
+    ["expired artifact", { artifacts: [{ ...artifact(), expired: true }] }],
+    ["invalid digest", { artifacts: [{ ...artifact(), digest: "invalid" }] }],
+    [
+      "wrong source",
+      {
+        artifacts: [
+          {
+            ...artifact(),
+            workflow_run: {
+              ...artifact().workflow_run,
+              head_sha: "c".repeat(40),
+            },
+          },
+        ],
+      },
+    ],
+    [
+      "wrong run",
+      {
+        artifacts: [
+          {
+            ...artifact(),
+            workflow_run: { ...artifact().workflow_run, id: 789 },
+          },
+        ],
+      },
+    ],
+    ["missing builder", { jobs: [] }],
+    ["failed builder", { jobs: [{ ...builder(), conclusion: "failure" }] }],
+    ["duplicate builder", { jobs: [builder(), builder()] }],
+    ["future builder attempt", { jobs: [{ ...builder(), run_attempt: 2 }] }],
+    [
+      "artifact outside builder lifetime",
+      { jobs: [{ ...builder(), completed_at: "2026-09-03T12:04:00Z" }] },
+    ],
+    ["non-main caller", { ref: "refs/heads/feature" }],
+  ])("rejects %s before publishing metadata", (_name, options) => {
+    const result = resolve(options);
+    expect(result.status).not.toBe(0);
+    expect(result.output).toBe("");
+  });
+});

--- a/__tests__/scripts/production-build-artifact.test.ts
+++ b/__tests__/scripts/production-build-artifact.test.ts
@@ -125,6 +125,7 @@ describe("production exact-artifact deployment contract", () => {
     );
     expect(deploy.jobs["build-upload-deploy"].needs).toEqual([
       "build-production-artifact",
+      "resolve-production-artifact",
       "verify-production-artifact",
     ]);
     expect(deploySource).toContain("sha256sum -c SHA256SUMS");

--- a/ops/docs/developer/deployment.md
+++ b/ops/docs/developer/deployment.md
@@ -48,6 +48,12 @@ Find the new run by workflow, branch, service, and commit; follow that run to
 completion. The workflows resolve and verify the source commit and artifact
 identity automatically.
 
+Frontend production resolves the uploaded artifact through a reusable workflow
+that receives no build secrets. It reads GitHub's artifact metadata and binds it
+to the successful builder attempt, including when only failed jobs are rerun.
+This avoids secret masking of ordinary build outputs while preserving the
+independent archive, manifest, package digest, and deployed-version checks.
+
 Backend production also carries release-note inputs:
 
 - `release_pull_request`: merged PR represented by the deployment;


### PR DESCRIPTION
## Issue

Production deployment run [33758324174](https://github.com/6529-Collections/6529seize-frontend/actions/runs/33758324174) built and uploaded its artifact, but GitHub redacted ordinary builder job outputs as possible secrets. Artifact verification therefore stopped before deployment.

## Fix

Resolve artifact metadata through a reusable workflow that receives no build secrets. Developers continue using the same production deploy action without supplying artifact identifiers.

## Changes

- Find the unique artifact for the current source and run through GitHub's API, and bind it to its successful builder attempt using upload and job timestamps.
- Preserve failed-job retries by retaining the original successful producer attempt.
- Feed the existing independent verifier with the resolved ID and digest. Deployment still compares the package digest with both the verifier result and the builder's manifest; it no longer relies on the duplicate digest output that GitHub redacted.
- Include metadata failures in existing deployment notifications and document the behavior.

## Validation

- 74 tests passed across six focused suites; the complete CI deployment-contract command then passed all 224 tests across 14 suites, including 15 resolver cases.
- Changed-file lint, formatting, and the unchanged Jest typecheck ratchet passed.
- Executed the resolver against the actual uploaded artifact and successful builder from the failed production run; its ID, digest, and attempt resolved correctly.
- Updated the existing notification-dependency assertion and added the resolver suite to the explicit CI deployment-contract gate. [GitHub CI](https://github.com/6529-Collections/6529seize-frontend/actions/runs/33760736018) and all 22 PR checks passed. The targeted Museum retry passed after an unrelated cookie-consent IP-country HTTP 400; prior successful jobs were retained. [Staging deployment and E2E](https://github.com/6529-Collections/6529seize-frontend/actions/runs/33763906855) are in progress before the production retry.

## Risk

- Medium: production deployment metadata plumbing changes; application code and backend services are unchanged.
- All existing independent provenance, archive, manifest, digest, ancestry, live-version, and E2E checks remain.
- A failed resolver stops before deployment. Reverting restores the prior workflow, including its output-masking failure.

## Review Notes

Follow-up to #3881. Focus on secret isolation, ambiguous artifact rejection, and successful producer selection during failed-job reruns. The verifier computes its own package SHA-256 from the archive bytes and checks the builder manifest, so the removed duplicate builder job output adds no independent witness. The security review confirmed this. Optional naming deduplication and per-call timeout suggestions are nonblocking; the existing five-minute job timeout and fail-closed identity checks remain. Production authorization and bypassing reviews were explicitly approved by the owner; required CI and runtime validation remain in place.
