### PR TITLE
Finish Release Bus retirement and restore separate automatic E2E

### DIFF
--- a/.github/workflows/build-upload-deploy-prod.yml
+++ b/.github/workflows/build-upload-deploy-prod.yml
@@ -331,20 +331,6 @@ jobs:
           if-no-files-found: ignore
           retention-days: 90
 
-  automatic-production-e2e:
-    name: Automatic production E2E
-    needs:
-      - build-upload-deploy
-      - notify-production-deployment
-    uses: ./.github/workflows/production-e2e.yml
-    with:
-      trusted_deployed_sha: ${{ github.sha }}
-      canonical_deploy_call: true
-      parent_deploy_run_id: ${{ github.run_id }}
-    secrets:
-      CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
-      CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
-
   notify-production-deployment:
     name: Notify production deployment outcome
     if: always()

--- a/.github/workflows/build-upload-deploy-prod.yml
+++ b/.github/workflows/build-upload-deploy-prod.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       release_note_opt_out:
-        description: Skip autonomous release notes for an internal operation
+        description: Suppress autonomous release notes only when explicitly requested by the user
         type: boolean
         required: false
         default: false

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -577,23 +577,6 @@ jobs:
           if-no-files-found: ignore
           retention-days: 30
 
-  automatic-staging-e2e:
-    name: Automatic staging E2E
-    needs:
-      - deploy-staging
-      - notify-staging-outcome
-    uses: ./.github/workflows/staging-e2e.yml
-    with:
-      trusted_deployed_sha: ${{ github.sha }}
-      canonical_deploy_call: true
-      parent_deploy_run_id: ${{ github.run_id }}
-      pack: all
-    secrets:
-      CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
-      CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
-      STAGING_AUTH: ${{ secrets.STAGING_AUTH }}
-      PLAYWRIGHT_STAGING_ACCESS_CODE: ${{ secrets.PLAYWRIGHT_STAGING_ACCESS_CODE }}
-
   notify-staging-outcome:
     name: Notify staging deployment outcome
     if: always()

--- a/.github/workflows/production-e2e-dispatch.yml
+++ b/.github/workflows/production-e2e-dispatch.yml
@@ -1,0 +1,121 @@
+name: Production E2E Dispatch
+
+on:
+  workflow_run:
+    workflows: ["Web Deploy - PROD"]
+    types: [completed]
+    branches: [main]
+
+permissions: {}
+
+run-name: Production E2E dispatch [${{ github.event.workflow_run.id }}]
+
+concurrency:
+  group: production-e2e-dispatch-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+# The wrapper is deliberately tiny: it dispatches only a successful,
+# same-repository main deployment. production-e2e.yml independently reads
+# the run back through GitHub and binds testing to its exact deployed SHA.
+jobs:
+  dispatch-successful-deploy:
+    name: Dispatch successful production deployment
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch exact successful deploy to production E2E
+        id: e2e
+        env:
+          DEPLOY_REF: main
+          DEPLOY_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          DEPLOY_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          DEPLOY_HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
+          DEPLOY_CREATED_AT: ${{ github.event.workflow_run.created_at }}
+          DEPLOY_WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [[ "$DEPLOY_WORKFLOW_RUN_ID" =~ ^[1-9][0-9]{0,19}$ ]]
+          test "$DEPLOY_REF" = main
+          test "$DEPLOY_CONCLUSION" = success
+          test "$DEPLOY_HEAD_BRANCH" = main
+          test "$DEPLOY_HEAD_REPOSITORY" = "$GITHUB_REPOSITORY"
+          [[ "$DEPLOY_CREATED_AT" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$ ]]
+
+          runs_file="$(mktemp)"
+          trap 'rm -f "$runs_file"' EXIT
+          list_exact_runs() {
+            gh api --method GET \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/production-e2e.yml/runs" \
+              -f branch=main \
+              -f event=workflow_dispatch \
+              -f created=">=${DEPLOY_CREATED_AT}" \
+              -f per_page=100 > "$runs_file"
+            test "$(stat -c %s "$runs_file")" -le 1048576
+            jq -e '.total_count <= 100 and (.workflow_runs | type == "array")' \
+              "$runs_file" >/dev/null
+            jq -c \
+              --arg repository "$GITHUB_REPOSITORY" \
+              --arg title "Production E2E automatic ${DEPLOY_WORKFLOW_RUN_ID}" '
+                [.workflow_runs[] |
+                  select(
+                    .name == $title and
+                    .path == ".github/workflows/production-e2e.yml" and
+                    .display_title == $title and
+                    .event == "workflow_dispatch" and
+                    .head_branch == "main" and
+                    .repository.full_name == $repository and
+                    .head_repository.full_name == $repository and
+                    .actor.login == "github-actions[bot]"
+                  ) |
+                  .id] |
+                unique | sort
+              ' "$runs_file"
+          }
+
+          existing="$(list_exact_runs)"
+          existing_count="$(jq -er 'length' <<<"$existing")"
+          if [ "$existing_count" -gt 1 ]; then
+            echo "::error::Multiple automatic Production E2E runs already exist for deploy ${DEPLOY_WORKFLOW_RUN_ID}."
+            exit 1
+          fi
+          if [ "$existing_count" = 1 ]; then
+            e2e_run_id="$(jq -er '.[0]' <<<"$existing")"
+            echo "Reusing automatic Production E2E run ${e2e_run_id}."
+            echo "run_id=$e2e_run_id" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          dispatch_payload="$(jq -cn \
+            --arg ref "$DEPLOY_REF" \
+            --arg deploy_run_id "$DEPLOY_WORKFLOW_RUN_ID" \
+            '{ref:$ref,inputs:{automatic_deploy_run_id:$deploy_run_id}}')"
+          dispatch_status=0
+          gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/production-e2e.yml/dispatches" \
+            --input - <<<"$dispatch_payload" || dispatch_status=$?
+
+          for _ in $(seq 1 20); do
+            observed="$(list_exact_runs)"
+            observed_count="$(jq -er 'length' <<<"$observed")"
+            if [ "$observed_count" -gt 1 ]; then
+              echo "::error::Automatic Production E2E dispatch became ambiguous for deploy ${DEPLOY_WORKFLOW_RUN_ID}."
+              exit 1
+            fi
+            if [ "$observed_count" = 1 ]; then
+              e2e_run_id="$(jq -er '.[0]' <<<"$observed")"
+              echo "Observed exact automatic Production E2E run ${e2e_run_id} after dispatch."
+              echo "run_id=$e2e_run_id" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "::error::No exact automatic Production E2E run became visible after dispatch (gh status ${dispatch_status})."
+          exit 1

--- a/.github/workflows/production-e2e-dispatch.yml
+++ b/.github/workflows/production-e2e-dispatch.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Dispatch exact successful deploy to production E2E
         id: e2e
         env:
+          # Run the verifier from main, then check out the exact deployed source for testing.
           DEPLOY_REF: main
           DEPLOY_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           DEPLOY_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
@@ -46,7 +47,7 @@ jobs:
           test "$DEPLOY_CONCLUSION" = success
           test "$DEPLOY_HEAD_BRANCH" = main
           test "$DEPLOY_HEAD_REPOSITORY" = "$GITHUB_REPOSITORY"
-          [[ "$DEPLOY_CREATED_AT" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$ ]]
+          [[ "$DEPLOY_CREATED_AT" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}([.][0-9]+)?Z$ ]]
 
           runs_file="$(mktemp)"
           trap 'rm -f "$runs_file"' EXIT
@@ -102,7 +103,11 @@ jobs:
             "repos/${GITHUB_REPOSITORY}/actions/workflows/production-e2e.yml/dispatches" \
             --input - <<<"$dispatch_payload" || dispatch_status=$?
 
-          for _ in $(seq 1 20); do
+          if [ "$dispatch_status" -ne 0 ]; then
+            echo "::warning::Dispatch request returned gh status ${dispatch_status}; checking whether GitHub accepted it before any retry."
+          fi
+
+          for _ in $(seq 1 60); do
             observed="$(list_exact_runs)"
             observed_count="$(jq -er 'length' <<<"$observed")"
             if [ "$observed_count" -gt 1 ]; then

--- a/.github/workflows/production-e2e.yml
+++ b/.github/workflows/production-e2e.yml
@@ -1,25 +1,6 @@
 name: Production E2E
 
 on:
-  workflow_call:
-    inputs:
-      trusted_deployed_sha:
-        description: Exact SHA deployed by the calling canonical production workflow
-        type: string
-        required: true
-      canonical_deploy_call:
-        description: Confirms invocation by the canonical production deploy workflow
-        type: boolean
-        required: true
-      parent_deploy_run_id:
-        description: Canonical production deployment run ID used for CI-wave reply correlation
-        type: string
-        required: true
-    secrets:
-      CI_PIPELINES_ALERT_API_AUTH:
-        required: false
-      CI_PIPELINES_ALERT_SECRET:
-        required: true
   workflow_dispatch:
     inputs:
       automatic_deploy_run_id:
@@ -32,13 +13,10 @@ permissions:
   contents: read
   packages: read
 
-run-name: Production E2E
+run-name: Production E2E ${{ inputs.automatic_deploy_run_id && format('automatic {0}', inputs.automatic_deploy_run_id) || 'manual' }}
 
 concurrency:
-  # Automatic E2E runs while the caller owns web-deploy-prod. Manual recovery
-  # runs acquire web-deploy-prod themselves so deployment cannot change the
-  # environment while it is being validated.
-  group: ${{ inputs.trusted_deployed_sha != '' && 'production-e2e' || 'web-deploy-prod' }}
+  group: production-e2e
   cancel-in-progress: false
 
 jobs:
@@ -58,52 +36,40 @@ jobs:
         id: source
         env:
           AUTOMATIC_DEPLOY_RUN_ID: ${{ inputs.automatic_deploy_run_id }}
-          CALLER_WORKFLOW_REF: ${{ github.workflow_ref }}
-          CANONICAL_DEPLOY_CALL: ${{ inputs.canonical_deploy_call && 'true' || 'false' }}
           GH_TOKEN: ${{ github.token }}
-          TRUSTED_DEPLOYED_SHA: ${{ inputs.trusted_deployed_sha }}
         run: |
           set -euo pipefail
-          if [ -n "$TRUSTED_DEPLOYED_SHA" ]; then
-            [[ "$TRUSTED_DEPLOYED_SHA" =~ ^[a-f0-9]{40}$ ]]
-            test -z "$AUTOMATIC_DEPLOY_RUN_ID"
-              test "$CANONICAL_DEPLOY_CALL" = true
-              test "$CALLER_WORKFLOW_REF" = \
-                "$GITHUB_REPOSITORY/.github/workflows/build-upload-deploy-prod.yml@refs/heads/main"
-            deployed_sha="$TRUSTED_DEPLOYED_SHA"
-          else
-            test "$GITHUB_REF" = refs/heads/main
-            [[ "$AUTOMATIC_DEPLOY_RUN_ID" =~ ^[1-9][0-9]{0,19}$ ]]
-            gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${AUTOMATIC_DEPLOY_RUN_ID}" > "$RUNNER_TEMP/deploy-run.json"
-            deployed_sha="$(jq -er \
-              --arg repository "$GITHUB_REPOSITORY" '
-                select(
-                  .path == ".github/workflows/build-upload-deploy-prod.yml" and
-                  .event == "workflow_dispatch" and
-                  .head_branch == "main" and
-                  .status == "completed" and
-                  .repository.full_name == $repository and
-                  .head_repository.full_name == $repository and
-                  (.run_attempt | type == "number" and . >= 1 and . <= 1000000) and
-                  (.head_sha | test("^[a-f0-9]{40}$"))
-                ) | .head_sha
-              ' "$RUNNER_TEMP/deploy-run.json")"
-            deploy_run_attempt="$(jq -er '.run_attempt' "$RUNNER_TEMP/deploy-run.json")"
-            gh api \
-              "repos/${GITHUB_REPOSITORY}/actions/runs/${AUTOMATIC_DEPLOY_RUN_ID}/attempts/${deploy_run_attempt}/jobs?per_page=100" \
-              > "$RUNNER_TEMP/deploy-jobs.json"
-            jq -e '
-              [.jobs[] | select(
-                .name == "Deploy verified production artifact" and
+          test "$GITHUB_REF" = refs/heads/main
+          [[ "$AUTOMATIC_DEPLOY_RUN_ID" =~ ^[1-9][0-9]{0,19}$ ]]
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${AUTOMATIC_DEPLOY_RUN_ID}" > "$RUNNER_TEMP/deploy-run.json"
+          deployed_sha="$(jq -er \
+            --arg repository "$GITHUB_REPOSITORY" '
+              select(
+                .path == ".github/workflows/build-upload-deploy-prod.yml" and
+                .event == "workflow_dispatch" and
+                .head_branch == "main" and
                 .status == "completed" and
-                .conclusion == "success"
-              )] | length == 1
-            ' "$RUNNER_TEMP/deploy-jobs.json" >/dev/null
-          fi
+                .conclusion == "success" and
+                .repository.full_name == $repository and
+                .head_repository.full_name == $repository and
+                (.run_attempt | type == "number" and . >= 1 and . <= 1000000) and
+                (.head_sha | test("^[a-f0-9]{40}$"))
+              ) | .head_sha
+            ' "$RUNNER_TEMP/deploy-run.json")"
+          deploy_run_attempt="$(jq -er '.run_attempt' "$RUNNER_TEMP/deploy-run.json")"
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${AUTOMATIC_DEPLOY_RUN_ID}/attempts/${deploy_run_attempt}/jobs?per_page=100" \
+            > "$RUNNER_TEMP/deploy-jobs.json"
+          jq -e '
+            [.jobs[] | select(
+              .name == "Deploy verified production artifact" and
+              .status == "completed" and
+              .conclusion == "success"
+            )] | length == 1
+          ' "$RUNNER_TEMP/deploy-jobs.json" >/dev/null
           echo "sha=$deployed_sha" >> "$GITHUB_OUTPUT"
 
       - name: Check out trusted version verifier
-        if: inputs.trusted_deployed_sha == ''
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
@@ -115,7 +81,6 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Require the selected production deployment to still be live
-        if: inputs.trusted_deployed_sha == ''
         env:
           EXPECTED_SHA: ${{ steps.source.outputs.sha }}
         run: |
@@ -166,7 +131,7 @@ jobs:
         id: museum-selection
         env:
           DEPLOYED_SHA: ${{ steps.source.outputs.sha }}
-          DEPLOY_RUN_ID: ${{ inputs.parent_deploy_run_id || inputs.automatic_deploy_run_id }}
+          DEPLOY_RUN_ID: ${{ inputs.automatic_deploy_run_id }}
           GH_TOKEN: ${{ github.token }}
           MUSEUM_RELEASE_TIER_MODE: ${{ vars.MUSEUM_RELEASE_TIER_MODE || 'tiered' }}
         run: |
@@ -364,6 +329,6 @@ jobs:
           CI_PIPELINES_TITLE: ${{ needs.readonly.result == 'success' && 'WEB E2E passed' || 'WEB E2E failed' }}
           CI_PIPELINES_SERVICE: web
           CI_PIPELINES_SHA: ${{ needs.readonly.outputs.expected-sha }}
-          CI_PIPELINES_PARENT_DEPLOY_RUN_ID: ${{ inputs.parent_deploy_run_id || inputs.automatic_deploy_run_id }}
+          CI_PIPELINES_PARENT_DEPLOY_RUN_ID: ${{ inputs.automatic_deploy_run_id }}
           CI_PIPELINES_VALIDATION_PACK: all
         run: node .ci-wave-notifier/scripts/notify-ci-wave.mjs

--- a/.github/workflows/production-e2e.yml
+++ b/.github/workflows/production-e2e.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       automatic_deploy_run_id:
-        description: Successful Web Deploy - PROD run ID to validate again
+        description: Successful Web Deploy - PROD run ID; supplied automatically, required for a manual rerun
         type: string
-        required: false
+        required: true
 
 permissions:
   actions: read

--- a/.github/workflows/staging-e2e-dispatch.yml
+++ b/.github/workflows/staging-e2e-dispatch.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Dispatch exact successful deploy to staging E2E
         id: e2e
         env:
+          # Run the verifier from main, then check out the exact deployed source for testing.
           DEPLOY_REF: main
           DEPLOY_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           DEPLOY_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
@@ -46,7 +47,7 @@ jobs:
           test "$DEPLOY_CONCLUSION" = success
           test "$DEPLOY_HEAD_BRANCH" = 1a-staging
           test "$DEPLOY_HEAD_REPOSITORY" = "$GITHUB_REPOSITORY"
-          [[ "$DEPLOY_CREATED_AT" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$ ]]
+          [[ "$DEPLOY_CREATED_AT" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}([.][0-9]+)?Z$ ]]
 
           runs_file="$(mktemp)"
           trap 'rm -f "$runs_file"' EXIT
@@ -102,7 +103,11 @@ jobs:
             "repos/${GITHUB_REPOSITORY}/actions/workflows/staging-e2e.yml/dispatches" \
             --input - <<<"$dispatch_payload" || dispatch_status=$?
 
-          for _ in $(seq 1 20); do
+          if [ "$dispatch_status" -ne 0 ]; then
+            echo "::warning::Dispatch request returned gh status ${dispatch_status}; checking whether GitHub accepted it before any retry."
+          fi
+
+          for _ in $(seq 1 60); do
             observed="$(list_exact_runs)"
             observed_count="$(jq -er 'length' <<<"$observed")"
             if [ "$observed_count" -gt 1 ]; then

--- a/.github/workflows/staging-e2e-dispatch.yml
+++ b/.github/workflows/staging-e2e-dispatch.yml
@@ -1,0 +1,121 @@
+name: Staging E2E Dispatch
+
+on:
+  workflow_run:
+    workflows: ["Web Deploy - STAGING"]
+    types: [completed]
+    branches: [1a-staging]
+
+permissions: {}
+
+run-name: Staging E2E dispatch [${{ github.event.workflow_run.id }}]
+
+concurrency:
+  group: staging-e2e-dispatch-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+# The wrapper is deliberately tiny: it dispatches only a successful,
+# same-repository staging deployment. staging-e2e.yml independently reads
+# the run back through GitHub and binds testing to its exact deployed SHA.
+jobs:
+  dispatch-successful-deploy:
+    name: Dispatch successful staging deployment
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.head_branch == '1a-staging'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch exact successful deploy to staging E2E
+        id: e2e
+        env:
+          DEPLOY_REF: main
+          DEPLOY_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          DEPLOY_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          DEPLOY_HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
+          DEPLOY_CREATED_AT: ${{ github.event.workflow_run.created_at }}
+          DEPLOY_WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [[ "$DEPLOY_WORKFLOW_RUN_ID" =~ ^[1-9][0-9]{0,19}$ ]]
+          test "$DEPLOY_REF" = main
+          test "$DEPLOY_CONCLUSION" = success
+          test "$DEPLOY_HEAD_BRANCH" = 1a-staging
+          test "$DEPLOY_HEAD_REPOSITORY" = "$GITHUB_REPOSITORY"
+          [[ "$DEPLOY_CREATED_AT" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$ ]]
+
+          runs_file="$(mktemp)"
+          trap 'rm -f "$runs_file"' EXIT
+          list_exact_runs() {
+            gh api --method GET \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/staging-e2e.yml/runs" \
+              -f branch=main \
+              -f event=workflow_dispatch \
+              -f created=">=${DEPLOY_CREATED_AT}" \
+              -f per_page=100 > "$runs_file"
+            test "$(stat -c %s "$runs_file")" -le 1048576
+            jq -e '.total_count <= 100 and (.workflow_runs | type == "array")' \
+              "$runs_file" >/dev/null
+            jq -c \
+              --arg repository "$GITHUB_REPOSITORY" \
+              --arg title "Staging E2E automatic ${DEPLOY_WORKFLOW_RUN_ID}" '
+                [.workflow_runs[] |
+                  select(
+                    .name == $title and
+                    .path == ".github/workflows/staging-e2e.yml" and
+                    .display_title == $title and
+                    .event == "workflow_dispatch" and
+                    .head_branch == "main" and
+                    .repository.full_name == $repository and
+                    .head_repository.full_name == $repository and
+                    .actor.login == "github-actions[bot]"
+                  ) |
+                  .id] |
+                unique | sort
+              ' "$runs_file"
+          }
+
+          existing="$(list_exact_runs)"
+          existing_count="$(jq -er 'length' <<<"$existing")"
+          if [ "$existing_count" -gt 1 ]; then
+            echo "::error::Multiple automatic Staging E2E runs already exist for deploy ${DEPLOY_WORKFLOW_RUN_ID}."
+            exit 1
+          fi
+          if [ "$existing_count" = 1 ]; then
+            e2e_run_id="$(jq -er '.[0]' <<<"$existing")"
+            echo "Reusing automatic Staging E2E run ${e2e_run_id}."
+            echo "run_id=$e2e_run_id" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          dispatch_payload="$(jq -cn \
+            --arg ref "$DEPLOY_REF" \
+            --arg deploy_run_id "$DEPLOY_WORKFLOW_RUN_ID" \
+            '{ref:$ref,inputs:{automatic_deploy_run_id:$deploy_run_id}}')"
+          dispatch_status=0
+          gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/staging-e2e.yml/dispatches" \
+            --input - <<<"$dispatch_payload" || dispatch_status=$?
+
+          for _ in $(seq 1 20); do
+            observed="$(list_exact_runs)"
+            observed_count="$(jq -er 'length' <<<"$observed")"
+            if [ "$observed_count" -gt 1 ]; then
+              echo "::error::Automatic Staging E2E dispatch became ambiguous for deploy ${DEPLOY_WORKFLOW_RUN_ID}."
+              exit 1
+            fi
+            if [ "$observed_count" = 1 ]; then
+              e2e_run_id="$(jq -er '.[0]' <<<"$observed")"
+              echo "Observed exact automatic Staging E2E run ${e2e_run_id} after dispatch."
+              echo "run_id=$e2e_run_id" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "::error::No exact automatic Staging E2E run became visible after dispatch (gh status ${dispatch_status})."
+          exit 1

--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -28,9 +28,9 @@ on:
           - museum-inside-system
           - museum-rights
       automatic_deploy_run_id:
-        description: Successful Web Deploy - STAGING run ID to validate again
+        description: Successful Web Deploy - STAGING run ID; supplied automatically, required for a manual rerun
         type: string
-        required: false
+        required: true
 
 permissions:
   actions: read

--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -1,34 +1,6 @@
 name: Staging E2E
 
 on:
-  workflow_call:
-    inputs:
-      pack:
-        description: Post-deploy pack alias; use all for the full set
-        type: string
-        required: false
-        default: all
-      trusted_deployed_sha:
-        description: Exact SHA deployed by the calling canonical staging workflow
-        type: string
-        required: true
-      canonical_deploy_call:
-        description: Confirms invocation by the canonical staging deploy workflow
-        type: boolean
-        required: true
-      parent_deploy_run_id:
-        description: Canonical staging deployment run ID used for CI-wave reply correlation
-        type: string
-        required: true
-    secrets:
-      CI_PIPELINES_ALERT_API_AUTH:
-        required: false
-      CI_PIPELINES_ALERT_SECRET:
-        required: true
-      STAGING_AUTH:
-        required: false
-      PLAYWRIGHT_STAGING_ACCESS_CODE:
-        required: true
   workflow_dispatch:
     inputs:
       pack:
@@ -65,13 +37,10 @@ permissions:
   contents: read
   packages: read
 
-run-name: Staging E2E
+run-name: Staging E2E ${{ inputs.automatic_deploy_run_id && format('automatic {0}', inputs.automatic_deploy_run_id) || 'manual' }}
 
 concurrency:
-  # Automatic E2E runs while the caller owns staging-deploy. Manual recovery
-  # runs acquire staging-deploy themselves so deployment cannot change the
-  # environment while it is being validated.
-  group: ${{ inputs.trusted_deployed_sha != '' && 'staging-e2e' || 'staging-deploy' }}
+  group: staging-e2e
   cancel-in-progress: false
 
 jobs:
@@ -93,52 +62,40 @@ jobs:
         id: source
         env:
           AUTOMATIC_DEPLOY_RUN_ID: ${{ inputs.automatic_deploy_run_id }}
-          CALLER_WORKFLOW_REF: ${{ github.workflow_ref }}
-          CANONICAL_DEPLOY_CALL: ${{ inputs.canonical_deploy_call && 'true' || 'false' }}
           GH_TOKEN: ${{ github.token }}
-          TRUSTED_DEPLOYED_SHA: ${{ inputs.trusted_deployed_sha }}
         run: |
           set -euo pipefail
-          if [ -n "$TRUSTED_DEPLOYED_SHA" ]; then
-            [[ "$TRUSTED_DEPLOYED_SHA" =~ ^[a-f0-9]{40}$ ]]
-            test -z "$AUTOMATIC_DEPLOY_RUN_ID"
-              test "$CANONICAL_DEPLOY_CALL" = true
-              test "$CALLER_WORKFLOW_REF" = \
-                "$GITHUB_REPOSITORY/.github/workflows/deploy-staging.yml@refs/heads/1a-staging"
-            deployed_sha="$TRUSTED_DEPLOYED_SHA"
-          else
-            test "$GITHUB_REF" = refs/heads/main
-            [[ "$AUTOMATIC_DEPLOY_RUN_ID" =~ ^[1-9][0-9]{0,19}$ ]]
-            gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${AUTOMATIC_DEPLOY_RUN_ID}" > "$RUNNER_TEMP/deploy-run.json"
-            deployed_sha="$(jq -er \
-              --arg repository "$GITHUB_REPOSITORY" '
-                select(
-                  .path == ".github/workflows/deploy-staging.yml" and
-                  (.event == "push" or .event == "workflow_dispatch") and
-                  .head_branch == "1a-staging" and
-                  .status == "completed" and
-                  .repository.full_name == $repository and
-                  .head_repository.full_name == $repository and
-                  (.run_attempt | type == "number" and . >= 1 and . <= 1000000) and
-                  (.head_sha | test("^[a-f0-9]{40}$"))
-                ) | .head_sha
-              ' "$RUNNER_TEMP/deploy-run.json")"
-            deploy_run_attempt="$(jq -er '.run_attempt' "$RUNNER_TEMP/deploy-run.json")"
-            gh api \
-              "repos/${GITHUB_REPOSITORY}/actions/runs/${AUTOMATIC_DEPLOY_RUN_ID}/attempts/${deploy_run_attempt}/jobs?per_page=100" \
-              > "$RUNNER_TEMP/deploy-jobs.json"
-            jq -e '
-              [.jobs[] | select(
-                .name == "Deploy exact staging artifact" and
+          test "$GITHUB_REF" = refs/heads/main
+          [[ "$AUTOMATIC_DEPLOY_RUN_ID" =~ ^[1-9][0-9]{0,19}$ ]]
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${AUTOMATIC_DEPLOY_RUN_ID}" > "$RUNNER_TEMP/deploy-run.json"
+          deployed_sha="$(jq -er \
+            --arg repository "$GITHUB_REPOSITORY" '
+              select(
+                .path == ".github/workflows/deploy-staging.yml" and
+                (.event == "push" or .event == "workflow_dispatch") and
+                .head_branch == "1a-staging" and
                 .status == "completed" and
-                .conclusion == "success"
-              )] | length == 1
-            ' "$RUNNER_TEMP/deploy-jobs.json" >/dev/null
-          fi
+                .conclusion == "success" and
+                .repository.full_name == $repository and
+                .head_repository.full_name == $repository and
+                (.run_attempt | type == "number" and . >= 1 and . <= 1000000) and
+                (.head_sha | test("^[a-f0-9]{40}$"))
+              ) | .head_sha
+            ' "$RUNNER_TEMP/deploy-run.json")"
+          deploy_run_attempt="$(jq -er '.run_attempt' "$RUNNER_TEMP/deploy-run.json")"
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${AUTOMATIC_DEPLOY_RUN_ID}/attempts/${deploy_run_attempt}/jobs?per_page=100" \
+            > "$RUNNER_TEMP/deploy-jobs.json"
+          jq -e '
+            [.jobs[] | select(
+              .name == "Deploy exact staging artifact" and
+              .status == "completed" and
+              .conclusion == "success"
+            )] | length == 1
+          ' "$RUNNER_TEMP/deploy-jobs.json" >/dev/null
           echo "sha=$deployed_sha" >> "$GITHUB_OUTPUT"
 
       - name: Check out trusted version verifier
-        if: inputs.trusted_deployed_sha == ''
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
@@ -150,7 +107,6 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Require the selected staging deployment to still be live
-        if: inputs.trusted_deployed_sha == ''
         env:
           EXPECTED_SHA: ${{ steps.source.outputs.sha }}
           STAGING_AUTH: ${{ secrets.STAGING_AUTH }}
@@ -202,7 +158,7 @@ jobs:
         id: museum-selection
         env:
           DEPLOYED_SHA: ${{ steps.source.outputs.sha }}
-          DEPLOY_RUN_ID: ${{ inputs.parent_deploy_run_id || inputs.automatic_deploy_run_id }}
+          DEPLOY_RUN_ID: ${{ inputs.automatic_deploy_run_id }}
           GH_TOKEN: ${{ github.token }}
           MUSEUM_RELEASE_TIER_MODE: ${{ vars.MUSEUM_RELEASE_TIER_MODE || 'tiered' }}
         run: |
@@ -405,6 +361,6 @@ jobs:
           CI_PIPELINES_TITLE: ${{ needs.staging-packs.result == 'success' && 'WEB E2E passed' || 'WEB E2E failed' }}
           CI_PIPELINES_SERVICE: web
           CI_PIPELINES_SHA: ${{ needs.staging-packs.outputs.expected-sha }}
-          CI_PIPELINES_PARENT_DEPLOY_RUN_ID: ${{ inputs.parent_deploy_run_id || inputs.automatic_deploy_run_id }}
+          CI_PIPELINES_PARENT_DEPLOY_RUN_ID: ${{ inputs.automatic_deploy_run_id }}
           CI_PIPELINES_VALIDATION_PACK: ${{ inputs.pack || 'all' }}
         run: node .ci-wave-notifier/scripts/notify-ci-wave.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -15,11 +15,9 @@
 /.playwright-mcp/
 /.deployment-e2e-output/
 # Keep retired local operational artifacts out of commits.
-/.release-bus-e2e-output/
 /.release-coordinator/
 /.deploy
 # Existing staging host storage, until its physical migration is complete.
-/.release-bus/
 /storageState.json
 /playwright/.auth/
 storageState.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,8 @@
   backend alone resolves the drop reply target; notification failures remain
   best effort. Keep receiver and sender contracts compatible during rollout.
 - Never author or post release notes manually. Preserve the autonomous bot's
-  PR/service grouping metadata and final publication signal; use the explicit
-  release-note opt-out for authorized internal operations.
+  PR/service grouping metadata and final publication signal; use the release-note opt-out
+  only when the user explicitly requests suppressing release notes.
 
 <!-- BEGIN:nextjs-agent-rules -->
 

--- a/__tests__/scripts/ci-wave-web-validation.test.ts
+++ b/__tests__/scripts/ci-wave-web-validation.test.ts
@@ -48,7 +48,6 @@ describe("frontend CI wave WEB E2E lifecycle", () => {
 
   it("posts the staging deploy before automatic E2E and preserves its reply identity", () => {
     const deployment = job(stagingDeploy, "notify-staging-outcome");
-    const automaticE2e = job(stagingDeploy, "automatic-staging-e2e");
     const success = step(deployment, "Notify CI wave about success");
 
     expect(deployment.needs).toEqual([
@@ -59,21 +58,10 @@ describe("frontend CI wave WEB E2E lifecycle", () => {
       CI_PIPELINES_ALERT_TYPE: "deploy",
       CI_PIPELINES_TITLE: "WEB deploy complete",
     });
-    expect(automaticE2e.needs).toEqual([
-      "deploy-staging",
-      "notify-staging-outcome",
-    ]);
-    expect(automaticE2e.with?.["parent_deploy_run_id"]).toBe(
-      "${{ github.run_id }}"
-    );
-    expect(automaticE2e.secrets).toMatchObject({
-      CI_PIPELINES_ALERT_SECRET: "${{ secrets.CI_PIPELINES_ALERT_SECRET }}",
-    });
   });
 
   it("posts the production deploy before automatic E2E and preserves its reply identity", () => {
     const deployment = job(productionDeploy, "notify-production-deployment");
-    const automaticE2e = job(productionDeploy, "automatic-production-e2e");
     const success = step(deployment, "Notify CI wave about success");
 
     expect(deployment.needs).toEqual([
@@ -85,16 +73,6 @@ describe("frontend CI wave WEB E2E lifecycle", () => {
     expect(success.env).toMatchObject({
       CI_PIPELINES_ALERT_TYPE: "deploy",
       CI_PIPELINES_TITLE: "WEB deploy complete",
-    });
-    expect(automaticE2e.needs).toEqual([
-      "build-upload-deploy",
-      "notify-production-deployment",
-    ]);
-    expect(automaticE2e.with?.["parent_deploy_run_id"]).toBe(
-      "${{ github.run_id }}"
-    );
-    expect(automaticE2e.secrets).toMatchObject({
-      CI_PIPELINES_ALERT_SECRET: "${{ secrets.CI_PIPELINES_ALERT_SECRET }}",
     });
   });
 
@@ -117,7 +95,7 @@ describe("frontend CI wave WEB E2E lifecycle", () => {
         CI_PIPELINES_VALIDATION_PACK:
           environment === "staging" ? "${{ inputs.pack || 'all' }}" : pack,
         CI_PIPELINES_PARENT_DEPLOY_RUN_ID:
-          "${{ inputs.parent_deploy_run_id || inputs.automatic_deploy_run_id }}",
+          "${{ inputs.automatic_deploy_run_id }}",
       });
       expect(post.env?.["CI_PIPELINES_TITLE"]).toContain("WEB E2E passed");
       expect(JSON.stringify(parsed)).not.toContain("release_validation");

--- a/__tests__/scripts/deploy-staging-artifact.test.ts
+++ b/__tests__/scripts/deploy-staging-artifact.test.ts
@@ -109,9 +109,8 @@ curl() { command cat "$REPO_DIR/.deploy/current/version.json"; }
   );
 }
 
-describe("staging runtime directory adoption", () => {
+describe("staging runtime directory", () => {
   let repo: string;
-  let legacyRoot: string;
   let runtimeRoot: string;
 
   beforeEach(() => {
@@ -119,7 +118,6 @@ describe("staging runtime directory adoption", () => {
       fs.mkdtempSync(path.join(os.tmpdir(), "staging-runtime-"))
     );
     fs.mkdirSync(path.join(repo, ".git"));
-    legacyRoot = path.join(repo, ".release-bus");
     runtimeRoot = path.join(repo, ".deploy");
   });
 
@@ -128,35 +126,35 @@ describe("staging runtime directory adoption", () => {
   });
 
   function createPreviousRuntime() {
-    const previousApp = createRelease(legacyRoot, previousSha, previousSha);
-    fs.symlinkSync(previousApp, path.join(legacyRoot, "current"));
-    fs.writeFileSync(path.join(legacyRoot, "deploy.lock"), "existing lock");
+    const previousApp = createRelease(runtimeRoot, previousSha, previousSha);
+    fs.symlinkSync(previousApp, path.join(runtimeRoot, "current"));
+    fs.writeFileSync(path.join(runtimeRoot, "deploy.lock"), "existing lock");
     fs.writeFileSync(
-      path.join(legacyRoot, "ecosystem.config.cjs"),
+      path.join(runtimeRoot, "ecosystem.config.cjs"),
       "// config\n"
     );
-    fs.writeFileSync(path.join(legacyRoot, "runtime-secrets.json"), "{}", {
+    fs.writeFileSync(path.join(runtimeRoot, "runtime-secrets.json"), "{}", {
       mode: 0o600,
     });
     return previousApp;
   }
 
   it.each(["current", "release"])(
-    "adopts a live previous %s path without moving files or replacing the lock",
+    "recognizes a live %s path without moving files or replacing the lock",
     (pm2Path) => {
       const previousApp = createPreviousRuntime();
-      const lockBefore = fs.statSync(path.join(legacyRoot, "deploy.lock"));
+      const lockBefore = fs.statSync(path.join(runtimeRoot, "deploy.lock"));
       const secretsBefore = fs.statSync(
-        path.join(legacyRoot, "runtime-secrets.json")
+        path.join(runtimeRoot, "runtime-secrets.json")
       );
       const result = runHostPreflight(
         repo,
-        pm2Path === "current" ? path.join(legacyRoot, "current") : previousApp
+        pm2Path === "current" ? path.join(runtimeRoot, "current") : previousApp
       );
 
       expect(result.stderr).toBe("");
       expect(result.status).toBe(0);
-      expect(fs.readlinkSync(runtimeRoot)).toBe(legacyRoot);
+      expect(fs.lstatSync(runtimeRoot).isDirectory()).toBe(true);
       expect(fs.realpathSync(path.join(runtimeRoot, "current"))).toBe(
         previousApp
       );
@@ -172,10 +170,9 @@ describe("staging runtime directory adoption", () => {
     }
   );
 
-  it("recognizes the new PM2 path and rolls back to a pre-adoption release", () => {
+  it("rolls back to the previous managed release", () => {
     const previousApp = createPreviousRuntime();
-    fs.symlinkSync(legacyRoot, runtimeRoot);
-    createRelease(legacyRoot, `${expectedSha}-${expectedDigest}`, expectedSha);
+    createRelease(runtimeRoot, `${expectedSha}-${expectedDigest}`, expectedSha);
 
     const result = runHostPreflight(
       repo,
@@ -200,19 +197,18 @@ describe("staging runtime directory adoption", () => {
     expect(result.status).toBe(0);
     expect(fs.lstatSync(runtimeRoot).isDirectory()).toBe(true);
     expect(fs.existsSync(path.join(runtimeRoot, "deploy.lock"))).toBe(true);
-    expect(fs.existsSync(legacyRoot)).toBe(false);
   });
 
-  it("keeps an already healthy exact artifact idempotent after adoption", () => {
+  it("keeps an already healthy exact artifact idempotent", () => {
     const releaseId = `${expectedSha}-${expectedDigest}`;
-    const app = createRelease(legacyRoot, releaseId, expectedSha);
-    fs.symlinkSync(app, path.join(legacyRoot, "current"));
+    const app = createRelease(runtimeRoot, releaseId, expectedSha);
+    fs.symlinkSync(app, path.join(runtimeRoot, "current"));
     fs.writeFileSync(
-      path.join(legacyRoot, "releases", releaseId, "artifact.env"),
+      path.join(runtimeRoot, "releases", releaseId, "artifact.env"),
       `source_sha=${expectedSha}\npackage_sha256=${expectedDigest}\n`
     );
 
-    const result = runHostPreflight(repo, path.join(legacyRoot, "current"));
+    const result = runHostPreflight(repo, path.join(runtimeRoot, "current"));
 
     expect(result.stderr).toBe("");
     expect(result.status).toBe(0);
@@ -225,7 +221,7 @@ describe("staging runtime directory adoption", () => {
     const previousApp = createPreviousRuntime();
     const result = runHostPreflight(
       repo,
-      path.join(legacyRoot, "current"),
+      path.join(runtimeRoot, "current"),
       "",
       true
     );
@@ -234,20 +230,10 @@ describe("staging runtime directory adoption", () => {
     expect(result.stderr).toContain(
       "Another instance-local staging deployment"
     );
-    expect(fs.realpathSync(path.join(legacyRoot, "current"))).toBe(previousApp);
-    expect(fs.existsSync(runtimeRoot)).toBe(false);
+    expect(fs.realpathSync(path.join(runtimeRoot, "current"))).toBe(
+      previousApp
+    );
     expect(fs.existsSync(path.join(repo, "pm2-events"))).toBe(false);
-  });
-
-  it("rejects separate old and new roots before creating a second lock", () => {
-    createPreviousRuntime();
-    fs.mkdirSync(runtimeRoot);
-
-    const result = runHostPreflight(repo, path.join(legacyRoot, "current"));
-
-    expect(result.status).toBe(1);
-    expect(result.stderr).toContain("separate staging runtime directories");
-    expect(fs.existsSync(path.join(runtimeRoot, "deploy.lock"))).toBe(false);
   });
 
   it("rejects an unexpected runtime symlink", () => {
@@ -256,14 +242,14 @@ describe("staging runtime directory adoption", () => {
     const result = runHostPreflight(repo);
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain("unexpected staging runtime symlink");
+    expect(result.stderr).toContain("staging runtime symlink");
     expect(fs.existsSync(path.join(repo, "deploy.lock"))).toBe(false);
   });
 
-  it("rejects a current release outside the adopted cache", () => {
+  it("rejects a current release outside the managed cache", () => {
     const otherApp = createRelease(repo, previousSha, previousSha);
-    fs.mkdirSync(legacyRoot);
-    fs.symlinkSync(otherApp, path.join(legacyRoot, "current"));
+    fs.mkdirSync(runtimeRoot);
+    fs.symlinkSync(otherApp, path.join(runtimeRoot, "current"));
 
     const result = runHostPreflight(repo, otherApp);
 

--- a/__tests__/scripts/deployment-e2e-workflows.test.ts
+++ b/__tests__/scripts/deployment-e2e-workflows.test.ts
@@ -182,7 +182,7 @@ describe("separate post-deploy E2E", () => {
       expect(
         e2e.workflow.on.workflow_dispatch.inputs.automatic_deploy_run_id
           .required
-      ).toBe(false);
+      ).toBe(true);
       expect(
         e2e.workflow.on.workflow_dispatch.inputs.target_sha
       ).toBeUndefined();
@@ -192,7 +192,11 @@ describe("separate post-deploy E2E", () => {
       );
       expect(resolve.run).toContain(`.head_branch == "${branch}"`);
       expect(resolve.run).toContain(`.name == "${deployJobName}"`);
-      expect(resolve.run).toContain('.conclusion == "success"');
+      const [runSelection, jobSelection] = resolve.run.split(
+        "deploy_run_attempt="
+      );
+      expect(runSelection).toContain('.conclusion == "success"');
+      expect(jobSelection).toContain('.conclusion == "success"');
       expect(resolve.run).toContain('test "$GITHUB_REF" = refs/heads/main');
       expect(resolve.run).toContain("/attempts/\${deploy_run_attempt}/jobs");
       expect(resolve.run).not.toContain("MANUAL_TARGET_SHA");

--- a/__tests__/scripts/deployment-e2e-workflows.test.ts
+++ b/__tests__/scripts/deployment-e2e-workflows.test.ts
@@ -140,62 +140,9 @@ exec "$NODE_BINARY" "$MUSEUM_SELECTION_TOOL" "$@"
   };
 }
 
-describe("serialized post-deploy E2E", () => {
-  const stagingDeploy = parse("deploy-staging.yml");
+describe("separate post-deploy E2E", () => {
   const stagingE2e = parse("staging-e2e.yml");
-  const productionDeploy = parse("build-upload-deploy-prod.yml");
   const productionE2e = parse("production-e2e.yml");
-
-  it.each([
-    [
-      "staging",
-      stagingDeploy.workflow,
-      "automatic-staging-e2e",
-      "deploy-staging",
-      "notify-staging-outcome",
-      "./.github/workflows/staging-e2e.yml",
-    ],
-    [
-      "production",
-      productionDeploy.workflow,
-      "automatic-production-e2e",
-      "build-upload-deploy",
-      "notify-production-deployment",
-      "./.github/workflows/production-e2e.yml",
-    ],
-  ])(
-    "keeps the %s environment-owning workflow open through automatic E2E",
-    (
-      _environment,
-      deploy,
-      e2eJobName,
-      deployJobName,
-      notificationJobName,
-      workflowPath
-    ) => {
-      expect(deploy.jobs[e2eJobName]).toMatchObject({
-        needs: [deployJobName, notificationJobName],
-        uses: workflowPath,
-        with: {
-          trusted_deployed_sha: "${{ github.sha }}",
-          canonical_deploy_call: true,
-          parent_deploy_run_id: "${{ github.run_id }}",
-        },
-      });
-    }
-  );
-
-  it.each([
-    ["staging", stagingDeploy, stagingE2e],
-    ["production", productionDeploy, productionE2e],
-  ])(
-    "grants the %s reusable E2E every requested workflow permission",
-    (_environment, deploy, e2e) => {
-      expect(deploy.workflow.permissions).toEqual(
-        expect.objectContaining(e2e.workflow.permissions)
-      );
-    }
-  );
 
   it.each([
     [
@@ -204,7 +151,6 @@ describe("serialized post-deploy E2E", () => {
       "build-upload-deploy-prod.yml",
       "main",
       "Deploy verified production artifact",
-      "web-deploy-prod",
       "production-e2e",
     ],
     [
@@ -213,20 +159,11 @@ describe("serialized post-deploy E2E", () => {
       "deploy-staging.yml",
       "1a-staging",
       "Deploy exact staging artifact",
-      "staging-deploy",
       "staging-e2e",
     ],
   ])(
     "binds %s manual E2E to a successful canonical deploy job that is still live",
-    (
-      environment,
-      e2e,
-      deployPath,
-      branch,
-      deployJobName,
-      environmentGroup,
-      automaticGroup
-    ) => {
+    (environment, e2e, deployPath, branch, deployJobName, automaticGroup) => {
       const job =
         e2e.workflow.jobs.readonly ?? e2e.workflow.jobs["staging-packs"];
       const resolve = job.steps.find(
@@ -249,15 +186,7 @@ describe("serialized post-deploy E2E", () => {
       expect(
         e2e.workflow.on.workflow_dispatch.inputs.target_sha
       ).toBeUndefined();
-      expect(e2e.workflow.on.workflow_call.inputs.trusted_deployed_sha).toEqual(
-        expect.objectContaining({ required: true, type: "string" })
-      );
-      expect(
-        e2e.workflow.on.workflow_call.inputs.canonical_deploy_call
-      ).toEqual(expect.objectContaining({ required: true, type: "boolean" }));
-      expect(
-        e2e.workflow.on.workflow_dispatch.inputs.canonical_deploy_call
-      ).toBeUndefined();
+      expect(e2e.workflow.on.workflow_call).toBeUndefined();
       expect(resolve.run).toContain(
         `.path == ".github/workflows/${deployPath}"`
       );
@@ -270,8 +199,7 @@ describe("serialized post-deploy E2E", () => {
       expect(liveVersion.run).toContain(
         "ops/scripts/verify-deployment-version.cjs"
       );
-      expect(liveVersion.if).toBe("inputs.trusted_deployed_sha == ''");
-      expect(e2e.workflow.concurrency.group).toContain(environmentGroup);
+      expect(liveVersion.if).toBeUndefined();
       expect(e2e.workflow.concurrency.group).toContain(automaticGroup);
 
       expect(sourceMaterialization.with.ref).toBe(
@@ -284,32 +212,6 @@ describe("serialized post-deploy E2E", () => {
       expect(e2e.source).toContain("DEPLOYMENT_E2E_SOURCE_SHA");
       expect(e2e.source).toContain("./bin/6529 run e2e:packs");
       expect(e2e.source).not.toMatch(/operation_id|authority/i);
-    }
-  );
-
-  it.each([
-    ["staging", stagingE2e, "deploy-staging.yml", "1a-staging"],
-    ["production", productionE2e, "build-upload-deploy-prod.yml", "main"],
-  ])(
-    "authenticates the canonical %s reusable-workflow caller",
-    (_environment, e2e, deployPath, branch) => {
-      const job = Object.values(e2e.workflow.jobs)[0] as {
-        steps: Array<{
-          name?: string;
-          run?: string;
-          env?: Record<string, string>;
-        }>;
-      };
-      const resolve = job.steps.find(
-        (step: { name?: string }) => step.name === "Resolve exact deployed SHA"
-      );
-
-      expect(resolve?.env?.["CALLER_WORKFLOW_REF"]).toBe(
-        "${{ github.workflow_ref }}"
-      );
-      expect(resolve?.run).toContain(
-        `"$GITHUB_REPOSITORY/.github/workflows/${deployPath}@refs/heads/${branch}"`
-      );
     }
   );
 
@@ -347,7 +249,7 @@ describe("serialized post-deploy E2E", () => {
 
     expect(notification.env.CI_PIPELINES_ALERT_TYPE).toBe("web_e2e");
     expect(notification.env.CI_PIPELINES_PARENT_DEPLOY_RUN_ID).toBe(
-      "${{ inputs.parent_deploy_run_id || inputs.automatic_deploy_run_id }}"
+      "${{ inputs.automatic_deploy_run_id }}"
     );
     expect(notification.env.CI_PIPELINES_VALIDATION_PACK).toBe("all");
     expect(notification.env).not.toHaveProperty(
@@ -365,34 +267,6 @@ describe("serialized post-deploy E2E", () => {
     expect(runPacks.env.PLAYWRIGHT_STAGING_ACCESS_CODE).toBe(
       "${{ secrets.PLAYWRIGHT_STAGING_ACCESS_CODE }}"
     );
-  });
-
-  it("passes only the required E2E and CI-wave secrets across reusable boundaries", () => {
-    const call = stagingDeploy.workflow.jobs["automatic-staging-e2e"];
-
-    expect(call.secrets).toEqual({
-      CI_PIPELINES_ALERT_API_AUTH: "${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}",
-      CI_PIPELINES_ALERT_SECRET: "${{ secrets.CI_PIPELINES_ALERT_SECRET }}",
-      STAGING_AUTH: "${{ secrets.STAGING_AUTH }}",
-      PLAYWRIGHT_STAGING_ACCESS_CODE:
-        "${{ secrets.PLAYWRIGHT_STAGING_ACCESS_CODE }}",
-    });
-    const declaredSecrets = stagingE2e.workflow.on.workflow_call.secrets;
-    expect(declaredSecrets.STAGING_AUTH).toEqual(
-      expect.objectContaining({ required: false })
-    );
-    expect(declaredSecrets.PLAYWRIGHT_STAGING_ACCESS_CODE).toEqual(
-      expect.objectContaining({ required: true })
-    );
-    expect(declaredSecrets.CI_PIPELINES_ALERT_SECRET).toEqual(
-      expect.objectContaining({ required: true })
-    );
-    expect(
-      productionDeploy.workflow.jobs["automatic-production-e2e"].secrets
-    ).toEqual({
-      CI_PIPELINES_ALERT_API_AUTH: "${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}",
-      CI_PIPELINES_ALERT_SECRET: "${{ secrets.CI_PIPELINES_ALERT_SECRET }}",
-    });
   });
 
   it.each([

--- a/__tests__/scripts/frontend-deployment-workflows.test.ts
+++ b/__tests__/scripts/frontend-deployment-workflows.test.ts
@@ -41,6 +41,8 @@ describe("frontend deployment workflow contract", () => {
       "production-build-artifact.yml",
       "production-e2e.yml",
       "staging-e2e.yml",
+      "staging-e2e-dispatch.yml",
+      "production-e2e-dispatch.yml",
     ];
     const forbidden =
       /release[-_ ]bus|deployment[-_ ]bus|operation_id|authority\/|authority completion/i;
@@ -62,68 +64,43 @@ describe("frontend deployment workflow contract", () => {
     );
   });
 
-  it("holds each environment lock through its matching automatic E2E", () => {
-    const staging = readWorkflow("deploy-staging.yml").workflow;
-    const stagingE2e = readWorkflow("staging-e2e.yml");
-    const production = readWorkflow("build-upload-deploy-prod.yml").workflow;
-    const productionE2e = readWorkflow("production-e2e.yml");
-
-    expect(staging.jobs["automatic-staging-e2e"]).toMatchObject({
-      needs: ["deploy-staging", "notify-staging-outcome"],
-      uses: "./.github/workflows/staging-e2e.yml",
-      with: {
-        pack: "all",
-        trusted_deployed_sha: "${{ github.sha }}",
-        parent_deploy_run_id: "${{ github.run_id }}",
-      },
-    });
-    expect(production.jobs["automatic-production-e2e"]).toMatchObject({
-      needs: ["build-upload-deploy", "notify-production-deployment"],
-      uses: "./.github/workflows/production-e2e.yml",
-      with: {
-        trusted_deployed_sha: "${{ github.sha }}",
-        parent_deploy_run_id: "${{ github.run_id }}",
-      },
-    });
-
-    for (const e2e of [stagingE2e, productionE2e]) {
+  it.each([
+    ["staging", "deploy-staging.yml", "Web Deploy - STAGING", "1a-staging"],
+    ["production", "build-upload-deploy-prod.yml", "Web Deploy - PROD", "main"],
+  ])(
+    "finishes the %s deployment before starting separate automatic E2E",
+    (environment, file, name, branch) => {
+      const deploy = readWorkflow(file).workflow;
+      const e2e = readWorkflow(`${environment}-e2e.yml`).workflow;
+      const dispatcher = readWorkflow(
+        `${environment}-e2e-dispatch.yml`
+      ).workflow;
+      expect(deploy.jobs[`automatic-${environment}-e2e`]).toBeUndefined();
       expect(
-        e2e.workflow.on.workflow_call.inputs.trusted_deployed_sha.required
-      ).toBe(true);
-      expect(
-        e2e.workflow.on.workflow_dispatch.inputs.automatic_deploy_run_id
-          .required
+        Object.values(deploy.jobs).some((job) =>
+          (job as { uses?: string }).uses?.endsWith("-e2e.yml")
+        )
       ).toBe(false);
-      expect(
-        e2e.workflow.on.workflow_dispatch.inputs.target_sha
-      ).toBeUndefined();
-      expect(e2e.source).not.toContain("MANUAL_TARGET_SHA");
+      expect(e2e.on.workflow_call).toBeUndefined();
+      expect(e2e.concurrency.group).toBe(`${environment}-e2e`);
+      expect(dispatcher.on.workflow_run).toEqual({
+        workflows: [name],
+        types: ["completed"],
+        branches: [branch],
+      });
+      expect(dispatcher.jobs["dispatch-successful-deploy"].if).toContain(
+        "conclusion == 'success'"
+      );
+      expect(dispatcher.jobs["dispatch-successful-deploy"].if).toContain(
+        "head_repository.full_name == github.repository"
+      );
+      expect(e2e.on.workflow_dispatch.inputs.target_sha).toBeUndefined();
     }
-
-    expect(stagingE2e.workflow.concurrency.group).toContain("staging-e2e");
-    expect(stagingE2e.workflow.concurrency.group).toContain("staging-deploy");
-    expect(productionE2e.workflow.concurrency.group).toContain(
-      "production-e2e"
-    );
-    expect(productionE2e.workflow.concurrency.group).toContain(
-      "web-deploy-prod"
-    );
-    expect(
-      fs.existsSync(
-        path.join(ROOT, ".github", "workflows", "staging-e2e-dispatch.yml")
-      )
-    ).toBe(false);
-    expect(
-      fs.existsSync(
-        path.join(ROOT, ".github", "workflows", "production-e2e-dispatch.yml")
-      )
-    ).toBe(false);
-  });
+  );
 
   it("notifies staging deployment before automatic E2E", () => {
     const staging = readWorkflow("deploy-staging.yml").workflow;
     const finalizer = staging.jobs["notify-staging-outcome"];
-    const automaticE2e = staging.jobs["automatic-staging-e2e"];
     const requiredJobs = ["build-staging-artifact", "deploy-staging"];
     const failure = finalizer.steps.find(
       (step: { name?: string }) => step.name === "Notify CI wave about failure"
@@ -138,16 +115,11 @@ describe("frontend deployment workflow contract", () => {
       expect(failure.if).toContain(`needs.${job}.result != 'success'`);
       expect(success.if).toContain(`needs.${job}.result == 'success'`);
     }
-    expect(automaticE2e.needs).toEqual([
-      "deploy-staging",
-      "notify-staging-outcome",
-    ]);
   });
 
   it("publishes production release notes after deploy before CI-wave E2E", () => {
     const production = readWorkflow("build-upload-deploy-prod.yml").workflow;
     const deployment = production.jobs["notify-production-deployment"];
-    const automaticE2e = production.jobs["automatic-production-e2e"];
     const deploymentSuccess = deployment.steps.find(
       (step: { name?: string }) => step.name === "Notify CI wave about success"
     );
@@ -163,10 +135,6 @@ describe("frontend deployment workflow contract", () => {
       "ops/release-notes/release-notes.prompt.md"
     );
     expect(deploymentSuccess.env.CI_PIPELINES_ALERT_TYPE).toBe("deploy");
-    expect(automaticE2e.needs).toEqual([
-      "build-upload-deploy",
-      "notify-production-deployment",
-    ]);
     expect(production.jobs).not.toHaveProperty("notify-production-validation");
   });
 

--- a/ops/docs/developer/deployment.md
+++ b/ops/docs/developer/deployment.md
@@ -27,6 +27,8 @@ actual deployment.
 - Keep CI, artifact integrity, deployed-version checks, and health checks.
   Successful frontend deployments automatically trigger separate E2E workflows.
   Web Deploy finishes before E2E; follow both runs before calling the change validated.
+  Automatic dispatch supplies the deployment run ID. To rerun E2E manually, select
+  `main` and supply that successful deployment run ID; no SHA input is needed.
 - Coordinate potentially conflicting deployments through GitHub run visibility;
   existing concurrency is repository-scoped. Do not cancel another developer's
   run. Wait for that work to finish when the environment would conflict.

--- a/ops/docs/developer/deployment.md
+++ b/ops/docs/developer/deployment.md
@@ -25,8 +25,8 @@ actual deployment.
   `dbMigrationsLoop` before `api`, then dependent frontend changes; queues and
   consumers may need their own earlier steps.
 - Keep CI, artifact integrity, deployed-version checks, and health checks.
-  Frontend workflows run their E2E checks automatically as part of the same
-  deployment. Follow the complete result before calling a deployment validated.
+  Successful frontend deployments automatically trigger separate E2E workflows.
+  Web Deploy finishes before E2E; follow both runs before calling the change validated.
 - Coordinate potentially conflicting deployments through GitHub run visibility;
   existing concurrency is repository-scoped. Do not cancel another developer's
   run. Wait for that work to finish when the environment would conflict.
@@ -61,7 +61,7 @@ Backend production also carries release-note inputs:
   across that PR's sequential deployments;
 - `release_note_publish`: `false` until the final service, then `true`;
 - `release_note_groups`: per-PR groups when several PRs share the deployment;
-- `release_note_opt_out=true`: an authorized internal operation that should not
+- `release_note_opt_out=true`: only when the user explicitly requests that the deployment not
   create a release note, with PR/group metadata omitted and publish left false.
 
 The autonomous bot owns release-note writing and publication. Preserve its

--- a/ops/scripts/deploy-staging-artifact.sh
+++ b/ops/scripts/deploy-staging-artifact.sh
@@ -55,52 +55,19 @@ ssr_client_secret="$(printf '%s' "$SSR_CLIENT_SECRET_B64" | base64 -d)"
 }
 
 release_root="$REPO_DIR/.deploy"
-# Compatibility for hosts deployed before the runtime-directory rename. Keep the
-# live directory in place: PM2 and rollback releases can still hold its absolute
-# paths, and old deployment scripts must continue to open the same lock inode.
-legacy_release_root="$REPO_DIR/.release-bus"
-lock_root="$release_root"
-if [[ -e "$legacy_release_root" || -L "$legacy_release_root" ]]; then
-  [[ -d "$legacy_release_root" ]] || {
-    echo "Refusing to adopt an invalid previous staging runtime directory." >&2
-    exit 1
-  }
-  if [[ ! -e "$release_root" && ! -L "$release_root" ]]; then
-    [[ ! -L "$legacy_release_root" ]] || {
-      echo "Refusing to adopt an unexpected staging runtime symlink." >&2
-      exit 1
-    }
-    lock_root="$legacy_release_root"
-  elif [[ ! "$release_root" -ef "$legacy_release_root" ]]; then
-    echo "Refusing to deploy with separate staging runtime directories and locks." >&2
-    exit 1
-  fi
-fi
 if [[ -L "$release_root" ]]; then
-  [[ "$(readlink "$release_root")" == "$legacy_release_root" && \
-    -d "$legacy_release_root" && ! -L "$legacy_release_root" ]] || {
-    echo "Refusing to use an unexpected staging runtime symlink." >&2
-    exit 1
-  }
+  echo "Refusing to use a staging runtime symlink." >&2
+  exit 1
 elif [[ -e "$release_root" && ! -d "$release_root" ]]; then
   echo "Refusing to replace a non-directory staging runtime path." >&2
   exit 1
 fi
-install -d -o "$RUN_AS" -g "$RUN_AS" "$lock_root"
-touch "$lock_root/deploy.lock"
-chown "$RUN_AS:$RUN_AS" "$lock_root/deploy.lock"
-exec 9>"$lock_root/deploy.lock"
+install -d -o "$RUN_AS" -g "$RUN_AS" "$release_root"
+touch "$release_root/deploy.lock"
+chown "$RUN_AS:$RUN_AS" "$release_root/deploy.lock"
+exec 9>"$release_root/deploy.lock"
 flock -n 9 || {
   echo "Another instance-local staging deployment is active." >&2
-  exit 1
-}
-# Adopt only while holding the shared lock, so simultaneous new/old deployments
-# cannot create independent roots or race the compatibility symlink creation.
-if [[ ! -e "$release_root" && ! -L "$release_root" ]]; then
-  ln -s "$legacy_release_root" "$release_root"
-fi
-[[ "$release_root" -ef "$lock_root" ]] || {
-  echo "The staging runtime directory moved while acquiring its lock." >&2
   exit 1
 }
 physical_release_root="$(readlink -f "$release_root")"

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -53,14 +53,15 @@ description: Execute authorized 6529 frontend, backend, or coupled staging and p
    release to each backend production run. Set `release_note_publish=true`
    only for the final successful service. Use `release_note_groups` when the
    release contains multiple PR groups, preserving their service membership.
-   For an authorized internal operation, omit PR/group metadata, set
-   `release_note_opt_out=true`, and leave `release_note_publish=false`.
+   Keep autonomous release notes enabled, including for internal maintenance.
+   Only if the user explicitly asks to suppress notes, omit PR/group metadata,
+   set `release_note_opt_out=true`, and leave `release_note_publish=false`.
 3. After required backend dependencies are deployed, merge the frontend
    development branch into current `main` and dispatch
    `.github/workflows/build-upload-deploy-prod.yml` (`Web Deploy - PROD`) with
-   `--ref main`. The workflow builds, verifies, deploys, and runs Production
-   E2E automatically; no separate artifact selection or E2E dispatch is needed.
-4. Wait for the complete workflow result. Preserve the workflow's autonomous
+   `--ref main`. The workflow builds, verifies, and deploys. Its successful
+   completion automatically starts a separate Production E2E workflow.
+4. Follow the deployment and its corresponding E2E run to completion. Preserve the workflow's autonomous
    release-note notification; never compose or publish the note yourself.
 
 ## Failure and closeout

--- a/ops/skills/deploy-6529/agents/openai.yaml
+++ b/ops/skills/deploy-6529/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Deploy 6529"
-  short_description: "Route exact releases by effective lane state."
-  default_prompt: "Use $deploy-6529 to route, deploy, validate, and recover an exact 6529 frontend, backend, or coupled release; while a lane is ON, route every deploy through Release Bus with no self-upgrade exception, and allow manual fallback only when OFF and changeable."
+  short_description: "Deploy with Git merges and GitHub Actions."
+  default_prompt: "Use $deploy-6529 to merge, deploy, and validate the requested 6529 frontend or coupled change in the authorized environment using GitHub Actions."


### PR DESCRIPTION
## Issue

Finish retiring the old deployment runtime and skill prompts while preserving the original deployment behavior: Web Deploy finishes before automatically triggered E2E, and autonomous release notes remain enabled.

## Fix

- Restore separate staging and production E2E dispatch workflows after successful Web Deploy completion, preserving the original deploy run ID for CI-wave replies.
- Remove the staging runtime directory alias after migrating the live host to `.deploy`, preserving its lock inode, current release, rollback releases, and PM2 configuration.
- Update the deployment skill launch prompt and guidance. Suppressing release notes now requires an explicit user request; internal maintenance keeps them enabled.

## Validation

- 38 deployment, E2E, notification, and staging-runtime tests passed.
- Both dispatch scripts passed isolated execution checks for a new run, duplicate reuse, another repository, and a failed deployment.
- The live staging host is healthy on the same application version with PM2 using `.deploy` paths.
- Changed-file lint and formatting passed; Jest typecheck ratchet checked separately.

## Risk

Medium: workflow orchestration changes. Builds, artifact verification, health checks, and E2E packs remain intact. E2E reports its own result after deployment; it no longer keeps Web Deploy open. Ordinary shared-branch history is preserved.

## Review Notes

- The dispatcher deliberately runs the trusted verifier/notifier from `main`, then checks out the deployed application's exact source for E2E. This preserves the former separate-dispatch trust model for staging too.
- GitHub's actual workflow-run API returns the dynamic `run-name` in both `name` and `display_title`; the exact run-title filter is intentional. Existing runs are reused regardless of conclusion; rerunning their failed jobs preserves the deployment correlation.
- Manual E2E reruns now explicitly require the successful deployment run ID, matching the validation already enforced by the workflow. Automatic dispatch supplies it. Ordinary deployments need no commit or run-ID inputs.
- The dispatch lookup allows three minutes and distinguishes a failed POST while checking for an accepted request before any retry. The resolver tests independently check run-level and job-level success.
- The live staging host has already migrated to the physical `.deploy` directory with neutral PM2 paths. The old directory is removed, the lock inode is preserved, and health/version checks passed.
- The deployment skill already keeps release notes enabled for internal maintenance; only an explicit user request enables opt-out and omits grouping/publication metadata.
