### PR TITLE
Keep unrelated E2E and post-deploy E2E outside release gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,9 +20,12 @@
   conflicts normally, and never force-push or overwrite a moved shared ref.
   Do not cancel another developer's deployment; coordinate through GitHub run
   visibility and wait when the work would conflict.
-- Follow each deployment through its existing health and automatic E2E checks.
-  Fix failures on the development branch and repeat the authorized sequence.
-  Keep ordinary CI, artifact integrity, and runtime version checks intact.
+- Complete deployments after build, artifact integrity, runtime version, and
+  health checks pass. Automatic E2E runs separately and does not hold up a
+  merge, deployment, or promotion to the next authorized environment.
+- Unrelated PR E2E failures or pending runs do not block releases. Keep relevant
+  build, unit/contract, and security checks intact; report E2E status separately.
+  Fix known regressions attributable to the change on the development branch.
 - CI wave notifications carry deploy run IDs through E2E and reruns. The
   backend alone resolves the drop reply target; notification failures remain
   best effort. Keep receiver and sender contracts compatible during rollout.

--- a/ops/docs/developer/deployment.md
+++ b/ops/docs/developer/deployment.md
@@ -26,7 +26,11 @@ actual deployment.
   consumers may need their own earlier steps.
 - Keep CI, artifact integrity, deployed-version checks, and health checks.
   Successful frontend deployments automatically trigger separate E2E workflows.
-  Web Deploy finishes before E2E; follow both runs before calling the change validated.
+  Deployment is complete when build, artifact, live-version, and health checks
+  pass. E2E reports separately and does not gate merges, deployments, promotion,
+  or release completion. Unrelated PR E2E (for example, Museum tests for a change
+  outside Museum) must not delay a release; keep relevant CI checks and report
+  the separate E2E status accurately.
   Automatic dispatch supplies the deployment run ID. To rerun E2E manually, select
   `main` and supply that successful deployment run ID; no SHA input is needed.
 - Coordinate potentially conflicting deployments through GitHub run visibility;
@@ -75,7 +79,9 @@ run IDs to correlate E2E replies.
 Inspect the failing job and logs. Fix attributable failures on the development
 branch, merge the fix into the authorized target, and repeat only the required
 deployments. Keep dependent frontend changes waiting for successful backend
-dependencies. A passed deploy with failed E2E is deployed but unvalidated.
+dependencies. Report deployment health and E2E as separate outcomes. Investigate
+known attributable regressions, but do not wait for E2E or block releases on
+unrelated E2E failures.
 
 Use a reviewed revert or compatible known-good source through the same ordinary
 workflow for rollback; retain shared history and account for database/API

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -38,10 +38,11 @@ description: Execute authorized 6529 frontend, backend, or coupled staging and p
    and workflow changes; its existing `ops/**`-only exclusion remains. When an
    authorized ops-only change needs deployment, dispatch `deploy-staging.yml`
    on `1a-staging` explicitly.
-4. Follow the frontend deployment and its automatic Staging E2E to completion.
-   Keep the target stable while its validation runs. Fix an attributable
-   failure on the development branch, merge the fix into staging, and repeat
-   the affected deployment and validation.
+4. Wait for the frontend build, artifact verification, deployed-version check,
+   and health checks. Successful Web Deploy completion starts Staging E2E
+   separately. Do not wait for E2E before reporting deployment complete or
+   continuing to the next authorized environment; report its current status
+   separately. Fix known regressions attributable to the change.
 
 ## Production
 
@@ -61,20 +62,29 @@ description: Execute authorized 6529 frontend, backend, or coupled staging and p
    `.github/workflows/build-upload-deploy-prod.yml` (`Web Deploy - PROD`) with
    `--ref main`. The workflow builds, verifies, and deploys. Its successful
    completion automatically starts a separate Production E2E workflow.
-4. Follow the deployment and its corresponding E2E run to completion. Preserve the workflow's autonomous
-   release-note notification; never compose or publish the note yourself.
+4. Complete the deployment after its artifact, version, and health checks pass.
+   Report Production E2E separately; it does not gate release completion.
+   Preserve the workflow's autonomous release-note notification; never compose
+   or publish the note yourself.
 
 ## Failure and closeout
 
-Inspect the failed job and logs before retrying. A successful deploy job with
-failed E2E is a deployed but unvalidated change. Fix attributable failures and
-repeat the necessary authorized work; do not report success from a green build
-alone. Roll back through the ordinary deployment workflow using a reviewed
+Inspect failed jobs and logs before retrying. A failed deployment, artifact,
+version, or health check blocks deployment completion; a green build alone is
+not sufficient. Automatic E2E is asynchronous and reports its own result.
+Do not hold up releases for pending E2E or unrelated failures such as Museum
+checks on a change outside Museum. Keep relevant build, unit/contract, and
+security checks. If an aggregate PR check is blocked solely by unrelated E2E,
+record the result and use the authorized merge path without changing repository
+protections or claiming those tests passed. Fix known attributable regressions
+through the development branch and the authorized deployment sequence.
+
+Roll back through the ordinary deployment workflow using a reviewed
 revert or compatible known-good source, preserving shared branch history and
 checking database/API compatibility first.
 
-Report the PRs, deployed services and order, deployment run links, automatic
-validation results, and any remaining failure. The workflows resolve and
+Report the PRs, deployed services and order, deployment run links, available
+E2E results, and any remaining failure. The workflows resolve and
 verify commits and artifact digests automatically; developers supply ordinary
 branch/environment/service choices. Keep credentials and private data out of
 reports.

--- a/ops/skills/deploy-6529/agents/openai.yaml
+++ b/ops/skills/deploy-6529/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Deploy 6529"
   short_description: "Deploy with Git merges and GitHub Actions."
-  default_prompt: "Use $deploy-6529 to merge, deploy, and validate the requested 6529 frontend or coupled change in the authorized environment using GitHub Actions."
+  default_prompt: "Use $deploy-6529 to merge and deploy the requested 6529 frontend or coupled change in the authorized environment using GitHub Actions. Complete deployment after artifact, version, and health checks; report automatic E2E separately without waiting for it."

--- a/ops/skills/write-prs/SKILL.md
+++ b/ops/skills/write-prs/SKILL.md
@@ -11,10 +11,10 @@ description: Write, open, iterate, and prepare pull requests for merge or deploy
    - `review-ready`: create or update the PR and stop once available review bots and the agent are satisfied.
    - `merge`: do everything in `review-ready`, then hand off to `ops/skills/deploy-6529/SKILL.md` for merge execution when required checks and approvals allow it.
    - `staging`: hand off to `ops/skills/deploy-6529/SKILL.md` for merge,
-     staging deployment, and E2E or smoke validation. Never prepare, publish,
+     staging deployment, and health validation. Never prepare, publish,
      or trigger a release note for staging.
    - `prod`: hand off to `ops/skills/deploy-6529/SKILL.md` for production
-     deployment and production E2E or smoke validation. Never author or post a
+     deployment and health validation. Never author or post a
      release note; the existing autonomous bot owns production release notes.
 
    If the user did not explicitly request merge or deployment, stop at `review-ready`.
@@ -69,7 +69,7 @@ description: Write, open, iterate, and prepare pull requests for merge or deploy
    - In this repo, use signed commits: `git commit -s ...`.
    - Keep follow-up commits focused and give them clear messages describing the bot/user feedback addressed.
    - Push after each meaningful round of fixes so review bots evaluate the latest head.
-   - After the initial PR push, keep the agent/thread open until every tracked bot or status check triggered for that head commit reaches a terminal state.
+   - After the initial PR push, keep the agent/thread open until relevant tracked bots and status checks for that head are complete; unrelated E2E does not hold up release work.
 
 6. Iterate with available review bots:
    - Discover available bot feedback from PR comments, review comments, review threads, checks, or local repo tools.
@@ -85,7 +85,7 @@ description: Write, open, iterate, and prepare pull requests for merge or deploy
      - `security/snyk (6529)`
      - `SonarCloud Code Analysis`
    - For each tracked bot or status check, verify the latest pushed commit, capture the current state, and inspect any failure, skipped review, alert, or warning details before deciding readiness.
-   - After every follow-up commit, repeat the wait: keep the agent/thread open until all tracked bots and checks for the new head commit are done, including success, failure, skipped, or cancelled states.
+   - After every follow-up commit, repeat the wait: keep the agent/thread open until relevant tracked bots and checks for the new head are done, excluding unrelated E2E as described below.
    - Review every new bot comment or finding and make an explicit fix-or-defer decision. The default is to address it; defer only when the comment is wrong, inapplicable, duplicative, or lower value than the churn it would create, and document the rationale.
    - For local CodeRabbit review in this repo, use `6529 run cr` or the `quality:cr` scripts when they fit the change scope.
    - Treat bot findings as review input, not orders. Fix valid correctness, security, performance, test, docs, accessibility, and maintainability issues.
@@ -96,7 +96,11 @@ description: Write, open, iterate, and prepare pull requests for merge or deploy
 7. Decide readiness:
    - Agent-happy means the diff is scoped, reviewed, validates the requested behavior, and has no known unaddressed high-risk issues.
    - Bot-happy means every available review bot has no remaining blocking concerns on the latest pushed commit, or the agent has documented why a remaining item is safe to defer.
-   - Human approval and required CI still govern merge eligibility.
+   - Required approvals and relevant CI govern merge eligibility, subject to the
+     user's existing authorization. Pending or failed E2E unrelated to the change
+     does not block release work. Report it separately and use the authorized
+     merge path if it is the only cause of a blocked aggregate check; do not
+     change repository protections or claim the E2E passed.
 
 ## Validation
 
@@ -112,9 +116,9 @@ description: Write, open, iterate, and prepare pull requests for merge or deploy
 - Use `ops/skills/deploy-6529/SKILL.md` for actual merge execution, staging deployment, production deployment, backend deployment coordination, cross-agent coordination, and deployed-environment E2E validation.
 - Before merging, ensure the PR is agent-happy, bot-happy, required checks are passing or explained, and required approvals are present.
 - Order the final gates correctly: bring the branch up to date with `main` first, then seek the maintainer approval. The `main` ruleset requires approval of the most recent push, so a branch update resets the approval requirement to unmet and prior approvals no longer satisfy it. The approval must come from the `6529seize-maintainers` team and be submitted on behalf of that team, or the ruleset rejects it.
-- For authorized staging deployment, merge the reviewed development branch into current `1a-staging` and push, then follow the automatic frontend deployment and E2E. Complete required backend service deployments first for coupled changes.
-- Before production deployment, require successful staging validation for the same reviewed change set unless the user explicitly authorizes an override. Separate staging and main merges can produce different commit IDs; verify the reviewed changes and normal workflow/runtime results without a cross-branch baseline requirement. Merge to `main` and dispatch `Web Deploy - PROD` in `.github/workflows/build-upload-deploy-prod.yml`, which rejects non-`main` refs.
-- If deployment or E2E fails, hand off to `ops/skills/deploy-6529/SKILL.md` to diagnose, fix, redeploy, and rerun validation before proceeding.
+- For authorized staging deployment, merge the reviewed development branch into current `1a-staging` and push, then follow the automatic frontend deployment through artifact, version, and health checks; report separate automatic E2E without waiting for it. Complete required backend service deployments first for coupled changes.
+- Before production deployment, require successful staging deployment, artifact, version, and health checks for the same reviewed change set unless the user explicitly authorizes an override. Staging E2E does not gate production. Separate staging and main merges can produce different commit IDs; verify the reviewed changes and normal workflow/runtime results without a cross-branch baseline requirement. Merge to `main` and dispatch `Web Deploy - PROD` in `.github/workflows/build-upload-deploy-prod.yml`, which rejects non-`main` refs.
+- If deployment, artifact verification, version, or health checks fail, use `ops/skills/deploy-6529/SKILL.md` to diagnose, fix, redeploy, and recheck before proceeding. Automatic E2E reports independently; fix known attributable regressions without turning pending or unrelated E2E into a release gate.
 
 ## Anti-Patterns
 


### PR DESCRIPTION
## Issue

Deployment and PR skills still instructed agents to wait for automatic E2E and unrelated Museum checks, even though E2E runs independently of Web Deploy.

## Fix

Complete deployments after their build, artifact, version, and health checks. Report automatic E2E separately and do not wait for unrelated PR E2E before releasing. Keep relevant CI, known-regression handling, backend dependency order, and release-note behavior.

## Validation

Documentation and skill metadata only. Formatting and diff checks passed; deployment and PR instructions were checked for contradictory E2E waits. No application or workflow code changed.

## Risk

Low. Existing CI workflows and repository protections remain in place. An unrelated E2E result is reported accurately and handled through the authorized merge path.

## Deployment

No backend service or production application deployment is required for these instructions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated deployment guidance to define completion through build, artifact, runtime-version, and health checks.
  - Clarified that automatic end-to-end results are reported separately and do not block merges, deployments, promotions, or releases.
  - Added guidance for handling unrelated or pending end-to-end failures without delaying releases.
  - Expanded failure and rollback guidance for artifact, version, and health-check issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->