### PR TITLE
Use stored package credentials before prompting

### DIFF
--- a/.github/workflows/build-upload-deploy-prod.yml
+++ b/.github/workflows/build-upload-deploy-prod.yml
@@ -47,6 +47,8 @@ jobs:
 
   resolve-production-artifact:
     name: Resolve production artifact metadata
+    permissions:
+      actions: read
     needs: build-production-artifact
     uses: ./.github/workflows/production-artifact-metadata.yml
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,13 +51,15 @@ normal interactive install, run:
 6529 install
 ```
 
-If `NODE_AUTH_TOKEN` is not already set, the wrapper asks for it silently and
-keeps it only for that command. CI and other non-interactive shells must supply
-`NODE_AUTH_TOKEN` at runtime. Do not store it in the repository or
-package-manager configuration. See
+If `NODE_AUTH_TOKEN` is not already set, the wrapper first checks the macOS
+Keychain or Windows Credential Manager, then asks for the token with hidden
+input when no stored credential is available. A prompted token is kept only for
+that command. CI and other non-interactive shells must supply `NODE_AUTH_TOKEN`
+at runtime. Do not store it in the repository or package-manager configuration.
+See
 [pnpm and Socket Firewall](ops/docs/developer/pnpm-and-socket-firewall.md) for
-the one-time Codex Keychain setup, the exact package-routing boundary, and other
-authenticated package commands.
+the one-time credential-store setup, the exact package-routing boundary, and
+other authenticated package commands.
 
 Create a local `.env` file from [.env.sample](.env.sample), then start the app:
 

--- a/README.md
+++ b/README.md
@@ -73,14 +73,15 @@ normal interactive install, simply run:
 6529 install
 ```
 
-If `NODE_AUTH_TOKEN` is not already set, the wrapper asks for it silently and
-keeps it only for that command. CI and other non-interactive shells must supply
-`NODE_AUTH_TOKEN` at runtime. Do not store it in the repository or
-package-manager configuration. Codex worktrees have a separate one-time macOS
-Keychain setup. See
+If `NODE_AUTH_TOKEN` is not already set, the wrapper first checks the macOS
+Keychain or Windows Credential Manager, then asks for the token with hidden
+input when no stored credential is available. A prompted token is kept only for
+that command. CI and other non-interactive shells must supply `NODE_AUTH_TOKEN`
+at runtime. Do not store it in the repository or package-manager configuration.
+See
 [pnpm and Socket Firewall](ops/docs/developer/pnpm-and-socket-firewall.md) for
-that setup, the exact package-routing boundary, and other authenticated package
-commands.
+the one-time credential-store setup, the exact package-routing boundary, and
+other authenticated package commands.
 
 Create a local `.env` file from [.env.sample](.env.sample), then start the app:
 

--- a/__tests__/scripts/private-github-packages-routing.test.ts
+++ b/__tests__/scripts/private-github-packages-routing.test.ts
@@ -1593,6 +1593,12 @@ describe("documented private-package setup flows", () => {
     expect(windowsCredentialHelper).toContain("CredWriteW");
     expect(windowsCredentialHelper).toContain("Read-Host");
     expect(windowsCredentialHelper).toContain("-AsSecureString");
+    expect(windowsCredentialHelper).toContain(
+      "[string]::IsNullOrEmpty($token)"
+    );
+    expect(windowsCredentialHelper).toMatch(
+      /if \(\[string\]::IsNullOrEmpty\(\$token\)\) \{\s+exit 1\s+\}/
+    );
     expect(windowsCredentialHelper).not.toContain("Write-Output $token");
     expect(installIndex).toBeGreaterThanOrEqual(0);
     expect(authRemovalIndex).toBeGreaterThan(installIndex);

--- a/__tests__/scripts/private-github-packages-routing.test.ts
+++ b/__tests__/scripts/private-github-packages-routing.test.ts
@@ -1464,6 +1464,8 @@ describe("documented private-package setup flows", () => {
     it("fails closed when the Codex Keychain item is missing", () => {
       const result = runAuthHarness({
         statements: [
+          "private_package_auth_is_macos() { return 0; }",
+          "private_package_auth_is_windows() { return 1; }",
           "private_package_auth_keychain_is_available() { return 0; }",
           "private_package_auth_read_keychain() { return 1; }",
           "load_private_package_auth_for_codex",

--- a/__tests__/scripts/private-github-packages-routing.test.ts
+++ b/__tests__/scripts/private-github-packages-routing.test.ts
@@ -114,6 +114,11 @@ const REPOSITORY_ROOT = path.resolve(__dirname, "../..");
 const TEST_TOKEN = "read-only-test-token";
 const AUTH_HELPER_RELATIVE_PATH = "scripts/private-github-packages-auth.sh";
 const AUTH_HELPER_PATH = path.join(REPOSITORY_ROOT, AUTH_HELPER_RELATIVE_PATH);
+const WINDOWS_CREDENTIAL_HELPER_PATH = path.join(
+  REPOSITORY_ROOT,
+  "scripts",
+  "private-github-packages-credential.ps1"
+);
 
 function isolatedAuthTestEnvironment(): NodeJS.ProcessEnv {
   const environment = { ...process.env };
@@ -1311,6 +1316,7 @@ describe("documented private-package setup flows", () => {
         input: `${TEST_TOKEN}\n`,
         statements: [
           "private_package_auth_is_interactive() { return 0; }",
+          "private_package_auth_stored_credential_is_available() { return 1; }",
           "set -x",
           "ensure_private_package_auth",
           'printf "auth-present=%s\\n" "${NODE_AUTH_TOKEN:+yes}"',
@@ -1328,6 +1334,7 @@ describe("documented private-package setup flows", () => {
         input: TEST_TOKEN,
         statements: [
           "private_package_auth_is_interactive() { return 0; }",
+          "private_package_auth_stored_credential_is_available() { return 1; }",
           "ensure_private_package_auth",
           'printf "auth-present=%s\\n" "${NODE_AUTH_TOKEN:+yes}"',
         ],
@@ -1343,6 +1350,7 @@ describe("documented private-package setup flows", () => {
         input: "\n",
         statements: [
           "private_package_auth_is_interactive() { return 0; }",
+          "private_package_auth_stored_credential_is_available() { return 1; }",
           "ensure_private_package_auth",
         ],
       });
@@ -1378,6 +1386,62 @@ describe("documented private-package setup flows", () => {
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("package commands in CI");
       expect(result.stderr).not.toContain("input hidden");
+      expect(`${result.stdout}${result.stderr}`).not.toContain(TEST_TOKEN);
+    });
+
+    it("uses a stored macOS credential without prompting", () => {
+      const result = runAuthHarness({
+        statements: [
+          "private_package_auth_is_interactive() { return 0; }",
+          "private_package_auth_keychain_is_available() { return 0; }",
+          "private_package_auth_windows_credential_is_available() { return 1; }",
+          `private_package_auth_read_keychain() { printf '%s' '${TEST_TOKEN}'; }`,
+          "set -x",
+          "ensure_private_package_auth",
+          'printf "auth-present=%s\\n" "${NODE_AUTH_TOKEN:+yes}"',
+        ],
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe("auth-present=yes\n");
+      expect(result.stderr).not.toContain("input hidden");
+      expect(`${result.stdout}${result.stderr}`).not.toContain(TEST_TOKEN);
+    });
+
+    it("uses a stored Windows credential without prompting", () => {
+      const result = runAuthHarness({
+        statements: [
+          "private_package_auth_is_interactive() { return 0; }",
+          "private_package_auth_keychain_is_available() { return 1; }",
+          "private_package_auth_windows_credential_is_available() { return 0; }",
+          `private_package_auth_read_windows_credential() { printf '%s' '${TEST_TOKEN}'; }`,
+          "set -x",
+          "ensure_private_package_auth",
+          'printf "auth-present=%s\\n" "${NODE_AUTH_TOKEN:+yes}"',
+        ],
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe("auth-present=yes\n");
+      expect(result.stderr).not.toContain("input hidden");
+      expect(`${result.stdout}${result.stderr}`).not.toContain(TEST_TOKEN);
+    });
+
+    it("falls back to the hidden prompt when no stored credential exists", () => {
+      const result = runAuthHarness({
+        input: `${TEST_TOKEN}\n`,
+        statements: [
+          "private_package_auth_is_interactive() { return 0; }",
+          "private_package_auth_stored_credential_is_available() { return 0; }",
+          "private_package_auth_read_stored_credential() { return 1; }",
+          "ensure_private_package_auth",
+          'printf "auth-present=%s\\n" "${NODE_AUTH_TOKEN:+yes}"',
+        ],
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe("auth-present=yes\n");
+      expect(result.stderr).toContain("input hidden");
       expect(`${result.stdout}${result.stderr}`).not.toContain(TEST_TOKEN);
     });
 
@@ -1516,7 +1580,18 @@ describe("documented private-package setup flows", () => {
       'PRIVATE_GITHUB_PACKAGES_KEYCHAIN_SERVICE="6529seize-frontend-github-packages"'
     );
     expect(authHelper).toContain("/usr/bin/security find-generic-password");
+    expect(authHelper).toContain("private-github-packages-credential.ps1");
     expect(authHelper).not.toContain("gh auth token");
+    const windowsCredentialHelper = fs.readFileSync(
+      WINDOWS_CREDENTIAL_HELPER_PATH,
+      "utf8"
+    );
+    expect(windowsCredentialHelper).toContain('ValidateSet("read", "store")');
+    expect(windowsCredentialHelper).toContain("CredReadW");
+    expect(windowsCredentialHelper).toContain("CredWriteW");
+    expect(windowsCredentialHelper).toContain("Read-Host");
+    expect(windowsCredentialHelper).toContain("-AsSecureString");
+    expect(windowsCredentialHelper).not.toContain("Write-Output $token");
     expect(installIndex).toBeGreaterThanOrEqual(0);
     expect(authRemovalIndex).toBeGreaterThan(installIndex);
     expect(environmentSetup).toContain("unset NODE_AUTH_TOKEN");
@@ -1914,12 +1989,22 @@ describe("GitHub Actions package access", () => {
           }
         }
 
-        const reusableWorkflow = job.uses?.match(/^\.\/\.github\/workflows\/([A-Za-z0-9_-]+\.yml)$/);
+        const reusableWorkflow = job.uses?.match(
+          /^\.\/\.github\/workflows\/([A-Za-z0-9_-]+\.yml)$/
+        );
         let delegatesFrozenInstall = false;
         if (reusableWorkflow) {
-          const child = parseYaml(fs.readFileSync(path.join(workflowDirectory, reusableWorkflow[1]!), "utf8"));
-          delegatesFrozenInstall = Object.values(child.jobs ?? {}).some((childJob) =>
-            ((childJob as { steps?: Array<{ run?: string }> }).steps ?? []).some((step) => step.run?.includes("./bin/6529 install:frozen"))
+          const child = parseYaml(
+            fs.readFileSync(
+              path.join(workflowDirectory, reusableWorkflow[1]!),
+              "utf8"
+            )
+          );
+          delegatesFrozenInstall = Object.values(child.jobs ?? {}).some(
+            (childJob) =>
+              (
+                (childJob as { steps?: Array<{ run?: string }> }).steps ?? []
+              ).some((step) => step.run?.includes("./bin/6529 install:frozen"))
           );
         }
         if (

--- a/__tests__/scripts/production-artifact-metadata.test.ts
+++ b/__tests__/scripts/production-artifact-metadata.test.ts
@@ -98,6 +98,9 @@ describe("production artifact metadata without build secrets", () => {
     expect(
       deployment.jobs["resolve-production-artifact"].secrets
     ).toBeUndefined();
+    expect(deployment.jobs["resolve-production-artifact"].permissions).toEqual({
+      actions: "read",
+    });
     expect(JSON.stringify(deployment.jobs)).not.toContain(
       "needs.build-production-artifact.outputs."
     );

--- a/ops/docs/developer/pnpm-and-socket-firewall.md
+++ b/ops/docs/developer/pnpm-and-socket-firewall.md
@@ -70,21 +70,22 @@ For a normal interactive package command, just use the existing wrapper:
 6529 install
 ```
 
-If `NODE_AUTH_TOKEN` is not already set, `6529` asks for it with hidden input.
-The token stays in memory only for that command. Empty input is rejected. CI
-and other non-interactive shells never prompt or wait; they must receive
-`NODE_AUTH_TOKEN` at runtime and fail closed when it is missing.
+If `NODE_AUTH_TOKEN` is not already set, `6529` first checks the macOS Keychain
+or Windows Credential Manager. When no stored credential is available, it asks
+for the token with hidden input and keeps it in memory only for that command.
+Empty input is rejected. CI and other non-interactive shells never read a
+developer credential, prompt, or wait; they must receive `NODE_AUTH_TOKEN` at
+runtime and fail closed when it is missing.
 
 The prompt applies only to package commands that can resolve or install
 dependencies: `install`, `i`, `ci`, `install:frozen`, `install:prod`, `add`,
 `update`, and `update:all`. It does not run for ordinary development, test,
 build, or application commands.
 
-### One-time Codex worktree setup on macOS
+### One-time credential-store setup
 
-Codex creates a worktree non-interactively, so it cannot use the terminal
-prompt. Save the read-only token once in your private macOS login Keychain with
-this command:
+On macOS, save the read-only token once in your private login Keychain with this
+command:
 
 ```bash
 security add-generic-password \
@@ -99,17 +100,29 @@ for the token separately with hidden input, so the token is not placed in the
 command or shell history. Run the same command again to replace an expired
 token.
 
-The checked-in Codex environment setup reads this one exact Keychain item only
-for `./bin/6529 install`. It passes the token into the existing secure package
-helper, then the helper process exits. The setup also removes any inherited
-`NODE_AUTH_TOKEN` before Codex captures the successful setup environment. It
-copies existing `.env.development` and `.env.production` files from the primary
-worktree for local development and restricts the copies to the current user.
-It does not write the package token into those files or a shell profile. If the
-Keychain item is missing, Codex setup fails immediately with a clear message.
+On Windows, open PowerShell in the repository and run:
 
-On non-macOS Codex hosts, supply `NODE_AUTH_TOKEN` to the setup process at
-runtime. The setup removes it before Codex captures the resulting environment.
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass `
+  -File .\scripts\private-github-packages-credential.ps1 store
+```
+
+The helper asks for the token with hidden input and stores it as the generic
+credential `6529seize-frontend-github-packages` in Windows Credential Manager.
+Run the same command again to replace an expired token.
+
+Normal interactive package commands read the matching operating-system
+credential automatically and fall back to the hidden terminal prompt when it
+is missing. The checked-in Codex environment setup uses the same credential for
+its non-interactive `./bin/6529 install`, then removes `NODE_AUTH_TOKEN` before
+Codex captures the successful setup environment. It also copies existing
+`.env.development` and `.env.production` files from the primary worktree for
+local development and restricts the copies to the current user. It does not
+write the package token into those files or a shell profile. If the credential
+is missing, Codex setup fails immediately with a clear message.
+
+On other Codex hosts, supply `NODE_AUTH_TOKEN` to the setup process at runtime.
+The setup removes it before Codex captures the resulting environment.
 
 Commands that may change dependency resolution first update the manifest and
 lockfile without package credentials. The helper validates the resulting

--- a/scripts/private-github-packages-auth.sh
+++ b/scripts/private-github-packages-auth.sh
@@ -9,6 +9,11 @@ if [[ "${PRIVATE_GITHUB_PACKAGES_AUTH_SH_LOADED:-}" == "1" ]] &&
 fi
 readonly PRIVATE_GITHUB_PACKAGES_AUTH_SH_LOADED="1"
 readonly PRIVATE_GITHUB_PACKAGES_KEYCHAIN_SERVICE="6529seize-frontend-github-packages"
+PRIVATE_GITHUB_PACKAGES_AUTH_SCRIPT_DIR="$(
+  cd "$(dirname "${BASH_SOURCE[0]}")" && pwd
+)"
+readonly PRIVATE_GITHUB_PACKAGES_AUTH_SCRIPT_DIR
+readonly PRIVATE_GITHUB_PACKAGES_WINDOWS_HELPER="${PRIVATE_GITHUB_PACKAGES_AUTH_SCRIPT_DIR}/private-github-packages-credential.ps1"
 
 private_package_auth_is_present() {
   [[ -n "${NODE_AUTH_TOKEN:-}" ]]
@@ -28,6 +33,105 @@ private_package_auth_restore_xtrace() {
   fi
 }
 
+private_package_auth_is_macos() {
+  [[ "$(uname -s)" == "Darwin" ]]
+}
+
+private_package_auth_is_windows() {
+  case "$(uname -s)" in
+    MINGW* | MSYS* | CYGWIN*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+private_package_auth_keychain_is_available() {
+  private_package_auth_is_macos && [[ -x /usr/bin/security ]]
+}
+
+private_package_auth_read_keychain() {
+  /usr/bin/security find-generic-password \
+    -a "$(id -un)" \
+    -s "$PRIVATE_GITHUB_PACKAGES_KEYCHAIN_SERVICE" \
+    -w
+}
+
+private_package_auth_windows_powershell() {
+  command -v powershell.exe || command -v pwsh.exe
+}
+
+private_package_auth_windows_helper_path() {
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -w "$PRIVATE_GITHUB_PACKAGES_WINDOWS_HELPER"
+  else
+    printf '%s\n' "$PRIVATE_GITHUB_PACKAGES_WINDOWS_HELPER"
+  fi
+}
+
+private_package_auth_windows_credential_is_available() {
+  private_package_auth_is_windows &&
+    [[ -f "$PRIVATE_GITHUB_PACKAGES_WINDOWS_HELPER" ]] &&
+    private_package_auth_windows_powershell >/dev/null 2>&1
+}
+
+private_package_auth_read_windows_credential() {
+  local powershell_binary
+  powershell_binary="$(private_package_auth_windows_powershell)" || return 1
+
+  local helper_path
+  helper_path="$(private_package_auth_windows_helper_path)" || return 1
+
+  "$powershell_binary" \
+    -NoLogo \
+    -NoProfile \
+    -NonInteractive \
+    -ExecutionPolicy Bypass \
+    -File "$helper_path" \
+    read
+}
+
+private_package_auth_stored_credential_is_available() {
+  private_package_auth_keychain_is_available ||
+    private_package_auth_windows_credential_is_available
+}
+
+private_package_auth_stored_credential_label() {
+  if private_package_auth_is_macos; then
+    printf '%s\n' "the macOS Keychain"
+  elif private_package_auth_is_windows; then
+    printf '%s\n' "Windows Credential Manager"
+  else
+    printf '%s\n' "the operating system credential store"
+  fi
+}
+
+private_package_auth_read_stored_credential() {
+  if private_package_auth_keychain_is_available; then
+    private_package_auth_read_keychain
+  elif private_package_auth_windows_credential_is_available; then
+    private_package_auth_read_windows_credential
+  else
+    return 1
+  fi
+}
+
+private_package_auth_try_load_stored_credential() {
+  private_package_auth_stored_credential_is_available || return 1
+
+  local package_auth_token
+  if ! package_auth_token="$(private_package_auth_read_stored_credential 2>/dev/null)"; then
+    unset package_auth_token
+    return 1
+  fi
+  if [[ -z "$package_auth_token" ]]; then
+    unset package_auth_token
+    return 1
+  fi
+
+  NODE_AUTH_TOKEN="$package_auth_token"
+  export NODE_AUTH_TOKEN
+  unset package_auth_token
+}
+
 ensure_private_package_auth() {
   if private_package_auth_is_present; then
     return 0
@@ -45,6 +149,11 @@ ensure_private_package_auth() {
       restore_xtrace=1
       ;;
   esac
+
+  if private_package_auth_try_load_stored_credential; then
+    private_package_auth_restore_xtrace "$restore_xtrace"
+    return 0
+  fi
 
   printf "GitHub Packages read token (input hidden): " >&2
   local read_status=0
@@ -68,21 +177,6 @@ ensure_private_package_auth() {
   private_package_auth_restore_xtrace "$restore_xtrace"
 }
 
-private_package_auth_is_macos() {
-  [[ "$(uname -s)" == "Darwin" ]]
-}
-
-private_package_auth_keychain_is_available() {
-  private_package_auth_is_macos && [[ -x /usr/bin/security ]]
-}
-
-private_package_auth_read_keychain() {
-  /usr/bin/security find-generic-password \
-    -a "$(id -un)" \
-    -s "$PRIVATE_GITHUB_PACKAGES_KEYCHAIN_SERVICE" \
-    -w
-}
-
 load_private_package_auth_for_codex() {
   if private_package_auth_is_present; then
     return 0
@@ -96,22 +190,24 @@ load_private_package_auth_for_codex() {
       ;;
   esac
 
-  if ! private_package_auth_keychain_is_available; then
-    echo "NODE_AUTH_TOKEN is required because secure Codex Keychain lookup is available only on macOS." >&2
+  if ! private_package_auth_stored_credential_is_available; then
+    echo "NODE_AUTH_TOKEN is required because no supported operating system credential store is available." >&2
     private_package_auth_restore_xtrace "$restore_xtrace"
     return 1
   fi
 
+  local credential_label
+  credential_label="$(private_package_auth_stored_credential_label)"
   local package_auth_token
-  if ! package_auth_token="$(private_package_auth_read_keychain 2>/dev/null)"; then
-    echo "No GitHub Packages token was found in the macOS Keychain." >&2
+  if ! package_auth_token="$(private_package_auth_read_stored_credential 2>/dev/null)"; then
+    echo "No GitHub Packages token was found in ${credential_label}." >&2
     echo "Follow ops/docs/developer/pnpm-and-socket-firewall.md to add it once, then create the Codex worktree again." >&2
     private_package_auth_restore_xtrace "$restore_xtrace"
     return 1
   fi
 
   if [[ -z "$package_auth_token" ]]; then
-    echo "The GitHub Packages token stored in the macOS Keychain is empty." >&2
+    echo "The GitHub Packages token stored in ${credential_label} is empty." >&2
     unset package_auth_token
     private_package_auth_restore_xtrace "$restore_xtrace"
     return 1

--- a/scripts/private-github-packages-credential.ps1
+++ b/scripts/private-github-packages-credential.ps1
@@ -1,0 +1,150 @@
+param(
+  [Parameter(Position = 0)]
+  [ValidateSet("read", "store")]
+  [string]$Action = "read"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$credentialTarget = "6529seize-frontend-github-packages"
+
+Add-Type -TypeDefinition @'
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Text;
+
+public static class SeizeCredentialManager
+{
+    private const uint CredentialTypeGeneric = 1;
+    private const uint CredentialPersistLocalMachine = 2;
+    private const int ErrorNotFound = 1168;
+    private const int MaximumCredentialBlobSize = 5 * 512;
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct Credential
+    {
+        public uint Flags;
+        public uint Type;
+        [MarshalAs(UnmanagedType.LPWStr)] public string TargetName;
+        [MarshalAs(UnmanagedType.LPWStr)] public string Comment;
+        public System.Runtime.InteropServices.ComTypes.FILETIME LastWritten;
+        public uint CredentialBlobSize;
+        public IntPtr CredentialBlob;
+        public uint Persist;
+        public uint AttributeCount;
+        public IntPtr Attributes;
+        [MarshalAs(UnmanagedType.LPWStr)] public string TargetAlias;
+        [MarshalAs(UnmanagedType.LPWStr)] public string UserName;
+    }
+
+    [DllImport("advapi32.dll", EntryPoint = "CredReadW", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern bool CredRead(string target, uint type, uint reservedFlag, out IntPtr credentialPointer);
+
+    [DllImport("advapi32.dll", EntryPoint = "CredWriteW", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern bool CredWrite([In] ref Credential credential, uint flags);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern void CredFree(IntPtr buffer);
+
+    public static string Read(string target)
+    {
+        IntPtr credentialPointer;
+        if (!CredRead(target, CredentialTypeGeneric, 0, out credentialPointer))
+        {
+            int error = Marshal.GetLastWin32Error();
+            if (error == ErrorNotFound)
+            {
+                return null;
+            }
+            throw new Win32Exception(error);
+        }
+
+        try
+        {
+            Credential credential = (Credential)Marshal.PtrToStructure(
+                credentialPointer,
+                typeof(Credential)
+            );
+            if (credential.CredentialBlobSize == 0)
+            {
+                return string.Empty;
+            }
+            return Marshal.PtrToStringUni(
+                credential.CredentialBlob,
+                checked((int)credential.CredentialBlobSize / 2)
+            );
+        }
+        finally
+        {
+            CredFree(credentialPointer);
+        }
+    }
+
+    public static void Write(string target, string secret)
+    {
+        byte[] secretBytes = Encoding.Unicode.GetBytes(secret);
+        if (secretBytes.Length > MaximumCredentialBlobSize)
+        {
+            throw new ArgumentException("The credential is too large for Windows Credential Manager.");
+        }
+
+        IntPtr secretPointer = Marshal.AllocHGlobal(secretBytes.Length);
+        try
+        {
+            Marshal.Copy(secretBytes, 0, secretPointer, secretBytes.Length);
+            Credential credential = new Credential
+            {
+                Type = CredentialTypeGeneric,
+                TargetName = target,
+                Comment = "Read-only GitHub Packages token for 6529seize-frontend",
+                CredentialBlobSize = checked((uint)secretBytes.Length),
+                CredentialBlob = secretPointer,
+                Persist = CredentialPersistLocalMachine,
+                UserName = Environment.UserName
+            };
+
+            if (!CredWrite(ref credential, 0))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+        }
+        finally
+        {
+            Array.Clear(secretBytes, 0, secretBytes.Length);
+            for (int index = 0; index < secretBytes.Length; index++)
+            {
+                Marshal.WriteByte(secretPointer, index, 0);
+            }
+            Marshal.FreeHGlobal(secretPointer);
+        }
+    }
+}
+'@
+
+if ($Action -eq "read") {
+  $token = [SeizeCredentialManager]::Read($credentialTarget)
+  if ([string]::IsNullOrEmpty($token)) {
+    exit 1
+  }
+
+  [Console]::Out.Write($token)
+  exit 0
+}
+
+$secureToken = Read-Host "GitHub Packages read token" -AsSecureString
+$tokenPointer = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureToken)
+try {
+  $token = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($tokenPointer)
+  if ([string]::IsNullOrEmpty($token)) {
+    throw "GitHub Packages read token cannot be empty."
+  }
+  [SeizeCredentialManager]::Write($credentialTarget, $token)
+}
+finally {
+  [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($tokenPointer)
+  $token = $null
+}
+
+Write-Host "Stored the GitHub Packages read token in Windows Credential Manager."

--- a/scripts/private-github-packages-credential.ps1
+++ b/scripts/private-github-packages-credential.ps1
@@ -18,6 +18,7 @@ using System.Text;
 public static class SeizeCredentialManager
 {
     private const uint CredentialTypeGeneric = 1;
+    // Persists across this user's logon sessions without making the credential machine-wide.
     private const uint CredentialPersistLocalMachine = 2;
     private const int ErrorNotFound = 1168;
     private const int MaximumCredentialBlobSize = 5 * 512;


### PR DESCRIPTION
## Issue

- Interactive `6529` package commands prompt for a GitHub Packages token even when the expected token already exists in the macOS Keychain.
- Windows developers have no equivalent documented credential-store path.
- The production artifact metadata job inherits unnecessary GitHub Packages read access, violating the repository's package-routing contract.

## Fix

- Check the supported operating-system credential store before showing the existing hidden token prompt.
- Preserve explicit `NODE_AUTH_TOKEN` handling for CI and other non-interactive shells.
- Limit the production metadata resolver to the `actions: read` permission it actually requires.

## Changes

- Load the existing macOS Keychain credential automatically for interactive package commands.
- Add a PowerShell helper that reads and stores the dedicated token in Windows Credential Manager via `CredReadW` and `CredWriteW`.
- Fall back to the hidden terminal prompt when no stored credential is available.
- Extend authentication routing and secret-redaction coverage for macOS, Windows, prompt fallback, CI, and Codex setup.
- Document one-time credential setup on both operating systems.
- Add an explicit least-privilege permission and regression assertion for production artifact metadata resolution.

## Validation

- `6529 run check:changed`
- Complete package-routing and production artifact metadata Jest suites: 79 tests passed
- Live macOS interactive lookup against the configured Keychain item, with no prompt and no token output
- Shell syntax and diff checks

The Windows PowerShell helper was contract-checked and covered through mocked routing, but was not executed on Windows from this macOS worktree.

## Risk

- Level: Medium
- Why: The change handles a package credential and adds Windows-native credential interop. The production workflow change only removes an unnecessary permission from a metadata-only reusable job.
- Rollback: Revert the PR to restore prompt-only interactive behavior and the previous production workflow permission inheritance.

## Review Notes

- Please focus on secret lifetime and redaction, CI remaining explicit, Git Bash path conversion, Windows Credential Manager interop declarations, and least-privilege production workflow permissions.
