### PR TITLE
Keep direct-linked waves visible in the sidebar

### DIFF
--- a/__tests__/components/brain/left-sidebar/waves/SidebarWaveTreeRowTransition.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/SidebarWaveTreeRowTransition.test.tsx
@@ -39,6 +39,10 @@ describe("SidebarWaveTreeRowTransition", () => {
     expect(screen.getByText("Child row").parentElement).toHaveClass(
       "tw-overflow-hidden"
     );
+    expect(screen.getByText("Child row").parentElement).toHaveAttribute(
+      "data-sidebar-wave-id",
+      "child"
+    );
   });
 
   it("does not clip entered child rows so connector segments can overlap", () => {

--- a/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
@@ -169,6 +169,7 @@ beforeEach(() => {
       { index: 2, start: 102, size: 1 },
     ],
     totalHeight: 103,
+    scrollToIndex: jest.fn(() => true),
   });
 });
 
@@ -493,7 +494,9 @@ it("keeps discovery-only worth checking out waves out of Joined", () => {
     />
   );
 
-  expect(screen.getByTestId("preview-avatar-recommendation")).toBeInTheDocument();
+  expect(
+    screen.getByTestId("preview-avatar-recommendation")
+  ).toBeInTheDocument();
   expect(screen.getByLabelText("Following waves list")).toBeInTheDocument();
   expect(screen.queryByTestId("wave-recommendation")).toBeNull();
   expect(screen.getByTestId("wave-joined-wave")).toBeInTheDocument();
@@ -532,11 +535,7 @@ it("keeps the overlaid score inside the wave link and opens details on hover", a
   const waveLink = screen.getByRole("link", {
     name: "Open Scored Discovery, score 93",
   });
-  expect(waveLink).toHaveClass(
-    "tw-relative",
-    "tw-size-8",
-    "tw-cursor-pointer"
-  );
+  expect(waveLink).toHaveClass("tw-relative", "tw-size-8", "tw-cursor-pointer");
   expect(waveLink.closest(".tw-pt-1")).not.toBeNull();
   const scoreBadgeText = screen.getByText("93", { selector: "text" });
   const scoreBadge = scoreBadgeText.closest("span");
@@ -1081,6 +1080,100 @@ it("auto-expands the parent for the active subwave", () => {
     })
   ).toHaveAttribute("aria-expanded", "true");
   expect(screen.getByTestId("wave-child")).toBeInTheDocument();
+});
+
+it("keeps the active parent tree ahead of newly paginated roots", async () => {
+  mockUseMyStream.mockReturnValue({
+    activeWave: { id: "child", parentWaveId: "parent", set: jest.fn() },
+    waves: {
+      loadSubwavesForParent,
+      prefetchSubwavesForParent,
+      loadingSubwaveParentIds: [],
+    },
+  });
+  const parent = createMockMinimalWave({
+    id: "parent",
+    hasSubwaves: true,
+    sidebarActivityTimestamp: 10,
+  });
+  const child = createMockMinimalWave({
+    id: "child",
+    parentWaveId: "parent",
+    sidebarActivityTimestamp: 20,
+  });
+  const recent = createMockMinimalWave({
+    id: "recent",
+    sidebarActivityTimestamp: 300,
+  });
+  const newlyPaginated = createMockMinimalWave({
+    id: "newly-paginated",
+    sidebarActivityTimestamp: 200,
+  });
+
+  const { rerender } = render(
+    <UnifiedWavesListWaves
+      waves={[recent, parent, child]}
+      onHover={jest.fn()}
+      scrollContainerRef={scrollRef}
+    />
+  );
+
+  expect(
+    mockUseVirtualizedWaves.mock.calls
+      .at(-1)?.[0]
+      .items.slice(0, 3)
+      .map((row: any) => row.key)
+  ).toEqual(["parent", "parent:subwaves-toggle", "parent:child"]);
+
+  rerender(
+    <UnifiedWavesListWaves
+      waves={[recent, newlyPaginated, parent, child]}
+      onHover={jest.fn()}
+      scrollContainerRef={scrollRef}
+    />
+  );
+  await flushAnimatedSidebarRows();
+
+  expect(
+    mockUseVirtualizedWaves.mock.calls
+      .at(-1)?.[0]
+      .items.slice(0, 3)
+      .map((row: any) => row.key)
+  ).toEqual(["parent", "parent:subwaves-toggle", "parent:child"]);
+});
+
+it("keeps active root waves in normal activity order", () => {
+  mockUseMyStream.mockReturnValue({
+    activeWave: { id: "older", parentWaveId: null, set: jest.fn() },
+    waves: {
+      loadSubwavesForParent,
+      prefetchSubwavesForParent,
+      loadingSubwaveParentIds: [],
+    },
+  });
+
+  render(
+    <UnifiedWavesListWaves
+      waves={[
+        createMockMinimalWave({
+          id: "older",
+          sidebarActivityTimestamp: 10,
+        }),
+        createMockMinimalWave({
+          id: "recent",
+          sidebarActivityTimestamp: 300,
+        }),
+      ]}
+      onHover={jest.fn()}
+      scrollContainerRef={scrollRef}
+    />
+  );
+
+  expect(
+    mockUseVirtualizedWaves.mock.calls
+      .at(-1)?.[0]
+      .items.map((row: any) => row.key)
+  ).toEqual(["recent", "older"]);
 });
 
 it("loads a direct active subwave parent before showing it expanded", async () => {

--- a/__tests__/components/brain/left-sidebar/waves/sidebarWaveListUtils.test.ts
+++ b/__tests__/components/brain/left-sidebar/waves/sidebarWaveListUtils.test.ts
@@ -1,5 +1,8 @@
 import { createMockMinimalWave } from "@/__tests__/utils/mockFactories";
-import { groupSidebarWaves } from "@/components/brain/left-sidebar/waves/sidebarWaveListUtils";
+import {
+  groupSidebarWaves,
+  prioritizeActiveWaveContainer,
+} from "@/components/brain/left-sidebar/waves/sidebarWaveListUtils";
 
 describe("sidebarWaveListUtils", () => {
   it("groups followed-subwave parent containers with following waves", () => {
@@ -100,5 +103,18 @@ describe("sidebarWaveListUtils", () => {
       "pinned-quality-wave",
     ]);
     expect(groups.highlyRatedWaves).toEqual([]);
+  });
+
+  it("anchors the active route container ahead of activity-sorted roots", () => {
+    const newest = createMockMinimalWave({ id: "newest" });
+    const activeParent = createMockMinimalWave({ id: "active-parent" });
+    const older = createMockMinimalWave({ id: "older" });
+
+    expect(
+      prioritizeActiveWaveContainer(
+        [newest, activeParent, older],
+        activeParent.id
+      ).map((wave) => wave.id)
+    ).toEqual(["active-parent", "newest", "older"]);
   });
 });

--- a/__tests__/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.test.tsx
@@ -146,6 +146,7 @@ beforeEach(() => {
       { index: 2, start: 102, size: 1 },
     ],
     totalHeight: 103,
+    scrollToIndex: jest.fn(() => true),
   });
 });
 
@@ -187,6 +188,7 @@ it("renders announcement, highly rated preview, pinned, and one filterable botto
       { index: 3, start: 186, size: 1 },
     ],
     totalHeight: 187,
+    scrollToIndex: jest.fn(() => true),
   });
 
   renderWebWaves({ sentinelRef });
@@ -200,10 +202,7 @@ it("renders announcement, highly rated preview, pinned, and one filterable botto
     name: "Discover Waves",
   });
   expect(discoverWavesLink).toHaveAttribute("href", "/discover");
-  expect(discoverWavesLink).toHaveClass(
-    "tw-text-[13px]",
-    "tw-font-medium"
-  );
+  expect(discoverWavesLink).toHaveClass("tw-text-[13px]", "tw-font-medium");
   expect(discoverWavesLink.querySelector("svg")).toBeNull();
   expect(screen.getByTestId("waves-filter-toggle")).toBeInTheDocument();
   expect(screen.getByLabelText("Announcement waves")).toBeInTheDocument();
@@ -299,7 +298,9 @@ it("keeps discovery-only worth checking out waves out of Joined", () => {
     ],
   });
 
-  expect(screen.getByTestId("preview-avatar-recommendation")).toBeInTheDocument();
+  expect(
+    screen.getByTestId("preview-avatar-recommendation")
+  ).toBeInTheDocument();
   expect(screen.getByLabelText("Following waves list")).toBeInTheDocument();
   expect(screen.queryByTestId("wave-recommendation")).toBeNull();
   expect(screen.getByTestId("wave-joined-wave")).toBeInTheDocument();
@@ -832,6 +833,93 @@ it("auto-expands the parent for the active subwave", () => {
     })
   ).toHaveAttribute("aria-expanded", "true");
   expect(screen.getByTestId("wave-child")).toBeInTheDocument();
+});
+
+it("keeps the active parent tree ahead of newly paginated roots", async () => {
+  mockUseMyStream.mockReturnValue({
+    activeWave: { id: "child", parentWaveId: "parent", set: jest.fn() },
+    waves: {
+      loadSubwavesForParent,
+      prefetchSubwavesForParent,
+      loadingSubwaveParentIds: [],
+    },
+  });
+  const parent = createMockMinimalWave({
+    id: "parent",
+    hasSubwaves: true,
+    sidebarActivityTimestamp: 10,
+  });
+  const child = createMockMinimalWave({
+    id: "child",
+    parentWaveId: "parent",
+    sidebarActivityTimestamp: 20,
+  });
+  const recent = createMockMinimalWave({
+    id: "recent",
+    sidebarActivityTimestamp: 300,
+  });
+  const newlyPaginated = createMockMinimalWave({
+    id: "newly-paginated",
+    sidebarActivityTimestamp: 200,
+  });
+
+  const { rerender } = renderWebWaves({
+    waves: [recent, parent, child],
+  });
+
+  expect(
+    mockUseVirtualizedWaves.mock.calls
+      .at(-1)?.[0]
+      .items.slice(0, 3)
+      .map((row: any) => row.key)
+  ).toEqual(["parent", "parent:subwaves-toggle", "parent:child"]);
+
+  rerender(
+    <WebUnifiedWavesListWaves
+      waves={[recent, newlyPaginated, parent, child]}
+      onHover={jest.fn()}
+      scrollContainerRef={scrollRef}
+      sentinelRef={React.createRef<HTMLDivElement>()}
+    />
+  );
+  await flushAnimatedSidebarRows();
+
+  expect(
+    mockUseVirtualizedWaves.mock.calls
+      .at(-1)?.[0]
+      .items.slice(0, 3)
+      .map((row: any) => row.key)
+  ).toEqual(["parent", "parent:subwaves-toggle", "parent:child"]);
+});
+
+it("keeps active root waves in normal activity order", () => {
+  mockUseMyStream.mockReturnValue({
+    activeWave: { id: "older", parentWaveId: null, set: jest.fn() },
+    waves: {
+      loadSubwavesForParent,
+      prefetchSubwavesForParent,
+      loadingSubwaveParentIds: [],
+    },
+  });
+
+  renderWebWaves({
+    waves: [
+      createMockMinimalWave({
+        id: "older",
+        sidebarActivityTimestamp: 10,
+      }),
+      createMockMinimalWave({
+        id: "recent",
+        sidebarActivityTimestamp: 300,
+      }),
+    ],
+  });
+
+  expect(
+    mockUseVirtualizedWaves.mock.calls
+      .at(-1)?.[0]
+      .items.map((row: any) => row.key)
+  ).toEqual(["recent", "older"]);
 });
 
 it("loads a direct active subwave parent before showing it expanded", async () => {

--- a/__tests__/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.test.tsx
+++ b/__tests__/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.test.tsx
@@ -148,6 +148,37 @@ describe("MyStreamWaveTabsHeader", () => {
     expect(scoreActions).toHaveClass("tw-gap-1.5");
   });
 
+  it("shows a linked parent wave above a subwave title", () => {
+    render(
+      <MyStreamWaveTabsHeader
+        wave={{
+          ...wave,
+          id: "child-wave",
+          name: "CI-PRODUCTION",
+          parent_wave: {
+            id: "parent-wave",
+            name: "Follow The Repo",
+          },
+        }}
+        activeContentTab={MyStreamWaveTab.CHAT}
+        setActiveContentTab={jest.fn()}
+        onSelectCuration={jest.fn()}
+        isCompact={false}
+        showBackButton={false}
+        headerActionsTooltipId="header-actions"
+        headerClassName="tw-flex"
+        actionsClassName="tw-flex"
+      />
+    );
+
+    expect(
+      screen.getByRole("navigation", { name: "Wave hierarchy" })
+    ).toHaveTextContent(/Subwave of\s*Follow The Repo/);
+    expect(
+      screen.getByRole("link", { name: "Follow The Repo" })
+    ).toHaveAttribute("href", "/waves/parent-wave");
+  });
+
   it("hides score actions in the compact mobile header", () => {
     render(
       <MyStreamWaveTabsHeader

--- a/__tests__/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.test.tsx
+++ b/__tests__/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.test.tsx
@@ -174,9 +174,14 @@ describe("MyStreamWaveTabsHeader", () => {
     expect(
       screen.getByRole("navigation", { name: "Wave hierarchy" })
     ).toHaveTextContent(/Subwave of\s*Follow The Repo/);
-    expect(
-      screen.getByRole("link", { name: "Follow The Repo" })
-    ).toHaveAttribute("href", "/waves/parent-wave");
+    const parentLink = screen.getByRole("link", {
+      name: "Subwave of Follow The Repo",
+    });
+    expect(parentLink).toHaveAttribute(
+      "title",
+      "Open parent wave: Follow The Repo"
+    );
+    expect(parentLink).toHaveAttribute("href", "/waves/parent-wave");
   });
 
   it("hides score actions in the compact mobile header", () => {

--- a/__tests__/components/header/AppHeader.test.tsx
+++ b/__tests__/components/header/AppHeader.test.tsx
@@ -508,9 +508,14 @@ describe("AppHeader", () => {
     expect(
       screen.getByRole("navigation", { name: "Wave hierarchy" })
     ).toHaveTextContent(/Subwave of\s*Follow The Repo/);
-    expect(
-      screen.getByRole("link", { name: "Follow The Repo" })
-    ).toHaveAttribute("href", "/waves/parent-wave");
+    const parentLink = screen.getByRole("link", {
+      name: "Subwave of Follow The Repo",
+    });
+    expect(parentLink).toHaveAttribute(
+      "title",
+      "Open parent wave: Follow The Repo"
+    );
+    expect(parentLink).toHaveAttribute("href", "/waves/parent-wave");
   });
 
   it("shows profile image on waves root page", () => {

--- a/__tests__/components/header/AppHeader.test.tsx
+++ b/__tests__/components/header/AppHeader.test.tsx
@@ -492,6 +492,27 @@ describe("AppHeader", () => {
     expect(screen.getByText("WaveOne")).toBeInTheDocument();
   });
 
+  it("shows a linked parent wave for an active subwave", () => {
+    const wave = {
+      id: "child-wave",
+      name: "CI-PRODUCTION",
+      parent_wave: { id: "parent-wave", name: "Follow The Repo" },
+      chat: { scope: { group: { is_direct_message: false } } },
+    };
+    setup({
+      wave,
+      asPath: "/waves/child-wave",
+      waveInfo: { isRankWave: false, isMemesWave: false, isDm: false },
+    });
+
+    expect(
+      screen.getByRole("navigation", { name: "Wave hierarchy" })
+    ).toHaveTextContent(/Subwave of\s*Follow The Repo/);
+    expect(
+      screen.getByRole("link", { name: "Follow The Repo" })
+    ).toHaveAttribute("href", "/waves/parent-wave");
+  });
+
   it("shows profile image on waves root page", () => {
     setup({
       address: "0xabc",

--- a/__tests__/components/waves/header/name/WaveHeaderName.test.tsx
+++ b/__tests__/components/waves/header/name/WaveHeaderName.test.tsx
@@ -87,10 +87,14 @@ describe("WaveHeaderName", () => {
     expect(hierarchy).toBeInTheDocument();
     expect(hierarchy).toHaveTextContent(/Subwave of\s*Parent Wave/);
     expect(screen.getByText("Subwave of")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Parent Wave" })).toHaveAttribute(
-      "href",
-      "/waves/parent-wave"
+    const parentLink = screen.getByRole("link", {
+      name: "Open parent wave: Parent Wave",
+    });
+    expect(parentLink).toHaveAttribute(
+      "title",
+      "Open parent wave: Parent Wave"
     );
+    expect(parentLink).toHaveAttribute("href", "/waves/parent-wave");
     expect(screen.getAllByText("Child Wave")).toHaveLength(1);
     expect(screen.getByRole("link", { name: "Child Wave" })).toHaveAttribute(
       "href",

--- a/__tests__/contexts/wave/MyStreamContext.resume.test.tsx
+++ b/__tests__/contexts/wave/MyStreamContext.resume.test.tsx
@@ -427,8 +427,9 @@ describe("MyStreamProvider resume sync", () => {
   });
 
   it("handles active wave data without metrics", () => {
+    const activeWave = { id: "wave-1" };
     useWaveByIdMock.mockReturnValue({
-      wave: { id: "wave-1" },
+      wave: activeWave,
       isLoading: false,
       isFetching: false,
     });
@@ -440,6 +441,26 @@ describe("MyStreamProvider resume sync", () => {
         </MyStreamProvider>
       );
     }).not.toThrow();
+    expect(useWavesListMock).toHaveBeenLastCalledWith({
+      activeWave,
+      enabled: true,
+    });
+  });
+
+  it("does not surface placeholder data from the previously active wave", () => {
+    useWaveByIdMock.mockReturnValue({
+      wave: { id: "wave-before-navigation" },
+      isLoading: false,
+      isFetching: true,
+    });
+
+    render(
+      <MyStreamProvider>
+        <div />
+      </MyStreamProvider>
+    );
+
+    expect(useWavesListMock).toHaveBeenLastCalledWith({ enabled: true });
   });
 
   it("treats a null pathname as a non-messages route", () => {

--- a/__tests__/hooks/useLoadActiveSidebarParentSubwaves.test.tsx
+++ b/__tests__/hooks/useLoadActiveSidebarParentSubwaves.test.tsx
@@ -52,6 +52,36 @@ describe("useLoadActiveSidebarParentSubwaves", () => {
     expect(loadSubwavesForParent).toHaveBeenCalledTimes(1);
   });
 
+  it("waits for a direct-linked parent to enter the sidebar before loading", () => {
+    const loadSubwavesForParent = jest.fn();
+    mockUseMyStream.mockReturnValue({
+      waves: { loadSubwavesForParent },
+    });
+    const parentWave = createMockMinimalWave({
+      id: "parent",
+      hasSubwaves: true,
+    });
+    const { rerender } = renderHook(
+      ({ waves }: { readonly waves: readonly (typeof parentWave)[] }) =>
+        useLoadActiveSidebarParentSubwaves({
+          activeParentWaveId: "parent",
+          waves,
+        }),
+      {
+        initialProps: {
+          waves: [] as readonly (typeof parentWave)[],
+        },
+      }
+    );
+
+    expect(loadSubwavesForParent).not.toHaveBeenCalled();
+
+    rerender({ waves: [parentWave] });
+
+    expect(loadSubwavesForParent).toHaveBeenCalledTimes(1);
+    expect(loadSubwavesForParent).toHaveBeenCalledWith("parent");
+  });
+
   it("allows a missing active parent to be requested again after leaving it", () => {
     const loadSubwavesForParent = jest.fn();
     mockUseMyStream.mockReturnValue({
@@ -93,7 +123,7 @@ describe("useLoadActiveSidebarParentSubwaves", () => {
     expect(loadSubwavesForParent).toHaveBeenLastCalledWith("parent");
   });
 
-  it("does not load when the active parent's child rows are already present", () => {
+  it("registers the active parent once when child rows are already present", () => {
     const loadSubwavesForParent = jest.fn();
     mockUseMyStream.mockReturnValue({
       waves: { loadSubwavesForParent },
@@ -116,6 +146,7 @@ describe("useLoadActiveSidebarParentSubwaves", () => {
       })
     );
 
-    expect(loadSubwavesForParent).not.toHaveBeenCalled();
+    expect(loadSubwavesForParent).toHaveBeenCalledTimes(1);
+    expect(loadSubwavesForParent).toHaveBeenCalledWith("parent");
   });
 });

--- a/__tests__/hooks/useRevealActiveSidebarWave.test.tsx
+++ b/__tests__/hooks/useRevealActiveSidebarWave.test.tsx
@@ -1,0 +1,102 @@
+import { renderHook } from "@testing-library/react";
+import { createMockMinimalWave } from "@/__tests__/utils/mockFactories";
+import { useRevealActiveSidebarWave } from "@/hooks/useRevealActiveSidebarWave";
+import type { SidebarWaveTreeRow } from "@/hooks/useSidebarWaveTree";
+
+const createWaveRow = (
+  waveId: string,
+  parentWaveId: string | null = null
+): SidebarWaveTreeRow => ({
+  key: parentWaveId === null ? waveId : `${parentWaveId}:${waveId}`,
+  rowType: "wave",
+  wave: createMockMinimalWave({ id: waveId, parentWaveId }),
+  depth: parentWaveId === null ? 0 : 1,
+  parentWaveId,
+  isExpanded: false,
+  isLoadingSubwaves: false,
+  canExpand: false,
+  hasUnreadSubwaves: false,
+  knownSubwavesCount: null,
+  unreadSubwaveDropsCount: 0,
+  isFirstSubwave: false,
+  isLastSubwave: false,
+});
+
+describe("useRevealActiveSidebarWave", () => {
+  it("reveals the parent while loading and then the active subwave", () => {
+    const parentRow = createWaveRow("parent");
+    const childRow = createWaveRow("child", "parent");
+    const scrollToVirtualIndex = jest.fn(() => true);
+    const scrollContainerRef = {
+      current: document.createElement("div"),
+    } as React.RefObject<HTMLElement>;
+    const { rerender } = renderHook(
+      ({ virtualRows }: { readonly virtualRows: SidebarWaveTreeRow[] }) =>
+        useRevealActiveSidebarWave({
+          activeParentWaveId: "parent",
+          activeWaveId: "child",
+          scrollContainerRef,
+          scrollToVirtualIndex,
+          staticRows: [],
+          virtualRows,
+        }),
+      { initialProps: { virtualRows: [parentRow] } }
+    );
+
+    expect(scrollToVirtualIndex).toHaveBeenLastCalledWith(0);
+
+    rerender({ virtualRows: [parentRow, childRow] });
+
+    expect(scrollToVirtualIndex).toHaveBeenLastCalledWith(1);
+    expect(scrollToVirtualIndex).toHaveBeenCalledTimes(2);
+  });
+
+  it("reveals active rows rendered in a static section", () => {
+    const container = document.createElement("div");
+    const rowElement = document.createElement("div");
+    const scrollIntoView = jest.fn();
+    rowElement.dataset["sidebarWaveId"] = "active-pinned";
+    rowElement.scrollIntoView = scrollIntoView;
+    container.append(rowElement);
+
+    renderHook(() =>
+      useRevealActiveSidebarWave({
+        activeParentWaveId: null,
+        activeWaveId: "active-pinned",
+        scrollContainerRef: { current: container },
+        scrollToVirtualIndex: jest.fn(() => true),
+        staticRows: [[createWaveRow("active-pinned")]],
+        virtualRows: [],
+      })
+    );
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+  });
+
+  it("reveals the active row again when hydrated rows move its position", () => {
+    const activeRow = createWaveRow("active");
+    const scrollToVirtualIndex = jest.fn(() => true);
+    const scrollContainerRef = {
+      current: document.createElement("div"),
+    } as React.RefObject<HTMLElement>;
+    const { rerender } = renderHook(
+      ({ virtualRows }: { readonly virtualRows: SidebarWaveTreeRow[] }) =>
+        useRevealActiveSidebarWave({
+          activeParentWaveId: null,
+          activeWaveId: "active",
+          scrollContainerRef,
+          scrollToVirtualIndex,
+          staticRows: [],
+          virtualRows,
+        }),
+      { initialProps: { virtualRows: [activeRow] } }
+    );
+
+    expect(scrollToVirtualIndex).toHaveBeenLastCalledWith(0);
+
+    rerender({ virtualRows: [createWaveRow("newer"), activeRow] });
+
+    expect(scrollToVirtualIndex).toHaveBeenLastCalledWith(1);
+    expect(scrollToVirtualIndex).toHaveBeenCalledTimes(2);
+  });
+});

--- a/__tests__/hooks/useSidebarWaveTree.test.tsx
+++ b/__tests__/hooks/useSidebarWaveTree.test.tsx
@@ -281,6 +281,41 @@ describe("useSidebarWaveTree", () => {
     ).toBeNull();
   });
 
+  it("ignores a persisted collapse while its subwave is active", () => {
+    globalThis.sessionStorage.setItem(
+      "sidebar-wave-tree-expansion-v1",
+      JSON.stringify({
+        expandedParentIds: ["parent"],
+        collapsedParentIds: ["parent"],
+      })
+    );
+
+    const { result } = renderHook(() =>
+      useSidebarWaveTree({
+        waves,
+        activeWaveId: "older-child",
+      })
+    );
+
+    expect(
+      getTreeRowKeys(result.current.getRows(result.current.topLevelWaves))
+    ).toEqual([
+      "parent",
+      "parent:subwaves-toggle",
+      "parent:older-child",
+      "parent:newer-child",
+    ]);
+    expect(
+      JSON.parse(
+        globalThis.sessionStorage.getItem("sidebar-wave-tree-expansion-v1") ??
+          "{}"
+      )
+    ).toEqual({
+      expandedParentIds: ["parent"],
+      collapsedParentIds: ["parent"],
+    });
+  });
+
   it("does not reload the same active parent when the expand callback changes", () => {
     const firstOnParentExpand = jest.fn();
     const secondOnParentExpand = jest.fn();
@@ -317,7 +352,7 @@ describe("useSidebarWaveTree", () => {
     ]);
   });
 
-  it("lets manual collapse hide the active subwave parent rows", () => {
+  it("keeps active subwave parent rows visible when collapse is requested", () => {
     const onParentExpand = jest.fn();
     const { result } = renderHook(() =>
       useSidebarWaveTree({
@@ -343,27 +378,30 @@ describe("useSidebarWaveTree", () => {
 
     expect(
       getTreeRowKeys(result.current.getRows(result.current.topLevelWaves))
-    ).toEqual(["parent", "parent:subwaves-toggle"]);
+    ).toEqual([
+      "parent",
+      "parent:subwaves-toggle",
+      "parent:older-child",
+      "parent:newer-child",
+    ]);
     expect(onParentExpand).not.toHaveBeenCalled();
   });
 
-  it("reopens a manually collapsed active subwave parent", () => {
+  it("applies an active-parent collapse after navigation leaves the subwave", () => {
     const onParentExpand = jest.fn();
-    const { result } = renderHook(() =>
-      useSidebarWaveTree({
-        waves,
-        activeWaveId: "older-child",
-        onParentExpand,
-      })
+    const { result, rerender } = renderHook(
+      ({ activeWaveId }: { readonly activeWaveId: string | null }) =>
+        useSidebarWaveTree({
+          waves,
+          activeWaveId,
+          onParentExpand,
+        }),
+      {
+        initialProps: {
+          activeWaveId: "older-child" as string | null,
+        },
+      }
     );
-
-    act(() => {
-      result.current.toggleParent("parent");
-    });
-
-    expect(
-      getTreeRowKeys(result.current.getRows(result.current.topLevelWaves))
-    ).toEqual(["parent", "parent:subwaves-toggle"]);
 
     act(() => {
       result.current.toggleParent("parent");
@@ -377,8 +415,13 @@ describe("useSidebarWaveTree", () => {
       "parent:older-child",
       "parent:newer-child",
     ]);
-    expect(onParentExpand).toHaveBeenCalledTimes(1);
-    expect(onParentExpand).toHaveBeenLastCalledWith("parent");
+
+    rerender({ activeWaveId: null });
+
+    expect(
+      getTreeRowKeys(result.current.getRows(result.current.topLevelWaves))
+    ).toEqual(["parent", "parent:subwaves-toggle"]);
+    expect(onParentExpand).not.toHaveBeenCalled();
   });
 
   it("loads a direct active subwave parent without showing it expanded before rows exist", () => {

--- a/__tests__/hooks/useVirtualizedWaves.test.tsx
+++ b/__tests__/hooks/useVirtualizedWaves.test.tsx
@@ -83,6 +83,50 @@ describe("useVirtualizedWaves", () => {
     ]);
   });
 
+  it("scrolls a requested row into the nearest visible position", () => {
+    const scrollContainer = document.createElement("div");
+    Object.defineProperty(scrollContainer, "clientHeight", { value: 100 });
+    const scrollTo = jest.fn(({ top }: { readonly top: number }) => {
+      scrollContainer.scrollTop = top;
+    });
+    Object.defineProperty(scrollContainer, "scrollTo", { value: scrollTo });
+    const listContainer = document.createElement("div");
+    Object.defineProperty(listContainer, "offsetTop", { value: 20 });
+    const scrollRef = {
+      current: scrollContainer,
+    } as React.RefObject<HTMLDivElement>;
+    const listRef = {
+      current: listContainer,
+    } as React.RefObject<HTMLDivElement>;
+
+    const { result } = renderHook(
+      () =>
+        useVirtualizedWaves({
+          items: Array.from({ length: 10 }, (_, index) => index),
+          key: "reveal-row",
+          scrollContainerRef: scrollRef,
+          listContainerRef: listRef,
+          rowHeight: 50,
+          overscan: 0,
+        }),
+      { wrapper }
+    );
+    scrollTo.mockClear();
+
+    act(() => {
+      expect(result.current.scrollToIndex(3)).toBe(true);
+    });
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 120 });
+    expect(scrollContainer.scrollTop).toBe(120);
+
+    scrollTo.mockClear();
+    act(() => {
+      expect(result.current.scrollToIndex(2)).toBe(true);
+    });
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
   it("binds scrolling when the scroll container ref is assigned after mount", () => {
     jest.useFakeTimers();
     const originalRequestAnimationFrame = globalThis.requestAnimationFrame;

--- a/__tests__/hooks/useWavesList.test.tsx
+++ b/__tests__/hooks/useWavesList.test.tsx
@@ -182,6 +182,33 @@ const createLegacyApiWave = (id: string, latestDropTimestamp: number) =>
     subscribed_actions: [],
   }) as any;
 
+const createApiWaveOverview = (id: string, latestDropTimestamp: number) =>
+  ({
+    id,
+    name: id,
+    created_at: 0,
+    pfp: null,
+    creator: {},
+    contributors: [],
+    has_competition: true,
+    is_dm_wave: false,
+    parent_wave: null,
+    has_subwaves: true,
+    description_drop: { contents: null, media: [] },
+    total_drops_count: 0,
+    is_private: false,
+    last_drop_time: latestDropTimestamp,
+    context_profile_context: {
+      first_unread_drop_serial_no: null,
+      followed_subwaves_count: 0,
+      muted: false,
+      pinned: false,
+      subscribed: false,
+      subwave_unread_drops: 0,
+      unread_drops: 0,
+    },
+  }) as any;
+
 const dmWave = createSidebarWave({
   id: "1",
   latestDropTimestamp: 50,
@@ -1231,6 +1258,123 @@ test("starts without subwave queries, then appends subwaves for loaded parents",
   expect(result.current.waves.map((wave: any) => wave.id)).toEqual([
     "parent",
     "child",
+  ]);
+});
+
+test("surfaces a direct-linked root wave outside the loaded overview", () => {
+  const activeWave = createLegacyApiWave("direct-root", 500);
+  useWavesV2Mock.mockReturnValue({
+    waves: [],
+    isFetching: false,
+    isFetchingNextPage: false,
+    hasNextPage: false,
+    fetchNextPage: jest.fn(),
+    status: "success",
+    refetch: jest.fn(),
+  });
+  usePinnedWavesServerMock.mockReturnValue({
+    pinnedIds: [],
+    pinnedWaves: [],
+    pinWave: jest.fn(),
+    unpinWave: jest.fn(),
+    isLoading: false,
+    isError: false,
+    refetch: jest.fn(),
+  });
+
+  const { result } = renderHook(() => useWavesList({ activeWave }), {
+    wrapper,
+  });
+
+  expect(result.current.waves).toHaveLength(1);
+  expect(result.current.waves[0]).toMatchObject({
+    id: "direct-root",
+    isInAllWaves: true,
+    isPinned: false,
+    parentWaveId: null,
+    sidebarSection: "all",
+    subscribed: false,
+  });
+});
+
+test("surfaces and loads a direct-linked subwave under its parent in Joined", () => {
+  useShowFollowingWavesMock.mockReturnValue([true]);
+  const parentWave = createApiWaveOverview("direct-parent", 400);
+  const activeSubwave = {
+    ...createLegacyApiWave("direct-child", 500),
+    parent_wave: parentWave,
+  };
+  const childWave = {
+    ...createSidebarWave({
+      id: "direct-child",
+      latestDropTimestamp: 500,
+      subscribed: false,
+    }),
+    parentWaveId: "direct-parent",
+  };
+  useWavesV2Mock.mockReturnValue({
+    waves: [],
+    isFetching: false,
+    isFetchingNextPage: false,
+    hasNextPage: false,
+    fetchNextPage: jest.fn(),
+    status: "success",
+    refetch: jest.fn(),
+  });
+  usePinnedWavesServerMock.mockReturnValue({
+    pinnedIds: [],
+    pinnedWaves: [],
+    pinWave: jest.fn(),
+    unpinWave: jest.fn(),
+    isLoading: false,
+    isError: false,
+    refetch: jest.fn(),
+  });
+  useWaveSubwavesMapMock.mockImplementation(
+    ({ parentWaveIds }: { readonly parentWaveIds: readonly string[] }) => ({
+      subwaves: parentWaveIds.includes("direct-parent") ? [childWave] : [],
+      subwavesByParentId: new Map(
+        parentWaveIds.includes("direct-parent")
+          ? [["direct-parent", { subwaves: [childWave], isFetching: false }]]
+          : []
+      ),
+      isFetching: false,
+      refetch: jest.fn(),
+    })
+  );
+
+  const { result } = renderHook(
+    () => useWavesList({ activeWave: activeSubwave }),
+    { wrapper }
+  );
+
+  expect(result.current.waves).toHaveLength(2);
+  expect(result.current.waves).toEqual([
+    expect.objectContaining({
+      id: "direct-parent",
+      hasSubwaves: true,
+      isInAllWaves: true,
+      parentWaveId: null,
+      subscribed: false,
+    }),
+    expect.objectContaining({
+      id: "direct-child",
+      parentWaveId: "direct-parent",
+      subscribed: false,
+    }),
+  ]);
+
+  act(() => {
+    result.current.loadSubwavesForParent("direct-parent");
+  });
+
+  expect(useWaveSubwavesMapMock).toHaveBeenLastCalledWith({
+    parentWaveIds: ["direct-parent"],
+    viewerIdentityKey: "0xabc:primary",
+  });
+  expect(result.current.waves.map((wave: any) => wave.id)).toEqual([
+    "direct-parent",
+    "direct-child",
   ]);
 });
 

--- a/components/brain/left-sidebar/waves/SidebarWaveTreeRowTransition.tsx
+++ b/components/brain/left-sidebar/waves/SidebarWaveTreeRowTransition.tsx
@@ -50,6 +50,7 @@ export function SidebarWaveTreeRowTransition({
 
   return (
     <div
+      data-sidebar-wave-id={row.rowType === "wave" ? row.wave.id : undefined}
       data-sidebar-subwave-row-state={row.animationState}
       className={`tw-transition-[top,height,max-height,opacity,transform] ${transitionDurationClass} tw-ease-out motion-reduce:tw-transition-none ${
         row.depth === 1 && row.animationState !== "entered"

--- a/components/brain/left-sidebar/waves/UnifiedWavesListWaves.tsx
+++ b/components/brain/left-sidebar/waves/UnifiedWavesListWaves.tsx
@@ -242,16 +242,15 @@ const UnifiedWavesListWaves = forwardRef<
       () => getRows(pinnedWaves),
       [pinnedWaves, getRows]
     );
-    const activeContainerWaveId = isDirectMessage
-      ? null
-      : effectiveActiveParentWaveId;
-    const prioritizedAllWaves = useMemo(
-      () => prioritizeActiveWaveContainer(allWaves, activeContainerWaveId),
-      [activeContainerWaveId, allWaves]
-    );
     const allRows = useMemo(
-      () => getRows(prioritizedAllWaves),
-      [getRows, prioritizedAllWaves]
+      () =>
+        getRows(
+          prioritizeActiveWaveContainer(
+            allWaves,
+            isDirectMessage ? null : effectiveActiveParentWaveId
+          )
+        ),
+      [allWaves, effectiveActiveParentWaveId, getRows, isDirectMessage]
     );
     const animatedAnnouncementRows =
       useAnimatedSidebarWaveRows(announcementRows);

--- a/components/brain/left-sidebar/waves/UnifiedWavesListWaves.tsx
+++ b/components/brain/left-sidebar/waves/UnifiedWavesListWaves.tsx
@@ -30,6 +30,7 @@ import { usePrefetchWaveData } from "@/hooks/usePrefetchWaveData";
 import { useLoadActiveSidebarParentSubwaves } from "@/hooks/useLoadActiveSidebarParentSubwaves";
 import { useLoadPersistedExpandedSubwaves } from "@/hooks/useLoadPersistedExpandedSubwaves";
 import { useActiveSubwaveParentHint } from "@/hooks/useActiveSubwaveParentHint";
+import { useRevealActiveSidebarWave } from "@/hooks/useRevealActiveSidebarWave";
 import { getWaveHomeRoute, getWaveRoute } from "@/helpers/navigation.helpers";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
 import {
@@ -44,6 +45,7 @@ import {
 import {
   groupSidebarWavesForView,
   isValidSidebarWave,
+  prioritizeActiveWaveContainer,
   validateSidebarWaveDetailed,
 } from "./sidebarWaveListUtils";
 import { DEFAULT_LOCALE } from "@/i18n/locales";
@@ -240,7 +242,17 @@ const UnifiedWavesListWaves = forwardRef<
       () => getRows(pinnedWaves),
       [pinnedWaves, getRows]
     );
-    const allRows = useMemo(() => getRows(allWaves), [allWaves, getRows]);
+    const activeContainerWaveId = isDirectMessage
+      ? null
+      : effectiveActiveParentWaveId;
+    const prioritizedAllWaves = useMemo(
+      () => prioritizeActiveWaveContainer(allWaves, activeContainerWaveId),
+      [activeContainerWaveId, allWaves]
+    );
+    const allRows = useMemo(
+      () => getRows(prioritizedAllWaves),
+      [getRows, prioritizedAllWaves]
+    );
     const animatedAnnouncementRows =
       useAnimatedSidebarWaveRows(announcementRows);
     const animatedHighlyRatedRows = useAnimatedSidebarWaveRows(highlyRatedRows);
@@ -382,6 +394,22 @@ const UnifiedWavesListWaves = forwardRef<
       listContainerRef,
       rowHeight: getSidebarRowHeight,
       overscan: VIRTUALIZATION_OVERSCAN,
+    });
+    const revealStaticRows = useMemo(
+      () => [
+        animatedAnnouncementRows,
+        animatedHighlyRatedRows,
+        animatedPinnedRows,
+      ],
+      [animatedAnnouncementRows, animatedHighlyRatedRows, animatedPinnedRows]
+    );
+    useRevealActiveSidebarWave({
+      activeParentWaveId: effectiveActiveParentWaveId,
+      activeWaveId,
+      scrollContainerRef,
+      scrollToVirtualIndex: virtual.scrollToIndex,
+      staticRows: revealStaticRows,
+      virtualRows: virtualizedRows,
     });
 
     const renderWaveRow = (

--- a/components/brain/left-sidebar/waves/sidebarWaveListUtils.ts
+++ b/components/brain/left-sidebar/waves/sidebarWaveListUtils.ts
@@ -132,3 +132,30 @@ export const groupSidebarWavesForView = ({
         isAnnouncementsWave,
         waves,
       });
+
+export const prioritizeActiveWaveContainer = (
+  waves: readonly MinimalWave[],
+  activeContainerWaveId: string | null | undefined
+): readonly MinimalWave[] => {
+  if (!activeContainerWaveId) {
+    return waves;
+  }
+
+  const activeContainerIndex = waves.findIndex(
+    (wave) => wave.id === activeContainerWaveId
+  );
+  if (activeContainerIndex <= 0) {
+    return waves;
+  }
+
+  const activeContainer = waves[activeContainerIndex];
+  if (!activeContainer) {
+    return waves;
+  }
+
+  return [
+    activeContainer,
+    ...waves.slice(0, activeContainerIndex),
+    ...waves.slice(activeContainerIndex + 1),
+  ];
+};

--- a/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.tsx
+++ b/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.tsx
@@ -7,6 +7,7 @@ import useIsTouchDevice from "@/hooks/useIsTouchDevice";
 import { useLoadActiveSidebarParentSubwaves } from "@/hooks/useLoadActiveSidebarParentSubwaves";
 import { useLoadPersistedExpandedSubwaves } from "@/hooks/useLoadPersistedExpandedSubwaves";
 import { useActiveSubwaveParentHint } from "@/hooks/useActiveSubwaveParentHint";
+import { useRevealActiveSidebarWave } from "@/hooks/useRevealActiveSidebarWave";
 import { usePrefetchWaveData } from "@/hooks/usePrefetchWaveData";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -51,6 +52,7 @@ import { getWaveRoute } from "@/helpers/navigation.helpers";
 import {
   groupSidebarWavesForView,
   isValidSidebarWave,
+  prioritizeActiveWaveContainer,
 } from "../waves/sidebarWaveListUtils";
 import { DEFAULT_LOCALE } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
@@ -180,7 +182,7 @@ function DiscoverWavesLink() {
   return (
     <Link
       href="/discover"
-      className="tw-inline-flex tw-h-7 tw-items-center tw-rounded-md tw-px-1.5 tw-text-[13px] tw-font-medium tw-leading-none tw-text-primary-300 tw-no-underline tw-transition-colors tw-duration-150 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-black active:tw-text-primary-100 desktop-hover:hover:tw-text-primary-200 motion-reduce:tw-transition-none"
+      className="active:tw-text-primary-100 desktop-hover:hover:tw-text-primary-200 tw-inline-flex tw-h-7 tw-items-center tw-rounded-md tw-px-1.5 tw-text-[13px] tw-font-medium tw-leading-none tw-text-primary-300 tw-no-underline tw-transition-colors tw-duration-150 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-black motion-reduce:tw-transition-none"
       aria-label={label}
     >
       {label}
@@ -320,7 +322,17 @@ const WebUnifiedWavesListWaves: React.FC<WebUnifiedWavesListWavesProps> = ({
     () => getRows(pinnedWaves),
     [pinnedWaves, getRows]
   );
-  const allRows = useMemo(() => getRows(allWaves), [allWaves, getRows]);
+  const activeContainerWaveId = isDirectMessage
+    ? null
+    : effectiveActiveParentWaveId;
+  const prioritizedAllWaves = useMemo(
+    () => prioritizeActiveWaveContainer(allWaves, activeContainerWaveId),
+    [activeContainerWaveId, allWaves]
+  );
+  const allRows = useMemo(
+    () => getRows(prioritizedAllWaves),
+    [getRows, prioritizedAllWaves]
+  );
   const rowAnimationOptions = useMemo(
     () => ({ keepExitingRows: !isCollapsed }),
     [isCollapsed]
@@ -467,6 +479,22 @@ const WebUnifiedWavesListWaves: React.FC<WebUnifiedWavesListWavesProps> = ({
     listContainerRef,
     rowHeight: getSidebarRowHeight,
     overscan: 5,
+  });
+  const revealStaticRows = useMemo(
+    () => [
+      animatedAnnouncementRows,
+      animatedHighlyRatedRows,
+      animatedPinnedRows,
+    ],
+    [animatedAnnouncementRows, animatedHighlyRatedRows, animatedPinnedRows]
+  );
+  useRevealActiveSidebarWave({
+    activeParentWaveId: effectiveActiveParentWaveId,
+    activeWaveId,
+    scrollContainerRef: scrollContainerRef ?? listContainerRef,
+    scrollToVirtualIndex: virtual.scrollToIndex,
+    staticRows: revealStaticRows,
+    virtualRows: virtualizedRows,
   });
 
   const renderWaveRow = (

--- a/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.tsx
+++ b/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.tsx
@@ -31,6 +31,7 @@ import { WaveTrustSignals } from "@/components/waves/WaveTrustSignals";
 import MyStreamActionTooltip from "../MyStreamActionTooltip";
 import { useSidebarState } from "../../../../hooks/useSidebarState";
 import WaveRepButton from "@/components/waves/header/rep/WaveRepButton";
+import WaveParentNavigation from "@/components/waves/header/WaveParentNavigation";
 import CompactWaveActions from "./CompactWaveActions";
 import { waveRightPanelText } from "@/helpers/waves/wave-right-panel.helpers";
 import { BRAIN_RIGHT_SIDEBAR_ID } from "@/components/brain/right-sidebar/BrainRightSidebarTypes";
@@ -181,6 +182,10 @@ function MyStreamWaveHeaderIdentity({
         />
       </div>
       <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col">
+        <WaveParentNavigation
+          parentWave={wave.parent_wave}
+          variant={isCompact ? "compact-header" : "header"}
+        />
         {showDescriptionPreview ? (
           <>
             <WaveDescriptionPopover
@@ -429,7 +434,7 @@ export default function MyStreamWaveTabsHeader({
             <button
               type="button"
               onClick={handleMobileBack}
-              className="tw-flex tw-h-9 tw-self-start tw-items-center tw-border-0 tw-bg-transparent tw-p-0 tw-px-1.5 tw-text-iron-300 tw-transition-colors hover:tw-text-iron-50 sm:-tw-ml-2.5 sm:tw-px-2.5"
+              className="tw-flex tw-h-9 tw-items-center tw-self-start tw-border-0 tw-bg-transparent tw-p-0 tw-px-1.5 tw-text-iron-300 tw-transition-colors hover:tw-text-iron-50 sm:-tw-ml-2.5 sm:tw-px-2.5"
               aria-label="Go back"
             >
               <ArrowLeftIcon className="tw-h-5 tw-w-5 tw-flex-shrink-0 sm:tw-h-6 sm:tw-w-6" />

--- a/components/header/AppHeader.tsx
+++ b/components/header/AppHeader.tsx
@@ -62,6 +62,7 @@ import {
   useHeaderActiveWave,
 } from "./app-header-wave-preview";
 import WaveHeaderRestrictionButton from "@/components/waves/header/WaveHeaderRestrictionButton";
+import WaveParentNavigation from "@/components/waves/header/WaveParentNavigation";
 import MainStageNominationPopover from "@/components/brain/my-stream/tabs/MainStageNominationPopover";
 import { useProfileDoubleActivate } from "./useProfileDoubleActivate";
 
@@ -259,25 +260,31 @@ const HeaderTitleContent = ({
       ) : (
         <>
           {wavePicture}
-          {activeWave !== null && !isDm && previewText !== null ? (
-            <WaveDescriptionPopover
-              wave={activeWave}
-              align="left"
-              ariaLabel="Show wave description"
-              triggerClassName="tw-flex tw-min-w-0 tw-flex-col tw-items-start tw-border-0 tw-bg-transparent tw-p-0 tw-text-left"
-            >
-              <span className="tw-w-full tw-truncate tw-text-sm tw-font-semibold">
+          <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-items-start">
+            <WaveParentNavigation
+              parentWave={activeWave?.parent_wave}
+              variant="compact-header"
+            />
+            {activeWave !== null && !isDm && previewText !== null ? (
+              <WaveDescriptionPopover
+                wave={activeWave}
+                align="left"
+                ariaLabel="Show wave description"
+                triggerClassName="tw-flex tw-w-full tw-min-w-0 tw-flex-col tw-items-start tw-border-0 tw-bg-transparent tw-p-0 tw-text-left"
+              >
+                <span className="tw-w-full tw-truncate tw-text-sm tw-font-semibold">
+                  {displayWave.name}
+                </span>
+                <span className="tw-hidden tw-w-full tw-truncate tw-text-xs tw-font-normal tw-text-iron-400 sm:tw-block">
+                  {previewText}
+                </span>
+              </WaveDescriptionPopover>
+            ) : (
+              <span className="tw-w-full tw-min-w-0 tw-truncate tw-text-sm tw-font-semibold">
                 {displayWave.name}
               </span>
-              <span className="tw-hidden tw-w-full tw-truncate tw-text-xs tw-font-normal tw-text-iron-400 sm:tw-block">
-                {previewText}
-              </span>
-            </WaveDescriptionPopover>
-          ) : (
-            <span className="tw-min-w-0 tw-truncate tw-text-sm tw-font-semibold">
-              {displayWave.name}
-            </span>
-          )}
+            )}
+          </div>
         </>
       )}
     </div>

--- a/components/waves/header/WaveParentNavigation.tsx
+++ b/components/waves/header/WaveParentNavigation.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import type { ApiWave } from "@/generated/models/ApiWave";
 import { getWavePathRoute } from "@/helpers/navigation.helpers";
 import { getParentWaveName } from "@/helpers/waves/waves.helpers";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 
 interface WaveParentNavigationProps {
   readonly parentWave: ApiWave["parent_wave"];
@@ -23,10 +25,18 @@ export default function WaveParentNavigation({
 
   const isCompactHeader = variant === "compact-header";
   const isHeader = variant === "header" || isCompactHeader;
+  const linkTitle = t(
+    DEFAULT_LOCALE,
+    "waves.header.parentNavigation.linkTitle",
+    { parentWaveName }
+  );
 
   return (
     <nav
-      aria-label="Wave hierarchy"
+      aria-label={t(
+        DEFAULT_LOCALE,
+        "waves.header.parentNavigation.regionLabel"
+      )}
       className={`tw-flex tw-min-w-0 tw-items-center tw-gap-x-1.5 tw-text-xs tw-leading-4 ${
         isHeader ? "tw-mb-0.5" : ""
       }`}
@@ -38,16 +48,23 @@ export default function WaveParentNavigation({
             : "tw-shrink-0 tw-font-medium tw-text-iron-400"
         }
       >
-        Subwave of
+        {t(DEFAULT_LOCALE, "waves.header.parentNavigation.relationshipLabel")}
       </span>
       <Link
         href={getWavePathRoute(parentWave.id)}
-        title={`Open parent wave: ${parentWaveName}`}
+        aria-label={
+          isHeader
+            ? t(DEFAULT_LOCALE, "waves.header.parentNavigation.linkAriaLabel", {
+                parentWaveName,
+              })
+            : linkTitle
+        }
+        title={linkTitle}
         className={`tw-inline-flex tw-min-w-0 tw-shrink tw-items-center tw-gap-x-1 tw-truncate tw-font-medium tw-no-underline tw-transition tw-duration-200 tw-ease-out focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-iron-950 ${
           isCompactHeader ? "tw-max-w-full" : "tw-max-w-[60%]"
         } ${
           isHeader
-            ? "desktop-hover:hover:tw-text-primary-200 tw-text-primary-300"
+            ? "desktop-hover:hover:tw-text-primary-200 tw-min-h-6 tw-text-primary-300"
             : "tw-text-iron-300 desktop-hover:hover:tw-text-iron-100"
         }`}
       >

--- a/components/waves/header/WaveParentNavigation.tsx
+++ b/components/waves/header/WaveParentNavigation.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { ArrowUpLeftIcon } from "@heroicons/react/24/outline";
+import Link from "next/link";
+import type { ApiWave } from "@/generated/models/ApiWave";
+import { getWavePathRoute } from "@/helpers/navigation.helpers";
+import { getParentWaveName } from "@/helpers/waves/waves.helpers";
+
+interface WaveParentNavigationProps {
+  readonly parentWave: ApiWave["parent_wave"];
+  readonly variant?: "compact-header" | "detail" | "header" | undefined;
+}
+
+export default function WaveParentNavigation({
+  parentWave,
+  variant = "detail",
+}: WaveParentNavigationProps) {
+  const parentWaveName = getParentWaveName(parentWave);
+
+  if (!parentWave || !parentWaveName) {
+    return null;
+  }
+
+  const isCompactHeader = variant === "compact-header";
+  const isHeader = variant === "header" || isCompactHeader;
+
+  return (
+    <nav
+      aria-label="Wave hierarchy"
+      className={`tw-flex tw-min-w-0 tw-items-center tw-gap-x-1.5 tw-text-xs tw-leading-4 ${
+        isHeader ? "tw-mb-0.5" : ""
+      }`}
+    >
+      <span
+        className={
+          isHeader
+            ? "tw-sr-only"
+            : "tw-shrink-0 tw-font-medium tw-text-iron-400"
+        }
+      >
+        Subwave of
+      </span>
+      <Link
+        href={getWavePathRoute(parentWave.id)}
+        title={`Open parent wave: ${parentWaveName}`}
+        className={`tw-inline-flex tw-min-w-0 tw-shrink tw-items-center tw-gap-x-1 tw-truncate tw-font-medium tw-no-underline tw-transition tw-duration-200 tw-ease-out focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-iron-950 ${
+          isCompactHeader ? "tw-max-w-full" : "tw-max-w-[60%]"
+        } ${
+          isHeader
+            ? "desktop-hover:hover:tw-text-primary-200 tw-text-primary-300"
+            : "tw-text-iron-300 desktop-hover:hover:tw-text-iron-100"
+        }`}
+      >
+        {isHeader && (
+          <ArrowUpLeftIcon
+            aria-hidden="true"
+            className="tw-size-3.5 tw-flex-shrink-0"
+          />
+        )}
+        <span className="tw-min-w-0 tw-truncate">{parentWaveName}</span>
+      </Link>
+    </nav>
+  );
+}

--- a/components/waves/header/name/WaveHeaderName.tsx
+++ b/components/waves/header/name/WaveHeaderName.tsx
@@ -5,36 +5,20 @@ import type { ApiWave } from "@/generated/models/ApiWave";
 import { useContext } from "react";
 import { AuthContext } from "@/components/auth/Auth";
 import WaveHeaderNameEdit from "./WaveHeaderNameEdit";
-import { canEditWave, getParentWaveName } from "@/helpers/waves/waves.helpers";
+import { canEditWave } from "@/helpers/waves/waves.helpers";
 import { getWavePathRoute } from "@/helpers/navigation.helpers";
+import WaveParentNavigation from "../WaveParentNavigation";
 
 export default function WaveHeaderName({ wave }: { readonly wave: ApiWave }) {
   const { connectedProfile, activeProfileProxy } = useContext(AuthContext);
   const isDirectMessage = wave.chat.scope.group?.is_direct_message ?? false;
-  const parentWave = wave.parent_wave;
-  const parentWaveName = getParentWaveName(parentWave);
   const showEdit =
     !isDirectMessage &&
     canEditWave({ connectedProfile, activeProfileProxy, wave });
 
   return (
     <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col">
-      {parentWave && parentWaveName && (
-        <nav
-          aria-label="Wave hierarchy"
-          className="tw-flex tw-min-w-0 tw-items-center tw-gap-x-1.5 tw-text-xs tw-leading-4"
-        >
-          <span className="tw-shrink-0 tw-font-medium tw-text-iron-400">
-            Subwave of
-          </span>
-          <Link
-            href={getWavePathRoute(parentWave.id)}
-            className="tw-block tw-min-w-0 tw-max-w-[50%] tw-shrink tw-truncate tw-font-medium tw-text-iron-300 tw-no-underline tw-transition tw-duration-200 tw-ease-out hover:tw-text-iron-100 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-iron-950"
-          >
-            {parentWaveName}
-          </Link>
-        </nav>
-      )}
+      <WaveParentNavigation parentWave={wave.parent_wave} />
       <div className="tw-group tw-flex tw-min-w-0 tw-items-start tw-gap-x-2">
         <Link
           href={getWavePathRoute(wave.id)}

--- a/contexts/wave/MyStreamContext.tsx
+++ b/contexts/wave/MyStreamContext.tsx
@@ -217,8 +217,11 @@ export const MyStreamProvider: React.FC<MyStreamProviderProps> = ({
   const { wave: activeWaveData } = useWaveById(activeWaveId, {
     enabled: Boolean(activeWaveId),
   });
+  const resolvedActiveWaveData =
+    activeWaveData?.id === activeWaveId ? activeWaveData : null;
   const mainWavesData = useWavesList({
     enabled: isMainWavesListEnabled,
+    ...(resolvedActiveWaveData ? { activeWave: resolvedActiveWaveData } : {}),
   });
   const dmWavesData = useDmWavesList({
     enabled: isDirectMessagesListEnabled,
@@ -328,8 +331,8 @@ export const MyStreamProvider: React.FC<MyStreamProviderProps> = ({
     dmWavesRef.current = dmWavesHookData.waves;
   }, [wavesHookData.waves, dmWavesHookData.waves]);
 
-  const activeWaveDataId = activeWaveData?.id ?? null;
-  const activeWaveMuted = getWaveMuted(activeWaveData);
+  const activeWaveDataId = resolvedActiveWaveData?.id ?? null;
+  const activeWaveMuted = getWaveMuted(resolvedActiveWaveData);
   const isWaveMuted = useCallback(
     (waveId: string): boolean => {
       const wave = wavesRef.current.find((w) => w.id === waveId);
@@ -491,8 +494,8 @@ export const MyStreamProvider: React.FC<MyStreamProviderProps> = ({
   // Create the context value using the nested structure
   const contextValue = useMemo<MyStreamContextType>(() => {
     const activeWaveParentId =
-      activeWaveData?.id === activeWaveId
-        ? (activeWaveData.parent_wave?.id ?? null)
+      resolvedActiveWaveData?.id === activeWaveId
+        ? (resolvedActiveWaveData.parent_wave?.id ?? null)
         : null;
 
     const waves: WavesContextData = {
@@ -587,7 +590,7 @@ export const MyStreamProvider: React.FC<MyStreamProviderProps> = ({
     dmWavesHookData.restoreWaveUnreadCount,
     markDirectMessageRead,
     activeWaveId,
-    activeWaveData,
+    resolvedActiveWaveData,
     setActiveWaveAndRegister,
     requestMainWavesList,
     requestDirectMessagesList,

--- a/hooks/useLoadActiveSidebarParentSubwaves.ts
+++ b/hooks/useLoadActiveSidebarParentSubwaves.ts
@@ -13,10 +13,12 @@ export function useLoadActiveSidebarParentSubwaves({
 }: UseLoadActiveSidebarParentSubwavesOptions) {
   const { waves: streamWaves } = useMyStream();
   const requestedParentIdsRef = useRef(new Set<string>());
-  const hasLoadedActiveParentSubwaves = useMemo(
+  const hasActiveParentInSidebar = useMemo(
     () =>
       activeParentWaveId !== null &&
-      waves.some((wave) => wave.parentWaveId === activeParentWaveId),
+      waves.some(
+        (wave) => wave.id === activeParentWaveId && wave.parentWaveId === null
+      ),
     [activeParentWaveId, waves]
   );
   const loadActiveParentSubwaves = useEffectEvent((parentWaveId: string) => {
@@ -24,12 +26,7 @@ export function useLoadActiveSidebarParentSubwaves({
   });
 
   useEffect(() => {
-    if (activeParentWaveId === null) {
-      return;
-    }
-
-    if (hasLoadedActiveParentSubwaves) {
-      requestedParentIdsRef.current.delete(activeParentWaveId);
+    if (activeParentWaveId === null || !hasActiveParentInSidebar) {
       return;
     }
 
@@ -44,5 +41,5 @@ export function useLoadActiveSidebarParentSubwaves({
     return () => {
       requestedParentIds.delete(activeParentWaveId);
     };
-  }, [activeParentWaveId, hasLoadedActiveParentSubwaves]);
+  }, [activeParentWaveId, hasActiveParentInSidebar]);
 }

--- a/hooks/useRevealActiveSidebarWave.ts
+++ b/hooks/useRevealActiveSidebarWave.ts
@@ -1,0 +1,126 @@
+"use client";
+
+import type { SidebarWaveTreeRow } from "@/hooks/useSidebarWaveTree";
+import { useLayoutEffect, useMemo, useRef, type RefObject } from "react";
+
+interface UseRevealActiveSidebarWaveOptions {
+  readonly activeParentWaveId: string | null;
+  readonly activeWaveId: string | null;
+  readonly scrollContainerRef: RefObject<HTMLElement | null>;
+  readonly scrollToVirtualIndex: (index: number) => boolean;
+  readonly staticRows: readonly (readonly SidebarWaveTreeRow[])[];
+  readonly virtualRows: readonly SidebarWaveTreeRow[];
+}
+
+const hasWaveRow = (
+  rows: readonly SidebarWaveTreeRow[],
+  waveId: string | null
+) =>
+  waveId !== null &&
+  rows.some((row) => row.rowType === "wave" && row.wave.id === waveId);
+
+const findWaveRowElement = (
+  container: HTMLElement,
+  waveId: string
+): HTMLElement | null => {
+  const rowElements = container.querySelectorAll<HTMLElement>(
+    "[data-sidebar-wave-id]"
+  );
+
+  return (
+    Array.from(rowElements).find(
+      (element) => element.dataset["sidebarWaveId"] === waveId
+    ) ?? null
+  );
+};
+
+export function useRevealActiveSidebarWave({
+  activeParentWaveId,
+  activeWaveId,
+  scrollContainerRef,
+  scrollToVirtualIndex,
+  staticRows,
+  virtualRows,
+}: UseRevealActiveSidebarWaveOptions) {
+  const lastRevealKeyRef = useRef<string | null>(null);
+  const staticWaveIds = useMemo(
+    () =>
+      new Set(
+        staticRows.flatMap((rows) =>
+          rows.filter((row) => row.rowType === "wave").map((row) => row.wave.id)
+        )
+      ),
+    [staticRows]
+  );
+  const revealWaveId = useMemo(() => {
+    if (hasWaveRow(virtualRows, activeWaveId)) {
+      return activeWaveId;
+    }
+
+    if (activeWaveId !== null && staticWaveIds.has(activeWaveId)) {
+      return activeWaveId;
+    }
+
+    if (hasWaveRow(virtualRows, activeParentWaveId)) {
+      return activeParentWaveId;
+    }
+
+    if (activeParentWaveId !== null && staticWaveIds.has(activeParentWaveId)) {
+      return activeParentWaveId;
+    }
+
+    return null;
+  }, [activeParentWaveId, activeWaveId, staticWaveIds, virtualRows]);
+  const virtualRowIndex = useMemo(
+    () =>
+      revealWaveId === null
+        ? -1
+        : virtualRows.findIndex(
+            (row) => row.rowType === "wave" && row.wave.id === revealWaveId
+          ),
+    [revealWaveId, virtualRows]
+  );
+
+  useLayoutEffect(() => {
+    if (activeWaveId === null || revealWaveId === null) {
+      lastRevealKeyRef.current = null;
+      return;
+    }
+
+    // Main-list queries hydrate independently. Include the virtual position so
+    // rows inserted ahead of the active wave cannot move it back off-screen
+    // after the first successful reveal.
+    const revealLocation =
+      virtualRowIndex >= 0 ? `virtual:${virtualRowIndex}` : "static";
+    const revealKey = `${activeWaveId}:${revealWaveId}:${revealLocation}`;
+    if (lastRevealKeyRef.current === revealKey) {
+      return;
+    }
+
+    if (virtualRowIndex >= 0) {
+      if (scrollToVirtualIndex(virtualRowIndex)) {
+        lastRevealKeyRef.current = revealKey;
+      }
+      return;
+    }
+
+    const scrollContainer = scrollContainerRef.current;
+    if (scrollContainer === null) {
+      return;
+    }
+
+    const rowElement = findWaveRowElement(scrollContainer, revealWaveId);
+    if (rowElement === null) {
+      return;
+    }
+
+    rowElement.scrollIntoView({ block: "nearest" });
+    lastRevealKeyRef.current = revealKey;
+  }, [
+    activeWaveId,
+    revealWaveId,
+    scrollContainerRef,
+    scrollToVirtualIndex,
+    virtualRowIndex,
+  ]);
+}

--- a/hooks/useSidebarWaveTree.ts
+++ b/hooks/useSidebarWaveTree.ts
@@ -311,13 +311,15 @@ export function useSidebarWaveTree({
 
   const getIsExpanded = useCallback(
     (waveId: string) => {
+      if (resolvedActiveParentWaveId === waveId) {
+        return true;
+      }
+
       if (collapsedParentIds.has(waveId)) {
         return false;
       }
 
-      return (
-        expandedParentIds.has(waveId) || resolvedActiveParentWaveId === waveId
-      );
+      return expandedParentIds.has(waveId);
     },
     [collapsedParentIds, resolvedActiveParentWaveId, expandedParentIds]
   );

--- a/hooks/useVirtualizedWaves.ts
+++ b/hooks/useVirtualizedWaves.ts
@@ -30,7 +30,10 @@ interface UseVirtualizedWavesOptions<T> {
 const restoreScrollPosition = (element: HTMLElement, top: number) => {
   if (typeof element.scrollTo === "function") {
     element.scrollTo({ top });
+    return;
   }
+
+  element.scrollTop = top;
 };
 
 const readVirtualLayout = (
@@ -184,6 +187,44 @@ export function useVirtualizedWaves<T>({
     () => measureRows(items, rowHeight),
     [items, rowHeight]
   );
+  const scrollToIndex = useCallback(
+    (index: number): boolean => {
+      const scrollContainer = scrollContainerRef.current;
+      const listContainer = listContainerRef.current;
+      const measurement = measurements[index];
+      const viewportHeight = scrollContainer?.clientHeight ?? 0;
+
+      if (
+        scrollContainer === null ||
+        listContainer === null ||
+        measurement === undefined ||
+        viewportHeight <= 0
+      ) {
+        return false;
+      }
+
+      const targetStart = listContainer.offsetTop + measurement.start;
+      const targetEnd = targetStart + measurement.size;
+      const viewportStart = scrollContainer.scrollTop;
+      const viewportEnd = viewportStart + viewportHeight;
+      let nextScrollTop: number | null = null;
+
+      if (targetStart < viewportStart) {
+        nextScrollTop = targetStart;
+      } else if (targetEnd > viewportEnd) {
+        nextScrollTop = Math.max(0, targetEnd - viewportHeight);
+      }
+
+      if (nextScrollTop !== null) {
+        restoreScrollPosition(scrollContainer, nextScrollTop);
+        setScrollOffset(nextScrollTop);
+        setPosition(key, nextScrollTop);
+      }
+
+      return true;
+    },
+    [key, listContainerRef, measurements, scrollContainerRef, setPosition]
+  );
   const visibleStart = Math.max(scrollOffset - layout.listOffset, 0);
   const visibleEnd = scrollOffset + layout.viewportHeight - layout.listOffset;
   const firstVisibleIndex = measurements.findIndex(
@@ -225,5 +266,6 @@ export function useVirtualizedWaves<T>({
     virtualItems,
     totalHeight,
     sentinelRef,
+    scrollToIndex,
   };
 }

--- a/hooks/useWavesList.helpers.ts
+++ b/hooks/useWavesList.helpers.ts
@@ -1,6 +1,11 @@
 "use client";
 
 import { ApiWavesPinFilter } from "@/generated/models/ApiWavesPinFilter";
+import type { ApiWave } from "@/generated/models/ApiWave";
+import {
+  mapApiWaveOverviewToSidebarWave,
+  mapApiWaveToSidebarWave,
+} from "@/services/api/waves-v2-api";
 import type { SidebarWave } from "@/types/waves.types";
 
 export type SidebarDiscoverySection = "highly-rated" | "all";
@@ -13,6 +18,49 @@ export type SidebarWaveWithDiscoverySection = SidebarWave & {
 export const SIDEBAR_DISCOVERY_SECTION_HIGHLY_RATED: SidebarDiscoverySection =
   "highly-rated";
 export const SIDEBAR_DISCOVERY_SECTION_ALL: SidebarDiscoverySection = "all";
+
+interface ActiveSidebarContext {
+  readonly containerWave: SidebarWaveWithDiscoverySection | null;
+  readonly subwave: SidebarWave | null;
+}
+
+export const getActiveSidebarContext = (
+  activeWave: ApiWave | null
+): ActiveSidebarContext => {
+  if (activeWave === null) {
+    return { containerWave: null, subwave: null };
+  }
+
+  const activeSidebarWave = mapApiWaveToSidebarWave(activeWave);
+  if (activeSidebarWave.isDirectMessage) {
+    return { containerWave: null, subwave: null };
+  }
+
+  if (activeSidebarWave.parentWaveId === null) {
+    return {
+      containerWave: {
+        ...activeSidebarWave,
+        isInAllWaves: true,
+        sidebarSection: SIDEBAR_DISCOVERY_SECTION_ALL,
+      },
+      subwave: null,
+    };
+  }
+
+  if (!activeWave.parent_wave) {
+    return { containerWave: null, subwave: null };
+  }
+
+  return {
+    containerWave: {
+      ...mapApiWaveOverviewToSidebarWave(activeWave.parent_wave),
+      hasSubwaves: true,
+      isInAllWaves: true,
+      sidebarSection: SIDEBAR_DISCOVERY_SECTION_ALL,
+    },
+    subwave: activeSidebarWave,
+  };
+};
 
 const HIGHLY_RATED_WAVE_LIMIT = 10;
 

--- a/hooks/useWavesList.ts
+++ b/hooks/useWavesList.ts
@@ -9,7 +9,6 @@ import { useSeizeConnectContext } from "@/components/auth/SeizeConnectContext";
 import { useSeizeSettings } from "@/contexts/SeizeSettingsContext";
 import { normalizeOptionalWaveId } from "@/helpers/waves/wave.helpers";
 import { mapApiWaveToSidebarWave, useWavesV2 } from "./useWavesV2";
-import { mapApiWaveOverviewToSidebarWave } from "@/services/api/waves-v2-api";
 import {
   SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS,
   WAVE_FOLLOWING_WAVES_PARAMS,
@@ -27,6 +26,7 @@ import type { SidebarWave } from "@/types/waves.types";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   buildMainWaves,
+  getActiveSidebarContext,
   getConnectedIdentity,
   getHasAuthenticatedProfile,
   getMainWavesFetching,
@@ -87,49 +87,6 @@ const getFirstUnreadSerialNo = (
 
 const noopWaveAction = (_waveId: string) => {};
 const noopListAction = () => {};
-
-interface ActiveSidebarContext {
-  readonly containerWave: SidebarWaveWithDiscoverySection | null;
-  readonly subwave: SidebarWave | null;
-}
-
-const getActiveSidebarContext = (
-  activeWave: ApiWave | null
-): ActiveSidebarContext => {
-  if (activeWave === null) {
-    return { containerWave: null, subwave: null };
-  }
-
-  const activeSidebarWave = mapApiWaveToSidebarWave(activeWave);
-  if (activeSidebarWave.isDirectMessage) {
-    return { containerWave: null, subwave: null };
-  }
-
-  if (activeSidebarWave.parentWaveId === null) {
-    return {
-      containerWave: {
-        ...activeSidebarWave,
-        isInAllWaves: true,
-        sidebarSection: SIDEBAR_DISCOVERY_SECTION_ALL,
-      },
-      subwave: null,
-    };
-  }
-
-  if (!activeWave.parent_wave) {
-    return { containerWave: null, subwave: null };
-  }
-
-  return {
-    containerWave: {
-      ...mapApiWaveOverviewToSidebarWave(activeWave.parent_wave),
-      hasSubwaves: true,
-      isInAllWaves: true,
-      sidebarSection: SIDEBAR_DISCOVERY_SECTION_ALL,
-    },
-    subwave: activeSidebarWave,
-  };
-};
 
 /**
  * Hook for managing and fetching waves list including pinned waves

--- a/hooks/useWavesList.ts
+++ b/hooks/useWavesList.ts
@@ -3,11 +3,13 @@
 /* eslint max-lines-per-function: "off" */
 
 import { useMemo, useCallback, useState } from "react";
+import type { ApiWave } from "@/generated/models/ApiWave";
 import { useAuth } from "@/components/auth/Auth";
 import { useSeizeConnectContext } from "@/components/auth/SeizeConnectContext";
 import { useSeizeSettings } from "@/contexts/SeizeSettingsContext";
 import { normalizeOptionalWaveId } from "@/helpers/waves/wave.helpers";
 import { mapApiWaveToSidebarWave, useWavesV2 } from "./useWavesV2";
+import { mapApiWaveOverviewToSidebarWave } from "@/services/api/waves-v2-api";
 import {
   SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS,
   WAVE_FOLLOWING_WAVES_PARAMS,
@@ -86,12 +88,56 @@ const getFirstUnreadSerialNo = (
 const noopWaveAction = (_waveId: string) => {};
 const noopListAction = () => {};
 
+interface ActiveSidebarContext {
+  readonly containerWave: SidebarWaveWithDiscoverySection | null;
+  readonly subwave: SidebarWave | null;
+}
+
+const getActiveSidebarContext = (
+  activeWave: ApiWave | null
+): ActiveSidebarContext => {
+  if (activeWave === null) {
+    return { containerWave: null, subwave: null };
+  }
+
+  const activeSidebarWave = mapApiWaveToSidebarWave(activeWave);
+  if (activeSidebarWave.isDirectMessage) {
+    return { containerWave: null, subwave: null };
+  }
+
+  if (activeSidebarWave.parentWaveId === null) {
+    return {
+      containerWave: {
+        ...activeSidebarWave,
+        isInAllWaves: true,
+        sidebarSection: SIDEBAR_DISCOVERY_SECTION_ALL,
+      },
+      subwave: null,
+    };
+  }
+
+  if (!activeWave.parent_wave) {
+    return { containerWave: null, subwave: null };
+  }
+
+  return {
+    containerWave: {
+      ...mapApiWaveOverviewToSidebarWave(activeWave.parent_wave),
+      hasSubwaves: true,
+      isInAllWaves: true,
+      sidebarSection: SIDEBAR_DISCOVERY_SECTION_ALL,
+    },
+    subwave: activeSidebarWave,
+  };
+};
+
 /**
  * Hook for managing and fetching waves list including pinned waves
  * @returns Wave list data and loading states
  */
 interface UseWavesListOptions {
   readonly enabled?: boolean | undefined;
+  readonly activeWave?: ApiWave | null | undefined;
 }
 
 const useWavesList = (options: UseWavesListOptions = {}) => {
@@ -105,6 +151,11 @@ const useWavesList = (options: UseWavesListOptions = {}) => {
   const { address, hasValidWalletAuth } = useSeizeConnectContext();
   const { seizeSettings, isAnnouncementsWave } = useSeizeSettings();
   const isEnabled = options.enabled !== false;
+  const activeWave = options.activeWave ?? null;
+  const activeSidebarContext = useMemo(
+    () => getActiveSidebarContext(activeWave),
+    [activeWave]
+  );
   const {
     pinnedIds,
     pinnedWaves: serverPinnedWaves,
@@ -411,7 +462,15 @@ const useWavesList = (options: UseWavesListOptions = {}) => {
     const pinnedWavesSet = new Set(pinnedIds);
     const allWavesArray: EnhancedWave[] = [];
 
-    [...mainWaves, ...separatelyFetchedPinnedWaves].forEach((wave) => {
+    const activeContainerWave = activeSidebarContext.containerWave;
+    const activeContainerWaveId = activeContainerWave?.id ?? null;
+    const sourceWaves = [
+      ...(activeContainerWave ? [activeContainerWave] : []),
+      ...mainWaves,
+      ...separatelyFetchedPinnedWaves,
+    ];
+
+    sourceWaves.forEach((wave) => {
       if (
         wave.isDirectMessage ||
         !isExpectedRootSidebarWave(wave) ||
@@ -443,7 +502,9 @@ const useWavesList = (options: UseWavesListOptions = {}) => {
       if (hasHighlyRatedSection && (!isJoinedMode || !hasAllSection)) {
         preservedSidebarSection = SIDEBAR_DISCOVERY_SECTION_HIGHLY_RATED;
       }
-      const isPinned = pinnedWavesSet.has(wave.id);
+      const isPinned =
+        pinnedWavesSet.has(wave.id) ||
+        (wave.id === activeContainerWaveId && wave.pinned);
 
       // The current source has the freshest wave payload; the fields below
       // intentionally preserve cross-source sidebar state that can appear only
@@ -525,6 +586,7 @@ const useWavesList = (options: UseWavesListOptions = {}) => {
     isAnnouncementsWave,
     isJoinedMode,
     shouldLoadMainWaves,
+    activeSidebarContext,
   ]);
 
   const [loadedSubwaveParentIds, setLoadedSubwaveParentIds] = useState<
@@ -639,27 +701,38 @@ const useWavesList = (options: UseWavesListOptions = {}) => {
   }, [combinedWaves, isAnnouncementsWave]);
 
   // Derived data should come directly from memoized inputs.
-  const allWaves = useMemo(
-    () =>
-      shouldLoadMainWaves
-        ? [
-            ...combinedWaves,
-            ...subwaves.filter(
-              (wave) =>
-                !isJoinedMode ||
-                wave.subscribed ||
-                topSectionWaveIds.has(wave.parentWaveId ?? "")
-            ),
-          ]
-        : [],
-    [
-      combinedWaves,
-      isJoinedMode,
-      shouldLoadMainWaves,
-      subwaves,
-      topSectionWaveIds,
-    ]
-  );
+  const allWaves = useMemo(() => {
+    if (!shouldLoadMainWaves) {
+      return [];
+    }
+
+    const visibleSubwaves = new Map<string, SidebarWave>();
+    const activeSubwave = activeSidebarContext.subwave;
+    if (activeSubwave !== null) {
+      visibleSubwaves.set(activeSubwave.id, activeSubwave);
+    }
+
+    subwaves.forEach((wave) => {
+      if (
+        !isJoinedMode ||
+        wave.subscribed ||
+        wave.id === activeSubwave?.id ||
+        topSectionWaveIds.has(wave.parentWaveId ?? "")
+      ) {
+        // The overview is fresher than the temporary full-wave route context.
+        visibleSubwaves.set(wave.id, wave);
+      }
+    });
+
+    return [...combinedWaves, ...visibleSubwaves.values()];
+  }, [
+    combinedWaves,
+    activeSidebarContext.subwave,
+    isJoinedMode,
+    shouldLoadMainWaves,
+    subwaves,
+    topSectionWaveIds,
+  ]);
 
   // New drops counting logic has been removed and will be managed by context
 

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -515,8 +515,7 @@ const PROFILE_WAVE_FEED_MESSAGES = objectMessages("waves.profileFeed", {
   errorTitle: "Couldn’t load profile posts",
   errorDescription: "Refresh this view to try again.",
   emptyTitle: "No profile posts yet",
-  emptyDescription:
-    "New posts from members’ Profile Waves will appear here.",
+  emptyDescription: "New posts from members’ Profile Waves will appear here.",
 } as const);
 
 const WAVE_LEADERBOARD_MESSAGES = objectMessages("waves.leaderboard", {
@@ -1192,6 +1191,10 @@ const WAVE_HEADER_MESSAGES = objectMessages("waves.header", {
   ownerOptionsDelete: "Delete",
   ownerOptionsOpenLabel: "Open options",
   ownerOptionsTitle: "Wave options",
+  "parentNavigation.linkAriaLabel": "Subwave of {parentWaveName}",
+  "parentNavigation.linkTitle": "Open parent wave: {parentWaveName}",
+  "parentNavigation.regionLabel": "Wave hierarchy",
+  "parentNavigation.relationshipLabel": "Subwave of",
   pictureEditCancel: "Cancel",
   pictureEditDescription: "Choose a new image up to 10 MB.",
   pictureEditLabel: "Edit wave picture",

--- a/ops/docs/wave-subwave-interaction-model.md
+++ b/ops/docs/wave-subwave-interaction-model.md
@@ -138,7 +138,28 @@ API returns enough parent-container metadata to do so.
 - The control shows a loading state while child rows are being fetched.
 - The control points down only when child rows are visible.
 - Active subwaves request their parent children so the parent can open once the rows are available.
+- A direct-linked active subwave can temporarily surface the visible parent
+  overview returned with the active-wave response, even when the parent is not
+  followed, pinned, or present in the current sidebar page.
+- The active route overrides a previously persisted collapse for that parent,
+  reveals the parent while children load, and then reveals and highlights the
+  exact subwave row.
+- In the activity section, the active route's parent tree stays ahead of the
+  timestamp-sorted roots. Loading another page cannot insert roots above the
+  expanded tree, so every sibling remains reachable without scroll chasing.
+- Surfacing route context does not join or pin the parent or child and does not
+  synthesize metadata for an inaccessible parent.
 - Collapsed icon-only sidebar mode hides child rows and preserves the expanded state for the full sidebar.
+
+## Active Wave Header
+
+- When the active destination is a subwave, its header shows an up-left arrow
+  followed by the parent wave name. Assistive technology receives the fuller
+  `Subwave of` relationship text.
+- The visible parent wave name is a navigation link that opens the parent wave.
+- Root-wave and direct-message headers do not show this hierarchy row.
+- Long parent names truncate in the compact header instead of overlapping the
+  wave title or header actions.
 
 ## Mobile
 

--- a/ops/docs/waves/sidebars/feature-wave-list-navigation.md
+++ b/ops/docs/waves/sidebars/feature-wave-list-navigation.md
@@ -16,8 +16,15 @@ Wave and DM rows in the left list control which thread is open.
   details without creating a competing click target.
 - `Worth Checking Out` is an overlapping discovery view: every recommended
   wave also appears in the `All` list at its recent-activity position. The
-  `Joined` list includes only waves the user has joined, so discovery-only
-  recommendations stay out of that bottom list.
+  `Joined` list normally includes only waves the user has joined, so
+  discovery-only recommendations stay out of that bottom list.
+- A wave opened from a direct link is temporarily added to the sidebar route
+  context when it is outside the loaded list, including in `Joined`. This does
+  not pin or join the wave.
+- When the direct link targets a subwave, its visible root parent is surfaced,
+  its subwaves are loaded, the parent opens, and the active child row is
+  highlighted.
+- The sidebar scrolls the active route row into the nearest visible position.
 - The expanded web Waves panel header includes a secondary `Discover Waves`
   link to `/discover`.
 - Browser back/forward keeps the active row and URL in sync.
@@ -64,6 +71,11 @@ Wave and DM rows in the left list control which thread is open.
 - Native-app edge swipe from `/waves/{waveId}` returns to `/waves`.
 - Inside the `/waves` or `/messages` shell, row changes update URL/history in
   place and keep row highlight aligned.
+- Opening `/waves/{waveId}` directly keeps that wave visible and highlighted
+  even when it is not followed, pinned, or present in the current overview
+  page.
+- Opening a subwave directly shows its root parent while children load, then
+  expands the parent and reveals the selected subwave row.
 - On signed-out desktop web `/waves`, clearing the active row returns to
   `/waves` and leaves the shell visible with a `Select a Wave` placeholder plus
   a connect-wallet CTA in the thread pane.
@@ -92,11 +104,18 @@ Wave and DM rows in the left list control which thread is open.
   their normal touch behavior.
 - Browser-default behavior is kept for modified clicks such as Cmd/Ctrl-click,
   Shift/Alt-click, middle-click, and right-click/context menu.
+- Route-context rows keep their server-returned pin and join state. Their
+  temporary visibility does not change account preferences.
+- A private or inaccessible parent is never synthesized: only parent metadata
+  included in the resolved active-wave response can be surfaced.
 
 ## Failure and Recovery
 
 - If the selected thread no longer resolves, the app returns to section home
   (`/waves` or `/messages`).
+- While direct-linked subwave children are loading, the parent row remains the
+  visible fallback. When the active child arrives, the same sidebar moves the
+  reveal target to that child.
 - Recovery removes stale `wave` query values when present.
 - After recovery, users can select another row immediately.
 

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -2295,14 +2295,18 @@
         "On desktop with no selected Wave, /waves shows the latest posts from members' effective public Profile Wave curations, newest first.",
         "Each latest-profile-post card identifies the author, posting time, and originating Profile Wave; curated replies can also appear. On small screens, the default /waves view remains a Wave navigator.",
         "In Worth Checking Out, each avatar and its overlaid score shield form one wave navigation link; hovering or focusing the combined link shows score details.",
-        "Every Worth Checking Out recommendation also appears in All at its recent-activity position; Joined includes only waves the user has joined."
+        "Every Worth Checking Out recommendation also appears in All at its recent-activity position; Joined normally includes only waves the user has joined.",
+        "A Wave opened from a direct link remains visible and highlighted in the left sidebar even when it is not followed, pinned, or present in the loaded overview; this temporary route context does not join or pin it.",
+        "When a direct link opens a subwave, the sidebar surfaces its visible parent, loads and expands the subwave list, reveals the selected child row, and keeps that parent tree ahead of paginated activity rows so every sibling remains reachable.",
+        "An active subwave header shows an up-left arrow and a linked parent wave name; selecting that name opens the parent wave."
       ],
       "canonical_path": "/waves",
       "related_paths": ["/waves?create=wave", "/messages"],
       "tags": ["waves", "glossary"],
       "source_refs": [
         "ops/docs/waves/README.md",
-        "ops/docs/waves/sidebars/feature-wave-list-navigation.md"
+        "ops/docs/waves/sidebars/feature-wave-list-navigation.md",
+        "ops/docs/wave-subwave-interaction-model.md"
       ]
     },
     {

--- a/public/glossary.json
+++ b/public/glossary.json
@@ -805,7 +805,10 @@
         "On desktop with no selected Wave, /waves shows the latest posts from members' effective public Profile Wave curations, newest first.",
         "Each latest-profile-post card identifies the author, posting time, and originating Profile Wave; curated replies can also appear. On small screens, the default /waves view remains a Wave navigator.",
         "In Worth Checking Out, each avatar and its overlaid score shield form one wave navigation link; hovering or focusing the combined link shows score details.",
-        "Every Worth Checking Out recommendation also appears in All at its recent-activity position; Joined includes only waves the user has joined."
+        "Every Worth Checking Out recommendation also appears in All at its recent-activity position; Joined normally includes only waves the user has joined.",
+        "A Wave opened from a direct link remains visible and highlighted in the left sidebar even when it is not followed, pinned, or present in the loaded overview; this temporary route context does not join or pin it.",
+        "When a direct link opens a subwave, the sidebar surfaces its visible parent, loads and expands the subwave list, reveals the selected child row, and keeps that parent tree ahead of paginated activity rows so every sibling remains reachable.",
+        "An active subwave header shows an up-left arrow and a linked parent wave name; selecting that name opens the parent wave."
       ],
       "canonical_path": "/waves",
       "related_paths": [

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -2291,14 +2291,18 @@
         "On desktop with no selected Wave, /waves shows the latest posts from members' effective public Profile Wave curations, newest first.",
         "Each latest-profile-post card identifies the author, posting time, and originating Profile Wave; curated replies can also appear. On small screens, the default /waves view remains a Wave navigator.",
         "In Worth Checking Out, each avatar and its overlaid score shield form one wave navigation link; hovering or focusing the combined link shows score details.",
-        "Every Worth Checking Out recommendation also appears in All at its recent-activity position; Joined includes only waves the user has joined."
+        "Every Worth Checking Out recommendation also appears in All at its recent-activity position; Joined normally includes only waves the user has joined.",
+        "A Wave opened from a direct link remains visible and highlighted in the left sidebar even when it is not followed, pinned, or present in the loaded overview; this temporary route context does not join or pin it.",
+        "When a direct link opens a subwave, the sidebar surfaces its visible parent, loads and expands the subwave list, reveals the selected child row, and keeps that parent tree ahead of paginated activity rows so every sibling remains reachable.",
+        "An active subwave header shows an up-left arrow and a linked parent wave name; selecting that name opens the parent wave."
       ],
       "canonical_path": "/waves",
       "related_paths": ["/waves?create=wave", "/messages"],
       "tags": ["waves", "glossary"],
       "source_refs": [
         "ops/docs/waves/README.md",
-        "ops/docs/waves/sidebars/feature-wave-list-navigation.md"
+        "ops/docs/waves/sidebars/feature-wave-list-navigation.md",
+        "ops/docs/wave-subwave-interaction-model.md"
       ]
     },
     {

--- a/scripts/debt-ratchet-baseline.json
+++ b/scripts/debt-ratchet-baseline.json
@@ -3,7 +3,7 @@
   "max_source_file_lines": 800,
   "counts": {
     "any_casts": 22,
-    "test_generic_any": 115,
+    "test_generic_any": 113,
     "todo_comments": 0,
     "oversized_files": 0,
     "legacy_wordpress_runtime": 0,

--- a/services/api/waves-v2-api.ts
+++ b/services/api/waves-v2-api.ts
@@ -155,7 +155,7 @@ export function getWavesV2OverviewQueryKeyParams({
 const getWaveOverviewContext = (wave: ApiWaveOverview) =>
   wave.context_profile_context;
 
-const mapApiWaveOverviewToSidebarWave = (
+export const mapApiWaveOverviewToSidebarWave = (
   wave: ApiWaveOverview
 ): SidebarWave => {
   const context = getWaveOverviewContext(wave);


### PR DESCRIPTION
## Issue

- Waves opened through a direct URL can be absent from the loaded left-sidebar page, leaving the active destination invisible.
- Direct-linked subwaves need their parent expanded and the active child revealed even when neither wave is followed or pinned.
- Pagination can otherwise keep inserting activity rows ahead of a low-positioned active subwave tree, making later sibling subwaves difficult to reach.
- A subwave header needs a clear route back to its parent wave.

## Fix

- Treat the resolved active wave and its API-provided parent overview as temporary route context in the sidebar without changing follow or pin state.
- Force the active subwave parent open, load its children, and reveal the active row in static or virtualized sidebar sections.
- Keep an active subwave's parent tree ahead of paginated activity roots so sibling rows remain stable and reachable.
- Show a compact up-left parent-wave link in active subwave headers.

## Changes

- Add active-wave route-context mapping and placeholder-data guards in the wave list/context flow.
- Add virtualized and static-row reveal behavior shared by the compact and expanded sidebars.
- Prioritize only the active subwave's root container; ordinary active root waves keep their normal activity ordering.
- Add a reusable, accessible parent-wave navigation component across desktop, compact, and detail headers.
- Expand unit/integration coverage for direct-linked roots, subwaves, forced expansion, loading, reveal, pagination stability, and header navigation.
- Update wave/sidebar documentation and synchronize the Help Bot index.

## Validation

- `./bin/6529 run check:changed`
- `./bin/6529 run test --runInBand --findRelatedTests ...` — 378 suites and 2,826 tests passed.
- `./bin/6529 run typecheck:ci`
- `./bin/6529 run typecheck:jest` — ratchet passed with the existing 2,007 diagnostics in 822 files.
- `./bin/6529 run react-doctor:diff` — 98/100; remaining findings are pre-existing large-component/inline-render/search-param advisories, with no new finding from this behavior.
- Manual browser verification on a direct-linked public subwave confirmed the parent tree is placed before paginated activity rows, all siblings remain contiguous, the active child is selected, and the parent header link navigates correctly.

## Risk

- Level: Medium
- Why: This changes sidebar list composition, expansion, virtualization scroll behavior, and shared wave headers, but does not change persistence, API contracts, authentication, or backend state.
- Rollback: Revert this frontend commit; no data migration or backend rollback is required.

## Review Notes

- Please focus on route-context deduplication when overview data arrives after the full active-wave response, virtualized scroll restoration, and the distinction between active subwave containers versus ordinary active root-wave sorting.
- This is frontend-only and has no backend deployment dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Direct-linked waves and subwaves now appear in the sidebar, with parent trees prioritized and active waves automatically revealed.
  * Active subwave parents remain expanded while active, even if previously collapsed.
  * Wave headers now show a navigable parent-wave hierarchy for subwaves.
  * Virtualized wave lists can scroll directly to active items.

* **Bug Fixes**
  * Prevented stale wave data from appearing during navigation or loading.

* **Documentation**
  * Updated wave navigation and subwave behavior documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->