### PR TITLE
Restore interactive HTML in Memes drop hero

### DIFF
--- a/__tests__/components/waves/drop/MemesSingleWaveDropInfoPanel.test.tsx
+++ b/__tests__/components/waves/drop/MemesSingleWaveDropInfoPanel.test.tsx
@@ -244,6 +244,20 @@ describe("MemesSingleWaveDropInfoPanel", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("keeps interactive HTML hero media on the viewport-aware renderer", () => {
+    render(
+      <MemesSingleWaveDropInfoPanel
+        drop={dropWithMedia("text/html", "interactive.html")}
+        wave={null}
+      />
+    );
+
+    expect(screen.getByTestId("media")).toHaveAttribute(
+      "data-load-strategy",
+      "in-view"
+    );
+  });
+
   it("passes single-drop close callback to resubmit source deletion", async () => {
     const onClose = jest.fn();
 

--- a/components/waves/drop/MemesDropArtworkHero.tsx
+++ b/components/waves/drop/MemesDropArtworkHero.tsx
@@ -9,6 +9,9 @@ interface MemesDropArtworkHeroProps {
 export function MemesDropArtworkHero({
   artworkMedia,
 }: MemesDropArtworkHeroProps) {
+  const loadStrategy =
+    artworkMedia?.mime_type === "text/html" ? "in-view" : "eager";
+
   return (
     <div className="tw-flex tw-w-full tw-flex-col lg:tw-min-h-screen">
       <div className="tw-flex tw-items-center tw-justify-center tw-px-4 tw-py-4 sm:tw-px-6 lg:tw-flex-1 lg:tw-py-8 xl:tw-px-20">
@@ -20,7 +23,7 @@ export function MemesDropArtworkHero({
                 media_url={artworkMedia.url}
                 isCompetitionDrop={true}
                 imageScale={ImageScale.AUTOx1080}
-                loadStrategy="eager"
+                loadStrategy={loadStrategy}
                 fillVideoContainer={true}
               />
             </div>


### PR DESCRIPTION
## Issue

- Interactive HTML artwork in the Memes single-drop hero renders as an empty fixed-height container.
- The hero used the eager media strategy, while the shared HTML renderer intentionally suppresses eager interactive content when no preview image is supplied.

## Fix

- Keep HTML hero artwork on the viewport-aware rendering path so the sandboxed iframe mounts when visible.
- Preserve eager loading for image, video, and model artwork.

## Changes

- Select the media loading strategy from the hero artwork MIME type.
- Add regression coverage for the HTML-specific in-view strategy.
- Preserve the existing hidden quick-vote preload behavior for interactive HTML.

## Validation

- Focused Jest suites: 2 passed, 27 tests.
- Changed-file lint, typecheck, and quality checks passed.
- React Doctor: 100/100, no findings.
- Browser and E2E checks were not run; this narrow fix is covered at the component boundary and by the existing HTML iframe renderer tests.

## Risk

- Level: Low
- Why: The behavior change is limited to text/html artwork in the Memes single-drop hero; other media types retain their current loading behavior.
- Rollback: Revert the single commit.

## Review Notes

- Confirm that visible HTML heroes use in-view loading while hidden quick-vote preloads remain unaffected.
- This restores the behavior already documented for shared drop surfaces without preview artwork.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved artwork media loading behavior: interactive HTML artwork now loads when it enters the viewport, while other media types continue to load immediately.
  - This provides more responsive handling for drop artwork while preserving existing loading behavior for images, videos, and other supported media.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->