### PR TITLE
Make native leaderboard cards easier to open

### DIFF
--- a/__tests__/components/brain/BrainMobile.test.tsx
+++ b/__tests__/components/brain/BrainMobile.test.tsx
@@ -26,6 +26,15 @@ let mockSearchParams = new URLSearchParams();
 let mockPathname = "/";
 const mockPush = jest.fn();
 const mockReplace = jest.fn();
+let mockCurrentWaveView: { waveId: string; view: BrainView } | null = null;
+const mockRememberWaveView = jest.fn();
+
+jest.mock("@/contexts/NavigationHistoryContext", () => ({
+  useNavigationHistoryContext: () => ({
+    currentWaveView: mockCurrentWaveView,
+    rememberWaveView: mockRememberWaveView,
+  }),
+}));
 
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush, replace: mockReplace }),
@@ -331,6 +340,7 @@ describe("BrainMobile", () => {
     mockPathname = "/";
     mockPush.mockClear();
     mockReplace.mockClear();
+    mockCurrentWaveView = null;
     dropData = null;
     waveData = null;
     isApp = true;
@@ -680,6 +690,48 @@ describe("BrainMobile", () => {
       expect(screen.getByText("child")).toBeInTheDocument();
     });
   });
+
+  it("records native tab selection and restores the matching history entry", async () => {
+    mockPathname = "/waves/1";
+    waveData = createWave(false);
+    const { unmount } = render(<BrainMobile>child</BrainMobile>);
+
+    await waitFor(() => expect(screen.getByTestId("tabs")).toBeInTheDocument());
+    act(() => {
+      latestTabsProps.onViewChange(BrainView.LEADERBOARD);
+    });
+    expect(mockRememberWaveView).toHaveBeenCalledWith({
+      waveId: "1",
+      view: BrainView.LEADERBOARD,
+    });
+    unmount();
+
+    mockCurrentWaveView = { waveId: "1", view: BrainView.LEADERBOARD };
+    render(<BrainMobile>child</BrainMobile>);
+
+    expect(await screen.findByTestId("leaderboard")).toBeInTheDocument();
+  });
+
+  it.each([
+    { app: true, rememberedWaveId: "2" },
+    { app: false, rememberedWaveId: "1" },
+  ])(
+    "ignores history tabs for app=$app remembered wave=$rememberedWaveId",
+    async ({ app, rememberedWaveId }) => {
+      isApp = app;
+      mockPathname = "/waves/1";
+      waveData = createWave(false);
+      mockCurrentWaveView = {
+        waveId: rememberedWaveId,
+        view: BrainView.LEADERBOARD,
+      };
+      render(<BrainMobile>child</BrainMobile>);
+
+      expect(await screen.findByText("child")).toBeInTheDocument();
+      expect(screen.queryByTestId("leaderboard")).toBeNull();
+      expect(mockRememberWaveView).not.toHaveBeenCalled();
+    }
+  );
 
   it("keeps the selected shell tab when web create modal query changes", async () => {
     isApp = false;

--- a/__tests__/components/brain/mobile/useBrainMobileActiveView.test.ts
+++ b/__tests__/components/brain/mobile/useBrainMobileActiveView.test.ts
@@ -28,6 +28,65 @@ const createProps = (
 });
 
 describe("useBrainMobileActiveView", () => {
+  it("restores an available view from the current navigation entry", () => {
+    const { result } = renderHook(() =>
+      useBrainMobileActiveView(
+        createProps({
+          isCompleted: false,
+          restoredView: BrainView.LEADERBOARD,
+          wave: { id: "wave-1" } as UseBrainMobileActiveViewProps["wave"],
+        })
+      )
+    );
+
+    expect(result.current.activeView).toBe(BrainView.LEADERBOARD);
+    act(() => {
+      result.current.onViewChange(BrainView.DEFAULT);
+    });
+    expect(result.current.activeView).toBe(BrainView.DEFAULT);
+  });
+
+  it("normalizes a restored view that is no longer available", () => {
+    const { result } = renderHook(() =>
+      useBrainMobileActiveView(
+        createProps({
+          restoredView: BrainView.MY_VOTES,
+          wave: { id: "wave-1" } as UseBrainMobileActiveViewProps["wave"],
+        })
+      )
+    );
+
+    expect(result.current.activeView).toBe(BrainView.SUBMISSIONS);
+  });
+
+  it.each(["42", ""])(
+    "opens explicit Chat target '%s' ahead of restored or locally selected views",
+    (serialNo) => {
+      const props = createProps({
+        isCompleted: false,
+        restoredView: BrainView.LEADERBOARD,
+        wave: { id: "wave-1" } as UseBrainMobileActiveViewProps["wave"],
+      });
+      const { result, rerender } = renderHook(useBrainMobileActiveView, {
+        initialProps: props,
+      });
+      act(() => {
+        result.current.onViewChange(BrainView.ABOUT);
+      });
+
+      rerender({
+        ...props,
+        searchParams: createSearchParams(`serialNo=${serialNo}`),
+      });
+
+      expect(result.current.activeView).toBe(BrainView.DEFAULT);
+      act(() => {
+        result.current.onViewChange(BrainView.LEADERBOARD);
+      });
+      expect(result.current.activeView).toBe(BrainView.LEADERBOARD);
+    }
+  );
+
   it("does not default to submissions while the wave is loading", () => {
     const { result } = renderHook(() =>
       useBrainMobileActiveView(createProps({ wave: undefined }))

--- a/__tests__/components/brain/mobile/useBrainMobileActiveView.test.ts
+++ b/__tests__/components/brain/mobile/useBrainMobileActiveView.test.ts
@@ -28,6 +28,30 @@ const createProps = (
 });
 
 describe("useBrainMobileActiveView", () => {
+  it("keeps the selection callback stable until its route context changes", () => {
+    const props = createProps({ isCompleted: false });
+    const { result, rerender } = renderHook(useBrainMobileActiveView, {
+      initialProps: props,
+    });
+    const initialCallback = result.current.onViewChange;
+
+    rerender({ ...props, hasAuthenticatedProfile: true });
+    expect(result.current.onViewChange).toBe(initialCallback);
+    act(() => {
+      result.current.onViewChange(BrainView.ABOUT);
+    });
+    expect(result.current.activeView).toBe(BrainView.ABOUT);
+    expect(result.current.onViewChange).toBe(initialCallback);
+
+    rerender({ ...props, waveId: "wave-2", pathname: "/waves/wave-2" });
+    expect(result.current.onViewChange).not.toBe(initialCallback);
+    expect(result.current.activeView).toBe(BrainView.DEFAULT);
+    act(() => {
+      result.current.onViewChange(BrainView.ABOUT);
+    });
+    expect(result.current.activeView).toBe(BrainView.ABOUT);
+  });
+
   it("restores an available view from the current navigation entry", () => {
     const { result } = renderHook(() =>
       useBrainMobileActiveView(

--- a/__tests__/components/drops/view/item/content/media/MediaDisplay.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/MediaDisplay.test.tsx
@@ -17,6 +17,7 @@ jest.mock(
       data-src={props.src}
       data-controls={String(props.showControls)}
       data-fill-container={String(props.fillContainer)}
+      data-inert-preview={String(props.isInertPreview)}
     />
   )
 );
@@ -114,6 +115,27 @@ describe("MediaDisplay", () => {
     expect(node).toHaveAttribute("data-src", "vid.mp4");
     expect(node).toHaveAttribute("data-controls", "true");
     expect(node).toHaveAttribute("data-fill-container", "false");
+    expect(node).toHaveAttribute("data-inert-preview", "false");
+  });
+
+  it("passes inert preview mode to native card video previews", () => {
+    render(
+      <MediaDisplay
+        media_mime_type="video/mp4"
+        media_url="vid.mp4"
+        disableMediaInteraction
+        isInertPreview
+      />
+    );
+
+    expect(screen.getByTestId("video")).toHaveAttribute(
+      "data-inert-preview",
+      "true"
+    );
+    expect(screen.getByTestId("video")).toHaveAttribute(
+      "data-controls",
+      "false"
+    );
   });
 
   it("forwards fill container sizing to video media", () => {

--- a/__tests__/components/drops/view/item/content/media/MediaDisplayVideo.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/MediaDisplayVideo.test.tsx
@@ -93,6 +93,26 @@ describe("MediaDisplayVideo", () => {
     ).toBeNull();
   });
 
+  it("does not expose playback controls or handle preview taps in inert mode", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <MediaDisplayVideo src="foo.mp4" isInertPreview />
+    );
+    const video = container.querySelector("video") as HTMLVideoElement;
+    Object.defineProperty(video, "paused", {
+      configurable: true,
+      get: () => false,
+    });
+    const playCalls = playMock.mock.calls.length;
+    const pauseCalls = pauseMock.mock.calls.length;
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    await user.click(video);
+
+    expect(playMock).toHaveBeenCalledTimes(playCalls);
+    expect(pauseMock).toHaveBeenCalledTimes(pauseCalls);
+  });
+
   it("always shows inline video media actions when controls are shown", () => {
     render(<MediaDisplayVideo src="foo.mp4" showControls />);
 

--- a/__tests__/components/memes/drops/MemesLeaderboardDrop.test.tsx
+++ b/__tests__/components/memes/drops/MemesLeaderboardDrop.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemesLeaderboardDrop } from "@/components/memes/drops/MemesLeaderboardDrop";
 
@@ -24,6 +24,9 @@ const useLongPressInteraction = jest.fn();
 jest.mock("@/hooks/useLongPressInteraction", () => ({
   __esModule: true,
   default: (...args: any[]) => useLongPressInteraction(...args),
+}));
+jest.mock("@/utils/monitoring/dropOpenTiming", () => ({
+  startDropOpen: jest.fn(),
 }));
 
 const mockVoteSummary = jest.fn(() => <div data-testid="summary" />);
@@ -67,14 +70,48 @@ jest.mock(
 );
 jest.mock(
   "@/components/memes/drops/MemesLeaderboardDropArtistInfo",
-  () => () => <div data-testid="artist" />
+  () => () => (
+    <a
+      href="/alice"
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+    >
+      alice
+    </a>
+  )
 );
 jest.mock("@/components/memes/drops/MemeDropTraits", () => () => (
-  <div data-testid="traits" />
+  <div data-testid="traits" data-tooltip-id="trait-tooltip" />
 ));
 jest.mock(
   "@/components/drops/view/item/content/media/DropListItemContentMedia",
-  () => () => <div data-testid="media" />
+  () => () => (
+    <div data-testid="media">
+      <button
+        type="button"
+        data-testid="media-preview"
+        onClick={(event) => event.stopPropagation()}
+      >
+        Open media preview
+      </button>
+    </div>
+  )
+);
+jest.mock(
+  "@/components/drops/view/item/content/media/MediaDisplay",
+  () =>
+    (props: {
+      readonly isInertPreview?: boolean;
+      readonly disableMediaInteraction?: boolean;
+    }) => (
+      <div
+        data-testid="media"
+        data-inert-preview={String(props.isInertPreview)}
+        data-disable-media-interaction={String(props.disableMediaInteraction)}
+      />
+    )
 );
 jest.mock("@/components/waves/drops/WaveDropActionsOpen", () => () => (
   <button
@@ -113,6 +150,9 @@ jest.mock(
   "@/components/utils/select/dropdown/CommonDropdownItemsMobileWrapper",
   () => (p: any) => (
     <div data-testid="wrapper">
+      <button data-testid="dismiss-menu" onClick={() => p.setOpen(false)}>
+        dismiss menu
+      </button>
       <button data-testid="after-leave" onClick={p.onAfterLeave}>
         after leave
       </button>
@@ -123,12 +163,19 @@ jest.mock(
 jest.mock("@/components/waves/drops/WaveDropMobileMenuDelete", () => () => (
   <div data-testid="mobile-delete" />
 ));
-jest.mock("@/components/waves/drops/WaveDropMobileMenuOpen", () => () => (
-  <div data-testid="mobile-open" />
+jest.mock("@/components/waves/drops/WaveDropMobileMenuOpen", () => (p: any) => (
+  <button
+    type="button"
+    data-testid="mobile-open"
+    onClick={() => p.onOpenChange(false)}
+  />
 ));
-jest.mock("@/components/waves/drops/WaveDropMobileMenuCopyLink", () => () => (
-  <div data-testid="mobile-copy" />
-));
+jest.mock(
+  "@/components/waves/drops/WaveDropMobileMenuCopyLink",
+  () => (p: any) => (
+    <button type="button" data-testid="mobile-copy" onClick={p.onCopy} />
+  )
+);
 jest.mock("@/components/waves/memes/submission/MemesArtResubmitAction", () => ({
   MemesArtResubmitAction: (p: any) => (
     <button data-testid="resubmit-action" onClick={p.onOpenModal}>
@@ -149,10 +196,10 @@ jest.mock("@/components/waves/memes/MemesArtSubmissionModal", () => ({
   __esModule: true,
   default: (p: any) => mockMemesArtSubmissionModal(p),
 }));
-jest.mock("react-dom", () => ({
-  ...jest.requireActual("react-dom"),
-  createPortal: (node: any) => node,
-}));
+
+const { startDropOpen } = require("@/utils/monitoring/dropOpenTiming") as {
+  startDropOpen: jest.Mock;
+};
 
 const drop: any = {
   id: "d1",
@@ -170,9 +217,8 @@ const drop: any = {
 };
 
 beforeEach(() => {
-  mockVoteSummary.mockClear();
-  mockVoteDetailsTrigger.mockClear();
-  mockMemesArtSubmissionModal.mockClear();
+  jest.clearAllMocks();
+  useDeviceInfo.mockReturnValue({ hasTouchScreen: false, isApp: false });
   useDropInteractionRules.mockReturnValue({ canDelete: true });
   useLongPressInteraction.mockReturnValue({
     isActive: false,
@@ -185,11 +231,132 @@ test("calls onDropClick when not touch screen", async () => {
   useDeviceInfo.mockReturnValue({ hasTouchScreen: false });
   useIsMobileScreen.mockReturnValue(false);
   const onClick = jest.fn();
-  const { container } = render(
-    <MemesLeaderboardDrop drop={drop} onDropClick={onClick} />
-  );
-  await userEvent.click(container.firstElementChild as HTMLElement);
+  render(<MemesLeaderboardDrop drop={drop} onDropClick={onClick} />);
+  await userEvent.click(screen.getByRole("button", { name: "Open T" }));
+  expect(onClick).toHaveBeenCalledTimes(1);
   expect(onClick).toHaveBeenCalledWith(drop);
+  expect(startDropOpen).toHaveBeenCalledTimes(1);
+});
+
+test.each(["header", "traits", "media"])(
+  "opens the desktop drop exactly once from passive %s content",
+  async (testId) => {
+    useIsMobileScreen.mockReturnValue(false);
+    const onDropClick = jest.fn();
+    render(<MemesLeaderboardDrop drop={drop} onDropClick={onDropClick} />);
+
+    await userEvent.click(screen.getByTestId(testId));
+
+    expect(onDropClick).toHaveBeenCalledTimes(1);
+    expect(onDropClick).toHaveBeenCalledWith(drop);
+    expect(startDropOpen).toHaveBeenCalledTimes(1);
+  }
+);
+
+test.each([
+  { environment: "native touch app", isApp: true },
+  { environment: "touch browser", isApp: false },
+])(
+  "does not open via passive-content bubbling in the $environment",
+  ({ isApp }) => {
+    useDeviceInfo.mockReturnValue({ hasTouchScreen: true, isApp });
+    useIsMobileScreen.mockReturnValue(true);
+    const onDropClick = jest.fn();
+    render(<MemesLeaderboardDrop drop={drop} onDropClick={onDropClick} />);
+
+    // Native hit testing opens through the sibling primary button, not bubbling.
+    fireEvent.click(screen.getByTestId("header"));
+    fireEvent.click(screen.getByTestId("traits"));
+    fireEvent.click(screen.getByTestId("media"));
+
+    expect(onDropClick).not.toHaveBeenCalled();
+    expect(startDropOpen).not.toHaveBeenCalled();
+  }
+);
+
+test("opens the drop with Enter and Space on its named primary button", async () => {
+  const user = userEvent.setup();
+  const onDropClick = jest.fn();
+  useDeviceInfo.mockReturnValue({ hasTouchScreen: false });
+  useIsMobileScreen.mockReturnValue(false);
+
+  render(<MemesLeaderboardDrop drop={drop} onDropClick={onDropClick} />);
+  const openButton = screen.getByRole("button", { name: "Open T" });
+
+  openButton.focus();
+  await user.keyboard("{Enter}");
+  await user.keyboard(" ");
+
+  expect(onDropClick).toHaveBeenCalledTimes(2);
+  expect(onDropClick).toHaveBeenLastCalledWith(drop);
+  expect(openButton.querySelector("a, button")).toBeNull();
+});
+
+test.each([
+  { environment: "touch browser", hasTouchScreen: true, isApp: false },
+  { environment: "desktop browser", hasTouchScreen: false, isApp: false },
+  { environment: "app without touch", hasTouchScreen: false, isApp: true },
+])(
+  "keeps author and media interactions independent in $environment",
+  async ({ hasTouchScreen, isApp }) => {
+    const onDropClick = jest.fn();
+    useDeviceInfo.mockReturnValue({ hasTouchScreen, isApp });
+    useIsMobileScreen.mockReturnValue(hasTouchScreen);
+
+    render(<MemesLeaderboardDrop drop={drop} onDropClick={onDropClick} />);
+    const authorLink = screen.getByRole("link", { name: "alice" });
+
+    expect(authorLink.closest("button")).toBeNull();
+    expect(screen.getByTestId("media").closest("[inert]")).toBeNull();
+    await userEvent.click(authorLink);
+    await userEvent.click(screen.getByTestId("media-preview"));
+
+    expect(onDropClick).not.toHaveBeenCalled();
+  }
+);
+
+test("keeps the native List username independent from submission opening", async () => {
+  useDeviceInfo.mockReturnValue({ hasTouchScreen: true, isApp: true });
+  useIsMobileScreen.mockReturnValue(true);
+  const onDropClick = jest.fn();
+  render(<MemesLeaderboardDrop drop={drop} onDropClick={onDropClick} />);
+
+  const authorLink = screen.getByRole("link", { name: "alice" });
+  expect(authorLink).toHaveAttribute("href", "/alice");
+  await userEvent.click(authorLink);
+  expect(onDropClick).not.toHaveBeenCalled();
+  expect(screen.getByTestId("media").closest("[inert]")).not.toBeNull();
+  expect(screen.getByTestId("media")).toHaveAttribute(
+    "data-inert-preview",
+    "true"
+  );
+  expect(screen.getByTestId("media")).toHaveAttribute(
+    "data-disable-media-interaction",
+    "true"
+  );
+  const primaryButton = screen.getByRole("button", { name: "Open T" });
+  expect(primaryButton.querySelector("a, button")).toBeNull();
+
+  // Physical-device coverage verifies preview hits reach this sibling button.
+  await userEvent.click(primaryButton);
+
+  expect(onDropClick).toHaveBeenCalledWith(drop);
+  await userEvent.click(screen.getByTestId("vote-btn"));
+  await userEvent.click(screen.getByTestId("vote-details"));
+  expect(onDropClick).toHaveBeenCalledTimes(1);
+  expect(screen.getByTestId("mobile-modal")).toHaveTextContent("open");
+});
+
+test("does not add a full-card open target to the touch browser", () => {
+  useDeviceInfo.mockReturnValue({ hasTouchScreen: true, isApp: false });
+  useIsMobileScreen.mockReturnValue(true);
+  render(<MemesLeaderboardDrop drop={drop} onDropClick={jest.fn()} />);
+
+  expect(
+    screen.queryByRole("button", { name: "Open T" })
+  ).not.toBeInTheDocument();
+  expect(screen.getByRole("link", { name: "alice" })).toBeInTheDocument();
+  expect(screen.getByTestId("media").closest("[inert]")).toBeNull();
 });
 
 test("passes the drop to vote summary and opens vote details without opening the card", async () => {
@@ -211,15 +378,148 @@ test("passes the drop to vote summary and opens vote details without opening the
   );
 });
 
-test("does not call onDropClick on touch devices", async () => {
-  useDeviceInfo.mockReturnValue({ hasTouchScreen: true });
-  useIsMobileScreen.mockReturnValue(false);
+test("opens the drop through its named primary button in the native touch app", async () => {
+  useDeviceInfo.mockReturnValue({ hasTouchScreen: true, isApp: true });
+  useIsMobileScreen.mockReturnValue(true);
   const onClick = jest.fn();
-  const { container } = render(
-    <MemesLeaderboardDrop drop={drop} onDropClick={onClick} />
+  render(<MemesLeaderboardDrop drop={drop} onDropClick={onClick} />);
+
+  // Native-device coverage verifies that title/background hit testing reaches this button.
+  await userEvent.click(screen.getByRole("button", { name: "Open T" }));
+
+  expect(startDropOpen).toHaveBeenCalledWith({
+    dropId: "d1",
+    waveId: "w1",
+    source: "leaderboard_memes",
+    isMobile: true,
+  });
+  expect(onClick).toHaveBeenCalledWith(drop);
+});
+
+test("keeps native touch scrolling enabled for long-press detection", () => {
+  useDeviceInfo.mockReturnValue({ hasTouchScreen: true });
+  useIsMobileScreen.mockReturnValue(true);
+
+  render(<MemesLeaderboardDrop drop={drop} onDropClick={jest.fn()} />);
+
+  expect(useLongPressInteraction).toHaveBeenCalledWith(
+    expect.objectContaining({
+      hasTouchScreen: true,
+      onInteractionStart: expect.any(Function),
+      preventDefault: false,
+    })
   );
-  await userEvent.click(container.firstElementChild as HTMLElement);
-  expect(onClick).not.toHaveBeenCalled();
+});
+
+test("rejects a scrolling release click without blocking the next intentional card tap", () => {
+  useDeviceInfo.mockReturnValue({ hasTouchScreen: true, isApp: true });
+  useIsMobileScreen.mockReturnValue(true);
+  const onDropClick = jest.fn();
+  render(<MemesLeaderboardDrop drop={drop} onDropClick={onDropClick} />);
+  const openButton = screen.getByRole("button", { name: "Open T" });
+  const touch = { identifier: 1, clientX: 10, clientY: 100 };
+
+  fireEvent.touchStart(openButton, { touches: [touch] });
+  fireEvent.touchMove(openButton, {
+    touches: [{ ...touch, clientY: 50 }],
+  });
+  fireEvent.touchEnd(openButton);
+  fireEvent.click(openButton, { detail: 1 });
+  expect(onDropClick).not.toHaveBeenCalled();
+
+  fireEvent.touchStart(openButton, { touches: [touch] });
+  fireEvent.touchEnd(openButton);
+  fireEvent.click(openButton, { detail: 1 });
+  expect(onDropClick).toHaveBeenCalledTimes(1);
+});
+
+test("keeps artwork taps in the media surface", async () => {
+  useDeviceInfo.mockReturnValue({ hasTouchScreen: true });
+  useIsMobileScreen.mockReturnValue(true);
+  const onDropClick = jest.fn();
+
+  render(<MemesLeaderboardDrop drop={drop} onDropClick={onDropClick} />);
+
+  await userEvent.click(screen.getByTestId("media-preview"));
+
+  expect(startDropOpen).not.toHaveBeenCalled();
+  expect(onDropClick).not.toHaveBeenCalled();
+});
+
+test("suppresses the click generated after a long press", async () => {
+  useDeviceInfo.mockReturnValue({ hasTouchScreen: true, isApp: true });
+  useIsMobileScreen.mockReturnValue(true);
+  const onDropClick = jest.fn();
+  render(<MemesLeaderboardDrop drop={drop} onDropClick={onDropClick} />);
+  const longPressOptions = useLongPressInteraction.mock.calls[0][0];
+  const openButton = screen.getByRole("button", { name: "Open T" });
+
+  longPressOptions.onInteractionStart();
+  fireEvent.touchEnd(openButton);
+  await userEvent.click(openButton);
+
+  expect(startDropOpen).not.toHaveBeenCalled();
+  expect(onDropClick).not.toHaveBeenCalled();
+
+  fireEvent.touchStart(openButton, {
+    touches: [{ identifier: 1, clientX: 10, clientY: 10 }],
+  });
+  fireEvent.touchEnd(openButton);
+  await userEvent.click(openButton);
+
+  expect(startDropOpen).toHaveBeenCalledTimes(1);
+  expect(onDropClick).toHaveBeenCalledTimes(1);
+});
+
+test("allows a fresh card tap after dismissing a long-press menu without a release click", () => {
+  const setIsActive = jest.fn();
+  const onDropClick = jest.fn();
+  useDeviceInfo.mockReturnValue({ hasTouchScreen: true, isApp: true });
+  useIsMobileScreen.mockReturnValue(true);
+  useLongPressInteraction.mockReturnValueOnce({
+    isActive: true,
+    setIsActive,
+    touchHandlers: {},
+  });
+
+  render(<MemesLeaderboardDrop drop={drop} onDropClick={onDropClick} />);
+  const openButton = screen.getByRole("button", { name: "Open T" });
+  useLongPressInteraction.mock.calls[0][0].onInteractionStart();
+  fireEvent.touchEnd(openButton);
+  fireEvent.click(screen.getByTestId("dismiss-menu"));
+
+  expect(setIsActive).toHaveBeenCalledWith(false);
+  expect(onDropClick).not.toHaveBeenCalled();
+
+  fireEvent.touchStart(openButton, {
+    touches: [{ identifier: 1, clientX: 10, clientY: 10 }],
+  });
+  fireEvent.touchEnd(openButton);
+  fireEvent.click(openButton);
+
+  expect(onDropClick).toHaveBeenCalledTimes(1);
+});
+
+test("allows the first real mobile-menu tap after a long press", () => {
+  const setIsActive = jest.fn();
+  useDeviceInfo.mockReturnValue({ hasTouchScreen: true });
+  useIsMobileScreen.mockReturnValue(true);
+  useLongPressInteraction.mockReturnValueOnce({
+    isActive: true,
+    setIsActive,
+    touchHandlers: {},
+  });
+  const onDropClick = jest.fn();
+
+  render(<MemesLeaderboardDrop drop={drop} onDropClick={onDropClick} />);
+  const longPressOptions = useLongPressInteraction.mock.calls[0][0];
+
+  longPressOptions.onInteractionStart();
+  fireEvent.click(screen.getByTestId("mobile-open"));
+
+  expect(setIsActive).toHaveBeenCalledWith(false);
+  expect(startDropOpen).not.toHaveBeenCalled();
+  expect(onDropClick).not.toHaveBeenCalled();
 });
 
 test("opens voting modal on desktop", async () => {

--- a/__tests__/components/waves/leaderboard/gallery/WaveLeaderboardGalleryItem.test.tsx
+++ b/__tests__/components/waves/leaderboard/gallery/WaveLeaderboardGalleryItem.test.tsx
@@ -1,11 +1,13 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { WaveLeaderboardGalleryItem } from "@/components/waves/leaderboard/gallery/WaveLeaderboardGalleryItem";
 import { ApiWaveParticipationSubmissionStrategyType } from "@/generated/models/ApiWaveParticipationSubmissionStrategyType";
 import { useDropVoteLogs } from "@/hooks/useDropVoteLogs";
 import { useDropVoters } from "@/hooks/useDropVoters";
 import useIsTouchDevice from "@/hooks/useIsTouchDevice";
+import useDeviceInfo from "@/hooks/useDeviceInfo";
+import { DEFAULT_LONG_PRESS_DURATION_MS } from "@/hooks/useLongPressInteraction";
 
 jest.mock(
   "@/components/drops/view/item/content/media/MediaDisplay",
@@ -14,6 +16,7 @@ jest.mock(
       data-testid="media"
       data-url={props.media_url}
       data-preview-image-url={props.previewImageUrl ?? ""}
+      data-inert-preview={String(props.isInertPreview)}
     />
   )
 );
@@ -43,14 +46,30 @@ jest.mock(
 jest.mock("@/components/waves/drops/winner/WinnerDropBadge", () => () => (
   <div data-testid="badge" />
 ));
-jest.mock("@/components/voting", () => ({
-  VotingModal: (props: any) => (
-    <div data-testid="modal" data-open={props.isOpen} />
-  ),
-  MobileVotingModal: (props: any) => (
-    <div data-testid="mobile-modal" data-open={props.isOpen} />
-  ),
-}));
+let mockVotingModalInline = false;
+jest.mock("@/components/voting", () => {
+  const { createPortal } = jest.requireActual("react-dom");
+  return {
+    VotingModal: (props: { readonly isOpen: boolean }) => {
+      const content = (
+        <div
+          data-testid="modal"
+          data-open={props.isOpen}
+          role={props.isOpen ? "dialog" : undefined}
+          aria-label="Voting"
+        />
+      );
+      return mockVotingModalInline
+        ? content
+        : createPortal(content, document.body);
+    },
+    MobileVotingModal: (props: { readonly isOpen: boolean }) =>
+      createPortal(
+        <div data-testid="mobile-modal" data-open={props.isOpen} />,
+        document.body
+      ),
+  };
+});
 jest.mock("@/components/voting/VotingModalButton", () => (props: any) => (
   <button
     data-testid="vote-btn"
@@ -62,6 +81,7 @@ jest.mock("@/components/voting/VotingModalButton", () => (props: any) => (
 ));
 jest.mock("@/hooks/isMobileScreen", () => () => false);
 jest.mock("@/hooks/useIsTouchDevice");
+jest.mock("@/hooks/useDeviceInfo");
 jest.mock("@/hooks/useDropVoters");
 jest.mock("@/hooks/useDropVoteLogs");
 jest.mock("@/hooks/useIntersectionObserver", () => ({
@@ -81,9 +101,38 @@ jest.mock("@/helpers/image.helpers", () => ({
   ImageScale: { AUTOx450: "x", AUTOx1080: "y" },
 }));
 
+const mockMenuOpen = jest.fn();
+jest.mock(
+  "@/components/waves/leaderboard/grid/WaveLeaderboardGridItemMobileActionsMenu",
+  () => ({
+    WaveLeaderboardGridItemMobileActionsMenu: (props: any) => {
+      const { createPortal } = jest.requireActual("react-dom");
+      return props.isOpen
+        ? createPortal(
+            <div role="dialog" aria-label="Artwork actions">
+              <button onClick={() => props.setIsActive(false)}>
+                Dismiss actions
+              </button>
+              <button
+                onClick={() => {
+                  mockMenuOpen();
+                  props.setIsActive(false);
+                }}
+              >
+                Open from actions
+              </button>
+            </div>,
+            document.body
+          )
+        : null;
+    },
+  })
+);
+
 const mockUseDropVoters = useDropVoters as jest.Mock;
 const mockUseDropVoteLogs = useDropVoteLogs as jest.Mock;
 const mockUseIsTouchDevice = useIsTouchDevice as jest.Mock;
+const mockUseDeviceInfo = useDeviceInfo as jest.Mock;
 
 describe("WaveLeaderboardGalleryItem", () => {
   const drop: any = {
@@ -99,6 +148,8 @@ describe("WaveLeaderboardGalleryItem", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockVotingModalInline = false;
+    mockUseDeviceInfo.mockReturnValue({ hasTouchScreen: false, isApp: false });
     mockUseIsTouchDevice.mockReturnValue(false);
     mockUseDropVoters.mockReturnValue({
       voters: [],
@@ -120,26 +171,345 @@ describe("WaveLeaderboardGalleryItem", () => {
     });
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it("handles click and keyboard events", async () => {
     const onDropClick = jest.fn();
-    const { container } = render(
+    render(
       <WaveLeaderboardGalleryItem drop={drop} onDropClick={onDropClick} />
     );
-    const mainButton = container.querySelector("button:first-of-type")!;
-    expect(mainButton).toHaveClass("tw-touch-pan-y");
+    const mainButton = screen.getByRole("button", {
+      name: "Open Untitled drop",
+    });
     expect(mainButton).not.toHaveClass("tw-touch-none");
     await userEvent.click(mainButton);
     expect(onDropClick).toHaveBeenCalledWith(drop);
     mainButton.focus();
     await userEvent.keyboard("{Enter}");
-    expect(onDropClick).toHaveBeenCalledTimes(2);
+    await userEvent.keyboard(" ");
+    expect(onDropClick).toHaveBeenCalledTimes(3);
+    expect(mainButton.querySelector("a, button")).toBeNull();
+  });
+
+  it("names the card-open action after the artwork", () => {
+    render(
+      <WaveLeaderboardGalleryItem
+        drop={{ ...drop, title: "A New Beginning" }}
+        onDropClick={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Open A New Beginning" })
+    ).toBeInTheDocument();
+  });
+
+  it.each([
+    { environment: "touch browser", hasTouchScreen: true, isApp: false },
+    { environment: "desktop browser", hasTouchScreen: false, isApp: false },
+    { environment: "app without touch", hasTouchScreen: false, isApp: true },
+  ])(
+    "keeps the author and static-media targets independent in $environment",
+    async ({ hasTouchScreen, isApp }) => {
+      mockUseDeviceInfo.mockReturnValue({ hasTouchScreen, isApp });
+      const onDropClick = jest.fn();
+      render(
+        <WaveLeaderboardGalleryItem drop={drop} onDropClick={onDropClick} />
+      );
+      const authorLink = screen.getByRole("link", {
+        name: "View alice's profile",
+      });
+
+      expect(authorLink).toHaveAttribute("href", "/alice");
+      expect(authorLink).toHaveClass("tw-block", "tw-max-w-full");
+      expect(authorLink).not.toHaveClass("tw-w-fit");
+      expect(authorLink.closest("button")).toBeNull();
+      expect(screen.getByTestId("media").closest("[inert]")).toBeNull();
+      expect(screen.getByTestId("media")).toHaveAttribute(
+        "data-inert-preview",
+        "false"
+      );
+      expect(screen.getByTestId("media").closest("button")).toBe(
+        screen.getByRole("button", { name: "Open Untitled drop" })
+      );
+      await userEvent.click(authorLink);
+
+      expect(onDropClick).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    { environment: "desktop browser", hasTouchScreen: false },
+    { environment: "touch browser", hasTouchScreen: true },
+  ])(
+    "preserves a whitespace-only title in the $environment",
+    ({ hasTouchScreen }) => {
+      mockUseDeviceInfo.mockReturnValue({ hasTouchScreen, isApp: false });
+      render(
+        <WaveLeaderboardGalleryItem
+          drop={{ ...drop, title: "   " }}
+          onDropClick={jest.fn()}
+        />
+      );
+
+      expect(screen.getByRole("heading", { level: 3 }).textContent).toBe("   ");
+      expect(screen.queryByText("Untitled drop")).not.toBeInTheDocument();
+    }
+  );
+
+  it("uses the fallback for a whitespace-only native-touch title", () => {
+    mockUseDeviceInfo.mockReturnValue({ hasTouchScreen: true, isApp: true });
+    render(
+      <WaveLeaderboardGalleryItem
+        drop={{ ...drop, title: "   " }}
+        onDropClick={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Untitled drop" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Open Untitled drop" })
+    ).toBeInTheDocument();
+  });
+
+  it.each(["image/png", "video/mp4"])(
+    "uses one native-touch open action for author and %s previews",
+    async (mimeType) => {
+      mockUseDeviceInfo.mockReturnValue({ hasTouchScreen: true, isApp: true });
+      const onDropClick = jest.fn();
+      const nativeDrop = {
+        ...drop,
+        title: "Native artwork",
+        parts: [{ media: [{ url: "artwork", mime_type: mimeType }] }],
+      };
+      render(
+        <WaveLeaderboardGalleryItem
+          drop={nativeDrop}
+          onDropClick={onDropClick}
+        />
+      );
+
+      expect(screen.getByText("alice").tagName).toBe("SPAN");
+      expect(
+        screen.queryByRole("link", { name: "View alice's profile" })
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("media").closest("[inert]")).not.toBeNull();
+      expect(screen.getByTestId("media")).toHaveAttribute(
+        "data-inert-preview",
+        "true"
+      );
+      expect(
+        screen.queryByRole("button", { name: "Open drop media" })
+      ).not.toBeInTheDocument();
+      const primaryButton = screen.getByRole("button", {
+        name: "Open Native artwork",
+      });
+      expect(primaryButton.querySelector("a, button")).toBeNull();
+
+      // Physical-device coverage verifies author/media hits reach the sibling primary button.
+      await userEvent.click(primaryButton);
+      expect(onDropClick).toHaveBeenCalledWith(nativeDrop);
+      await userEvent.click(screen.getByTestId("vote-btn"));
+      expect(onDropClick).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("modal")).toHaveAttribute("data-open", "true");
+    }
+  );
+
+  it("does not add a long-press menu to touch-browser cards", () => {
+    jest.useFakeTimers();
+    mockUseDeviceInfo.mockReturnValue({ hasTouchScreen: true, isApp: false });
+    const onDropClick = jest.fn();
+    render(
+      <WaveLeaderboardGalleryItem drop={drop} onDropClick={onDropClick} />
+    );
+    const mainButton = screen.getByRole("button", {
+      name: "Open Untitled drop",
+    });
+
+    fireEvent.touchStart(mainButton, {
+      touches: [{ clientX: 10, clientY: 10 }],
+    });
+    act(() => jest.advanceTimersByTime(DEFAULT_LONG_PRESS_DURATION_MS));
+    fireEvent.touchEnd(mainButton);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    fireEvent.click(mainButton);
+    expect(onDropClick).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["portaled", "inline"])(
+    "does not start the card long press from a %s voting dialog",
+    (rendering) => {
+      jest.useFakeTimers();
+      mockVotingModalInline = rendering === "inline";
+      mockUseDeviceInfo.mockReturnValue({ hasTouchScreen: true, isApp: true });
+      const onDropClick = jest.fn();
+      render(
+        <WaveLeaderboardGalleryItem drop={drop} onDropClick={onDropClick} />
+      );
+      fireEvent.click(screen.getByTestId("vote-btn"));
+      const modal = screen.getByTestId("modal");
+      expect(modal).toHaveAttribute("data-open", "true");
+
+      fireEvent.touchStart(modal, {
+        touches: [{ clientX: 10, clientY: 10 }],
+      });
+      act(() => jest.advanceTimersByTime(DEFAULT_LONG_PRESS_DURATION_MS));
+      fireEvent.touchEnd(modal);
+
+      expect(
+        screen.queryByRole("dialog", { name: "Artwork actions" })
+      ).not.toBeInTheDocument();
+      expect(onDropClick).not.toHaveBeenCalled();
+    }
+  );
+
+  it("preserves long press, suppresses its release click, and allows a fresh tap after dismissal", () => {
+    jest.useFakeTimers();
+    mockUseDeviceInfo.mockReturnValue({ hasTouchScreen: true, isApp: true });
+    const onDropClick = jest.fn();
+    render(
+      <WaveLeaderboardGalleryItem drop={drop} onDropClick={onDropClick} />
+    );
+    const mainButton = screen.getByRole("button", {
+      name: "Open Untitled drop",
+    });
+
+    fireEvent.touchStart(mainButton, {
+      touches: [{ clientX: 10, clientY: 10 }],
+    });
+    act(() => jest.advanceTimersByTime(DEFAULT_LONG_PRESS_DURATION_MS));
+    expect(
+      screen.getByRole("dialog", { name: "Artwork actions" })
+    ).toBeInTheDocument();
+    fireEvent.touchEnd(mainButton);
+    fireEvent.click(mainButton);
+    expect(onDropClick).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss actions" }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    fireEvent.touchStart(mainButton, {
+      touches: [{ clientX: 10, clientY: 10 }],
+    });
+    fireEvent.touchEnd(mainButton);
+    fireEvent.click(mainButton);
+
+    expect(onDropClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels the pending long press when a second finger touches the card", () => {
+    jest.useFakeTimers();
+    mockUseDeviceInfo.mockReturnValue({ hasTouchScreen: true, isApp: true });
+    const onDropClick = jest.fn();
+    render(
+      <WaveLeaderboardGalleryItem drop={drop} onDropClick={onDropClick} />
+    );
+    const mainButton = screen.getByRole("button", {
+      name: "Open Untitled drop",
+    });
+    const firstTouch = { identifier: 1, clientX: 10, clientY: 10 };
+    const secondTouch = { identifier: 2, clientX: 30, clientY: 10 };
+
+    fireEvent.touchStart(mainButton, { touches: [firstTouch] });
+    act(() => jest.advanceTimersByTime(100));
+    fireEvent.touchStart(mainButton, {
+      touches: [firstTouch, secondTouch],
+      changedTouches: [secondTouch],
+    });
+    fireEvent.touchEnd(mainButton, {
+      touches: [firstTouch],
+      changedTouches: [secondTouch],
+    });
+    fireEvent.touchEnd(mainButton, {
+      touches: [],
+      changedTouches: [firstTouch],
+    });
+    act(() => jest.advanceTimersByTime(DEFAULT_LONG_PRESS_DURATION_MS));
+    fireEvent.click(mainButton, { detail: 1 });
+
+    expect(
+      screen.queryByRole("dialog", { name: "Artwork actions" })
+    ).not.toBeInTheDocument();
+    expect(onDropClick).not.toHaveBeenCalled();
+
+    fireEvent.touchStart(mainButton, { touches: [firstTouch] });
+    act(() => jest.advanceTimersByTime(DEFAULT_LONG_PRESS_DURATION_MS));
+    expect(
+      screen.getByRole("dialog", { name: "Artwork actions" })
+    ).toBeInTheDocument();
+    fireEvent.touchEnd(mainButton, {
+      touches: [],
+      changedTouches: [firstTouch],
+    });
+  });
+
+  it("does not suppress the first action in the portaled long-press menu", () => {
+    jest.useFakeTimers();
+    mockUseDeviceInfo.mockReturnValue({ hasTouchScreen: true, isApp: true });
+    const onDropClick = jest.fn();
+    render(
+      <WaveLeaderboardGalleryItem drop={drop} onDropClick={onDropClick} />
+    );
+    const mainButton = screen.getByRole("button", {
+      name: "Open Untitled drop",
+    });
+
+    fireEvent.touchStart(mainButton, {
+      touches: [{ clientX: 10, clientY: 10 }],
+    });
+    act(() => jest.advanceTimersByTime(DEFAULT_LONG_PRESS_DURATION_MS));
+    fireEvent.touchEnd(mainButton);
+    fireEvent.click(screen.getByRole("button", { name: "Open from actions" }));
+
+    expect(mockMenuOpen).toHaveBeenCalledTimes(1);
+    expect(onDropClick).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("cancels long-press detection when the user scrolls", () => {
+    jest.useFakeTimers();
+    mockUseDeviceInfo.mockReturnValue({ hasTouchScreen: true, isApp: true });
+    const onDropClick = jest.fn();
+    render(
+      <WaveLeaderboardGalleryItem drop={drop} onDropClick={onDropClick} />
+    );
+    const mainButton = screen.getByRole("button", {
+      name: "Open Untitled drop",
+    });
+
+    expect(
+      fireEvent.touchStart(mainButton, {
+        touches: [{ clientX: 10, clientY: 100 }],
+        cancelable: true,
+      })
+    ).toBe(true);
+    expect(
+      fireEvent.touchMove(mainButton, {
+        touches: [{ clientX: 10, clientY: 50 }],
+        cancelable: true,
+      })
+    ).toBe(true);
+    act(() => jest.advanceTimersByTime(DEFAULT_LONG_PRESS_DURATION_MS));
+    fireEvent.touchEnd(mainButton);
+    fireEvent.click(mainButton, { detail: 1 });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(onDropClick).not.toHaveBeenCalled();
   });
 
   it("opens voting modal when vote button clicked", async () => {
-    render(<WaveLeaderboardGalleryItem drop={drop} onDropClick={jest.fn()} />);
+    const onDropClick = jest.fn();
+    render(
+      <WaveLeaderboardGalleryItem drop={drop} onDropClick={onDropClick} />
+    );
     expect(screen.getByTestId("modal")).toHaveAttribute("data-open", "false");
     await userEvent.click(screen.getByTestId("vote-btn"));
     expect(screen.getByTestId("modal")).toHaveAttribute("data-open", "true");
+    expect(onDropClick).not.toHaveBeenCalled();
   });
 
   it("renders the title as natural wrapping text without truncation", () => {

--- a/__tests__/components/waves/leaderboard/identity/WaveLeaderboardIdentity.test.tsx
+++ b/__tests__/components/waves/leaderboard/identity/WaveLeaderboardIdentity.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { WaveLeaderboardIdentity } from "@/components/waves/leaderboard/identity/WaveLeaderboardIdentity";
 import { ApiWaveParticipationSubmissionStrategyType } from "@/generated/models/ApiWaveParticipationSubmissionStrategyType";
+import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 
 jest.mock(
   "@/components/waves/drops/participation/ParticipationIdentityProfileCard",
@@ -98,6 +99,48 @@ describe("WaveLeaderboardIdentity", () => {
     expect(
       screen.getByTestId("wave-leaderboard-identity-summary")
     ).toBeInTheDocument();
+  });
+
+  it("keeps condensed identity content readable without profile navigation", () => {
+    render(
+      <WaveLeaderboardIdentity
+        drop={
+          {
+            id: "d1",
+            wave: {
+              submission_type:
+                ApiWaveParticipationSubmissionStrategyType.Identity,
+            },
+            metadata: [
+              {
+                data_key: "identity",
+                data_value: "0xabc",
+                resolved_profile: {
+                  ...resolvedProfile,
+                  pfp: "https://example.com/avatar.png",
+                  bio: "Identity bio",
+                  top_rep_categories: [{ category: "Art", rep: 12 }],
+                },
+              },
+            ],
+          } as ExtendedDrop
+        }
+        variant="condensed"
+        disableNavigation
+      />
+    );
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "alice avatar" })
+    ).toBeInTheDocument();
+    for (const text of ["alice", "0xabc", "7", "Identity bio", "Art"]) {
+      expect(screen.getByText(text)).toBeInTheDocument();
+      expect(screen.getByText(text).closest("[inert]")).toBeNull();
+    }
+    expect(screen.getByTestId("identity-badges").parentElement).toHaveAttribute(
+      "inert"
+    );
   });
 
   it("renders a plain fallback when the identity is unresolved", () => {

--- a/__tests__/components/waves/leaderboard/identity/WaveLeaderboardIdentity.test.tsx
+++ b/__tests__/components/waves/leaderboard/identity/WaveLeaderboardIdentity.test.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { WaveLeaderboardIdentity } from "@/components/waves/leaderboard/identity/WaveLeaderboardIdentity";
+import type { ApiDropResolvedIdentityProfile } from "@/generated/models/ApiDropResolvedIdentityProfile";
+import { ApiProfileClassification } from "@/generated/models/ApiProfileClassification";
 import { ApiWaveParticipationSubmissionStrategyType } from "@/generated/models/ApiWaveParticipationSubmissionStrategyType";
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 
@@ -19,7 +21,7 @@ jest.mock("@/components/waves/drops/DropAuthorBadges", () => ({
 }));
 
 describe("WaveLeaderboardIdentity", () => {
-  const resolvedProfile = {
+  const resolvedProfile: ApiDropResolvedIdentityProfile = {
     id: "p1",
     handle: "alice",
     primary_address: "0xabc",
@@ -33,12 +35,17 @@ describe("WaveLeaderboardIdentity", () => {
     xtdh: 5,
     xtdh_rate: 6,
     level: 7,
+    classification: ApiProfileClassification.Pseudonym,
+    sub_classification: null,
     subscribed_actions: [],
     archived: false,
     active_main_stage_submission_ids: [],
     winner_main_stage_drop_ids: [],
     artist_of_prevote_cards: [],
+    profile_wave_id: null,
     is_wave_creator: false,
+    bio: null,
+    top_rep_categories: [],
   };
 
   it("renders the condensed summary for resolved identities", () => {
@@ -120,7 +127,7 @@ describe("WaveLeaderboardIdentity", () => {
                   pfp: "https://example.com/avatar.png",
                   bio: "Identity bio",
                   top_rep_categories: [{ category: "Art", rep: 12 }],
-                },
+                } satisfies ApiDropResolvedIdentityProfile,
               },
             ],
           } as ExtendedDrop

--- a/__tests__/contexts/navigationHistory.test.tsx
+++ b/__tests__/contexts/navigationHistory.test.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/contexts/NavigationHistoryContext";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { useViewContext } from "@/components/navigation/ViewContext";
+import { BrainView } from "@/components/brain/mobile/brainMobileViews";
 
 jest.mock("next/navigation", () => ({
   useRouter: jest.fn(),
@@ -33,7 +34,9 @@ let mockSearchParams = new URLSearchParams();
 const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <NavigationHistoryProvider>{children}</NavigationHistoryProvider>
 );
-const strictWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+const strictWrapper: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => (
   <React.StrictMode>
     <NavigationHistoryProvider>{children}</NavigationHistoryProvider>
   </React.StrictMode>
@@ -170,5 +173,76 @@ describe("NavigationHistoryContext", () => {
       result.current.goBack();
     });
     expect(routerMock.push).toHaveBeenCalledWith("/network");
+  });
+
+  it("restores the wave view on repeated profile Back round trips", () => {
+    mockPathname = "/waves/wave-1";
+    const { result, rerender } = renderHook(
+      () => useNavigationHistoryContext(),
+      { wrapper }
+    );
+    const selection = { waveId: "wave-1", view: BrainView.LEADERBOARD };
+
+    act(() => {
+      result.current.rememberWaveView(selection);
+    });
+
+    for (let visit = 0; visit < 2; visit += 1) {
+      mockPathname = "/Articulate";
+      rerender();
+      expect(result.current.currentWaveView).toBeNull();
+
+      act(() => {
+        result.current.goBack();
+      });
+
+      expect(routerMock.push).toHaveBeenLastCalledWith("/waves/wave-1");
+      mockPathname = "/waves/wave-1";
+      rerender();
+      expect(result.current.currentWaveView).toEqual(selection);
+    }
+  });
+
+  it("does not restore a previous visit when navigating normally between waves", () => {
+    mockPathname = "/waves/wave-1";
+    const { result, rerender } = renderHook(
+      () => useNavigationHistoryContext(),
+      { wrapper }
+    );
+
+    act(() => {
+      result.current.rememberWaveView({
+        waveId: "wave-1",
+        view: BrainView.ABOUT,
+      });
+    });
+    mockPathname = "/waves/wave-2";
+    rerender();
+    mockPathname = "/waves/wave-1";
+    rerender();
+
+    expect(result.current.currentWaveView).toBeNull();
+  });
+
+  it("does not record a wave selection against another route", () => {
+    mockPathname = "/Articulate";
+    const { result, rerender } = renderHook(
+      () => useNavigationHistoryContext(),
+      { wrapper }
+    );
+
+    act(() => {
+      result.current.rememberWaveView({
+        waveId: "wave-1",
+        view: BrainView.LEADERBOARD,
+      });
+    });
+    mockPathname = "/waves/wave-1";
+    rerender();
+    act(() => {
+      result.current.goBack();
+    });
+
+    expect(result.current.currentWaveView).toBeNull();
   });
 });

--- a/__tests__/contexts/navigationHistory.test.tsx
+++ b/__tests__/contexts/navigationHistory.test.tsx
@@ -175,33 +175,40 @@ describe("NavigationHistoryContext", () => {
     expect(routerMock.push).toHaveBeenCalledWith("/network");
   });
 
-  it("restores the wave view on repeated profile Back round trips", () => {
-    mockPathname = "/waves/wave-1";
-    const { result, rerender } = renderHook(
-      () => useNavigationHistoryContext(),
-      { wrapper }
-    );
-    const selection = { waveId: "wave-1", view: BrainView.LEADERBOARD };
-
-    act(() => {
-      result.current.rememberWaveView(selection);
-    });
-
-    for (let visit = 0; visit < 2; visit += 1) {
-      mockPathname = "/Articulate";
-      rerender();
-      expect(result.current.currentWaveView).toBeNull();
+  it.each(["goBack", "goBackTo"] as const)(
+    "restores the wave view on repeated profile round trips using %s",
+    (navigation) => {
+      mockPathname = "/waves/wave-1";
+      const { result, rerender } = renderHook(
+        () => useNavigationHistoryContext(),
+        { wrapper }
+      );
+      const selection = { waveId: "wave-1", view: BrainView.LEADERBOARD };
 
       act(() => {
-        result.current.goBack();
+        result.current.rememberWaveView(selection);
       });
 
-      expect(routerMock.push).toHaveBeenLastCalledWith("/waves/wave-1");
-      mockPathname = "/waves/wave-1";
-      rerender();
-      expect(result.current.currentWaveView).toEqual(selection);
+      for (let visit = 0; visit < 2; visit += 1) {
+        mockPathname = "/Articulate";
+        rerender();
+        expect(result.current.currentWaveView).toBeNull();
+
+        act(() => {
+          if (navigation === "goBackTo") {
+            result.current.goBackTo("/waves/wave-1");
+          } else {
+            result.current.goBack();
+          }
+        });
+
+        expect(routerMock.push).toHaveBeenLastCalledWith("/waves/wave-1");
+        mockPathname = "/waves/wave-1";
+        rerender();
+        expect(result.current.currentWaveView).toEqual(selection);
+      }
     }
-  });
+  );
 
   it("does not restore a previous visit when navigating normally between waves", () => {
     mockPathname = "/waves/wave-1";

--- a/__tests__/hooks/useCardTouchNavigationGuard.test.tsx
+++ b/__tests__/hooks/useCardTouchNavigationGuard.test.tsx
@@ -1,0 +1,278 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { createPortal } from "react-dom";
+import useCardTouchNavigationGuard from "@/hooks/useCardTouchNavigationGuard";
+
+const touch = { identifier: 1, clientX: 40, clientY: 50 };
+
+function Harness({
+  onOpen,
+  onPortal,
+}: {
+  readonly onOpen: () => void;
+  readonly onPortal?: () => void;
+}) {
+  const guard = useCardTouchNavigationGuard();
+  return (
+    <div data-testid="scroll-parent">
+      <div
+        ref={guard.cardRef}
+        onTouchStartCapture={guard.handleTouchStart}
+        onTouchMoveCapture={guard.handleTouchMove}
+        onTouchEndCapture={guard.handleTouchEnd}
+        onTouchCancelCapture={guard.handleTouchCancel}
+        onClickCapture={guard.handleClickCapture}
+      >
+        <button onClick={onOpen}>Open artwork</button>
+        <div data-testid="nested-scroll" />
+        {createPortal(
+          <button onClick={onPortal}>Portal action</button>,
+          document.body
+        )}
+      </div>
+      <div data-testid="unrelated-scroll" />
+    </div>
+  );
+}
+
+function start(target: HTMLElement) {
+  return fireEvent.touchStart(target, { touches: [touch], cancelable: true });
+}
+
+function end(target: HTMLElement, endTouch = touch) {
+  return fireEvent.touchEnd(target, {
+    touches: [],
+    changedTouches: [endTouch],
+    cancelable: true,
+  });
+}
+
+function click(target: HTMLElement, detail = 1) {
+  return fireEvent.click(target, { detail, cancelable: true });
+}
+
+describe("useCardTouchNavigationGuard", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(1000);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("allows a stationary touch or small finger jitter without preventing native touch events", () => {
+    const onOpen = jest.fn();
+    render(<Harness onOpen={onOpen} />);
+    const button = screen.getByRole("button", { name: "Open artwork" });
+
+    expect(start(button)).toBe(true);
+    expect(
+      fireEvent.touchMove(button, {
+        touches: [{ ...touch, clientX: 45, clientY: 54 }],
+        cancelable: true,
+      })
+    ).toBe(true);
+    expect(end(button, { ...touch, clientX: 45, clientY: 54 })).toBe(true);
+    expect(click(button)).toBe(true);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a drag even when the finger returns to its starting position", () => {
+    const onOpen = jest.fn();
+    render(<Harness onOpen={onOpen} />);
+    const button = screen.getByRole("button", { name: "Open artwork" });
+
+    start(button);
+    fireEvent.touchMove(button, { touches: [{ ...touch, clientY: 59 }] });
+    fireEvent.touchMove(button, { touches: [touch] });
+    end(button);
+
+    expect(click(button)).toBe(false);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("checks the release position when no touchmove event was delivered", () => {
+    const onOpen = jest.fn();
+    render(<Harness onOpen={onOpen} />);
+    const button = screen.getByRole("button", { name: "Open artwork" });
+
+    start(button);
+    end(button, { ...touch, clientY: 70 });
+    click(button);
+
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it.each(["scroll-parent", "document"])(
+    "rejects a touch when %s scrolls during its gesture",
+    (scrollTarget) => {
+      const onOpen = jest.fn();
+      render(<Harness onOpen={onOpen} />);
+      const button = screen.getByRole("button", { name: "Open artwork" });
+
+      start(button);
+      fireEvent.scroll(
+        scrollTarget === "document"
+          ? document
+          : screen.getByTestId(scrollTarget)
+      );
+      end(button);
+      click(button);
+
+      expect(onOpen).not.toHaveBeenCalled();
+    }
+  );
+
+  it("rejects a momentum-stop tap but allows a fresh tap once scrolling settles", () => {
+    const onOpen = jest.fn();
+    render(<Harness onOpen={onOpen} />);
+    const button = screen.getByRole("button", { name: "Open artwork" });
+
+    fireEvent.scroll(screen.getByTestId("scroll-parent"));
+    jest.advanceTimersByTime(100);
+    start(button);
+    end(button);
+    click(button);
+    expect(onOpen).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(51);
+    start(button);
+    end(button);
+    click(button);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["unrelated-scroll", "nested-scroll"])(
+    "ignores %s instead of cancelling unrelated card taps",
+    (scrollTarget) => {
+      const onOpen = jest.fn();
+      render(<Harness onOpen={onOpen} />);
+      const button = screen.getByRole("button", { name: "Open artwork" });
+
+      start(button);
+      fireEvent.scroll(screen.getByTestId(scrollTarget));
+      end(button);
+      click(button);
+
+      expect(onOpen).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it("rejects touch cancellation and permits the next intentional gesture", () => {
+    const onOpen = jest.fn();
+    render(<Harness onOpen={onOpen} />);
+    const button = screen.getByRole("button", { name: "Open artwork" });
+
+    start(button);
+    fireEvent.touchCancel(button);
+    click(button);
+    expect(onOpen).not.toHaveBeenCalled();
+
+    start(button);
+    end(button);
+    click(button);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects multi-touch even after returning to one finger", () => {
+    const onOpen = jest.fn();
+    render(<Harness onOpen={onOpen} />);
+    const button = screen.getByRole("button", { name: "Open artwork" });
+
+    start(button);
+    fireEvent.touchStart(button, {
+      touches: [touch, { ...touch, identifier: 2 }],
+    });
+    fireEvent.touchEnd(button, {
+      touches: [touch],
+      changedTouches: [{ ...touch, identifier: 2 }],
+    });
+    end(button);
+    click(button);
+
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("allows keyboard activation even while a delayed touch click is rejected", () => {
+    const onOpen = jest.fn();
+    render(<Harness onOpen={onOpen} />);
+    const button = screen.getByRole("button", { name: "Open artwork" });
+
+    start(button);
+    end(button, { ...touch, clientY: 70 });
+    click(button, 0);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+
+    click(button);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not intercept portal touches or consume suppression for a portal click", () => {
+    const onOpen = jest.fn();
+    const onPortal = jest.fn();
+    render(<Harness onOpen={onOpen} onPortal={onPortal} />);
+    const button = screen.getByRole("button", { name: "Open artwork" });
+    const portal = screen.getByRole("button", { name: "Portal action" });
+
+    start(button);
+    end(button, { ...touch, clientY: 70 });
+    start(portal);
+    end(portal);
+    click(portal);
+    click(button);
+
+    expect(onPortal).toHaveBeenCalledTimes(1);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("expires a rejected release click without a timer or blocking a later mouse click", () => {
+    const onOpen = jest.fn();
+    render(<Harness onOpen={onOpen} />);
+    const button = screen.getByRole("button", { name: "Open artwork" });
+
+    start(button);
+    end(button, { ...touch, clientY: 70 });
+    jest.advanceTimersByTime(751);
+    click(button);
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("clears a rejected gesture on a fresh tap even if the browser emitted no release click", () => {
+    const onOpen = jest.fn();
+    render(<Harness onOpen={onOpen} />);
+    const button = screen.getByRole("button", { name: "Open artwork" });
+
+    start(button);
+    end(button, { ...touch, clientY: 70 });
+    start(button);
+    end(button);
+    click(button);
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes its passive capture listener on unmount", () => {
+    const addListener = jest.spyOn(document, "addEventListener");
+    const removeListener = jest.spyOn(document, "removeEventListener");
+    const { unmount } = render(<Harness onOpen={jest.fn()} />);
+    const registration = addListener.mock.calls.find(
+      ([type]) => type === "scroll"
+    );
+
+    expect(registration).toEqual([
+      "scroll",
+      expect.any(Function),
+      { capture: true, passive: true },
+    ]);
+    unmount();
+    expect(removeListener).toHaveBeenCalledWith(
+      "scroll",
+      registration?.[1],
+      true
+    );
+    addListener.mockRestore();
+    removeListener.mockRestore();
+  });
+});

--- a/components/brain/BrainMobile.tsx
+++ b/components/brain/BrainMobile.tsx
@@ -8,12 +8,7 @@ import React, {
   useState,
   useSyncExternalStore,
 } from "react";
-import {
-  LazyMotion,
-  domAnimation,
-  m,
-  useReducedMotion,
-} from "framer-motion";
+import { LazyMotion, domAnimation, m, useReducedMotion } from "framer-motion";
 import BrainMobileTabs from "./mobile/BrainMobileTabs";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
@@ -59,6 +54,7 @@ import { SidebarTab } from "./right-sidebar/BrainRightSidebarTypes";
 import { WaveContentTabs } from "./right-sidebar/WaveContent";
 import { waveRightPanelText } from "@/helpers/waves/wave-right-panel.helpers";
 import { useLayout } from "./my-stream/layout/LayoutContext";
+import { useNavigationHistoryContext } from "@/contexts/NavigationHistoryContext";
 
 interface Props {
   readonly children: ReactNode;
@@ -75,6 +71,7 @@ const BrainMobileContent: React.FC<Props> = ({ children }) => {
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const { isApp } = useDeviceInfo();
+  const { currentWaveView, rememberWaveView } = useNavigationHistoryContext();
   const shouldReduceMotion = useReducedMotion() ?? false;
   const { registerRef } = useLayout();
   const { connectedProfile, fetchingProfile } = useAuth();
@@ -150,7 +147,7 @@ const BrainMobileContent: React.FC<Props> = ({ children }) => {
       !(isCompetitionWave && isWaveMetadataPending) &&
       !isWavePollsPending
     );
-  const { activeView, onViewChange } = useBrainMobileActiveView({
+  const { activeView, onViewChange: selectView } = useBrainMobileActiveView({
     firstDecisionDone,
     isApp,
     isCompleted,
@@ -165,7 +162,15 @@ const BrainMobileContent: React.FC<Props> = ({ children }) => {
     searchParams,
     wave,
     waveId,
+    restoredView:
+      isApp && currentWaveView?.waveId === waveId ? currentWaveView.view : null,
   });
+  const onViewChange = (view: BrainView) => {
+    selectView(view);
+    if (isApp && waveId) {
+      rememberWaveView({ waveId, view });
+    }
+  };
   const [aboutTabState, setAboutTabState] = useState<MobileAboutTabState>({
     waveId: null,
     activeTab: SidebarTab.ABOUT,

--- a/components/brain/BrainMobile.tsx
+++ b/components/brain/BrainMobile.tsx
@@ -65,6 +65,15 @@ interface MobileAboutTabState {
   readonly activeTab: SidebarTab;
 }
 
+const getRestoredWaveView = (
+  isApp: boolean,
+  waveId: string | null,
+  currentWaveView: ReturnType<
+    typeof useNavigationHistoryContext
+  >["currentWaveView"]
+): BrainView | null =>
+  isApp && currentWaveView?.waveId === waveId ? currentWaveView.view : null;
+
 const BrainMobileContent: React.FC<Props> = ({ children }) => {
   const router = useRouter();
   // react-doctor-disable-next-line react-doctor/nextjs-no-use-search-params-without-suspense covered by BrainMobile Suspense wrapper
@@ -162,15 +171,17 @@ const BrainMobileContent: React.FC<Props> = ({ children }) => {
     searchParams,
     wave,
     waveId,
-    restoredView:
-      isApp && currentWaveView?.waveId === waveId ? currentWaveView.view : null,
+    restoredView: getRestoredWaveView(isApp, waveId, currentWaveView),
   });
-  const onViewChange = (view: BrainView) => {
-    selectView(view);
-    if (isApp && waveId) {
-      rememberWaveView({ waveId, view });
-    }
-  };
+  const onViewChange = useCallback(
+    (view: BrainView) => {
+      selectView(view);
+      if (isApp && waveId) {
+        rememberWaveView({ waveId, view });
+      }
+    },
+    [selectView, isApp, waveId, rememberWaveView]
+  );
   const [aboutTabState, setAboutTabState] = useState<MobileAboutTabState>({
     waveId: null,
     activeTab: SidebarTab.ABOUT,

--- a/components/brain/mobile/useBrainMobileActiveView.ts
+++ b/components/brain/mobile/useBrainMobileActiveView.ts
@@ -35,6 +35,7 @@ interface UseBrainMobileActiveViewParams {
   readonly searchParams: ReadonlyURLSearchParams;
   readonly wave: ApiWave | null | undefined;
   readonly waveId: string | null;
+  readonly restoredView?: BrainView | null | undefined;
 }
 
 interface UseBrainMobileActiveViewResult {
@@ -243,11 +244,13 @@ export function useBrainMobileActiveView({
   searchParams,
   wave,
   waveId,
+  restoredView = null,
 }: UseBrainMobileActiveViewParams): UseBrainMobileActiveViewResult {
   const [selection, setSelection] = useState<ActiveViewSelection | null>(null);
   const hasWave = Boolean(waveId);
   const viewParam = searchParams.get("view");
   const createParam = searchParams.get("create");
+  const serialNoParam = searchParams.get("serialNo");
   const routeDefaultView = getRouteDefaultView({
     createParam,
     isApp,
@@ -256,7 +259,10 @@ export function useBrainMobileActiveView({
     waveId,
   });
   const shellContextKey = `shell:${pathname}:${viewParam ?? ""}`;
-  const currentContextKey = waveId ? `wave:${waveId}` : shellContextKey;
+  const chatTargetKey = serialNoParam === null ? "" : `serial:${serialNoParam}`;
+  const currentContextKey = waveId
+    ? `wave:${waveId}:${chatTargetKey}`
+    : shellContextKey;
   const currentContextToken = useMemo(
     () => Symbol(currentContextKey),
     [currentContextKey]
@@ -268,9 +274,13 @@ export function useBrainMobileActiveView({
     isCompleted,
     isRankWave,
   });
-  const baseView = hasWave
-    ? waveDefaultView
-    : (routeDefaultView ?? BrainView.DEFAULT);
+  let baseView = routeDefaultView ?? BrainView.DEFAULT;
+  if (hasWave) {
+    baseView =
+      serialNoParam !== null
+        ? BrainView.DEFAULT
+        : (restoredView ?? waveDefaultView);
+  }
   const candidateView =
     selection?.contextToken === currentContextToken ? selection.view : baseView;
 

--- a/components/brain/mobile/useBrainMobileActiveView.ts
+++ b/components/brain/mobile/useBrainMobileActiveView.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReadonlyURLSearchParams } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { ApiWave } from "@/generated/models/ApiWave";
 import { BrainView } from "./brainMobileViews";
 
@@ -284,12 +284,15 @@ export function useBrainMobileActiveView({
   const candidateView =
     selection?.contextToken === currentContextToken ? selection.view : baseView;
 
-  const onViewChange = (view: BrainView) => {
-    setSelection({
-      contextToken: currentContextToken,
-      view,
-    });
-  };
+  const onViewChange = useCallback(
+    (view: BrainView) => {
+      setSelection({
+        contextToken: currentContextToken,
+        view,
+      });
+    },
+    [currentContextToken]
+  );
 
   const activeView = normalizeActiveView({
     activeView: candidateView,

--- a/components/drops/view/item/content/media/MediaDisplay.tsx
+++ b/components/drops/view/item/content/media/MediaDisplay.tsx
@@ -166,6 +166,7 @@ export default function MediaDisplay({
   media_mime_type,
   media_url,
   disableMediaInteraction = false,
+  isInertPreview = false,
   imageScale = ImageScale.AUTOx1080,
   previewImageUrl,
   requireInteractionToLoad = false,
@@ -176,6 +177,7 @@ export default function MediaDisplay({
   readonly media_mime_type: string;
   readonly media_url: string;
   readonly disableMediaInteraction?: boolean | undefined;
+  readonly isInertPreview?: boolean | undefined;
   readonly imageScale?: ImageScale | undefined;
   readonly previewImageUrl?: string | null | undefined;
   readonly requireInteractionToLoad?: boolean | undefined;
@@ -267,6 +269,7 @@ export default function MediaDisplay({
           src={media_url}
           mimeType={media_mime_type}
           showControls={!disableMediaInteraction}
+          isInertPreview={isInertPreview}
           fillContainer={fillVideoContainer}
         />
       );

--- a/components/drops/view/item/content/media/MediaDisplayVideo.tsx
+++ b/components/drops/view/item/content/media/MediaDisplayVideo.tsx
@@ -13,6 +13,7 @@ interface Props {
   readonly src: string;
   readonly mimeType?: string | undefined;
   readonly showControls?: boolean | undefined;
+  readonly isInertPreview?: boolean | undefined;
   readonly fillContainer?: boolean | undefined;
 }
 
@@ -20,6 +21,7 @@ const MediaDisplayVideo: React.FC<Props> = ({
   src,
   mimeType,
   showControls = false,
+  isInertPreview = false,
   fillContainer = false,
 }) => {
   // Intersection observer for scroll-based triggers
@@ -125,7 +127,7 @@ const MediaDisplayVideo: React.FC<Props> = ({
     >
       <SeizeVideoPlayer
         videoRef={videoRef}
-        template="ambient-media"
+        template={isInertPreview ? "card-preview" : "ambient-media"}
         layout={fillContainer ? "fill" : "natural"}
         align={fillContainer ? "center" : "left"}
         showActions={showControls}

--- a/components/memes/drops/MemesLeaderboardDrop.tsx
+++ b/components/memes/drops/MemesLeaderboardDrop.tsx
@@ -4,6 +4,7 @@ import MediaTypeBadge from "@/components/drops/media/MediaTypeBadge";
 import ContentModerationDropActions from "@/components/content-moderation/ContentModerationDropActions";
 import ReportDropModal from "@/components/content-moderation/ReportDropModal";
 import DropListItemContentMedia from "@/components/drops/view/item/content/media/DropListItemContentMedia";
+import MediaDisplay from "@/components/drops/view/item/content/media/MediaDisplay";
 import CommonDropdownItemsMobileWrapper from "@/components/utils/select/dropdown/CommonDropdownItemsMobileWrapper";
 import { MobileVotingModal, VotingModal } from "@/components/voting";
 import VotingModalButton from "@/components/voting/VotingModalButton";
@@ -20,10 +21,15 @@ import ParticipationDropVoteDetailsTrigger from "@/components/waves/drops/partic
 import type { ApiWave } from "@/generated/models/ApiWave";
 import { getScaledImageUri, ImageScale } from "@/helpers/image.helpers";
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
+import { getDropPreviewImageUrl } from "@/helpers/waves/drop.helpers";
 import { useDropInteractionRules } from "@/hooks/drops/useDropInteractionRules";
 import useIsMobileScreen from "@/hooks/isMobileScreen";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
 import useLongPressInteraction from "@/hooks/useLongPressInteraction";
+import useLongPressClickSuppression from "@/hooks/useLongPressClickSuppression";
+import useCardTouchNavigationGuard from "@/hooks/useCardTouchNavigationGuard";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import { t } from "@/i18n/messages";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { startDropOpen } from "@/utils/monitoring/dropOpenTiming";
 import Image from "next/image";
@@ -72,9 +78,26 @@ export const MemesLeaderboardDrop: React.FC<MemesLeaderboardDropProps> = ({
     useState<boolean>(false);
   const [isReportOpen, setIsReportOpen] = useState(false);
   const openResubmitAfterMenuCloseRef = useRef<boolean>(false);
+  const locale = useBrowserLocale();
+  const {
+    cardRef,
+    handleTouchStart: guardTouchStart,
+    handleTouchMove: guardTouchMove,
+    handleTouchEnd: guardTouchEnd,
+    handleTouchCancel: guardTouchCancel,
+    handleClickCapture: guardClickCapture,
+  } = useCardTouchNavigationGuard();
+  const {
+    markNextClickForSuppression,
+    releaseSuppressionAfterTouchEnd,
+    clearSuppression,
+    handleClickCapture,
+  } = useLongPressClickSuppression();
 
   // Get device info from useDeviceInfo hook
-  const { hasTouchScreen } = useDeviceInfo();
+  const { hasTouchScreen, isApp } = useDeviceInfo();
+  const opensWholeCard = isApp && hasTouchScreen;
+  const canOpenCard = opensWholeCard || !hasTouchScreen;
   let mediaImageScale = ImageScale.AUTOx800;
   if (isMobileScreen) {
     mediaImageScale = ImageScale.AUTOx450;
@@ -86,6 +109,11 @@ export const MemesLeaderboardDrop: React.FC<MemesLeaderboardDropProps> = ({
     openResubmitAfterMenuCloseRef.current = false;
   }, []);
 
+  const handleInteractionStart = useCallback(() => {
+    clearDeferredResubmitOpen();
+    markNextClickForSuppression();
+  }, [clearDeferredResubmitOpen, markNextClickForSuppression]);
+
   useEffect(
     () => () => {
       clearDeferredResubmitOpen();
@@ -96,13 +124,29 @@ export const MemesLeaderboardDrop: React.FC<MemesLeaderboardDropProps> = ({
   // Use long press interaction hook with touch screen info from device hook
   const { isActive, setIsActive, touchHandlers } = useLongPressInteraction({
     hasTouchScreen,
-    onInteractionStart: clearDeferredResubmitOpen,
+    onInteractionStart: handleInteractionStart,
+    preventDefault: false,
   });
+
+  const handleMobileMenuOpenChange = useCallback(
+    (nextIsActive: boolean) => {
+      if (!nextIsActive) {
+        clearSuppression();
+      }
+
+      setIsActive(nextIsActive);
+    },
+    [clearSuppression, setIsActive]
+  );
+
+  const handleMobileMenuClose = useCallback(() => {
+    handleMobileMenuOpenChange(false);
+  }, [handleMobileMenuOpenChange]);
 
   const openResubmitAfterMobileMenuCloses = useCallback(() => {
     openResubmitAfterMenuCloseRef.current = true;
-    setIsActive(false);
-  }, [setIsActive]);
+    handleMobileMenuClose();
+  }, [handleMobileMenuClose]);
 
   const handleMobileMenuAfterLeave = useCallback(() => {
     if (!openResubmitAfterMenuCloseRef.current) {
@@ -129,138 +173,202 @@ export const MemesLeaderboardDrop: React.FC<MemesLeaderboardDropProps> = ({
   // Get top voters for votes display
   const firstThreeVoters = drop.top_raters.slice(0, 3);
 
+  const openDrop = useCallback(() => {
+    startDropOpen({
+      dropId: drop.id,
+      waveId: drop.wave.id,
+      source: "leaderboard_memes",
+      isMobile: isMobileScreen,
+    });
+    onDropClick(drop);
+  }, [drop, isMobileScreen, onDropClick]);
+
   return (
     <div
-      className="tw-w-full tw-cursor-pointer tw-@container"
-      onClick={() => {
-        if (hasTouchScreen) return;
-        startDropOpen({
-          dropId: drop.id,
-          waveId: drop.wave.id,
-          source: "leaderboard_memes",
-          isMobile: isMobileScreen,
-        });
-        onDropClick(drop);
+      ref={cardRef}
+      className="tw-w-full tw-cursor-pointer tw-rounded-xl tw-@container has-[[data-leaderboard-card-open]:focus-visible]:tw-outline has-[[data-leaderboard-card-open]:focus-visible]:tw-outline-2 has-[[data-leaderboard-card-open]:focus-visible]:tw-outline-offset-2 has-[[data-leaderboard-card-open]:focus-visible]:tw-outline-white"
+      onClick={(event) => {
+        if (
+          !hasTouchScreen &&
+          event.currentTarget.contains(event.target as Node)
+        ) {
+          openDrop();
+        }
+      }}
+      onClickCapture={(event) => {
+        if (!guardClickCapture(event)) handleClickCapture(event);
+      }}
+      onTouchStartCapture={(event) => {
+        clearSuppression();
+        guardTouchStart(event);
+      }}
+      onTouchMoveCapture={guardTouchMove}
+      onTouchEndCapture={(event) => {
+        guardTouchEnd(event);
+        releaseSuppressionAfterTouchEnd();
+      }}
+      onTouchCancelCapture={(event) => {
+        guardTouchCancel(event);
+        clearSuppression();
       }}
     >
       <div className="tw-group tw-w-full">
         <div {...touchHandlers}>
           <MemesLeaderboardDropCard>
-            <div>
-              {/* Artist info section */}
-              <div className="tw-p-4 tw-pb-3">
-                <div className="tw-flex tw-items-center tw-justify-between tw-gap-4">
-                  <MemesLeaderboardDropArtistInfo drop={drop} />
-                  <div className="tw-flex tw-h-10 tw-items-center tw-gap-2 tw-text-iron-400 [&>button]:tw-flex [&>button]:tw-h-8 [&>button]:tw-items-center [&>button]:tw-justify-center [&>button]:tw-py-0">
-                    {!hasTouchScreen && (
-                      <>
-                        <WaveDropActionsOpen drop={drop} />
-                        <MemesArtResubmitAction
-                          drop={drop}
-                          wave={wave}
-                          onSourceDropDeleted={onSourceDropDeleted}
-                        />
-                        {canDelete && <WaveDropActionsOptions drop={drop} />}
-                      </>
-                    )}
-                  </div>
-                </div>
-              </div>
-
-              {/* Title and Description */}
-              <div className="tw-px-4 tw-pb-4 tw-pt-4">
-                <div className="tw-max-w-screen-sm tw-space-y-1">
-                  <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
-                    <MediaTypeBadge
-                      mimeType={artworkMedia?.mime_type}
-                      dropId={drop.id}
-                      size="xs"
-                    />
-                    <MemesLeaderboardDropHeader title={title} />
-                    {drop.is_additional_action_promised === true && (
-                      <AdditionalActionPromiseBadge />
-                    )}
-                  </div>
-                  <MemesLeaderboardDropDescription description={description} />
-                </div>
-              </div>
-
-              {artworkMedia && (
-                <div
-                  className={`tw-flex tw-h-96 tw-justify-center tw-overflow-hidden ${
-                    location === DropLocation.WAVE
-                      ? "tw-bg-iron-900/30"
-                      : "tw-bg-iron-900/40"
-                  }`}
-                >
-                  <DropListItemContentMedia
-                    media_mime_type={artworkMedia.mime_type}
-                    media_url={artworkMedia.url}
-                    isCompetitionDrop={true}
-                    fillVideoContainer={true}
-                    imageScale={mediaImageScale}
-                  />
-                </div>
+            <div className="tw-relative tw-isolate">
+              {canOpenCard && (
+                <button
+                  type="button"
+                  data-leaderboard-card-open
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    openDrop();
+                  }}
+                  aria-label={t(locale, "waves.leaderboard.grid.openNamed", {
+                    title,
+                  })}
+                  className="tw-absolute tw-inset-0 tw-z-0 tw-cursor-pointer tw-rounded-xl tw-border-0 tw-bg-transparent tw-p-0 focus-visible:tw-outline-none"
+                />
               )}
-
-              {/* Footer Section: Traits + Vote Summary + Vote Button */}
-              <div className="tw-mt-4 tw-flex tw-flex-col tw-gap-y-4 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/5 tw-bg-iron-900/30 tw-p-4">
-                <MemeDropTraits drop={drop} />
-
-                <div className="tw-flex tw-flex-col tw-justify-between tw-gap-4 @[700px]:tw-flex-row @[700px]:tw-items-center">
-                  <MemesLeaderboardDropVoteSummary drop={drop} />
-
-                  <div
-                    className="tw-flex tw-w-full tw-flex-shrink-0 tw-items-center tw-justify-between tw-gap-4 @[700px]:tw-w-auto @[700px]:tw-justify-end"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    {/* Voters - only on small containers */}
-                    <div className="tw-flex tw-items-center tw-gap-2 @[700px]:tw-hidden">
-                      {firstThreeVoters.length > 0 && (
-                        <div className="tw-flex tw-items-center -tw-space-x-2">
-                          {firstThreeVoters.map((voter) => (
-                            <Link
-                              key={
-                                voter.profile.handle ??
-                                voter.profile.primary_address
-                              }
-                              href={`/${voter.profile.handle ?? voter.profile.primary_address}`}
-                              onClick={(e) => e.stopPropagation()}
-                            >
-                              {voter.profile.pfp ? (
-                                <Image
-                                  className="tw-h-6 tw-w-6 tw-rounded-md tw-border-2 tw-border-solid tw-border-[#111] tw-bg-iron-800 tw-object-contain"
-                                  src={getScaledImageUri(
-                                    voter.profile.pfp,
-                                    ImageScale.W_AUTO_H_50
-                                  )}
-                                  alt="Recent voter"
-                                  width={24}
-                                  height={24}
-                                />
-                              ) : (
-                                <div className="tw-h-6 tw-w-6 tw-rounded-lg tw-border-2 tw-border-solid tw-border-[#111] tw-bg-iron-800" />
-                              )}
-                            </Link>
-                          ))}
-                        </div>
+              <div
+                className={`tw-relative tw-z-10 ${opensWholeCard ? "tw-pointer-events-none [&_[data-tooltip-id]]:tw-pointer-events-auto [&_[tabindex]]:tw-pointer-events-auto [&_a]:tw-pointer-events-auto [&_button]:tw-pointer-events-auto" : ""}`}
+              >
+                {/* Artist info section */}
+                <div className="tw-p-4 tw-pb-3">
+                  <div className="tw-flex tw-items-center tw-justify-between tw-gap-4">
+                    <MemesLeaderboardDropArtistInfo
+                      drop={drop}
+                      isNativeTouch={opensWholeCard}
+                    />
+                    <div className="tw-flex tw-h-10 tw-items-center tw-gap-2 tw-text-iron-400 [&>button]:tw-flex [&>button]:tw-h-8 [&>button]:tw-items-center [&>button]:tw-justify-center [&>button]:tw-py-0">
+                      {!hasTouchScreen && (
+                        <>
+                          <WaveDropActionsOpen drop={drop} />
+                          <MemesArtResubmitAction
+                            drop={drop}
+                            wave={wave}
+                            onSourceDropDeleted={onSourceDropDeleted}
+                          />
+                          {canDelete && <WaveDropActionsOptions drop={drop} />}
+                        </>
                       )}
-                      <ParticipationDropVoteDetailsTrigger
+                    </div>
+                  </div>
+                </div>
+
+                {/* Title and Description */}
+                <div className="tw-px-4 tw-pb-4 tw-pt-4">
+                  <div className="tw-max-w-screen-sm tw-space-y-1">
+                    <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
+                      <MediaTypeBadge
+                        mimeType={artworkMedia?.mime_type}
+                        dropId={drop.id}
+                        size="xs"
+                        showTooltip={!opensWholeCard}
+                      />
+                      <MemesLeaderboardDropHeader title={title} />
+                      {drop.is_additional_action_promised === true && (
+                        <AdditionalActionPromiseBadge
+                          focusable={!opensWholeCard}
+                        />
+                      )}
+                    </div>
+                    <MemesLeaderboardDropDescription
+                      description={description}
+                    />
+                  </div>
+                </div>
+
+                {artworkMedia && (
+                  <div
+                    inert={opensWholeCard}
+                    className={`${opensWholeCard ? "tw-pointer-events-none" : "tw-pointer-events-auto"} tw-flex tw-h-96 tw-justify-center tw-overflow-hidden ${
+                      location === DropLocation.WAVE
+                        ? "tw-bg-iron-900/30"
+                        : "tw-bg-iron-900/40"
+                    }`}
+                  >
+                    {opensWholeCard ? (
+                      <MediaDisplay
+                        media_mime_type={artworkMedia.mime_type}
+                        media_url={artworkMedia.url}
+                        disableMediaInteraction
+                        isInertPreview
+                        fillVideoContainer
+                        imageScale={mediaImageScale}
+                        previewImageUrl={getDropPreviewImageUrl(drop.metadata)}
+                      />
+                    ) : (
+                      <DropListItemContentMedia
+                        media_mime_type={artworkMedia.mime_type}
+                        media_url={artworkMedia.url}
+                        isCompetitionDrop={true}
+                        fillVideoContainer={true}
+                        imageScale={mediaImageScale}
+                      />
+                    )}
+                  </div>
+                )}
+
+                {/* Footer Section: Traits + Vote Summary + Vote Button */}
+                <div className="tw-mt-4 tw-flex tw-flex-col tw-gap-y-4 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/5 tw-bg-iron-900/30 tw-p-4">
+                  <MemeDropTraits drop={drop} />
+
+                  <div className="tw-flex tw-flex-col tw-justify-between tw-gap-4 @[700px]:tw-flex-row @[700px]:tw-items-center">
+                    <MemesLeaderboardDropVoteSummary drop={drop} />
+
+                    <div
+                      className="tw-flex tw-w-full tw-flex-shrink-0 tw-items-center tw-justify-between tw-gap-4 @[700px]:tw-w-auto @[700px]:tw-justify-end"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {/* Voters - only on small containers */}
+                      <div className="tw-flex tw-items-center tw-gap-2 @[700px]:tw-hidden">
+                        {firstThreeVoters.length > 0 && (
+                          <div className="tw-flex tw-items-center -tw-space-x-2">
+                            {firstThreeVoters.map((voter) => (
+                              <Link
+                                key={
+                                  voter.profile.handle ??
+                                  voter.profile.primary_address
+                                }
+                                href={`/${voter.profile.handle ?? voter.profile.primary_address}`}
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                {voter.profile.pfp ? (
+                                  <Image
+                                    className="tw-h-6 tw-w-6 tw-rounded-md tw-border-2 tw-border-solid tw-border-[#111] tw-bg-iron-800 tw-object-contain"
+                                    src={getScaledImageUri(
+                                      voter.profile.pfp,
+                                      ImageScale.W_AUTO_H_50
+                                    )}
+                                    alt="Recent voter"
+                                    width={24}
+                                    height={24}
+                                  />
+                                ) : (
+                                  <div className="tw-h-6 tw-w-6 tw-rounded-lg tw-border-2 tw-border-solid tw-border-[#111] tw-bg-iron-800" />
+                                )}
+                              </Link>
+                            ))}
+                          </div>
+                        )}
+                        <ParticipationDropVoteDetailsTrigger
+                          drop={drop}
+                          visualVariant="memes"
+                        />
+                      </div>
+                      <VotingModalButton
                         drop={drop}
-                        visualVariant="memes"
+                        className="!tw-text-meta"
+                        onClick={() => {
+                          if (onVoteClick) {
+                            onVoteClick(drop);
+                            return;
+                          }
+                          setIsVotingModalOpen(true);
+                        }}
                       />
                     </div>
-                    <VotingModalButton
-                      drop={drop}
-                      className="!tw-text-meta"
-                      onClick={() => {
-                        if (onVoteClick) {
-                          onVoteClick(drop);
-                          return;
-                        }
-                        setIsVotingModalOpen(true);
-                      }}
-                    />
                   </div>
                 </div>
               </div>
@@ -288,24 +396,27 @@ export const MemesLeaderboardDrop: React.FC<MemesLeaderboardDropProps> = ({
           createPortal(
             <CommonDropdownItemsMobileWrapper
               isOpen={isActive}
-              setOpen={setIsActive}
+              setOpen={handleMobileMenuOpenChange}
               onAfterLeave={handleMobileMenuAfterLeave}
             >
-              <div className="tw-grid tw-grid-cols-1 tw-gap-y-2">
+              <div
+                className="tw-grid tw-grid-cols-1 tw-gap-y-2"
+                onClickCapture={clearSuppression}
+              >
                 {/* Open drop option */}
                 <WaveDropMobileMenuOpen
                   drop={drop}
-                  onOpenChange={() => setIsActive(false)}
+                  onOpenChange={handleMobileMenuClose}
                 />
                 <WaveDropMobileMenuCopyLink
                   drop={drop}
-                  onCopy={() => setIsActive(false)}
+                  onCopy={handleMobileMenuClose}
                 />
                 <ContentModerationDropActions
                   drop={drop}
                   mobile
                   onReport={() => {
-                    setIsActive(false);
+                    handleMobileMenuClose();
                     setIsReportOpen(true);
                   }}
                 />
@@ -322,7 +433,7 @@ export const MemesLeaderboardDrop: React.FC<MemesLeaderboardDropProps> = ({
                 {canDelete && (
                   <WaveDropMobileMenuDelete
                     drop={drop}
-                    onDropDeleted={() => setIsActive(false)}
+                    onDropDeleted={handleMobileMenuClose}
                   />
                 )}
               </div>

--- a/components/memes/drops/MemesLeaderboardDropArtistInfo.tsx
+++ b/components/memes/drops/MemesLeaderboardDropArtistInfo.tsx
@@ -10,42 +10,50 @@ import WaveDropTime from "@/components/waves/drops/time/WaveDropTime";
 import UserProfileTooltipWrapper from "@/components/utils/tooltip/UserProfileTooltipWrapper";
 import { DropAuthorBadges } from "@/components/waves/drops/DropAuthorBadges";
 import MemesLeaderboardDropRank from "./MemesLeaderboardDropRank";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import { t } from "@/i18n/messages";
 
 interface MemesLeaderboardDropArtistInfoProps {
   readonly drop: ExtendedDrop;
+  readonly isNativeTouch?: boolean;
 }
 
 const MemesLeaderboardDropArtistInfo = ({
   drop,
+  isNativeTouch = false,
 }: MemesLeaderboardDropArtistInfoProps) => {
+  const locale = useBrowserLocale();
+  const profileLabel = t(locale, "waves.leaderboard.grid.authorProfile", {
+    author: drop.author.handle ?? drop.author.primary_address,
+  });
+  const authorName = (
+    <span className="tw-text-sm tw-font-bold tw-leading-none tw-tracking-identity tw-text-white">
+      {drop.author.handle ?? drop.author.primary_address}
+    </span>
+  );
+  const authorLink = (
+    <Link
+      href={`/${drop.author.handle ?? drop.author.primary_address}`}
+      aria-label={profileLabel}
+      onClick={(event) => event.stopPropagation()}
+      className={`tw-no-underline desktop-hover:hover:tw-underline ${isNativeTouch ? "tw-inline-flex tw-min-h-10 tw-items-center" : ""}`}
+    >
+      {authorName}
+    </Link>
+  );
+  const authorIdentity = drop.author.handle ? (
+    <UserProfileTooltipWrapper user={drop.author.handle}>
+      {authorLink}
+    </UserProfileTooltipWrapper>
+  ) : (
+    authorLink
+  );
   return (
     <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-x-3">
       <MemesLeaderboardDropRank rank={drop.rank} />
-      <WaveDropAuthorPfp drop={drop} />
+      <WaveDropAuthorPfp drop={drop} disableNavigation={isNativeTouch} />
       <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-wrap tw-items-center tw-gap-x-2 tw-gap-y-1">
-        {drop.author.handle ? (
-          <UserProfileTooltipWrapper user={drop.author.handle}>
-            <Link
-              href={`/${drop.author.handle}`}
-              onClick={(e) => e.stopPropagation()}
-              className="tw-no-underline desktop-hover:hover:tw-underline"
-            >
-              <span className="tw-text-sm tw-font-bold tw-leading-none tw-tracking-identity tw-text-white">
-                {drop.author.handle}
-              </span>
-            </Link>
-          </UserProfileTooltipWrapper>
-        ) : (
-          <Link
-            href={`/${drop.author.handle ?? drop.author.primary_address}`}
-            onClick={(e) => e.stopPropagation()}
-            className="tw-no-underline desktop-hover:hover:tw-underline"
-          >
-            <span className="tw-text-sm tw-font-bold tw-leading-none tw-tracking-identity tw-text-white">
-              {drop.author.primary_address}
-            </span>
-          </Link>
-        )}
+        {authorIdentity}
 
         {!!drop.author.level && (
           <UserCICAndLevel
@@ -54,10 +62,12 @@ const MemesLeaderboardDropArtistInfo = ({
           />
         )}
 
-        <DropAuthorBadges
-          profile={drop.author}
-          tooltipIdPrefix={`leaderboard-author-badges-${drop.id}`}
-        />
+        <span inert={isNativeTouch} className="tw-contents">
+          <DropAuthorBadges
+            profile={drop.author}
+            tooltipIdPrefix={`leaderboard-author-badges-${drop.id}`}
+          />
+        </span>
 
         <span className="tw-inline-flex tw-items-center tw-gap-x-1.5 tw-whitespace-nowrap">
           <span className="tw-text-sm tw-text-iron-500">•</span>

--- a/components/waves/drops/WaveDropAuthorPfp.tsx
+++ b/components/waves/drops/WaveDropAuthorPfp.tsx
@@ -11,6 +11,7 @@ import React, { useState } from "react";
 
 interface WaveDropAuthorPfpProps {
   readonly drop: ApiDrop;
+  readonly disableNavigation?: boolean;
 }
 
 type PfpLoadMode = "optimized" | "unoptimized" | "placeholder";
@@ -20,7 +21,10 @@ type PfpLoadState = {
   mode: PfpLoadMode;
 };
 
-const WaveDropAuthorPfp: React.FC<WaveDropAuthorPfpProps> = ({ drop }) => {
+const WaveDropAuthorPfp: React.FC<WaveDropAuthorPfpProps> = ({
+  drop,
+  disableNavigation = false,
+}) => {
   const compact = useCompactMode();
   const resolvedPfp = drop.author.pfp
     ? resolveIpfsUrlSync(drop.author.pfp)
@@ -72,7 +76,7 @@ const WaveDropAuthorPfp: React.FC<WaveDropAuthorPfpProps> = ({ drop }) => {
     event.stopPropagation();
   };
 
-  if (!profileHref) {
+  if (!profileHref || disableNavigation) {
     return <div className={containerClasses}>{avatarContent}</div>;
   }
 

--- a/components/waves/leaderboard/gallery/WaveLeaderboardGalleryItem.tsx
+++ b/components/waves/leaderboard/gallery/WaveLeaderboardGalleryItem.tsx
@@ -75,6 +75,102 @@ function LeaderboardResultBadge({
   );
 }
 
+function LeaderboardMediaPreview({
+  drop,
+  title,
+  opensWholeCard,
+  hasTouchScreen,
+  isHighlighting,
+  onOpen,
+}: {
+  readonly drop: ExtendedDrop;
+  readonly title: string;
+  readonly opensWholeCard: boolean;
+  readonly hasTouchScreen: boolean;
+  readonly isHighlighting: boolean;
+  readonly onOpen: () => void;
+}) {
+  const locale = useBrowserLocale();
+  const isTabletOrSmaller = useMediaQuery("(max-width: 1023px)");
+  const primaryMedia = drop.parts[0]?.media[0];
+  const mediaImageScale = isTabletOrSmaller
+    ? ImageScale.AUTOx450
+    : ImageScale.AUTOx1080;
+  const previewImageUrl = useMemo(
+    () => getDropPreviewImageUrl(drop.metadata),
+    [drop.metadata]
+  );
+  const hasStaticMediaPreview =
+    primaryMedia?.mime_type.includes("image") === true ||
+    Boolean(previewImageUrl);
+  const highlightAnimation =
+    isHighlighting && !hasTouchScreen ? "tw-animate-gallery-reveal" : "";
+  const imageContainerClass =
+    "tw-aspect-square tw-relative tw-flex-shrink-0 tw-touch-pan-y tw-overflow-hidden tw-bg-iron-900 tw-group/image";
+  const imageScaleClasses =
+    hasTouchScreen || !hasStaticMediaPreview
+      ? ""
+      : `tw-transform tw-duration-700 tw-ease-out group-hover/image:tw-scale-105 ${highlightAnimation}`;
+  const mediaContent = (
+    <div
+      className={`tw-flex tw-h-full tw-w-full tw-items-center tw-justify-center ${imageScaleClasses}`}
+    >
+      <MediaDisplay
+        media_mime_type={primaryMedia?.mime_type ?? "image/jpeg"}
+        media_url={primaryMedia?.url ?? ""}
+        disableMediaInteraction={true}
+        isInertPreview={opensWholeCard}
+        fillVideoContainer={true}
+        imageScale={mediaImageScale}
+        previewImageUrl={previewImageUrl}
+      />
+    </div>
+  );
+
+  if (opensWholeCard) {
+    return (
+      <div
+        inert
+        className={`${imageContainerClass} tw-m-0 tw-w-full tw-rounded-lg`}
+      >
+        {mediaContent}
+      </div>
+    );
+  }
+
+  if (hasStaticMediaPreview) {
+    return (
+      <button
+        type="button"
+        onClick={onOpen}
+        aria-label={t(locale, "waves.leaderboard.grid.openNamed", { title })}
+        className={`${imageContainerClass} tw-m-0 tw-w-full tw-cursor-pointer tw-rounded-lg tw-border-none tw-bg-transparent tw-p-0 tw-text-left`}
+      >
+        {mediaContent}
+      </button>
+    );
+  }
+
+  return (
+    <div className={`${imageContainerClass} tw-m-0 tw-w-full tw-rounded-lg`}>
+      {mediaContent}
+      <button
+        type="button"
+        onClick={onOpen}
+        aria-label={t(locale, "drop.media.openMedia")}
+        title={t(locale, "drop.media.openMedia")}
+        className="tw-absolute tw-right-2 tw-top-2 tw-z-20 tw-flex tw-size-8 tw-cursor-pointer tw-items-center tw-justify-center tw-rounded-md tw-border tw-border-solid tw-border-white/[0.08] tw-bg-black/70 tw-p-0 tw-text-iron-300 tw-shadow-md tw-backdrop-blur-sm tw-transition-colors tw-duration-200 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 desktop-hover:hover:tw-bg-iron-900 desktop-hover:hover:tw-text-iron-100"
+      >
+        <FontAwesomeIcon
+          icon={faArrowUpRightFromSquare}
+          className="tw-size-3.5"
+          aria-hidden="true"
+        />
+      </button>
+    </div>
+  );
+}
+
 export const WaveLeaderboardGalleryItem = memo<WaveLeaderboardGalleryItemProps>(
   ({
     drop,
@@ -96,7 +192,6 @@ export const WaveLeaderboardGalleryItem = memo<WaveLeaderboardGalleryItemProps>(
     } = useVotingModalState(isVotingActionLocked);
     const [isHighlighting, setIsHighlighting] = useState(false);
     const isMobileScreen = useIsMobileScreen();
-    const isTabletOrSmaller = useMediaQuery("(max-width: 1023px)");
     const locale = useBrowserLocale();
     const {
       cardRef,
@@ -129,17 +224,6 @@ export const WaveLeaderboardGalleryItem = memo<WaveLeaderboardGalleryItemProps>(
     const { canShowVote } = useDropInteractionRules(drop);
     const canShowVotingAction = canShowVote && !isVotingActionLocked;
     const primaryMedia = drop.parts[0]?.media[0];
-    const mediaImageScale = isTabletOrSmaller
-      ? ImageScale.AUTOx450
-      : ImageScale.AUTOx1080;
-
-    const previewImageUrl = useMemo(
-      () => getDropPreviewImageUrl(drop.metadata),
-      [drop.metadata]
-    );
-    const hasStaticMediaPreview =
-      primaryMedia?.mime_type.includes("image") === true ||
-      Boolean(previewImageUrl);
 
     const isFirstRenderRef = useRef(true);
     const previousSortRef = useRef(activeSort);
@@ -222,78 +306,6 @@ export const WaveLeaderboardGalleryItem = memo<WaveLeaderboardGalleryItemProps>(
       ? drop.title
       : t(locale, "waves.leaderboard.grid.untitled");
 
-    const highlightAnimation =
-      isHighlighting && !hasTouchScreen ? "tw-animate-gallery-reveal" : "";
-
-    const baseImageClasses =
-      "tw-aspect-square tw-relative tw-flex-shrink-0 tw-touch-pan-y tw-overflow-hidden tw-bg-iron-900 tw-group/image";
-
-    const imageScaleClasses =
-      hasTouchScreen || !hasStaticMediaPreview
-        ? ""
-        : `tw-transform tw-duration-700 tw-ease-out group-hover/image:tw-scale-105 ${highlightAnimation}`;
-
-    const imageContainerClass = baseImageClasses;
-    const mediaContent = (
-      <div
-        className={`tw-flex tw-h-full tw-w-full tw-items-center tw-justify-center ${imageScaleClasses}`}
-      >
-        <MediaDisplay
-          media_mime_type={primaryMedia?.mime_type ?? "image/jpeg"}
-          media_url={primaryMedia?.url ?? ""}
-          disableMediaInteraction={true}
-          isInertPreview={opensWholeCard}
-          fillVideoContainer={true}
-          imageScale={mediaImageScale}
-          previewImageUrl={previewImageUrl}
-        />
-      </div>
-    );
-
-    let mediaPreview;
-    if (opensWholeCard) {
-      mediaPreview = (
-        <div
-          inert
-          className={`${imageContainerClass} tw-m-0 tw-w-full tw-rounded-lg`}
-        >
-          {mediaContent}
-        </div>
-      );
-    } else if (hasStaticMediaPreview) {
-      mediaPreview = (
-        <button
-          type="button"
-          onClick={openDrop}
-          aria-label={t(locale, "waves.leaderboard.grid.openNamed", { title })}
-          className={`${imageContainerClass} tw-m-0 tw-w-full tw-cursor-pointer tw-rounded-lg tw-border-none tw-bg-transparent tw-p-0 tw-text-left`}
-        >
-          {mediaContent}
-        </button>
-      );
-    } else {
-      mediaPreview = (
-        <div
-          className={`${imageContainerClass} tw-m-0 tw-w-full tw-rounded-lg`}
-        >
-          {mediaContent}
-          <button
-            type="button"
-            onClick={openDrop}
-            aria-label={t(locale, "drop.media.openMedia")}
-            title={t(locale, "drop.media.openMedia")}
-            className="tw-absolute tw-right-2 tw-top-2 tw-z-20 tw-flex tw-size-8 tw-cursor-pointer tw-items-center tw-justify-center tw-rounded-md tw-border tw-border-solid tw-border-white/[0.08] tw-bg-black/70 tw-p-0 tw-text-iron-300 tw-shadow-md tw-backdrop-blur-sm tw-transition-colors tw-duration-200 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 desktop-hover:hover:tw-bg-iron-900 desktop-hover:hover:tw-text-iron-100"
-          >
-            <FontAwesomeIcon
-              icon={faArrowUpRightFromSquare}
-              className="tw-size-3.5"
-              aria-hidden="true"
-            />
-          </button>
-        </div>
-      );
-    }
-
     return (
       <div
         ref={cardRef}
@@ -343,7 +355,14 @@ export const WaveLeaderboardGalleryItem = memo<WaveLeaderboardGalleryItemProps>(
         <div
           className={`tw-relative tw-z-10 tw-flex tw-flex-1 tw-flex-col ${opensWholeCard ? "tw-pointer-events-none [&_[data-tooltip-id]]:tw-pointer-events-auto [&_[tabindex]]:tw-pointer-events-auto [&_a]:tw-pointer-events-auto [&_button]:tw-pointer-events-auto" : ""}`}
         >
-          {mediaPreview}
+          <LeaderboardMediaPreview
+            drop={drop}
+            title={title}
+            opensWholeCard={opensWholeCard}
+            hasTouchScreen={hasTouchScreen}
+            isHighlighting={isHighlighting}
+            onOpen={openDrop}
+          />
           <div className="tw-flex tw-flex-1 tw-flex-col tw-rounded-b-lg tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-800 tw-bg-iron-950/50 tw-p-3">
             <div className="tw-mb-3 tw-min-w-0">
               <div className="tw-flex tw-min-w-0 tw-items-start tw-justify-between tw-gap-2">

--- a/components/waves/leaderboard/gallery/WaveLeaderboardGalleryItem.tsx
+++ b/components/waves/leaderboard/gallery/WaveLeaderboardGalleryItem.tsx
@@ -18,13 +18,17 @@ import { WAVE_VOTING_LABELS } from "@/helpers/waves/waves.constants";
 import { useDropInteractionRules } from "@/hooks/drops/useDropInteractionRules";
 import useIsMobileScreen from "@/hooks/isMobileScreen";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
+import useLongPressInteraction from "@/hooks/useLongPressInteraction";
+import useLongPressClickSuppression from "@/hooks/useLongPressClickSuppression";
+import useCardTouchNavigationGuard from "@/hooks/useCardTouchNavigationGuard";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import type { WaveDropsLeaderboardSort } from "@/hooks/useWaveDropsLeaderboard";
 import { startDropOpen } from "@/utils/monitoring/dropOpenTiming";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
 import Link from "next/link";
-import { memo, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { WaveLeaderboardGridItemMobileActionsMenu } from "../grid/WaveLeaderboardGridItemMobileActionsMenu";
 import { WaveLeaderboardIdentity } from "../identity/WaveLeaderboardIdentity";
 import WaveLeaderboardGalleryItemVotes from "./WaveLeaderboardGalleryItemVotes";
 import ApprovalStatusBadge from "@/components/waves/approval/ApprovalStatusBadge";
@@ -94,7 +98,34 @@ export const WaveLeaderboardGalleryItem = memo<WaveLeaderboardGalleryItemProps>(
     const isMobileScreen = useIsMobileScreen();
     const isTabletOrSmaller = useMediaQuery("(max-width: 1023px)");
     const locale = useBrowserLocale();
-    const { hasTouchScreen } = useDeviceInfo();
+    const {
+      cardRef,
+      handleTouchStart: guardTouchStart,
+      handleTouchMove: guardTouchMove,
+      handleTouchEnd: guardTouchEnd,
+      handleTouchCancel: guardTouchCancel,
+      handleClickCapture: guardClickCapture,
+    } = useCardTouchNavigationGuard();
+    const { hasTouchScreen, isApp } = useDeviceInfo();
+    const opensWholeCard = isApp && hasTouchScreen;
+    const {
+      markNextClickForSuppression,
+      releaseSuppressionAfterTouchEnd,
+      clearSuppression,
+      handleClickCapture,
+    } = useLongPressClickSuppression();
+    const { isActive, setIsActive, touchHandlers } = useLongPressInteraction({
+      hasTouchScreen: opensWholeCard,
+      preventDefault: false,
+      onInteractionStart: markNextClickForSuppression,
+    });
+    const handleMenuOpenChange = useCallback(
+      (open: boolean) => {
+        if (!open) clearSuppression();
+        setIsActive(open);
+      },
+      [clearSuppression, setIsActive]
+    );
     const { canShowVote } = useDropInteractionRules(drop);
     const canShowVotingAction = canShowVote && !isVotingActionLocked;
     const primaryMedia = drop.parts[0]?.media[0];
@@ -164,7 +195,7 @@ export const WaveLeaderboardGalleryItem = memo<WaveLeaderboardGalleryItemProps>(
     const isApproveDrop =
       typeof winningThreshold === "number" && winningThreshold > 0;
 
-    const handleImageClick = () => {
+    const openDrop = () => {
       startDropOpen({
         dropId: drop.id,
         waveId: drop.wave.id,
@@ -186,7 +217,10 @@ export const WaveLeaderboardGalleryItem = memo<WaveLeaderboardGalleryItemProps>(
       ? ""
       : "tw-transition-all tw-duration-300 tw-ease-out";
     const groupClasses = artFocused ? `tw-group ${transitionClasses}` : "";
-    const containerClass = `${groupClasses} tw-relative tw-flex tw-h-full tw-w-full tw-min-w-0 tw-flex-col tw-bg-iron-950/50 tw-border tw-border-solid tw-border-iron-800 tw-rounded-lg desktop-hover:hover:tw-border-iron-700 tw-shadow-lg desktop-hover:hover:tw-shadow-xl`;
+    const containerClass = `${groupClasses} ${opensWholeCard ? "touch-select-none" : ""} tw-relative tw-isolate tw-flex tw-h-full tw-w-full tw-min-w-0 tw-flex-col tw-bg-iron-950/50 tw-border tw-border-solid tw-border-iron-800 tw-rounded-lg desktop-hover:hover:tw-border-iron-700 tw-shadow-lg desktop-hover:hover:tw-shadow-xl`;
+    const title = drop.title?.trim()
+      ? drop.title
+      : t(locale, "waves.leaderboard.grid.untitled");
 
     const highlightAnimation =
       isHighlighting && !hasTouchScreen ? "tw-animate-gallery-reveal" : "";
@@ -194,9 +228,10 @@ export const WaveLeaderboardGalleryItem = memo<WaveLeaderboardGalleryItemProps>(
     const baseImageClasses =
       "tw-aspect-square tw-relative tw-flex-shrink-0 tw-touch-pan-y tw-overflow-hidden tw-bg-iron-900 tw-group/image";
 
-    const imageScaleClasses = hasTouchScreen || !hasStaticMediaPreview
-      ? ""
-      : `tw-transform tw-duration-700 tw-ease-out group-hover/image:tw-scale-105 ${highlightAnimation}`;
+    const imageScaleClasses =
+      hasTouchScreen || !hasStaticMediaPreview
+        ? ""
+        : `tw-transform tw-duration-700 tw-ease-out group-hover/image:tw-scale-105 ${highlightAnimation}`;
 
     const imageContainerClass = baseImageClasses;
     const mediaContent = (
@@ -207,6 +242,7 @@ export const WaveLeaderboardGalleryItem = memo<WaveLeaderboardGalleryItemProps>(
           media_mime_type={primaryMedia?.mime_type ?? "image/jpeg"}
           media_url={primaryMedia?.url ?? ""}
           disableMediaInteraction={true}
+          isInertPreview={opensWholeCard}
           fillVideoContainer={true}
           imageScale={mediaImageScale}
           previewImageUrl={previewImageUrl}
@@ -214,109 +250,184 @@ export const WaveLeaderboardGalleryItem = memo<WaveLeaderboardGalleryItemProps>(
       </div>
     );
 
-    return (
-      <div className={containerClass}>
-        {hasStaticMediaPreview ? (
+    let mediaPreview;
+    if (opensWholeCard) {
+      mediaPreview = (
+        <div
+          inert
+          className={`${imageContainerClass} tw-m-0 tw-w-full tw-rounded-lg`}
+        >
+          {mediaContent}
+        </div>
+      );
+    } else if (hasStaticMediaPreview) {
+      mediaPreview = (
+        <button
+          type="button"
+          onClick={openDrop}
+          aria-label={t(locale, "waves.leaderboard.grid.openNamed", { title })}
+          className={`${imageContainerClass} tw-m-0 tw-w-full tw-cursor-pointer tw-rounded-lg tw-border-none tw-bg-transparent tw-p-0 tw-text-left`}
+        >
+          {mediaContent}
+        </button>
+      );
+    } else {
+      mediaPreview = (
+        <div
+          className={`${imageContainerClass} tw-m-0 tw-w-full tw-rounded-lg`}
+        >
+          {mediaContent}
           <button
-            className={`${imageContainerClass} tw-m-0 tw-w-full tw-cursor-pointer tw-overflow-hidden tw-rounded-lg tw-border-none tw-bg-transparent tw-p-0 tw-text-left`}
-            onClick={handleImageClick}
             type="button"
+            onClick={openDrop}
+            aria-label={t(locale, "drop.media.openMedia")}
+            title={t(locale, "drop.media.openMedia")}
+            className="tw-absolute tw-right-2 tw-top-2 tw-z-20 tw-flex tw-size-8 tw-cursor-pointer tw-items-center tw-justify-center tw-rounded-md tw-border tw-border-solid tw-border-white/[0.08] tw-bg-black/70 tw-p-0 tw-text-iron-300 tw-shadow-md tw-backdrop-blur-sm tw-transition-colors tw-duration-200 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 desktop-hover:hover:tw-bg-iron-900 desktop-hover:hover:tw-text-iron-100"
           >
-            {mediaContent}
+            <FontAwesomeIcon
+              icon={faArrowUpRightFromSquare}
+              className="tw-size-3.5"
+              aria-hidden="true"
+            />
           </button>
-        ) : (
-          <div
-            className={`${imageContainerClass} tw-m-0 tw-w-full tw-overflow-hidden tw-rounded-lg`}
-          >
-            {mediaContent}
-            <button
-              type="button"
-              onClick={handleImageClick}
-              aria-label={t(locale, "drop.media.openMedia")}
-              title={t(locale, "drop.media.openMedia")}
-              className="tw-absolute tw-right-2 tw-top-2 tw-z-20 tw-flex tw-size-8 tw-cursor-pointer tw-items-center tw-justify-center tw-rounded-md tw-border tw-border-solid tw-border-white/[0.08] tw-bg-black/70 tw-p-0 tw-text-iron-300 tw-shadow-md tw-backdrop-blur-sm tw-transition-colors tw-duration-200 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 desktop-hover:hover:tw-bg-iron-900 desktop-hover:hover:tw-text-iron-100"
-            >
-              <FontAwesomeIcon
-                icon={faArrowUpRightFromSquare}
-                className="tw-size-3.5"
-                aria-hidden="true"
-              />
-            </button>
-          </div>
-        )}
-        <div className="tw-flex tw-flex-1 tw-flex-col tw-rounded-b-lg tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-800 tw-bg-iron-950/50 tw-p-3">
-          <div className="tw-mb-3 tw-min-w-0">
-            <div className="tw-flex tw-min-w-0 tw-items-start tw-justify-between tw-gap-2">
-              <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-wrap tw-items-center tw-gap-1.5">
-                <MediaTypeBadge
-                  mimeType={primaryMedia?.mime_type}
-                  dropId={drop.id}
-                  size="sm"
-                />
-                {drop.is_additional_action_promised === true && (
-                  <AdditionalActionPromiseBadge />
-                )}
-              </div>
-              <div className="tw-flex-shrink-0">
-                <LeaderboardResultBadge
-                  drop={drop}
-                  isApproveDrop={isApproveDrop}
-                />
-              </div>
-            </div>
-            {drop.title && (
-              <h3 className="tw-[overflow-wrap:anywhere] tw-mb-0 tw-mt-2 tw-min-w-0 tw-whitespace-normal tw-break-words tw-text-sm tw-font-bold tw-leading-tight tw-text-iron-200">
-                {drop.title}
-              </h3>
-            )}
-            {drop.author?.handle && (
-              <UserProfileTooltipWrapper
-                user={drop.author.handle ?? drop.author.id}
-              >
-                <Link
-                  onClick={(e) => e.stopPropagation()}
-                  href={`/${drop.author?.handle}`}
-                  className="tw-mt-1 tw-block tw-max-w-full tw-truncate tw-text-xs tw-text-iron-400 tw-no-underline tw-transition-colors tw-duration-150 desktop-hover:hover:tw-text-iron-300 desktop-hover:hover:tw-underline"
-                >
-                  {drop.author?.handle}
-                </Link>
-              </UserProfileTooltipWrapper>
-            )}
-          </div>
-          <WaveLeaderboardIdentity
-            drop={drop}
-            variant="condensed"
-            className="tw-mb-3"
+        </div>
+      );
+    }
+
+    return (
+      <div
+        ref={cardRef}
+        className={containerClass}
+        {...touchHandlers}
+        onTouchStart={(event) => {
+          if (
+            !event.currentTarget.contains(event.target as Node) ||
+            (event.target instanceof Element &&
+              event.target.closest('[role="dialog"]'))
+          ) {
+            return;
+          }
+          if (event.touches.length !== 1) {
+            touchHandlers.onTouchCancel();
+            return;
+          }
+          touchHandlers.onTouchStart(event);
+        }}
+        onClickCapture={(event) => {
+          if (!guardClickCapture(event)) handleClickCapture(event);
+        }}
+        onTouchStartCapture={(event) => {
+          clearSuppression();
+          guardTouchStart(event);
+        }}
+        onTouchMoveCapture={guardTouchMove}
+        onTouchEndCapture={(event) => {
+          guardTouchEnd(event);
+          releaseSuppressionAfterTouchEnd();
+        }}
+        onTouchCancelCapture={(event) => {
+          guardTouchCancel(event);
+          clearSuppression();
+        }}
+      >
+        {opensWholeCard && (
+          <button
+            type="button"
+            onClick={openDrop}
+            aria-label={t(locale, "waves.leaderboard.grid.openNamed", {
+              title,
+            })}
+            className="tw-absolute tw-inset-0 tw-z-0 tw-cursor-pointer tw-rounded-lg tw-border-0 tw-bg-transparent tw-p-0 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-white"
           />
-          <div className="tw-mb-3 tw-flex tw-min-w-0 tw-flex-wrap tw-items-center tw-justify-between tw-gap-y-2 tw-text-xs">
-            <div className="tw-min-w-0 tw-flex-1">
-              <WaveLeaderboardGalleryItemVotes
-                drop={drop}
-                variant={artFocused ? "subtle" : "default"}
-                winningThreshold={winningThreshold}
-                winningThresholdMinDurationMs={winningThresholdMinDurationMs}
-                isVotingClosed={isVotingClosed}
-              />
-            </div>
-          </div>
-          <div className="tw-mt-auto tw-flex tw-min-w-0 tw-flex-wrap tw-items-center tw-gap-3 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-800/50 tw-pt-2">
-            <div className="tw-flex tw-flex-shrink-0">
-              <ParticipationDropVoteDetailsTrigger
-                drop={drop}
-                density="gallery"
-              />
-            </div>
-            {canShowVotingAction && (
-              <div className="tw-ml-auto tw-flex tw-min-w-0 tw-flex-1 tw-justify-end">
-                <VotingModalButton
-                  drop={drop}
-                  onClick={handleVoteButtonClick}
-                  className="tw-box-border tw-min-w-0 tw-max-w-full"
-                >
-                  {voteButtonLabel}
-                </VotingModalButton>
+        )}
+        <div
+          className={`tw-relative tw-z-10 tw-flex tw-flex-1 tw-flex-col ${opensWholeCard ? "tw-pointer-events-none [&_[data-tooltip-id]]:tw-pointer-events-auto [&_[tabindex]]:tw-pointer-events-auto [&_a]:tw-pointer-events-auto [&_button]:tw-pointer-events-auto" : ""}`}
+        >
+          {mediaPreview}
+          <div className="tw-flex tw-flex-1 tw-flex-col tw-rounded-b-lg tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-800 tw-bg-iron-950/50 tw-p-3">
+            <div className="tw-mb-3 tw-min-w-0">
+              <div className="tw-flex tw-min-w-0 tw-items-start tw-justify-between tw-gap-2">
+                <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-wrap tw-items-center tw-gap-1.5">
+                  <MediaTypeBadge
+                    mimeType={primaryMedia?.mime_type}
+                    dropId={drop.id}
+                    size="sm"
+                    showTooltip={!opensWholeCard}
+                  />
+                  {drop.is_additional_action_promised === true && (
+                    <AdditionalActionPromiseBadge focusable={!opensWholeCard} />
+                  )}
+                </div>
+                <div className="tw-flex-shrink-0">
+                  <LeaderboardResultBadge
+                    drop={drop}
+                    isApproveDrop={isApproveDrop}
+                  />
+                </div>
               </div>
-            )}
+              {(Boolean(drop.title) || opensWholeCard) && (
+                <h3 className="tw-[overflow-wrap:anywhere] tw-mb-0 tw-mt-2 tw-min-w-0 tw-whitespace-normal tw-break-words tw-text-sm tw-font-bold tw-leading-tight tw-text-iron-200">
+                  {opensWholeCard ? title : drop.title}
+                </h3>
+              )}
+              {drop.author.handle && opensWholeCard && (
+                <span className="tw-mt-1 tw-block tw-max-w-full tw-truncate tw-text-xs tw-text-iron-400">
+                  {drop.author.handle}
+                </span>
+              )}
+              {drop.author.handle && !opensWholeCard && (
+                <UserProfileTooltipWrapper user={drop.author.handle}>
+                  <Link
+                    onClick={(e) => e.stopPropagation()}
+                    href={`/${drop.author.handle}`}
+                    aria-label={t(
+                      locale,
+                      "waves.leaderboard.grid.authorProfile",
+                      { author: drop.author.handle }
+                    )}
+                    className="tw-mt-1 tw-block tw-max-w-full tw-truncate tw-text-xs tw-text-iron-400 tw-no-underline tw-transition-colors tw-duration-150 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 desktop-hover:hover:tw-text-iron-300 desktop-hover:hover:tw-underline"
+                  >
+                    {drop.author.handle}
+                  </Link>
+                </UserProfileTooltipWrapper>
+              )}
+            </div>
+            <WaveLeaderboardIdentity
+              drop={drop}
+              variant="condensed"
+              disableNavigation={opensWholeCard}
+              className="tw-mb-3"
+            />
+            <div className="tw-mb-3 tw-flex tw-min-w-0 tw-flex-wrap tw-items-center tw-justify-between tw-gap-y-2 tw-text-xs">
+              <div className="tw-min-w-0 tw-flex-1">
+                <WaveLeaderboardGalleryItemVotes
+                  drop={drop}
+                  variant={artFocused ? "subtle" : "default"}
+                  winningThreshold={winningThreshold}
+                  winningThresholdMinDurationMs={winningThresholdMinDurationMs}
+                  isVotingClosed={isVotingClosed}
+                />
+              </div>
+            </div>
+            <div className="tw-mt-auto tw-flex tw-min-w-0 tw-flex-wrap tw-items-center tw-gap-3 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-800/50 tw-pt-2">
+              <div className="tw-flex tw-flex-shrink-0">
+                <ParticipationDropVoteDetailsTrigger
+                  drop={drop}
+                  density="gallery"
+                />
+              </div>
+              {canShowVotingAction && (
+                <div className="tw-ml-auto tw-flex tw-min-w-0 tw-flex-1 tw-justify-end">
+                  <VotingModalButton
+                    drop={drop}
+                    onClick={handleVoteButtonClick}
+                    className="tw-box-border tw-min-w-0 tw-max-w-full"
+                  >
+                    {voteButtonLabel}
+                  </VotingModalButton>
+                </div>
+              )}
+            </div>
           </div>
         </div>
 
@@ -334,6 +445,16 @@ export const WaveLeaderboardGalleryItem = memo<WaveLeaderboardGalleryItemProps>(
               onClose={closeVoteModal}
             />
           ))}
+        {opensWholeCard && (
+          <WaveLeaderboardGridItemMobileActionsMenu
+            drop={drop}
+            isOpen={isActive}
+            setIsActive={handleMenuOpenChange}
+            canOpenDrop
+            canShowVotingAction={canShowVotingAction}
+            onVoteClick={handleVoteButtonClick}
+          />
+        )}
       </div>
     );
   }

--- a/components/waves/leaderboard/identity/WaveLeaderboardIdentity.tsx
+++ b/components/waves/leaderboard/identity/WaveLeaderboardIdentity.tsx
@@ -17,16 +17,22 @@ import { shortenAddress } from "@/helpers/address.helpers";
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 import Link from "next/link";
 
-type WaveLeaderboardIdentityVariant = "responsive" | "condensed";
-
-interface WaveLeaderboardIdentityProps {
+type WaveLeaderboardIdentityProps = {
   readonly drop: ExtendedDrop;
-  readonly variant: WaveLeaderboardIdentityVariant;
   readonly cardVariant?: ParticipationIdentityProfileCardVariant | undefined;
   readonly className?: string | undefined;
   readonly showIdentityHeader?: boolean | undefined;
   readonly supplementFullWidth?: boolean | undefined;
-}
+} & (
+  | {
+      readonly variant: "responsive";
+      readonly disableNavigation?: false | undefined;
+    }
+  | {
+      readonly variant: "condensed";
+      readonly disableNavigation?: boolean | undefined;
+    }
+);
 
 interface WaveLeaderboardIdentitySummaryProps {
   readonly profile: ApiDropResolvedIdentityProfile | null;
@@ -34,6 +40,7 @@ interface WaveLeaderboardIdentitySummaryProps {
   readonly contextId?: string | number | undefined;
   readonly showIdentityHeader?: boolean | undefined;
   readonly supplementFullWidth?: boolean | undefined;
+  readonly disableNavigation?: boolean | undefined;
 }
 
 function WaveLeaderboardIdentitySummary({
@@ -42,6 +49,7 @@ function WaveLeaderboardIdentitySummary({
   contextId,
   showIdentityHeader = true,
   supplementFullWidth: _supplementFullWidth = false,
+  disableNavigation = false,
 }: WaveLeaderboardIdentitySummaryProps) {
   const displayLabel =
     profile?.handle ?? profile?.primary_address ?? fallbackValue;
@@ -53,6 +61,15 @@ function WaveLeaderboardIdentitySummary({
   const rootHref = profile
     ? `/${encodeURIComponent(displayLabel.toLowerCase())}`
     : null;
+  const profileLinkEnabled = rootHref !== null && !disableNavigation;
+  const labelClassName = rootHref
+    ? "tw-max-w-full tw-text-sm tw-font-semibold tw-leading-none tw-text-iron-50 tw-no-underline"
+    : "tw-break-all tw-text-sm tw-font-semibold tw-leading-none tw-text-iron-50";
+  const labelContent = (
+    <span className={rootHref ? "tw-block tw-truncate" : undefined}>
+      {displayLabel}
+    </span>
+  );
   const primaryAddress = profile?.primary_address;
   const shouldShowAddress =
     !!profile?.handle &&
@@ -84,7 +101,7 @@ function WaveLeaderboardIdentitySummary({
     >
       {showIdentityHeader && (
         <div className="tw-flex tw-items-start tw-gap-3">
-          {rootHref ? (
+          {profileLinkEnabled ? (
             <Link
               href={rootHref}
               prefetch={false}
@@ -101,7 +118,7 @@ function WaveLeaderboardIdentitySummary({
             </Link>
           ) : (
             <ProfileAvatar
-              pfpUrl={null}
+              pfpUrl={profile?.pfp ?? null}
               size={ProfileBadgeSize.SMALL}
               alt={`${displayLabel} avatar`}
               fallbackContent={avatarFallback}
@@ -110,19 +127,17 @@ function WaveLeaderboardIdentitySummary({
 
           <div className="tw-min-w-0 tw-flex-1">
             <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-x-2 tw-gap-y-1">
-              {rootHref ? (
+              {profileLinkEnabled ? (
                 <Link
                   href={rootHref}
                   prefetch={false}
                   onClick={(event) => event.stopPropagation()}
-                  className="tw-max-w-full tw-text-sm tw-font-semibold tw-leading-none tw-text-iron-50 tw-no-underline desktop-hover:hover:tw-text-iron-300"
+                  className={`${labelClassName} desktop-hover:hover:tw-text-iron-300`}
                 >
-                  <span className="tw-block tw-truncate">{displayLabel}</span>
+                  {labelContent}
                 </Link>
               ) : (
-                <span className="tw-break-all tw-text-sm tw-font-semibold tw-leading-none tw-text-iron-50">
-                  {displayLabel}
-                </span>
+                <span className={labelClassName}>{labelContent}</span>
               )}
 
               {profile && (
@@ -131,10 +146,12 @@ function WaveLeaderboardIdentitySummary({
                     level={profile.level}
                     size={UserCICAndLevelSize.SMALL}
                   />
-                  <DropAuthorBadges
-                    profile={profile}
-                    tooltipIdPrefix={`leaderboard-identity-${contextId ?? profile.id}`}
-                  />
+                  <div inert={disableNavigation} className="tw-contents">
+                    <DropAuthorBadges
+                      profile={profile}
+                      tooltipIdPrefix={`leaderboard-identity-${contextId ?? profile.id}`}
+                    />
+                  </div>
                 </>
               )}
             </div>
@@ -171,6 +188,7 @@ export function WaveLeaderboardIdentity({
   className,
   showIdentityHeader = true,
   supplementFullWidth = false,
+  disableNavigation = false,
 }: WaveLeaderboardIdentityProps) {
   const identityProfile = getDropIdentityProfile({
     wave: drop.wave,
@@ -223,6 +241,7 @@ export function WaveLeaderboardIdentity({
         contextId={drop.id}
         showIdentityHeader={showIdentityHeader}
         supplementFullWidth={supplementFullWidth}
+        disableNavigation={disableNavigation}
       />
     </div>
   );

--- a/contexts/NavigationHistoryContext.tsx
+++ b/contexts/NavigationHistoryContext.tsx
@@ -13,6 +13,7 @@ import {
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import type { ViewKey } from "@/components/navigation/navTypes";
 import { useViewContext } from "@/components/navigation/ViewContext";
+import type { BrainView } from "@/components/brain/mobile/brainMobileViews";
 import {
   getActiveWaveIdFromUrl,
   getMessagePathRoute,
@@ -21,9 +22,15 @@ import {
   sameMainPath,
 } from "@/helpers/navigation.helpers";
 
+interface WaveViewSelection {
+  readonly waveId: string;
+  readonly view: BrainView;
+}
+
 interface StackRoute {
   type: "route";
   path: string;
+  waveView?: WaveViewSelection;
 }
 interface StackView {
   type: "view";
@@ -37,6 +44,8 @@ interface NavigationHistoryContextValue {
   goBack: () => void;
   goBackTo: (path: string) => void;
   pushView: (view: ViewKey) => void;
+  currentWaveView: WaveViewSelection | null;
+  rememberWaveView: (selection: WaveViewSelection) => void;
 }
 
 const Context = createContext<NavigationHistoryContextValue | undefined>(
@@ -61,6 +70,27 @@ export const NavigationHistoryProvider: React.FC<{
   const skipNext = useRef(false);
   const prevPathRef = useRef<string>("");
 
+  const [currentWaveView, setCurrentWaveView] =
+    useState<WaveViewSelection | null>(null);
+
+  const rememberWaveView = useCallback(
+    (selection: WaveViewSelection) => {
+      const entry = historyRef.current[index];
+      if (entry?.type !== "route") return;
+
+      const entryWaveId = getActiveWaveIdFromUrl({
+        pathname: entry.path,
+        searchParams: new URLSearchParams(),
+      });
+      if (entryWaveId !== selection.waveId) return;
+
+      // Keep the selected tab with this visit, not with every visit to the wave.
+      entry.waveView = selection;
+      setCurrentWaveView(selection);
+    },
+    [index]
+  );
+
   const canGoBack = useMemo(() => {
     if (index === 0) return false;
     const current = historyRef.current[index];
@@ -78,6 +108,7 @@ export const NavigationHistoryProvider: React.FC<{
   }, [index]);
 
   const pushStack = useCallback((entry: StackEntry) => {
+    setCurrentWaveView(null);
     setIndex((prev) => {
       const newHistory = [
         ...historyRef.current.slice(0, prev + 1),
@@ -93,6 +124,7 @@ export const NavigationHistoryProvider: React.FC<{
 
     if (skipNext.current) {
       skipNext.current = false;
+      prevPathRef.current = url;
       return;
     }
 
@@ -142,38 +174,40 @@ export const NavigationHistoryProvider: React.FC<{
 
   const goBack = useCallback(() => {
     if (!canGoBack) return;
-    setIndex((prev) => {
-      let targetIndex = prev - 1;
-      const current = historyRef.current[prev];
+    let targetIndex = index - 1;
+    const current = historyRef.current[index];
 
-      while (targetIndex >= 0) {
-        const entry = historyRef.current[targetIndex];
-        if (
-          entry?.type === "route" &&
-          current?.type === "route" &&
-          sameMainPath(entry.path, current.path)
-        ) {
-          targetIndex -= 1;
-          continue;
-        }
-        break;
+    while (targetIndex >= 0) {
+      const entry = historyRef.current[targetIndex];
+      if (
+        entry?.type === "route" &&
+        current?.type === "route" &&
+        sameMainPath(entry.path, current.path)
+      ) {
+        targetIndex -= 1;
+        continue;
       }
+      break;
+    }
 
-      if (targetIndex < 0) {
-        window.history.back();
-        return prev;
-      }
+    if (targetIndex < 0) {
+      window.history.back();
+      return;
+    }
 
-      const target = historyRef.current[targetIndex];
-      if (target?.type === "route") {
-        skipNext.current = true;
-        router.push(target.path);
-      } else {
-        hardBack(target!.view);
-      }
-      return targetIndex;
-    });
-  }, [canGoBack, router, hardBack]);
+    const target = historyRef.current[targetIndex];
+    historyRef.current = historyRef.current.slice(0, targetIndex + 1);
+    setCurrentWaveView(
+      target?.type === "route" ? (target.waveView ?? null) : null
+    );
+    if (target?.type === "route") {
+      skipNext.current = true;
+      router.push(target.path);
+    } else {
+      hardBack(target!.view);
+    }
+    setIndex(targetIndex);
+  }, [canGoBack, index, router, hardBack]);
 
   const goBackTo = useCallback(
     (path: string) => {
@@ -192,19 +226,32 @@ export const NavigationHistoryProvider: React.FC<{
           ...historyRef.current.slice(0, index),
           { type: "route", path },
         ];
+        setCurrentWaveView(null);
         router.replace(path);
         return;
       }
 
+      const target = historyRef.current[targetIndex];
+      setCurrentWaveView(
+        target?.type === "route" ? (target.waveView ?? null) : null
+      );
       router.push(path);
+      historyRef.current = historyRef.current.slice(0, targetIndex + 1);
       setIndex(targetIndex);
     },
     [index, router]
   );
 
   const value = useMemo(
-    () => ({ canGoBack, goBack, goBackTo, pushView }),
-    [canGoBack, goBack, goBackTo, pushView]
+    () => ({
+      canGoBack,
+      goBack,
+      goBackTo,
+      pushView,
+      currentWaveView,
+      rememberWaveView,
+    }),
+    [canGoBack, goBack, goBackTo, pushView, currentWaveView, rememberWaveView]
   );
 
   return <Context.Provider value={value}>{children}</Context.Provider>;

--- a/hooks/useCardTouchNavigationGuard.ts
+++ b/hooks/useCardTouchNavigationGuard.ts
@@ -1,0 +1,154 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import type { MouseEvent, Touch, TouchEvent } from "react";
+
+const MOVE_THRESHOLD_PX = 8;
+const SCROLL_SETTLE_MS = 150;
+const DELAYED_CLICK_WINDOW_MS = 750;
+
+interface TouchGesture {
+  readonly identifier: number | undefined;
+  readonly startX: number;
+  readonly startY: number;
+  cancelled: boolean;
+  endedAt: number | null;
+}
+
+const isFromCard = (
+  event: TouchEvent<HTMLDivElement> | MouseEvent<HTMLDivElement>
+): boolean => event.currentTarget.contains(event.target as Node);
+
+const hasMoved = (touch: Touch, gesture: TouchGesture): boolean =>
+  Math.hypot(touch.clientX - gesture.startX, touch.clientY - gesture.startY) >
+  MOVE_THRESHOLD_PX;
+
+/** Keep scrolling, momentum-stop taps, and multi-touch from activating a card. */
+export default function useCardTouchNavigationGuard() {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const gestureRef = useRef<TouchGesture | null>(null);
+  const lastAncestorScrollAtRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const handleScroll = (event: Event) => {
+      const card = cardRef.current;
+      if (!card) return;
+
+      const target = event.target;
+      if (
+        target !== document &&
+        !(target instanceof Node && target.contains(card))
+      ) {
+        return;
+      }
+
+      lastAncestorScrollAtRef.current = Date.now();
+      const gesture = gestureRef.current;
+      if (gesture?.endedAt === null) {
+        gesture.cancelled = true;
+      }
+    };
+
+    document.addEventListener("scroll", handleScroll, {
+      capture: true,
+      passive: true,
+    });
+    return () => document.removeEventListener("scroll", handleScroll, true);
+  }, []);
+
+  const handleTouchStart = useCallback((event: TouchEvent<HTMLDivElement>) => {
+    if (!isFromCard(event)) return;
+
+    const currentGesture = gestureRef.current;
+    if (currentGesture?.endedAt === null) {
+      currentGesture.cancelled = true;
+      return;
+    }
+
+    const touch = event.touches[0];
+    const lastScrollAt = lastAncestorScrollAtRef.current;
+    gestureRef.current = {
+      identifier: touch?.identifier,
+      startX: touch?.clientX ?? 0,
+      startY: touch?.clientY ?? 0,
+      cancelled:
+        event.touches.length !== 1 ||
+        (lastScrollAt !== null && Date.now() - lastScrollAt < SCROLL_SETTLE_MS),
+      endedAt: null,
+    };
+  }, []);
+
+  const handleTouchMove = useCallback((event: TouchEvent<HTMLDivElement>) => {
+    if (!isFromCard(event)) return;
+    const gesture = gestureRef.current;
+    if (gesture?.endedAt !== null) return;
+
+    const touch = event.touches[0];
+    if (
+      event.touches.length !== 1 ||
+      !touch ||
+      touch.identifier !== gesture.identifier ||
+      hasMoved(touch, gesture)
+    ) {
+      gesture.cancelled = true;
+    }
+  }, []);
+
+  const handleTouchEnd = useCallback((event: TouchEvent<HTMLDivElement>) => {
+    if (!isFromCard(event)) return;
+    const gesture = gestureRef.current;
+    if (!gesture) return;
+
+    const endedTouch = Array.from(event.changedTouches).find(
+      (touch) => touch.identifier === gesture.identifier
+    );
+    if (endedTouch && hasMoved(endedTouch, gesture)) {
+      gesture.cancelled = true;
+    }
+    if (event.touches.length > 0) {
+      gesture.cancelled = true;
+      return;
+    }
+    gesture.endedAt = Date.now();
+  }, []);
+
+  const handleTouchCancel = useCallback((event: TouchEvent<HTMLDivElement>) => {
+    if (!isFromCard(event)) return;
+    const gesture = gestureRef.current;
+    if (!gesture) return;
+
+    gesture.cancelled = true;
+    gesture.endedAt = Date.now();
+  }, []);
+
+  const handleClickCapture = useCallback(
+    (event: MouseEvent<HTMLDivElement>): boolean => {
+      // Keyboard and assistive activation must not inherit a touch rejection.
+      if (!isFromCard(event) || event.detail === 0) return false;
+
+      const gesture = gestureRef.current;
+      gestureRef.current = null;
+      if (
+        !gesture?.cancelled ||
+        (gesture.endedAt !== null &&
+          Date.now() - gesture.endedAt > DELAYED_CLICK_WINDOW_MS)
+      ) {
+        return false;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      return true;
+    },
+    []
+  );
+
+  return {
+    cardRef,
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+    handleTouchCancel,
+    handleClickCapture,
+  };
+}

--- a/ops/docs/waves/chat/feature-content-tabs.md
+++ b/ops/docs/waves/chat/feature-content-tabs.md
@@ -7,8 +7,10 @@ wave sections such as `Chat`, `Leaderboard`, `Sales`, `Winners`, and other
 wave-dependent views.
 
 In the `My Votes` tab, non-image drops use a preview image from drop metadata when available, so rows render quickly and stay stable in list form.
-The app stores the last selected tab for each wave on the current device, then
-restores it whenever that wave is opened again and the tab is still available.
+The web layout stores the last selected tab for each wave on the current device,
+then restores it when that wave is opened again and the tab is still available.
+In the native app, Back restores the wave section from that navigation-history
+entry. Opening another wave normally still uses its default section.
 
 ## Location in the Site
 
@@ -33,9 +35,10 @@ restores it whenever that wave is opened again and the tab is still available.
 3. If multiple sections are available, the tab strip appears and selects the
    active tab:
    - Most waves default to `Chat`.
-   - Memes waves default to `Leaderboard` when that tab is available.
-   - Returning to a previously viewed wave restores the last saved valid tab when
-     it is still available.
+   - On web, Memes waves default to `Leaderboard` when that tab is available;
+     a fresh native-app visit defaults to `Chat` while voting is open.
+   - Web restores a previously saved valid tab. Native app Back restores the
+     section from that visit when it is still available.
 4. Select a tab to switch sections.
 5. The main content panel updates in place while staying on the same route.
 6. When open polls still need the signed-in user's answer and the user can
@@ -62,8 +65,10 @@ restores it whenever that wave is opened again and the tab is still available.
   video, or interactive media is indicated with a small badge at the title row.
 - In `My Votes`, non-image drops show a static preview thumbnail in the row when
   `preview_image` metadata is valid.
-- Move between waves and return later; the previously selected tab is restored for the
-  wave if it remains available.
+- On web, move between waves and return later to restore the saved valid tab.
+- In the native app, open an author profile from Leaderboard and use Back to
+  return to Leaderboard. Repeated profile visits preserve the same behavior.
+- A link targeting a specific chat message still opens Chat.
 - Polls can allow every reader to respond or limit responses to people who can
   chat. Readers who cannot respond still see poll results, but vote controls are
   hidden.

--- a/ops/docs/waves/drop-actions/feature-open-and-copy-links.md
+++ b/ops/docs/waves/drop-actions/feature-open-and-copy-links.md
@@ -23,6 +23,9 @@ Drop-level `Open` / `Open drop` actions and link-card `Open link` /
 - Link preview and quote cards in thread markdown: `Link actions` ->
   `Copy link`, `Open link`
 - Leaderboard and winners cards can also show `Open` (same `drop` behavior).
+- In the native mobile app on a touchscreen, Memes leaderboard List and artwork
+  Grid cards also open from their title, media, or free card space. A List
+  username opens the author's profile; a Grid username opens the submission.
 
 ## Entry Points
 
@@ -36,8 +39,8 @@ Drop-level `Open` / `Open drop` actions and link-card `Open link` /
 ## User Journey
 
 1. Open a thread and find either a posted drop or a rendered link/quote card.
-2. Choose `Open` / `Open drop` from drop actions when you want focused
-   single-drop view.
+2. Choose `Open` / `Open drop` from drop actions, or tap a leaderboard card in
+   the touchscreen native app, when you want focused single-drop view.
 3. The app sets `drop={dropId}` in the current URL and opens single-drop view.
 4. For preview or quote cards, open `Link actions`.
 5. The card menu shows `Copy link` and `Open link`.
@@ -62,6 +65,21 @@ Drop-level `Open` / `Open drop` actions and link-card `Open link` /
 - Mobile copy uses Clipboard API when available and falls back to textarea copy.
 - Memes submission drop copy links use canonical wave drop URLs and open the
   single-drop overlay when opened.
+- In the native mobile app on a touchscreen, a short tap on a Memes leaderboard
+  List or artwork Grid card opens the submission. The title, media,
+  description, and free card space are part of that opening target.
+- In native-app List view, the username opens the author's profile, while the
+  avatar and author badges remain part of the submission-opening target. In Grid
+  view, the username remains part of the submission-opening target.
+- Explicit vote, rating, and other action buttons keep their own actions and do
+  not also open the submission.
+- Native-app touchscreen cards show non-interactive media previews, using a
+  provided poster image when available. Open the submission to use media
+  controls instead of playing media directly in the card.
+- Browser views, including mobile browsers, keep their author profile links and
+  media interactions. The native-app whole-card touch rule does not apply there.
+- In the native app, scroll gestures do not open the card. Press and hold opens
+  the action sheet instead; see [Wave Drop Touch Menu](feature-touch-drop-menu.md).
 
 ## Edge Cases
 

--- a/ops/docs/waves/drop-actions/feature-touch-drop-menu.md
+++ b/ops/docs/waves/drop-actions/feature-touch-drop-menu.md
@@ -17,8 +17,9 @@ Use the touch drop menu to run drop actions without leaving the thread.
   mobile/tablet layout on a touch surface.
 - Press and hold an eligible drop, or use `Open drop actions` when that button
   is the touch entry surface.
-- On leaderboard list cards, press and hold the card to open the compact
-  slide-up sheet.
+- In the native mobile app on a touchscreen, tap a Memes leaderboard List or
+  artwork Grid card to open the drop, or press and hold to open the compact
+  slide-up sheet. Tapping the List username opens the author's profile instead.
 
 ## Menu Entry Rules
 
@@ -77,11 +78,14 @@ actions` in the drop header.
 ## User Journey
 
 1. Open a touch-supported drop surface.
-2. Enter the menu from long-press or the touch action button, depending on the
-   current layout.
-3. Review the actions available for that drop and your current session state.
-4. Select an action.
-5. The menu closes or hands off to the selected action flow in the current
+2. In the touchscreen native app, tap a Memes leaderboard List or artwork Grid
+   card when you only need to open the drop, or press and hold when you need the
+   complete action sheet. The List username opens the author's profile instead.
+3. On other drop surfaces, enter the menu from long-press or the touch action
+   button, depending on the current layout.
+4. Review the actions available for that drop and your current session state.
+5. Select an action.
+6. The menu closes or hands off to the selected action flow in the current
    thread.
 
 ## Common Scenarios
@@ -94,6 +98,19 @@ actions` in the drop header.
   layouts, including when the embedded browser reports hover support.
 - Winner and participation drops support touch long-press in compact
   mobile/tablet layouts and on touch-only desktop-width surfaces without hover.
+- On touchscreen native-app Memes leaderboard List and artwork Grid cards,
+  tapping the title, media, description, or free card space opens the
+  submission. Explicit vote, rating, and other action buttons stay independent.
+- In native-app List view, tapping the username opens the author's profile;
+  tapping the avatar or author badges opens the submission. In Grid view,
+  tapping the username still opens the submission.
+- On these native-app cards, releasing a long press does not also open the drop.
+  Dismissing the sheet lets the next normal tap open it.
+- Swiping to scroll, cancelling a touch, or touching a native-app card to stop
+  ongoing scrolling does not open it. Once scrolling settles, a normal tap opens
+  it.
+- Browser views, including mobile browsers, keep their author profile links and
+  media behavior; they do not use the native-app whole-card touch rule.
 - Leaderboard list cards keep vertical scrolling responsive until the hold
   completes, then show the compact action sheet.
 - Wave admins can use the same touch sheet to change the wave's pinned

--- a/ops/docs/waves/leaderboard/feature-gallery-cards.md
+++ b/ops/docs/waves/leaderboard/feature-gallery-cards.md
@@ -32,35 +32,46 @@ works from the card.
 1. Open `Leaderboard` and switch to `Grid view`.
 2. Review each card:
    - media surface
-   - media format badge (with tooltip label)
-   - optional title
-   - optional author handle link
+   - media format badge
+   - title, or `Untitled drop` in the touchscreen native app when missing
+   - optional author handle
    - optional rank/winner badge
 3. Review vote summary:
    - current vote total
    - projected vote total only when current and projected values are both numeric and different
    - rater count
    - optional `Your votes` with wave credit label when viewer rating context exists
-4. Select card media to open drop detail, or select `Vote` when the action is available.
+4. In the native app on a touchscreen, tap the card to open drop detail. In a
+   browser, use the card's media or open control. Select `Vote` separately when
+   the action is available.
 5. Select `Load more drops` to fetch the next page.
 
 ## Common Scenarios
 
 - Non-image media with additional `preview_image` metadata shows a static image preview.
-- Non-image media without preview metadata renders native media output in-card
-  (video, audio, or interactive content).
-- Known MIME values show tooltip labels like `Image - PNG`, `Video - MP4`, and
-  `Interactive - GLB`.
-- Unknown or missing MIME values still show a badge tooltip as `Unknown`.
-- On narrow/mobile layouts, long titles and author handles truncate inside the
-  card and vote/rater rows wrap instead of forcing horizontal overflow.
-- On touch devices, dragging vertically on card media continues page scrolling;
-  a tap still opens the drop detail.
+- Browser cards without a provided preview use the corresponding media output
+  (video, audio, or interactive content). Native-app touchscreen cards use
+  non-interactive media previews; open the submission for media controls.
+- In browsers, known media formats show tooltip labels like `Image - PNG`,
+  `Video - MP4`, and `Interactive - GLB`. Unknown or missing formats show
+  `Unknown`.
+- In the touchscreen native app, media-format and additional-action-promise
+  badges are informational, not separate tap or keyboard-focus actions.
+- On narrow/mobile layouts, long titles wrap inside the card, author handles
+  truncate, and vote/rater rows wrap instead of forcing horizontal overflow.
+- Native-app touchscreen cards open from the title, author, media, or free card
+  space, while explicit vote/rating action buttons stay independent. See
+  [Wave Drop Open and Copy Links](../drop-actions/feature-open-and-copy-links.md).
+- Browser views, including mobile browsers, keep author handles as profile links
+  and retain their media interactions.
+- In the touchscreen native app, dragging vertically scrolls without opening
+  the card. Press and hold opens the [touch action sheet](../drop-actions/feature-touch-drop-menu.md).
 - On non-touch devices, sort changes briefly highlight card media to signal reordering.
 
 ## Edge Cases
 
-- Missing title or author handle: the missing field is omitted, other fields still render.
+- Missing title: touchscreen native-app cards show `Untitled drop`; browser
+  cards omit the title. A missing author handle is omitted on both surfaces.
 - Missing rank metadata: rank/winner badge is omitted.
 - If projected vote equals current vote, projected vote indicator is hidden.
 - Gallery can show `No drops to show` even when list view has entries, if none of

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -5387,6 +5387,7 @@
         "Wave content tabs organize the visible wave content area.",
         "Some waves can switch between chat and gallery-style views.",
         "Available tabs depend on wave type, state, and content.",
+        "Native app Back restores the wave section from that visit, such as returning from an author profile to Leaderboard; normally opening another wave still uses its default section.",
         "Open unanswered polls can show a View results control so eligible readers can inspect counts and percentages before voting, then return to Vote while the poll is open."
       ],
       "canonical_path": "/waves",
@@ -5882,6 +5883,9 @@
       "facts": [
         "Wave drop open and copy link actions are documented under drop actions.",
         "Use this when users ask how to copy or open a specific drop.",
+        "In the native mobile app on a touchscreen, tapping the title, media, description, or free space of a Memes leaderboard List or artwork Grid card opens the submission. In List view, the username opens the author's profile, while the avatar and author badges open the submission. In Grid view, the username opens the submission. Explicit vote, rating, and other action buttons keep their own actions.",
+        "Native-app touchscreen leaderboard cards show non-interactive media previews, using a provided poster image when available; open the submission for media controls. Media-format and additional-action-promise badges are informational, not separate tap or keyboard-focus actions.",
+        "Browser views, including mobile browsers, retain their author profile links and media interactions; the native-app whole-card touch rule does not apply there.",
         "Wave-level sharing is handled in the wave header."
       ],
       "canonical_path": "/waves",
@@ -5944,6 +5948,8 @@
       "keywords": ["waves", "drop", "touch", "long", "press", "menu", "mobile"],
       "facts": [
         "Wave drop touch menu behavior covers long-press and touch action button entry points.",
+        "In the native mobile app on a touchscreen, a short tap on a Memes leaderboard List or artwork Grid card opens the drop, including taps on its media. The List username opens the author's profile, while the List avatar and author badges open the submission; the Grid username opens the submission. A long press still opens the action sheet without also opening the drop on release. Explicit vote, rating, and other action buttons stay independent.",
+        "Scrolling gestures, cancelled touches, and touches that stop ongoing scrolling do not open native-app leaderboard cards; tap normally once scrolling settles. Browser views, including mobile browsers, retain their own profile-link and media behavior.",
         "Menu entries depend on device, drop state, and available actions.",
         "Use this when mobile users ask where drop actions went."
       ],

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -5383,6 +5383,7 @@
         "Wave content tabs organize the visible wave content area.",
         "Some waves can switch between chat and gallery-style views.",
         "Available tabs depend on wave type, state, and content.",
+        "Native app Back restores the wave section from that visit, such as returning from an author profile to Leaderboard; normally opening another wave still uses its default section.",
         "Open unanswered polls can show a View results control so eligible readers can inspect counts and percentages before voting, then return to Vote while the poll is open."
       ],
       "canonical_path": "/waves",
@@ -5878,6 +5879,9 @@
       "facts": [
         "Wave drop open and copy link actions are documented under drop actions.",
         "Use this when users ask how to copy or open a specific drop.",
+        "In the native mobile app on a touchscreen, tapping the title, media, description, or free space of a Memes leaderboard List or artwork Grid card opens the submission. In List view, the username opens the author's profile, while the avatar and author badges open the submission. In Grid view, the username opens the submission. Explicit vote, rating, and other action buttons keep their own actions.",
+        "Native-app touchscreen leaderboard cards show non-interactive media previews, using a provided poster image when available; open the submission for media controls. Media-format and additional-action-promise badges are informational, not separate tap or keyboard-focus actions.",
+        "Browser views, including mobile browsers, retain their author profile links and media interactions; the native-app whole-card touch rule does not apply there.",
         "Wave-level sharing is handled in the wave header."
       ],
       "canonical_path": "/waves",
@@ -5940,6 +5944,8 @@
       "keywords": ["waves", "drop", "touch", "long", "press", "menu", "mobile"],
       "facts": [
         "Wave drop touch menu behavior covers long-press and touch action button entry points.",
+        "In the native mobile app on a touchscreen, a short tap on a Memes leaderboard List or artwork Grid card opens the drop, including taps on its media. The List username opens the author's profile, while the List avatar and author badges open the submission; the Grid username opens the submission. A long press still opens the action sheet without also opening the drop on release. Explicit vote, rating, and other action buttons stay independent.",
+        "Scrolling gestures, cancelled touches, and touches that stop ongoing scrolling do not open native-app leaderboard cards; tap normally once scrolling settles. Browser views, including mobile browsers, retain their own profile-link and media behavior.",
         "Menu entries depend on device, drop state, and available actions.",
         "Use this when mobile users ask where drop actions went."
       ],

--- a/scripts/typecheck-test-baseline.json
+++ b/scripts/typecheck-test-baseline.json
@@ -658,7 +658,6 @@
     "__tests__/components/waves/leaderboard/drops/QuorumWaveLeaderboardDrop.test.tsx": 2,
     "__tests__/components/waves/leaderboard/drops/WaveLeaderboardDrop.test.tsx": 1,
     "__tests__/components/waves/leaderboard/drops/WaveLeaderboardLoading.test.tsx": 1,
-    "__tests__/components/waves/leaderboard/gallery/WaveLeaderboardGalleryItem.test.tsx": 1,
     "__tests__/components/waves/leaderboard/gallery/WaveLeaderboardGalleryItemVotes.test.tsx": 1,
     "__tests__/components/waves/leaderboard/grid/WaveLeaderboardGrid.test.tsx": 2,
     "__tests__/components/waves/leaderboard/grid/WaveLeaderboardGridItem.test.tsx": 1,


### PR DESCRIPTION
## Issue

Native-app leaderboard cards were difficult to open with a normal tap, and small adjacent targets made accidental profile navigation easy in Grid view.

## Fix

Use a consistent submission-opening target for ordinary card content on native touch screens, while preserving the larger List card's username as a profile link.

## Changes

- Native List: title, media, avatar, badges, and free card space open the submission; the username opens the author profile.
- Native Grid: ordinary card content, including the author name and media, opens the submission. Explicit voting/rating actions remain independent.
- Keep long-press actions and suppress navigation after scrolling, cancelled gestures, momentum-stop taps, and multi-touch. Cancel the new Grid long-press timer when a second finger arrives.
- Use inert native media previews and the existing video card-preview template. Browser media and author-link behavior remain separate and unchanged.
- Restore the native wave section on profile Back navigation; explicit chat-message links still select Chat.
- Retain the existing card design without added chevrons, username boxes, or a persistent whole-card blue frame. New card keyboard focus uses a neutral visible outline.
- Update the relevant user guides and synchronized Help Bot records.

## Validation

- [Staging deployment succeeded](https://github.com/6529-Collections/6529seize-frontend/actions/runs/34136050245) at staging merge `383b0741ad51d5b3c36eb91dd73a820c0978f462`, containing reviewed PR head `7fbb018db0efdd72a6dbe6f3b9987f0a999e7d4e` and preserving existing staging changes. Build, artifact integrity, instance runtime health, and public version checks passed; the public version matched exactly with HTTP 200 and no-store on the first attempt. [Automatic Staging E2E](https://github.com/6529-Collections/6529seize-frontend/actions/runs/34136957293) started separately and reports its own result.
- Latest main integrated before final validation.
- Focused Jest: 161 tests pass across 9 suites, including gesture, nested-control, desktop, navigation, and callback-identity regressions.
- `check:changed` passed, including formatting, changed-file lint, TypeScript checking, and the scoped quality scan. No incidental formatter changes.
- Full Jest typecheck ratchet passed after correcting the typed Identity fixture and recording Gallery's one-diagnostic improvement; no diagnostic baseline increases.
- Help index regenerated without an additional diff; documentation links pass across 299 Markdown files.
- React Doctor branch comparison: 95/100. Existing media-effect diagnostics remain unchanged; test-double link warnings and component-size warnings were reviewed.
- Desktop Chromium at 1280×900: List/Grid opening and closing, keyboard opening, and absence of the added whole-card focus frame verified after main integration. No page errors or attempted writes in this check.
- Real-device-runtime evidence: physical iPhone native shell, local frontend, read-only production artwork. List/Grid target mapping, long-press, scrolling, and dismissal were exercised before main integration. After main integration, Grid author opening, close, long-press dismissal, fresh tapping, and native multi-touch suppression passed. Final List and post-multi-touch fresh-tap rechecks remain incomplete because the device was reassigned to another test session; no further device control was attempted.
- Desktop media-viewer navigation was exercised, but loaded-image enlargement could not be fully reverified in the final desktop session because the artwork CDN returned HTTP 403. No HTML/media-source repair is included here.
- Authenticated permission-specific controls have focused component coverage; the final physical-device session was logged out. No votes or production content were changed.
- The advisory responsiveness review could not start because its separate workflow invokes the retired `install:frozen` wrapper command. Local desktop evidence and the PR Playwright packs provide browser coverage; the advisory run is not counted as a pass.

## Risk

- Level: Medium
- Why: touch event routing and native navigation history are shared interaction boundaries. Native whole-card behavior is gated by app and touch capability; existing browser media behavior and explicit action controls are preserved.
- Rollback: revert the focused change through the normal reviewed release workflow.

## Review Notes

- Review native hit targets, synthetic-click suppression, portaled actions, and repeated profile Back navigation.
- Profile Back restores the selected wave section, not the previous scrolled card/page. That pre-existing query/scroll-restoration gap remains a separate follow-up.
- The existing List/shared long-press hook's two-finger timer behavior is outside this PR's new Grid handling; the shared hook was not broadened.
- A visible share/copy action in the focused submission header remains intentionally deferred; existing action-menu Copy link behavior is unchanged.
- The separately merged interactive HTML hero fix is preserved from main and is not part of this PR's diff. The only shared media changes add a default-off inert video-preview option used by native leaderboard call sites.
- Deployment followed the current direct GitHub Actions workflow. The reviewed PR has all 20 checks green and includes latest main. Staging is deployed; this PR has not been merged to main and production was not changed.
