### PR TITLE
Restore Coordinator release-request submission in deployment guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,9 @@
 
 - Follow `ops/skills/deploy-6529/SKILL.md` for authorized staging and production
   work, using ordinary Git merges and the existing GitHub Actions workflows.
+- Follow the skill's [Coordinator release recording](ops/skills/deploy-6529/SKILL.md#coordinator-release-recording)
+  step before release merges or deployments. Preserve this current Coordinator
+  integration when changing deployment instructions; keep its details in the skill.
 - For staging, merge the development branch into the latest `1a-staging` and
   push. Frontend changes automatically start `Web Deploy - STAGING`; backend
   changes require dispatching `Deploy a service` for the required services.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,10 @@
 
 - Follow `ops/skills/deploy-6529/SKILL.md` for authorized staging and production
   work, using ordinary Git merges and the existing GitHub Actions workflows.
-- Follow the skill's [Coordinator release recording](ops/skills/deploy-6529/SKILL.md#coordinator-release-recording)
-  step before release merges or deployments. Preserve this current Coordinator
-  integration when changing deployment instructions; keep its details in the skill.
+- For new staging or direct production release intents that include frontend,
+  follow the skill's [Coordinator release recording](ops/skills/deploy-6529/SKILL.md#coordinator-release-recording)
+  step before release merges or deployments. Preserve this current integration
+  when changing deployment instructions; keep its details in the skill.
 - For staging, merge the development branch into the latest `1a-staging` and
   push. Frontend changes automatically start `Web Deploy - STAGING`; backend
   changes require dispatching `Deploy a service` for the required services.

--- a/ops/docs/developer/deployment.md
+++ b/ops/docs/developer/deployment.md
@@ -4,6 +4,12 @@ Agents and developers deploy with ordinary merges and the repository's GitHub
 Actions workflows. Use the phase authorized by the user; a staging request does
 not authorize production.
 
+For a new staging or direct production release intent that includes frontend,
+follow [Coordinator release recording](../../skills/deploy-6529/SKILL.md#coordinator-release-recording)
+after authorization, scope, and exact release inputs are established, before any
+merge or deployment. Use the same recording outcome for retries, resumes, and
+promotion; the skill defines submission and failure handling.
+
 | Target     | Frontend                                                                       | Backend                                                                                                         |
 | ---------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
 | Staging    | Merge into `1a-staging` and push; `Web Deploy - STAGING` starts automatically. | Merge into `1a-staging`, then dispatch `Deploy a service` for each required service with `environment=staging`. |

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -15,8 +15,9 @@ description: Execute authorized 6529 frontend, backend, or coupled staging and p
    backend `src/config/deploy-services.json`, including real dependency order
    and allowed environments. Deploy only required units. Follow each repo's
    `6529` wrapper rules for package commands.
-3. Establish the exact release inputs for that scope, including the requester,
-   target, database-change status, PR branches, and full PR head SHAs. Follow
+3. For a new staging or direct production release intent that includes frontend,
+   establish the exact release inputs: requester, target, database-change status,
+   PR branches, and full PR head SHAs. Follow
    [Coordinator release recording](#coordinator-release-recording) before any
    merge or deployment mutation.
 4. Fetch the destination branch and merge without discarding other developers'
@@ -87,6 +88,7 @@ separately through direct `gh` commands.
 
 Version `0.0.4` runs synchronously in the foreground and waits for the central
 GitHub workflow. Queueing and execution can add waiting time before deployment.
+Re-verify these semantics against the installed CLI when changing its version.
 Do not retry, background, detach, or wrap it in an invented shell timeout. If the
 wait does not return, report the available evidence and escalate to the
 Coordinator owner; do not interrupt it merely to continue deployment.
@@ -99,7 +101,9 @@ Handle the outcome before returning to Prepare:
 - Ordinary returned failure (exit `1` through `127`): report one short warning
   with the reason or first error and any available request ID, Issue/workflow
   links, and local record paths. Keep the local records and continue the same
-  authorized deployment path without requiring a recording fix.
+  authorized deployment path without requiring a recording fix. This includes
+  returned setup, input-validation, and dispatch errors: successful submission
+  is not a deployment gate. Report missing evidence honestly.
 - Signal-style interruption (exit `128` or higher): report the status and
   available evidence, stop release work, and escalate to the Coordinator owner.
   Do not silently treat an interrupted or unfinished wait as an ordinary failure.

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -15,13 +15,99 @@ description: Execute authorized 6529 frontend, backend, or coupled staging and p
    backend `src/config/deploy-services.json`, including real dependency order
    and allowed environments. Deploy only required units. Follow each repo's
    `6529` wrapper rules for package commands.
-3. Fetch the destination branch and merge without discarding other developers'
+3. Establish the exact release inputs for that scope, including the requester,
+   target, database-change status, PR branches, and full PR head SHAs. Follow
+   [Coordinator release recording](#coordinator-release-recording) before any
+   merge or deployment mutation.
+4. Fetch the destination branch and merge without discarding other developers'
    work. If it moves, fetch and recompute; resolve conflicts in the development
    branch where appropriate. Never force-push shared branches.
-4. Use GitHub Actions run visibility to avoid conflicting deployments. Wait for
+5. Use GitHub Actions run visibility to avoid conflicting deployments. Wait for
    another developer's conflicting work to finish; do not cancel it. Existing
    workflow concurrency is repository-scoped, so coordinate coupled BE/FE
    work explicitly.
+
+## Coordinator release recording
+
+Run this step once per new staging release intent or new direct production
+release intent that includes frontend. For a coupled release, submit one request
+from the frontend repository containing all relevant frontend and backend parts.
+Backend-only work is outside this integration.
+
+Do not create another request for status checks, monitoring, merge-only work,
+retries, resumes, recovery, production continuation, or promotion of an already
+recorded release. Reuse the existing outcome and evidence on continuation,
+including after a returned failure; do not resubmit to repair the record during
+the release.
+
+From the repository root, print the installed CLI's current input template:
+
+```bash
+./bin/6529 exec 6529-release-request template
+```
+
+This command is read-only and creates no request or run record. Fill the current
+template with actual release metadata:
+
+- `requested_by`: the actual requester; `target`: `staging` or `production`;
+  `database_change`: `yes`, `no`, or `unknown` when not yet confirmed.
+- `release_parts[]`: each included part's `id`, `repository`
+  (`6529seize-frontend` or `6529seize-backend`), `pull_requests[]`, and
+  `depends_on[]` part IDs for real prerequisites.
+- Each PR's `number`, source `branch`, and `commit`: its verified exact
+  40-character lowercase head SHA, not a short SHA or destination branch name.
+- Each backend part's `deploy_units[]` and `deploy_dependencies[]`: the selected
+  backend units and applicable release-specific ordering edges of the form
+  `{ "before": "unit", "after": "unit" }`, consistent with the service catalog.
+  Frontend parts have no backend deployment fields.
+
+Remove absent template parts and references to them; for a frontend-only release,
+remove the backend part and set frontend `depends_on` to `[]`. Replace all sample
+values with verified inputs, retaining empty dependency arrays when applicable.
+Do not provide `schema_version`, `request_id`, or `created_at`; the CLI generates
+them. The central inbox is public: include only release metadata, never tokens,
+cookies, signed URLs, environment values, production data, or private context.
+`requested_by` is descriptive context, not authentication or approval; the
+central workflow records the actual GitHub sender.
+
+Pass the completed JSON exactly once through standard input to:
+
+```bash
+./bin/6529 exec 6529-release-request submit --input -
+```
+
+Use a shell conditional to capture the command's actual exit status so `set -e`
+does not abort on an ordinary returned failure. Do not mask the status with
+`|| true`. Do not create an extra input file or call `create` separately:
+`submit` owns creation, validation, local records, central workflow dispatch,
+waiting, and result handling. It saves run records under
+`.release-coordinator/runs/` and valid requests under `.release-coordinator/outbox/`.
+Do not duplicate submission, choose or dispatch its workflow, or poll it
+separately through direct `gh` commands.
+
+Version `0.0.4` runs synchronously in the foreground and waits for the central
+GitHub workflow. Queueing and execution can add waiting time before deployment.
+Do not retry, background, detach, or wrap it in an invented shell timeout. If the
+wait does not return, report the available evidence and escalate to the
+Coordinator owner; do not interrupt it merely to continue deployment.
+
+Handle the outcome before returning to Prepare:
+
+- Success (exit `0`): retain and report `request_id`, `inbox_issue_number`,
+  `inbox_issue_url`, `workflow_run_url`, `run_path`, and `request_path`, then
+  continue the existing authorized direct deployment steps.
+- Ordinary returned failure (exit `1` through `127`): report one short warning
+  with the reason or first error and any available request ID, Issue/workflow
+  links, and local record paths. Keep the local records and continue the same
+  authorized deployment path without requiring a recording fix.
+- Signal-style interruption (exit `128` or higher): report the status and
+  available evidence, stop release work, and escalate to the Coordinator owner.
+  Do not silently treat an interrupted or unfinished wait as an ordinary failure.
+
+An accepted request records the release intent in the public Coordinator inbox.
+It grants no approval or deployment authority and does not replace the existing
+authorization, merge, dependency-order, deployment, or validation requirements.
+At closeout, include the recording outcome and retained evidence described above.
 
 ## Staging
 


### PR DESCRIPTION
## Issue

The deployment cleanup in #3881 removed the independent Coordinator request observation introduced in #3876. The current direct deployment instructions no longer record new frontend release intents, although the public npm CLI is already installed at version 0.0.4.

## Fix

Restore Coordinator release recording after authorization, scope, and exact release inputs are established, before the first merge or deployment mutation.

## Changes

- Keep the detailed instructions in `ops/skills/deploy-6529/SKILL.md`, with short links in root `AGENTS.md` and the developer deployment guide. Limit all entry points explicitly to new staging or direct production release intents that include frontend.
- Use the installed CLI through the repository wrapper: read its current template and submit the completed JSON once through stdin. Record coupled frontend/backend releases in one request and prevent duplicate requests on retries, resumes, or promotion.
- Limit input to public release metadata, retain the returned request/Issue/workflow evidence and local paths, and continue the authorized direct deployment path after an ordinary returned failure.
- Describe 0.0.4's synchronous wait honestly; escalate interrupted or unfinished waits without automatic retries, backgrounding, or an invented timeout.

## Validation

- Passed `git diff --check` and `./bin/6529 exec prettier --check AGENTS.md ops/skills/deploy-6529/SKILL.md ops/docs/developer/deployment.md`.
- Passed `./bin/6529 exec python3 -B ops/skills/commit-docs-updater/scripts/validate_docs_links.py` (299 Markdown files) and checked all seven local links/anchors in the three changed files.
- Ran the CLI's read-only `--version` and `template` commands through `./bin/6529 exec`; verified the instructions against the installed 0.0.4 implementation and schema.
- Checked local links/anchors and skill structure, and confirmed existing staging, production, and failure/closeout sections are unchanged. The generic Python skill validator could not run because PyYAML is unavailable; a read-only fallback checked the unchanged frontmatter, folder/name match, fences, and scaffolding.
- No live submission or deployment was performed. No documentation-matching tests were added.
- The separate responsiveness bot did not reach testing: its workflow uses the retired `6529 install:frozen` command. This change has no UI surface; the package wrapper remains unchanged.

## Risk

- Level: Low. This is an instruction-only restoration; package/version, lockfile, install-safety controls, and deployment workflows are unchanged. Recording can add waiting time, but grants no approval or deployment authority.
- Rollback: revert this documentation change.

## Review Notes

Focus on the pre-merge placement, one-request scope, public metadata boundary, and distinction between ordinary returned failures and interrupted or unfinished waits. This does not restore Release Bus routing, controls, authentication, or workflows.
