### PR TITLE
Improve notification readability, voting interactions, and card spacing

### DIFF
--- a/__tests__/components/brain/my-stream/votes/MyStreamWaveMyVote.test.tsx
+++ b/__tests__/components/brain/my-stream/votes/MyStreamWaveMyVote.test.tsx
@@ -75,10 +75,17 @@ describe("MyStreamWaveMyVote", () => {
   });
 
   it.each(["row", "total", "voters"] as const)(
-    "opens the submission once when clicking the %s",
+    "toggles reset selection once without opening the submission when clicking the %s",
     (target) => {
       const onDropClick = jest.fn();
-      render(<MyStreamWaveMyVote drop={drop} onDropClick={onDropClick} />);
+      const onToggleCheck = jest.fn();
+      const { rerender } = render(
+        <MyStreamWaveMyVote
+          drop={drop}
+          onDropClick={onDropClick}
+          onToggleCheck={onToggleCheck}
+        />
+      );
       const targets = {
         row: screen.getByRole("article", { name: "Drop Title" }),
         total: screen.getByTestId("votes"),
@@ -87,19 +94,41 @@ describe("MyStreamWaveMyVote", () => {
 
       fireEvent.click(targets[target]);
 
-      expect(onDropClick).toHaveBeenCalledTimes(1);
-      expect(onDropClick).toHaveBeenCalledWith(drop);
+      expect(onToggleCheck).toHaveBeenCalledTimes(1);
+      expect(onToggleCheck).toHaveBeenCalledWith("d1");
+      expect(onDropClick).not.toHaveBeenCalled();
+
+      rerender(
+        <MyStreamWaveMyVote
+          drop={drop}
+          onDropClick={onDropClick}
+          onToggleCheck={onToggleCheck}
+          isChecked
+        />
+      );
+      expect(screen.getByRole("checkbox")).toBeChecked();
+      fireEvent.click(targets[target]);
+      expect(onToggleCheck).toHaveBeenCalledTimes(2);
+      expect(onDropClick).not.toHaveBeenCalled();
     }
   );
 
-  it("does not open the row when text is selected", () => {
+  it("does not toggle or open the row when text is selected", () => {
     const onDropClick = jest.fn();
+    const onToggleCheck = jest.fn();
     (globalThis.getSelection as any) = () => ({ toString: () => "selected" });
-    render(<MyStreamWaveMyVote drop={drop} onDropClick={onDropClick} />);
+    render(
+      <MyStreamWaveMyVote
+        drop={drop}
+        onDropClick={onDropClick}
+        onToggleCheck={onToggleCheck}
+      />
+    );
 
     fireEvent.click(screen.getByRole("article", { name: "Drop Title" }));
 
     expect(onDropClick).not.toHaveBeenCalled();
+    expect(onToggleCheck).not.toHaveBeenCalled();
   });
 
   it.each(["Open Drop Title", "Drop Title"])(
@@ -107,7 +136,14 @@ describe("MyStreamWaveMyVote", () => {
     async (buttonName) => {
       const user = userEvent.setup();
       const onDropClick = jest.fn();
-      render(<MyStreamWaveMyVote drop={drop} onDropClick={onDropClick} />);
+      const onToggleCheck = jest.fn();
+      render(
+        <MyStreamWaveMyVote
+          drop={drop}
+          onDropClick={onDropClick}
+          onToggleCheck={onToggleCheck}
+        />
+      );
       const row = screen.getByRole("article", { name: "Drop Title" });
       expect(row).not.toHaveAttribute("tabindex");
       expect(
@@ -119,12 +155,20 @@ describe("MyStreamWaveMyVote", () => {
 
       expect(onDropClick).toHaveBeenCalledTimes(1);
       expect(onDropClick).toHaveBeenCalledWith(drop);
+      expect(onToggleCheck).not.toHaveBeenCalled();
     }
   );
 
-  it("keeps vote controls and their surrounding area separate from navigation", () => {
+  it("keeps vote controls and their surrounding area separate from row selection", () => {
     const onDropClick = jest.fn();
-    render(<MyStreamWaveMyVote drop={drop} onDropClick={onDropClick} />);
+    const onToggleCheck = jest.fn();
+    render(
+      <MyStreamWaveMyVote
+        drop={drop}
+        onDropClick={onDropClick}
+        onToggleCheck={onToggleCheck}
+      />
+    );
 
     fireEvent.click(screen.getByTestId("input"));
     fireEvent.click(screen.getByText("TDH"));
@@ -137,24 +181,38 @@ describe("MyStreamWaveMyVote", () => {
     fireEvent.click(screen.getByText("Disabled vote"));
 
     expect(onDropClick).not.toHaveBeenCalled();
+    expect(onToggleCheck).not.toHaveBeenCalled();
   });
 
   it("keeps the profile link separate from submission navigation", () => {
     const onDropClick = jest.fn();
+    const onToggleCheck = jest.fn();
     const openProfile = jest.spyOn(window, "open").mockReturnValue(null);
-    render(<MyStreamWaveMyVote drop={drop} onDropClick={onDropClick} />);
+    render(
+      <MyStreamWaveMyVote
+        drop={drop}
+        onDropClick={onDropClick}
+        onToggleCheck={onToggleCheck}
+      />
+    );
 
     fireEvent.click(screen.getByRole("link", { name: "alice" }));
 
     expect(openProfile).toHaveBeenCalledWith("/alice", "_blank");
     expect(onDropClick).not.toHaveBeenCalled();
+    expect(onToggleCheck).not.toHaveBeenCalled();
     openProfile.mockRestore();
   });
 
   it("keeps the media tooltip separate from submission navigation", () => {
     const onDropClick = jest.fn();
+    const onToggleCheck = jest.fn();
     const { container } = render(
-      <MyStreamWaveMyVote drop={drop} onDropClick={onDropClick} />
+      <MyStreamWaveMyVote
+        drop={drop}
+        onDropClick={onDropClick}
+        onToggleCheck={onToggleCheck}
+      />
     );
     const mediaBadge = container.querySelector(
       '[data-tooltip-id="format-badge-d1"]'
@@ -165,19 +223,26 @@ describe("MyStreamWaveMyVote", () => {
     fireEvent.keyDown(mediaBadge!, { key: "Enter" });
 
     expect(onDropClick).not.toHaveBeenCalled();
+    expect(onToggleCheck).not.toHaveBeenCalled();
   });
 
   it.each(["Open Drop Title", "Drop Title"])(
     "triggers onDropClick from %s when no text is selected",
     (buttonName) => {
       const onDropClick = jest.fn();
+      const onToggleCheck = jest.fn();
       (globalThis.getSelection as any) = () => ({ toString: () => "" });
       render(
-        <MyStreamWaveMyVote drop={drop} onDropClick={onDropClick} />
+        <MyStreamWaveMyVote
+          drop={drop}
+          onDropClick={onDropClick}
+          onToggleCheck={onToggleCheck}
+        />
       );
       fireEvent.click(screen.getByRole("button", { name: buttonName }));
       expect(onDropClick).toHaveBeenCalledTimes(1);
       expect(onDropClick).toHaveBeenCalledWith(drop);
+      expect(onToggleCheck).not.toHaveBeenCalled();
     }
   );
 
@@ -211,9 +276,60 @@ describe("MyStreamWaveMyVote", () => {
     });
     expect(checkbox).not.toBeChecked();
     fireEvent.click(checkbox);
+    expect(onToggleCheck).toHaveBeenCalledTimes(1);
     expect(onToggleCheck).toHaveBeenCalledWith("d1");
     expect(onDropClick).not.toHaveBeenCalled();
   });
+
+  it("toggles reset selection once with Space on the native checkbox", async () => {
+    const user = userEvent.setup();
+    const onToggleCheck = jest.fn();
+    const onDropClick = jest.fn();
+    render(
+      <MyStreamWaveMyVote
+        drop={drop}
+        onDropClick={onDropClick}
+        onToggleCheck={onToggleCheck}
+      />
+    );
+    screen.getByRole("checkbox").focus();
+
+    await user.keyboard(" ");
+
+    expect(onToggleCheck).toHaveBeenCalledTimes(1);
+    expect(onToggleCheck).toHaveBeenCalledWith("d1");
+    expect(onDropClick).not.toHaveBeenCalled();
+  });
+
+  it.each(["isResetting", "isVotingClosed"] as const)(
+    "blocks row selection while %s but keeps title and artwork navigation",
+    (disabledProp) => {
+      const onToggleCheck = jest.fn();
+      const onDropClick = jest.fn();
+      render(
+        <MyStreamWaveMyVote
+          drop={drop}
+          onDropClick={onDropClick}
+          onToggleCheck={onToggleCheck}
+          {...{ [disabledProp]: true }}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("article", { name: "Drop Title" }));
+      const checkbox = screen.queryByRole("checkbox");
+      if (checkbox) {
+        expect(checkbox).toBeDisabled();
+        fireEvent.click(checkbox);
+      }
+      expect(onToggleCheck).not.toHaveBeenCalled();
+      expect(onDropClick).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByRole("button", { name: "Drop Title" }));
+      fireEvent.click(screen.getByRole("button", { name: "Open Drop Title" }));
+      expect(onDropClick).toHaveBeenCalledTimes(2);
+      expect(onToggleCheck).not.toHaveBeenCalled();
+    }
+  );
 
   it("keeps the checkbox label click separate from submission navigation", () => {
     const onDropClick = jest.fn();

--- a/__tests__/components/memes/drops/MemesLeaderboardDrop.test.tsx
+++ b/__tests__/components/memes/drops/MemesLeaderboardDrop.test.tsx
@@ -150,7 +150,13 @@ jest.mock("@/components/voting", () => ({
   ),
 }));
 jest.mock("@/components/voting/VotingModalButton", () => (p: any) => (
-  <button data-testid="vote-btn" onClick={p.onClick}>
+  <button
+    data-testid="vote-btn"
+    onClick={(event) => {
+      event.stopPropagation();
+      p.onClick();
+    }}
+  >
     vote
   </button>
 ));

--- a/__tests__/components/memes/drops/MemesLeaderboardDrop.test.tsx
+++ b/__tests__/components/memes/drops/MemesLeaderboardDrop.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemesLeaderboardDrop } from "@/components/memes/drops/MemesLeaderboardDrop";
+import type MemesLeaderboardDropVoteSummary from "@/components/memes/drops/MemesLeaderboardDropVoteSummary";
 
 const useIsMobileScreen = jest.fn();
 jest.mock("@/hooks/isMobileScreen", () => ({
@@ -29,7 +30,14 @@ jest.mock("@/utils/monitoring/dropOpenTiming", () => ({
   startDropOpen: jest.fn(),
 }));
 
-const mockVoteSummary = jest.fn(() => <div data-testid="summary" />);
+const mockVoteSummary = jest.fn(
+  (props: React.ComponentProps<typeof MemesLeaderboardDropVoteSummary>) => {
+    const Summary = jest.requireActual<
+      typeof import("@/components/memes/drops/MemesLeaderboardDropVoteSummary")
+    >("@/components/memes/drops/MemesLeaderboardDropVoteSummary").default;
+    return <Summary {...props} />;
+  }
+);
 const mockVoteDetailsTrigger = jest.fn((props: any) => (
   <button
     type="button"

--- a/__tests__/components/memes/drops/MemesLeaderboardDropVoteSummary.test.tsx
+++ b/__tests__/components/memes/drops/MemesLeaderboardDropVoteSummary.test.tsx
@@ -23,7 +23,7 @@ jest.mock("@/hooks/useIsTouchDevice", () => ({
 
 describe("MemesLeaderboardDropVoteSummary", () => {
   const voter = {
-    profile: { id: "profile-bob", handle: "bob", pfp: "" },
+    profile: { id: "profile-bob", handle: "bob", primary_address: "0x123", pfp: "" },
     rating: 2,
   } as any;
   it("shows positive current value and voter count text", () => {

--- a/__tests__/components/memes/drops/MemesLeaderboardDropVoteSummary.test.tsx
+++ b/__tests__/components/memes/drops/MemesLeaderboardDropVoteSummary.test.tsx
@@ -1,9 +1,17 @@
-import { render, screen } from '@testing-library/react';
-import React from 'react';
-import MemesLeaderboardDropVoteSummary from '@/components/memes/drops/MemesLeaderboardDropVoteSummary';
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import MemesLeaderboardDropVoteSummary from "@/components/memes/drops/MemesLeaderboardDropVoteSummary";
 
-jest.mock('next/link', () => ({ __esModule: true, default: ({ children, href }: any) => <a href={href}>{children}</a> }));
-jest.mock('@/components/drops/view/utils/DropVoteProgressing', () => ({ __esModule: true, default: () => <div data-testid="progress" /> }));
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, ...props }: React.ComponentProps<"a">) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+jest.mock("@/components/drops/view/utils/DropVoteProgressing", () => ({
+  __esModule: true,
+  default: () => <div data-testid="progress" />,
+}));
 jest.mock("@/hooks/isMobileScreen", () => ({
   __esModule: true,
   default: () => false,
@@ -13,9 +21,12 @@ jest.mock("@/hooks/useIsTouchDevice", () => ({
   default: () => false,
 }));
 
-describe('MemesLeaderboardDropVoteSummary', () => {
-  const voter = { profile: { handle: 'bob', pfp: '' }, rating: 2 } as any;
-  it('shows positive current value and voter count text', () => {
+describe("MemesLeaderboardDropVoteSummary", () => {
+  const voter = {
+    profile: { id: "profile-bob", handle: "bob", pfp: "" },
+    rating: 2,
+  } as any;
+  it("shows positive current value and voter count text", () => {
     const drop = {
       id: "drop-1",
       rating: 5,
@@ -38,7 +49,7 @@ describe('MemesLeaderboardDropVoteSummary', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows user vote', () => {
+  it("shows user vote", () => {
     const drop = {
       id: "drop-1",
       rating: -1,
@@ -50,7 +61,45 @@ describe('MemesLeaderboardDropVoteSummary', () => {
     } as any;
 
     render(<MemesLeaderboardDropVoteSummary drop={drop} />);
-    expect(screen.getByText('Your vote:')).toBeInTheDocument();
-    expect(screen.getByText('-3')).toBeInTheDocument();
+    expect(screen.getByText("Your vote:")).toBeInTheDocument();
+    expect(screen.getByText("-3")).toBeInTheDocument();
   });
+
+  it.each([
+    { handle: " bob/name ", address: "0x123", identity: "bob/name" },
+    { handle: " ", address: "0x123", identity: "0x123" },
+    { handle: null, address: "UNKNOWN", identity: "profile-bob" },
+    { handle: "", address: "", identity: "profile-bob" },
+  ])(
+    "links to the usable voter identity $identity",
+    ({ handle, address, identity }) => {
+      const drop = {
+        id: "drop-1",
+        rating: 5,
+        rating_prediction: 6,
+        raters_count: 1,
+        top_raters: [
+          {
+            profile: {
+              id: "profile-bob",
+              handle,
+              primary_address: address,
+              pfp: "",
+            },
+            rating: 2,
+          },
+        ],
+        wave: { voting_credit_type: "pts" },
+        context_profile_context: null,
+      } as React.ComponentProps<typeof MemesLeaderboardDropVoteSummary>["drop"];
+
+      render(<MemesLeaderboardDropVoteSummary drop={drop} />);
+      const link = screen.getByRole("link", { name: `Voter ${identity}` });
+      expect(link).toHaveAttribute("href", `/${encodeURIComponent(identity)}`);
+      expect(link).toHaveAttribute(
+        "data-tooltip-id",
+        "voter-drop-1-profile-bob"
+      );
+    }
+  );
 });

--- a/__tests__/components/waves/drop/MemesDropSummarySection.test.tsx
+++ b/__tests__/components/waves/drop/MemesDropSummarySection.test.tsx
@@ -29,7 +29,7 @@ const renderSummary = (drop: ExtendedDrop) =>
   );
 
 describe("MemesDropSummarySection", () => {
-  it("shows a prominent mapped Meme card pill with the minted outcome", () => {
+  it("shows a compact mapped Meme card pill with the minted outcome", () => {
     renderSummary({
       submission_context: { meme_card_id: 521 },
     } as ExtendedDrop);
@@ -40,7 +40,7 @@ describe("MemesDropSummarySection", () => {
     });
 
     expect(memeCardLink).toHaveAttribute("href", "/the-memes/521");
-    expect(memeCardLink).toHaveClass("tw-min-h-9", "tw-px-4", "tw-text-base");
+    expect(memeCardLink).toHaveClass("tw-px-2.5", "tw-py-0.5", "tw-text-xs");
     expect(memeCardLink.parentElement).toHaveTextContent(
       "Minted on The MemesThe Memes #521"
     );

--- a/components/brain/my-stream/votes/MyStreamWaveMyVote.tsx
+++ b/components/brain/my-stream/votes/MyStreamWaveMyVote.tsx
@@ -166,6 +166,7 @@ const MyStreamWaveMyVote: React.FC<MyStreamWaveMyVoteProps> = ({
     artWork?.mime_type ?? curationPreviewMedia?.mimeType ?? DEFAULT_MIME_TYPE;
   const badgeMimeType = artWork?.mime_type ?? curationPreviewMedia?.mimeType;
   const isSelected = !isVotingClosed && isChecked;
+  const isSelectionDisabled = isVotingClosed || isResetting || !onToggleCheck;
   const selectionInputId = `my-vote-reset-selection-${drop.id}`;
   const titleId = `my-vote-title-${drop.id}`;
 
@@ -176,14 +177,21 @@ const MyStreamWaveMyVote: React.FC<MyStreamWaveMyVoteProps> = ({
     onDropClick(drop);
   };
 
-  // Row clicks extend the native artwork/title buttons' pointer target.
-  // Those buttons provide keyboard activation; other controls stay independent.
+  const handleSelectionChange = () => {
+    if (!isSelectionDisabled) {
+      onToggleCheck(drop.id);
+    }
+  };
+
+  // Row clicks extend the native checkbox's pointer target.
+  // The checkbox provides keyboard selection; other controls stay independent.
   const handleRowClick = (event: React.MouseEvent<HTMLElement>) => {
     const target = event.target;
     if (
       event.defaultPrevented ||
       !(target instanceof Element) ||
-      !event.currentTarget.contains(target)
+      !event.currentTarget.contains(target) ||
+      window.getSelection()?.toString()
     ) {
       return;
     }
@@ -195,31 +203,25 @@ const MyStreamWaveMyVote: React.FC<MyStreamWaveMyVoteProps> = ({
       return;
     }
 
-    handleOpenDrop();
+    handleSelectionChange();
   };
 
   const handleExplainVote = (voteTotal: number, voteChange: number) => {
     onExplainVote?.(drop, voteTotal, voteChange);
   };
 
-  const handleSelectionChange = () => {
-    if (isVotingClosed || isResetting) {
-      return;
-    }
-
-    if (onToggleCheck) {
-      onToggleCheck(drop.id);
-    }
-  };
-
   return (
-    <article // NOSONAR -- S1082/S6847: native artwork/title buttons provide keyboard activation.
+    <article // NOSONAR -- S1082/S6847: the native checkbox provides keyboard selection.
       aria-labelledby={titleId}
       onClick={handleRowClick}
-      className={`tw-group/my-vote tw-cursor-pointer tw-px-2 tw-py-5 tw-transition-colors tw-duration-200 tw-@container/my-vote motion-reduce:tw-transition-none sm:tw-px-4 sm:tw-py-6 ${
-        isSelected
-          ? "tw-bg-primary-500/10"
-          : "tw-bg-iron-950 desktop-hover:hover:tw-bg-iron-900"
+      className={`tw-px-2 tw-py-5 tw-transition-colors tw-duration-200 tw-@container/my-vote motion-reduce:tw-transition-none sm:tw-px-4 sm:tw-py-6 ${
+        isSelectionDisabled ? "" : "tw-cursor-pointer"
+      } ${
+        isSelected ? "tw-bg-primary-500/10" : "tw-bg-iron-950"
+      } ${
+        !isSelected && !isSelectionDisabled
+          ? "desktop-hover:hover:tw-bg-iron-900"
+          : ""
       }`}
     >
       <div
@@ -240,7 +242,7 @@ const MyStreamWaveMyVote: React.FC<MyStreamWaveMyVoteProps> = ({
                 type="checkbox"
                 checked={isSelected}
                 onChange={handleSelectionChange}
-                disabled={isResetting}
+                disabled={isSelectionDisabled}
                 className="tw-peer tw-absolute tw-inset-0 tw-m-0 tw-cursor-pointer tw-opacity-0 disabled:tw-cursor-not-allowed"
               />
               <span className="tw-sr-only">
@@ -319,7 +321,7 @@ const MyStreamWaveMyVote: React.FC<MyStreamWaveMyVoteProps> = ({
               <button
                 type="button"
                 onClick={handleOpenDrop}
-                className="tw-max-w-full tw-border-0 tw-bg-transparent tw-p-0 tw-text-left tw-text-base tw-font-semibold tw-leading-6 tw-text-iron-50 tw-transition-colors tw-duration-200 [overflow-wrap:anywhere] focus-visible:tw-rounded-sm focus-visible:tw-text-primary-400 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 desktop-hover:group-hover/my-vote:tw-text-primary-400 motion-reduce:tw-transition-none"
+                className="tw-max-w-full tw-border-0 tw-bg-transparent tw-p-0 tw-text-left tw-text-base tw-font-semibold tw-leading-6 tw-text-iron-50 tw-transition-colors tw-duration-200 [overflow-wrap:anywhere] focus-visible:tw-rounded-sm focus-visible:tw-text-primary-400 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 desktop-hover:hover:tw-text-primary-400 motion-reduce:tw-transition-none"
               >
                 {dropTitle}
               </button>

--- a/components/brain/my-stream/votes/MyStreamWaveMyVote.tsx
+++ b/components/brain/my-stream/votes/MyStreamWaveMyVote.tsx
@@ -196,6 +196,7 @@ const MyStreamWaveMyVote: React.FC<MyStreamWaveMyVoteProps> = ({
       return;
     }
 
+    // Input/label clicks already select through onChange; do not toggle twice.
     const control = target.closest(
       "a, button, input, select, textarea, label, [role='button'], [role='link'], [role='checkbox'], [role='dialog'], [tabindex], [contenteditable='true'], [data-vote-controls]"
     );

--- a/components/brain/notifications/NotificationItems.tsx
+++ b/components/brain/notifications/NotificationItems.tsx
@@ -5,7 +5,6 @@ import { ApiNotificationCause } from "@/generated/models/ApiNotificationCause";
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 import type { ActiveDropState } from "@/types/dropInteractionTypes";
 import { useBrowserLocale } from "@/hooks/useBrowserLocale";
-import useDeviceInfo from "@/hooks/useDeviceInfo";
 import { t } from "@/i18n/messages";
 import {
   DROP_POLL_VOTED_NOTIFICATION_CAUSE,
@@ -72,7 +71,6 @@ function NotificationItemsComponent({
   onMarkGroupAsRead,
 }: NotificationItemsProps) {
   const locale = useBrowserLocale();
-  const { isApp } = useDeviceInfo();
   const { findCustomEmoji, findNativeEmoji } = useEmoji();
   const keyedItems = useMemo(
     () =>
@@ -94,7 +92,7 @@ function NotificationItemsComponent({
       return true;
     }
 
-    // Match the child renderers before adding a row label or divider.
+    // Match the child renderers before adding a row label.
     switch (item.cause) {
       case ApiNotificationCause.DropReacted: {
         if (!Array.isArray(item.related_drops) || !item.related_drops[0]) {
@@ -124,7 +122,7 @@ function NotificationItemsComponent({
   };
 
   return (
-    <div className="tw-flex tw-flex-col tw-pb-3">
+    <div className="tw-flex tw-flex-col tw-space-y-3 tw-pb-3">
       {keyedItems.map(({ item, key, domId }) => {
         if (!hasNotificationContent(item)) {
           return null;
@@ -141,9 +139,7 @@ function NotificationItemsComponent({
             key={key}
             id={domId}
             style={NOTIFICATION_ITEM_RENDERING_STYLE}
-            className={`tw-min-w-0 tw-border-0 tw-border-b tw-border-solid tw-py-3 first:tw-pt-1 last:tw-border-b-0 ${
-              isApp ? "tw-border-iron-700" : "tw-border-iron-800"
-            }`}
+            className="tw-min-w-0"
           >
             {isUnread && (
               <div className="tw-mb-2 tw-flex tw-items-center tw-gap-1.5 tw-text-xs tw-font-semibold tw-text-iron-200">

--- a/components/brain/notifications/subcomponents/NotificationDrop.tsx
+++ b/components/brain/notifications/subcomponents/NotificationDrop.tsx
@@ -5,7 +5,6 @@ import Drop, { DropLocation } from "@/components/waves/drops/Drop";
 import type { ApiDrop } from "@/generated/models/ApiDrop";
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 import { convertApiDropToExtendedDrop } from "@/helpers/waves/drop.helpers";
-import useDeviceInfo from "@/hooks/useDeviceInfo";
 import type { ActiveDropState } from "@/types/dropInteractionTypes";
 import type { ReactNode } from "react";
 import CompactDropPreview from "./CompactDropPreview";
@@ -35,13 +34,10 @@ export default function NotificationDrop({
   onQuoteClick,
   onDropContentClick,
 }: NotificationDropProps) {
-  const { isApp } = useDeviceInfo();
   const extendedDrop = convertApiDropToExtendedDrop(drop);
 
   return (
-    <div
-      className={`tw-w-full tw-min-w-0 ${isApp ? "[--drop-card-background:theme(colors.iron.900)]" : ""}`}
-    >
+    <div className="tw-w-full tw-min-w-0">
       <Drop
         drop={extendedDrop}
         previousDrop={null}

--- a/components/common/SandboxedExternalIframe.tsx
+++ b/components/common/SandboxedExternalIframe.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { canonicalizeInteractiveMediaUrl } from "@/components/waves/memes/submission/constants/security";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import { t } from "@/i18n/messages";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 
 // Sandbox policy for external interactive media:
@@ -45,6 +47,7 @@ const SandboxedExternalIframe: React.FC<SandboxedExternalIframeProps> = ({
   iframeRef,
   onVisible,
 }) => {
+  const locale = useBrowserLocale();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [isVisible, setIsVisible] = useState(false);
 
@@ -162,7 +165,7 @@ const SandboxedExternalIframe: React.FC<SandboxedExternalIframeProps> = ({
       aria-live="polite"
     >
       <span className="tw-text-[11px] tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-300">
-        Untrusted interactive content
+        {t(locale, "media.interactive.untrustedContent")}
       </span>
       {parsedCanonicalUrl ? (
         <a

--- a/components/common/SandboxedExternalIframe.tsx
+++ b/components/common/SandboxedExternalIframe.tsx
@@ -54,9 +54,13 @@ const SandboxedExternalIframe: React.FC<SandboxedExternalIframeProps> = ({
   );
 
   const frameClassName = useMemo(() => {
-    const classes = ["tw-h-full", "tw-w-full", className].filter(
-      (value): value is string => Boolean(value)
-    );
+    const classes = [
+      "tw-block",
+      "tw-h-full",
+      "tw-w-full",
+      "tw-border-0",
+      className,
+    ].filter((value): value is string => Boolean(value));
     return classes.join(" ");
   }, [className]);
 
@@ -157,7 +161,7 @@ const SandboxedExternalIframe: React.FC<SandboxedExternalIframeProps> = ({
       className="tw-flex tw-items-center tw-justify-between tw-gap-2 tw-rounded-t-md tw-border tw-border-iron-800 tw-bg-iron-950 tw-px-3 tw-py-2"
       aria-live="polite"
     >
-      <span className="tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-300">
+      <span className="tw-text-[11px] tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-300">
         Untrusted interactive content
       </span>
       {parsedCanonicalUrl ? (

--- a/components/memes/drops/MemesLeaderboardDrop.tsx
+++ b/components/memes/drops/MemesLeaderboardDrop.tsx
@@ -17,9 +17,8 @@ import WaveDropMobileMenuCopyLink from "@/components/waves/drops/WaveDropMobileM
 import WaveDropMobileMenuOpen from "@/components/waves/drops/WaveDropMobileMenuOpen";
 import MemesArtSubmissionModal from "@/components/waves/memes/MemesArtSubmissionModal";
 import { MemesArtResubmitAction } from "@/components/waves/memes/submission/MemesArtResubmitAction";
-import ParticipationDropVoteDetailsTrigger from "@/components/waves/drops/participation/ratings/ParticipationDropVoteDetailsTrigger";
 import type { ApiWave } from "@/generated/models/ApiWave";
-import { getScaledImageUri, ImageScale } from "@/helpers/image.helpers";
+import { ImageScale } from "@/helpers/image.helpers";
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 import { getDropPreviewImageUrl } from "@/helpers/waves/drop.helpers";
 import { useDropInteractionRules } from "@/hooks/drops/useDropInteractionRules";
@@ -32,8 +31,6 @@ import { useBrowserLocale } from "@/hooks/useBrowserLocale";
 import { t } from "@/i18n/messages";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { startDropOpen } from "@/utils/monitoring/dropOpenTiming";
-import Image from "next/image";
-import Link from "next/link";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import MemeDropTraits from "./MemeDropTraits";
@@ -170,9 +167,6 @@ export const MemesLeaderboardDrop: React.FC<MemesLeaderboardDropProps> = ({
   // Get artwork media URL if available
   const artworkMedia = firstPart?.media.at(0);
 
-  // Get top voters for votes display
-  const firstThreeVoters = drop.top_raters.slice(0, 3);
-
   const openDrop = useCallback(() => {
     startDropOpen({
       dropId: drop.id,
@@ -259,19 +253,23 @@ export const MemesLeaderboardDrop: React.FC<MemesLeaderboardDropProps> = ({
                 {/* Title and Description */}
                 <div className="tw-px-4 tw-pb-4 tw-pt-4">
                   <div className="tw-max-w-screen-sm tw-space-y-1">
-                    <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
+                    <div className="tw-flex tw-items-start tw-gap-2">
                       <MediaTypeBadge
                         mimeType={artworkMedia?.mime_type}
                         dropId={drop.id}
                         size="xs"
+                        className="tw-mt-0.5"
                         showTooltip={!opensWholeCard}
                       />
-                      <MemesLeaderboardDropHeader title={title} />
-                      {drop.is_additional_action_promised === true && (
-                        <AdditionalActionPromiseBadge
-                          focusable={!opensWholeCard}
-                        />
-                      )}
+                      <div className="tw-min-w-0 tw-flex-1">
+                        <MemesLeaderboardDropHeader title={title} />
+                        {drop.is_additional_action_promised === true && (
+                          <AdditionalActionPromiseBadge
+                            className="tw-mt-2"
+                            focusable={!opensWholeCard}
+                          />
+                        )}
+                      </div>
                     </div>
                     <MemesLeaderboardDropDescription
                       description={description}
@@ -314,49 +312,9 @@ export const MemesLeaderboardDrop: React.FC<MemesLeaderboardDropProps> = ({
                 <div className="tw-mt-4 tw-flex tw-flex-col tw-gap-y-4 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/5 tw-bg-iron-900/30 tw-p-4">
                   <MemeDropTraits drop={drop} />
 
-                  <div className="tw-flex tw-flex-col tw-justify-between tw-gap-4 @[700px]:tw-flex-row @[700px]:tw-items-center">
-                    <MemesLeaderboardDropVoteSummary drop={drop} />
-
-                    <div
-                      className="tw-flex tw-w-full tw-flex-shrink-0 tw-items-center tw-justify-between tw-gap-4 @[700px]:tw-w-auto @[700px]:tw-justify-end"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      {/* Voters - only on small containers */}
-                      <div className="tw-flex tw-items-center tw-gap-2 @[700px]:tw-hidden">
-                        {firstThreeVoters.length > 0 && (
-                          <div className="tw-flex tw-items-center -tw-space-x-2">
-                            {firstThreeVoters.map((voter) => (
-                              <Link
-                                key={
-                                  voter.profile.handle ??
-                                  voter.profile.primary_address
-                                }
-                                href={`/${voter.profile.handle ?? voter.profile.primary_address}`}
-                                onClick={(e) => e.stopPropagation()}
-                              >
-                                {voter.profile.pfp ? (
-                                  <Image
-                                    className="tw-h-6 tw-w-6 tw-rounded-md tw-border-2 tw-border-solid tw-border-[#111] tw-bg-iron-800 tw-object-contain"
-                                    src={getScaledImageUri(
-                                      voter.profile.pfp,
-                                      ImageScale.W_AUTO_H_50
-                                    )}
-                                    alt="Recent voter"
-                                    width={24}
-                                    height={24}
-                                  />
-                                ) : (
-                                  <div className="tw-h-6 tw-w-6 tw-rounded-lg tw-border-2 tw-border-solid tw-border-[#111] tw-bg-iron-800" />
-                                )}
-                              </Link>
-                            ))}
-                          </div>
-                        )}
-                        <ParticipationDropVoteDetailsTrigger
-                          drop={drop}
-                          visualVariant="memes"
-                        />
-                      </div>
+                  <MemesLeaderboardDropVoteSummary
+                    drop={drop}
+                    voteButton={
                       <VotingModalButton
                         drop={drop}
                         className="!tw-text-meta"
@@ -368,8 +326,8 @@ export const MemesLeaderboardDrop: React.FC<MemesLeaderboardDropProps> = ({
                           setIsVotingModalOpen(true);
                         }}
                       />
-                    </div>
-                  </div>
+                    }
+                  />
                 </div>
               </div>
             </div>

--- a/components/memes/drops/MemesLeaderboardDropHeader.tsx
+++ b/components/memes/drops/MemesLeaderboardDropHeader.tsx
@@ -4,11 +4,11 @@ interface MemesLeaderboardDropHeaderProps {
   readonly title: string;
 }
 
-const MemesLeaderboardDropHeader: React.FC<
-  MemesLeaderboardDropHeaderProps
-> = ({ title }) => {
+const MemesLeaderboardDropHeader: React.FC<MemesLeaderboardDropHeaderProps> = ({
+  title,
+}) => {
   return (
-    <h3 className="tw-mb-0 tw-mt-0 tw-text-lg tw-font-bold tw-leading-tight tw-tracking-title tw-text-white">
+    <h3 className="tw-mb-0 tw-mt-0 tw-min-w-0 tw-text-lg tw-font-bold tw-leading-6 tw-tracking-title tw-text-white [overflow-wrap:anywhere]">
       {title}
     </h3>
   );

--- a/components/memes/drops/MemesLeaderboardDropVoteSummary.tsx
+++ b/components/memes/drops/MemesLeaderboardDropVoteSummary.tsx
@@ -78,10 +78,14 @@ const MemesLeaderboardDropVoteSummary: React.FC<
           {topVoters.length > 0 && (
             <div className="tw-flex tw-items-center -tw-space-x-2">
               {topVoters.map((voter) => {
-                const address = voter.profile.primary_address?.trim();
-                const identity =
-                  voter.profile.handle?.trim() ||
-                  (address && address !== "UNKNOWN" ? address : voter.profile.id);
+                const address = voter.profile.primary_address.trim();
+                const handle = voter.profile.handle?.trim();
+                let identity = voter.profile.id;
+                if (handle) {
+                  identity = handle;
+                } else if (address && address !== "UNKNOWN") {
+                  identity = address;
+                }
                 const tooltipId = `voter-${drop.id}-${voter.profile.id}`;
 
                 return (

--- a/components/memes/drops/MemesLeaderboardDropVoteSummary.tsx
+++ b/components/memes/drops/MemesLeaderboardDropVoteSummary.tsx
@@ -2,18 +2,24 @@ import DropVoteProgressing from "@/components/drops/view/utils/DropVoteProgressi
 import DropLargestVote from "@/components/waves/drop/DropLargestVote";
 import ParticipationDropVoteDetailsTrigger from "@/components/waves/drops/participation/ratings/ParticipationDropVoteDetailsTrigger";
 import { formatNumberWithCommas } from "@/helpers/Helpers";
+import { getScaledImageUri, ImageScale } from "@/helpers/image.helpers";
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import { t } from "@/i18n/messages";
+import Image from "next/image";
 import Link from "next/link";
 import React from "react";
 import { Tooltip } from "react-tooltip";
 
 interface MemesLeaderboardDropVoteSummaryProps {
   readonly drop: ExtendedDrop;
+  readonly voteButton?: React.ReactNode;
 }
 
 const MemesLeaderboardDropVoteSummary: React.FC<
   MemesLeaderboardDropVoteSummaryProps
-> = ({ drop }) => {
+> = ({ drop, voteButton }) => {
+  const locale = useBrowserLocale();
   const current = drop.rating;
   const projected = drop.rating_prediction;
   const creditType = drop.wave.voting_credit_type;
@@ -28,11 +34,11 @@ const MemesLeaderboardDropVoteSummary: React.FC<
   const isUserVoteNegative = userVote < 0;
 
   return (
-    <div className="tw-flex tw-min-w-0 tw-flex-wrap @[700px]:tw-flex-1 tw-items-center tw-gap-x-4 tw-gap-y-1 @[700px]:tw-justify-between">
+    <div className="tw-grid tw-min-w-0 tw-grid-cols-1 tw-items-center tw-gap-x-4 tw-gap-y-1 @[700px]:tw-grid-cols-[minmax(0,1fr)_auto]">
       {/* Left side: Vote counts + User vote (on large) */}
-      <div className="tw-flex tw-items-baseline tw-gap-2 tw-text-sm">
+      <div className="tw-flex tw-min-w-0 tw-flex-wrap tw-items-baseline tw-gap-2 tw-text-sm">
         <span
-          className={`tw-text-body tw-font-semibold tw-leading-5 tw-tracking-identity tw-tabular-nums ${
+          className={`tw-text-body tw-font-semibold tw-tabular-nums tw-leading-5 tw-tracking-identity ${
             isPositive ? "tw-text-iron-100" : "tw-text-rose-400"
           }`}
         >
@@ -53,9 +59,9 @@ const MemesLeaderboardDropVoteSummary: React.FC<
         </div>
         {/* User vote badge - hidden on small containers */}
         {hasUserVoted && (
-          <span className="tw-hidden @[500px]:tw-inline tw-text-xs tw-text-iron-500 tw-font-mono tw-ml-3 tw-border-l tw-border-solid tw-border-white/10 tw-pl-3 tw-border-t-0 tw-border-r-0 tw-border-b-0">
+          <span className="tw-ml-3 tw-hidden tw-border-b-0 tw-border-l tw-border-r-0 tw-border-t-0 tw-border-solid tw-border-white/10 tw-pl-3 tw-font-mono tw-text-xs tw-text-iron-500 @[500px]:tw-inline">
             Your vote:{" "}
-            <span className="tw-text-white tw-font-bold">
+            <span className="tw-font-bold tw-text-white">
               {isUserVoteNegative && "-"}
               {formatNumberWithCommas(Math.abs(userVote))}
             </span>
@@ -63,54 +69,77 @@ const MemesLeaderboardDropVoteSummary: React.FC<
         )}
       </div>
 
-      {/* Right side: Voters - hidden on small containers (shown next to button) */}
-      <div className="tw-hidden @[700px]:tw-flex tw-items-center tw-gap-2">
-        <div className="tw-flex tw-items-center -tw-space-x-2">
-          {topVoters.map((voter) => (
-            <React.Fragment key={voter.profile.handle}>
-              <Link
-                href={`/${voter.profile.handle}`}
-                onClick={(e) => e.stopPropagation()}
-                data-tooltip-id={`voter-${voter.profile.handle}`}
-              >
-                {voter.profile.pfp ? (
-                  <img
-                    className="tw-w-6 tw-h-6 tw-rounded-md tw-border-2 tw-border-solid tw-border-[#111] tw-bg-iron-800 tw-object-contain"
-                    src={voter.profile.pfp}
-                    alt="Recent voter"
-                  />
-                ) : (
-                  <div className="tw-w-6 tw-h-6 tw-rounded-lg tw-border-2 tw-border-solid tw-border-[#111] tw-bg-iron-800" />
-                )}
-              </Link>
-              <Tooltip
-                id={`voter-${voter.profile.handle}`}
-                place="top"
-                offset={8}
-                opacity={1}
-                style={{
-                  padding: "4px 8px",
-                  background: "#37373E",
-                  color: "white",
-                  fontSize: "13px",
-                  fontWeight: 500,
-                  borderRadius: "6px",
-                  boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
-                  zIndex: 99999,
-                  pointerEvents: "none",
-                }}
-              >
-                {voter.profile.handle} - {formatNumberWithCommas(voter.rating)}
-              </Tooltip>
-            </React.Fragment>
-          ))}
+      {/* Keep voters and voting centered together, above the secondary summary. */}
+      <div
+        className="tw-flex tw-items-center tw-justify-between tw-gap-4 @[700px]:tw-justify-end"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="tw-flex tw-items-center tw-gap-2">
+          {topVoters.length > 0 && (
+            <div className="tw-flex tw-items-center -tw-space-x-2">
+              {topVoters.map((voter) => {
+                const identity =
+                  voter.profile.handle ?? voter.profile.primary_address;
+                const tooltipId = `voter-${drop.id}-${identity}`;
+
+                return (
+                  <React.Fragment key={identity}>
+                    <Link
+                      href={`/${identity}`}
+                      onClick={(e) => e.stopPropagation()}
+                      data-tooltip-id={tooltipId}
+                      aria-label={t(locale, "waves.myVotes.voterAvatar", {
+                        profile: identity,
+                      })}
+                      className="tw-rounded-md focus-visible:tw-relative focus-visible:tw-z-10 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-white"
+                    >
+                      {voter.profile.pfp ? (
+                        <Image
+                          className="tw-h-6 tw-w-6 tw-rounded-md tw-border-2 tw-border-solid tw-border-[#111] tw-bg-iron-800 tw-object-contain"
+                          src={getScaledImageUri(
+                            voter.profile.pfp,
+                            ImageScale.W_AUTO_H_50
+                          )}
+                          alt=""
+                          width={24}
+                          height={24}
+                        />
+                      ) : (
+                        <div className="tw-h-6 tw-w-6 tw-rounded-lg tw-border-2 tw-border-solid tw-border-[#111] tw-bg-iron-800" />
+                      )}
+                    </Link>
+                    <Tooltip
+                      id={tooltipId}
+                      place="top"
+                      offset={8}
+                      opacity={1}
+                      style={{
+                        padding: "4px 8px",
+                        background: "#37373E",
+                        color: "white",
+                        fontSize: "13px",
+                        fontWeight: 500,
+                        borderRadius: "6px",
+                        boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
+                        zIndex: 99999,
+                        pointerEvents: "none",
+                      }}
+                    >
+                      {identity} - {formatNumberWithCommas(voter.rating)}
+                    </Tooltip>
+                  </React.Fragment>
+                );
+              })}
+            </div>
+          )}
+          <ParticipationDropVoteDetailsTrigger
+            drop={drop}
+            visualVariant="memes"
+          />
         </div>
-        <ParticipationDropVoteDetailsTrigger
-          drop={drop}
-          visualVariant="memes"
-        />
+        {voteButton}
       </div>
-      <DropLargestVote drop={drop} className="tw-w-full" />
+      <DropLargestVote drop={drop} className="@[700px]:tw-col-span-2" />
     </div>
   );
 };

--- a/components/memes/drops/MemesLeaderboardDropVoteSummary.tsx
+++ b/components/memes/drops/MemesLeaderboardDropVoteSummary.tsx
@@ -1,11 +1,11 @@
 import DropVoteProgressing from "@/components/drops/view/utils/DropVoteProgressing";
 import DropLargestVote from "@/components/waves/drop/DropLargestVote";
 import ParticipationDropVoteDetailsTrigger from "@/components/waves/drops/participation/ratings/ParticipationDropVoteDetailsTrigger";
-import { formatNumberWithCommas } from "@/helpers/Helpers";
 import { getScaledImageUri, ImageScale } from "@/helpers/image.helpers";
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 import { useBrowserLocale } from "@/hooks/useBrowserLocale";
-import { t } from "@/i18n/messages";
+import { formatInteger } from "@/i18n/format";
+import { t, tRich } from "@/i18n/messages";
 import Image from "next/image";
 import Link from "next/link";
 import React from "react";
@@ -31,7 +31,6 @@ const MemesLeaderboardDropVoteSummary: React.FC<
   const hasUserVoted =
     userContext?.rating !== undefined && userContext?.rating !== 0;
   const userVote = userContext?.rating ?? 0;
-  const isUserVoteNegative = userVote < 0;
 
   return (
     <div className="tw-grid tw-min-w-0 tw-grid-cols-1 tw-items-center tw-gap-x-4 tw-gap-y-1 @[700px]:tw-grid-cols-[minmax(0,1fr)_auto]">
@@ -42,50 +41,53 @@ const MemesLeaderboardDropVoteSummary: React.FC<
             isPositive ? "tw-text-iron-100" : "tw-text-rose-400"
           }`}
         >
-          {formatNumberWithCommas(current)}
+          {formatInteger(locale, current)}
         </span>
         <div className="tw-flex tw-items-baseline tw-gap-1">
           <DropVoteProgressing
             current={current}
             projected={projected}
+            projectedLabel={formatInteger(locale, projected)}
+            tooltipLabel={t(locale, "waves.myVotes.projectedAtDecision")}
             numberFont="sans"
             numberSize="body"
             numberWeight="semibold"
             visualVariant="memes"
           />
           <span className="tw-whitespace-nowrap tw-text-label tw-font-semibold tw-uppercase tw-leading-5 tw-tracking-ordinal tw-text-iron-600">
-            {creditType} total
+            {t(locale, "waves.leaderboard.voteSummary.total", { creditType })}
           </span>
         </div>
         {/* User vote badge - hidden on small containers */}
         {hasUserVoted && (
           <span className="tw-ml-3 tw-hidden tw-border-b-0 tw-border-l tw-border-r-0 tw-border-t-0 tw-border-solid tw-border-white/10 tw-pl-3 tw-font-mono tw-text-xs tw-text-iron-500 @[500px]:tw-inline">
-            Your vote:{" "}
-            <span className="tw-font-bold tw-text-white">
-              {isUserVoteNegative && "-"}
-              {formatNumberWithCommas(Math.abs(userVote))}
-            </span>
+            {tRich(locale, "waves.leaderboard.voteSummary.yourVote", {
+              vote: (
+                <span key="user-vote" className="tw-font-bold tw-text-white">
+                  {formatInteger(locale, userVote)}
+                </span>
+              ),
+            })}
           </span>
         )}
       </div>
 
       {/* Keep voters and voting centered together, above the secondary summary. */}
-      <div
-        className="tw-flex tw-items-center tw-justify-between tw-gap-4 @[700px]:tw-justify-end"
-        onClick={(event) => event.stopPropagation()}
-      >
+      <div className="tw-flex tw-items-center tw-justify-between tw-gap-4 @[700px]:tw-justify-end">
         <div className="tw-flex tw-items-center tw-gap-2">
           {topVoters.length > 0 && (
             <div className="tw-flex tw-items-center -tw-space-x-2">
               {topVoters.map((voter) => {
+                const address = voter.profile.primary_address?.trim();
                 const identity =
-                  voter.profile.handle ?? voter.profile.primary_address;
-                const tooltipId = `voter-${drop.id}-${identity}`;
+                  voter.profile.handle?.trim() ||
+                  (address && address !== "UNKNOWN" ? address : voter.profile.id);
+                const tooltipId = `voter-${drop.id}-${voter.profile.id}`;
 
                 return (
-                  <React.Fragment key={identity}>
+                  <React.Fragment key={voter.profile.id}>
                     <Link
-                      href={`/${identity}`}
+                      href={`/${encodeURIComponent(identity)}`}
                       onClick={(e) => e.stopPropagation()}
                       data-tooltip-id={tooltipId}
                       aria-label={t(locale, "waves.myVotes.voterAvatar", {
@@ -125,7 +127,7 @@ const MemesLeaderboardDropVoteSummary: React.FC<
                         pointerEvents: "none",
                       }}
                     >
-                      {identity} - {formatNumberWithCommas(voter.rating)}
+                      {identity} - {formatInteger(locale, voter.rating)}
                     </Tooltip>
                   </React.Fragment>
                 );

--- a/components/user/identity/header/UserPageIdentityHeader.tsx
+++ b/components/user/identity/header/UserPageIdentityHeader.tsx
@@ -14,10 +14,10 @@ export default function UserPageIdentityHeader({
   return (
     <div className="tw-px-6 tw-pt-6">
       <div className="tw-mb-6">
-        <h2 className="tw-mb-1 tw-text-xl tw-font-semibold tw-text-iron-100">
+        <h2 className="tw-mb-1 tw-mt-0 tw-text-xl tw-font-semibold tw-text-iron-100">
           Network Identity Check (NIC)
         </h2>
-        <p className="tw-mb-0 tw-text-sm tw-font-normal tw-leading-relaxed tw-text-iron-500">
+        <p className="tw-m-0 tw-text-sm tw-font-normal tw-leading-relaxed tw-text-iron-500">
           Does the network believe this profile accurately represents its
           identity?
         </p>

--- a/components/user/rep/header/UserPageRepHeader.tsx
+++ b/components/user/rep/header/UserPageRepHeader.tsx
@@ -99,12 +99,12 @@ export default function UserPageRepHeader({
         <div className="tw-absolute tw-bottom-0 tw-right-0 tw-top-0 tw-w-px tw-bg-gradient-to-b tw-from-transparent tw-via-blue-400/10 tw-to-transparent" />
 
         <div className="tw-relative tw-p-6">
-          <div className="tw-flex tw-items-end tw-justify-between tw-gap-6">
+          <div className="tw-flex tw-items-start tw-justify-between tw-gap-6">
             <div className="tw-min-w-0">
-              <h2 className="tw-mb-1 tw-text-xl tw-font-semibold tw-text-iron-100">
+              <h2 className="tw-mb-1 tw-mt-0 tw-text-xl tw-font-semibold tw-text-iron-100">
                 Rep
               </h2>
-              <p className="tw-mb-0 tw-text-sm tw-font-normal tw-leading-relaxed tw-text-iron-500">
+              <p className="tw-m-0 tw-text-sm tw-font-normal tw-leading-relaxed tw-text-iron-500">
                 {repDirection === "received"
                   ? "What others recognize this identity for."
                   : "What this identity recognizes others for."}

--- a/components/waves/drop/MemesDropSummarySection.tsx
+++ b/components/waves/drop/MemesDropSummarySection.tsx
@@ -114,15 +114,12 @@ export function MemesDropSummarySection({
             {manualOutcomes.map((outcome) => (
               <span
                 key={outcome}
-                className="tw-text-base tw-font-medium tw-text-amber-400/80"
+                className="tw-text-sm tw-text-amber-400/70"
               >
                 {outcome}
               </span>
             ))}
-            <MainStageMemeCardLink
-              memeCardId={memeCardId}
-              variant="prominent"
-            />
+            <MainStageMemeCardLink memeCardId={memeCardId} />
           </div>
         )}
       </div>

--- a/components/waves/drops/DropMinimalIdentityRow.tsx
+++ b/components/waves/drops/DropMinimalIdentityRow.tsx
@@ -22,6 +22,7 @@ export default function DropMinimalIdentityRow({
 }: DropMinimalIdentityRowProps) {
   const router = useRouter();
   const compact = useCompactMode();
+  const identityRowHeightClass = compact ? "tw-min-h-8" : "tw-min-h-10";
   const authorIdentity = drop.author.handle ?? drop.author.primary_address;
   const isStackedTimestamp = timestampLayout === "stacked";
 
@@ -43,7 +44,7 @@ export default function DropMinimalIdentityRow({
       }
     >
       <div
-        className={`tw-flex tw-min-w-0 tw-max-w-full tw-flex-wrap tw-items-center tw-gap-x-1.5 tw-gap-y-1 ${compact ? "tw-min-h-8" : "tw-min-h-10"}`}
+        className={`tw-flex tw-min-w-0 tw-max-w-full tw-flex-wrap tw-items-center tw-gap-x-1.5 tw-gap-y-1 ${isStackedTimestamp ? identityRowHeightClass : ""}`}
       >
         <p className="tw-m-0 tw-min-w-0 tw-max-w-full tw-text-sm tw-font-semibold tw-leading-5 [overflow-wrap:anywhere]">
           <UserProfileTooltipWrapper user={authorIdentity}>

--- a/components/waves/drops/WaveDropHeader.tsx
+++ b/components/waves/drops/WaveDropHeader.tsx
@@ -63,9 +63,7 @@ const WaveDropHeader: React.FC<WaveDropHeaderProps> = ({
 
   return (
     <>
-      <div
-        className={`tw-flex tw-items-center tw-justify-between tw-gap-x-2 ${identityRowHeightClass}`}
-      >
+      <div className="tw-flex tw-items-center tw-justify-between tw-gap-x-2">
         <div className="tw-flex tw-min-w-0 tw-flex-wrap tw-items-center tw-gap-x-1.5 tw-gap-y-1">
           <div
             className={

--- a/components/waves/winners/drops/MemesWaveWinnerDrop.tsx
+++ b/components/waves/winners/drops/MemesWaveWinnerDrop.tsx
@@ -21,7 +21,6 @@ import WaveDropMobileMenuCopyLink from "@/components/waves/drops/WaveDropMobileM
 import WaveDropMobileMenuOpen from "@/components/waves/drops/WaveDropMobileMenuOpen";
 import WaveDropTime from "@/components/waves/drops/time/WaveDropTime";
 import { DropAuthorBadges } from "@/components/waves/drops/DropAuthorBadges";
-import { getRankHoverBorderClass } from "@/components/waves/drops/dropRankStyles";
 import type { ApiWave } from "@/generated/models/ApiWave";
 import type { ApiWaveDecisionWinner } from "@/generated/models/ApiWaveDecisionWinner";
 import type { ApiDropV2View } from "@/services/api/drop-v2-view.types";
@@ -54,10 +53,6 @@ interface MemesWaveWinnersDropProps {
   readonly wave: ApiWave;
   readonly onDropClick: (drop: ExtendedDrop) => void;
 }
-
-const getRankHoverClass = (place: number | null): string => {
-  return getRankHoverBorderClass(place);
-};
 
 const isClickFromCardDom = (
   event: React.MouseEvent<HTMLDivElement>
@@ -220,10 +215,10 @@ export const MemesWaveWinnersDrop: React.FC<MemesWaveWinnersDropProps> = ({
       className="touch-select-none tw-w-full tw-cursor-pointer tw-rounded-xl tw-transition-all tw-duration-300 tw-ease-out"
     >
       <div
-        className={`tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-white/[0.08] tw-bg-iron-950/85 tw-shadow-[0_18px_45px_-32px_rgba(0,0,0,0.95)] tw-transition-all tw-duration-200 tw-ease-out ${getRankHoverClass(winner.place)}`}
+        className="tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-iron-900 tw-bg-iron-950 tw-transition-all tw-duration-200 tw-ease-out desktop-hover:hover:tw-border-white/10"
       >
         <div className="tw-flex tw-flex-col" {...touchHandlers}>
-          <div className="tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-white/[0.05] tw-bg-black/10 tw-px-[13px] tw-py-[8px]">
+          <div className="tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-white/5 tw-px-[13px] tw-py-[8px]">
             <div className="tw-flex tw-items-center tw-justify-between tw-gap-[13px]">
               <div className="tw-flex tw-gap-x-2">
                 <WaveWinnersDropHeaderAuthorPfp winner={winner} size="sm" />
@@ -320,7 +315,7 @@ export const MemesWaveWinnersDrop: React.FC<MemesWaveWinnersDropProps> = ({
           />
 
           {artworkMedia && (
-            <div className="tw-flex tw-h-96 tw-justify-center tw-bg-iron-950">
+            <div className="tw-flex tw-h-96 tw-justify-center tw-bg-iron-900/30">
               <DropListItemContentMedia
                 media_mime_type={artworkMedia.mime_type}
                 media_url={artworkMedia.url}
@@ -332,7 +327,7 @@ export const MemesWaveWinnersDrop: React.FC<MemesWaveWinnersDropProps> = ({
           )}
 
           {/* Footer Section: Traits + Vote Summary */}
-          <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/[0.05] tw-bg-black/10 tw-px-[13px] tw-py-3 lg:tw-space-y-[13px]">
+          <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/5 tw-bg-iron-900/30 tw-px-[13px] tw-py-3 lg:tw-space-y-[13px]">
             <MemeDropTraits drop={winner.drop} />
 
             <div className="tw-flex tw-w-full tw-flex-wrap tw-items-center tw-gap-x-[13px] tw-gap-y-[8px]">

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -591,6 +591,8 @@ const PROFILE_WAVE_FEED_MESSAGES = objectMessages("waves.profileFeed", {
 } as const);
 
 const WAVE_LEADERBOARD_MESSAGES = objectMessages("waves.leaderboard", {
+  "voteSummary.total": "{creditType} total",
+  "voteSummary.yourVote": "Your vote: {vote}",
   listLabel: "Leaderboard drops",
   loadingEarlier: "Loading earlier drops",
   previousLoadError:
@@ -3714,6 +3716,7 @@ export const EN_US_MESSAGES = {
   "drop.media.saveDialogTitle": "Save image",
   "drop.media.processingFailed": "Image processing failed.",
   "drop.media.processingTimedOut": "Image processing timed out.",
+  "media.interactive.untrustedContent": "Untrusted interactive content",
   "walletAddress.copy.optionsAriaLabel": "Copy wallet options",
   "walletAddress.copy.ensAriaLabel": "Copy ENS name",
   "walletAddress.copy.walletAriaLabel": "Copy wallet address",

--- a/ops/docs/media/rendering/feature-interactive-html-rendering.md
+++ b/ops/docs/media/rendering/feature-interactive-html-rendering.md
@@ -61,7 +61,8 @@
 ## Common Scenarios
 
 - Shared wave/drop cards without a preview-image override render the host
-  banner plus sandboxed iframe.
+  banner plus a borderless sandboxed iframe. The banner keeps its uppercase
+  untrusted-content label at 11px and a separate source link.
 - Gallery, leaderboard, and other card surfaces that already have preview
   artwork can show a static preview image for HTML media instead of a live
   iframe.

--- a/ops/docs/notifications/feature-notifications-feed.md
+++ b/ops/docs/notifications/feature-notifications-feed.md
@@ -81,14 +81,13 @@ with a multi-select cause filter, grouped reactions, and inline drop previews.
 
 ## Row and Action Behavior
 
-- Dividers separate notifications, with stronger definition in the app, and
-  timestamps use secondary emphasis.
+- Notifications are separated by spacing, and timestamps use secondary emphasis.
 - Long profile names, wave names, rating categories, and fallback details wrap
   within the row. Keyboard focus visibly identifies profile and wave links and
   the `Show full drop` action.
 - Drop-linked rows show inline drop context with reply/quote actions.
-- In the app, drop previews use a slightly lighter charcoal surface to separate
-  posts from the black feed background. Wave names have space below the author.
+- Drop previews use the standard dark post backgrounds. Wave names appear below
+  the author.
 - Long drop previews can collapse and show `Show full drop`.
 - Repeated `DROP_REACTED` notifications on one drop are grouped into one
   `New reactions` row with grouped avatars and reaction badges.

--- a/ops/docs/waves/leaderboard/feature-my-votes-tab.md
+++ b/ops/docs/waves/leaderboard/feature-my-votes-tab.md
@@ -21,7 +21,8 @@ The tab is available only on eligible rank-wave layouts:
 
 - Open an eligible wave.
 - Switch to `My Votes` from the wave tab row.
-- Use row checkboxes, vote inputs, and `Explain` actions in the list.
+- Use rows or their checkboxes to select votes for reset, vote inputs to edit
+  votes, and `Explain` actions to explain them.
 
 ## User Journey
 
@@ -30,14 +31,15 @@ The tab is available only on eligible rank-wave layouts:
    `You haven't voted on any submissions in this wave yet.`
 3. Review each row: preview, title, rank (when available), author, total vote
    value, voter count, and your current vote input.
-4. Optional: click a row outside its controls to open that drop in the current
-   wave route. You can also use its artwork or title buttons, including with
-   `Enter` or `Space`. Checkboxes, vote controls, and profile links keep their
-   own actions; selecting text does not open the drop.
+4. Optional: click a row outside its controls to select or deselect its vote for
+   reset. Use its artwork or title buttons to open the drop in the current wave
+   route, including with `Enter` or `Space`. Checkboxes, vote controls, and
+   profile links keep their own actions; selecting text does not toggle the row.
 5. Edit a vote, then submit with `Vote` or `Enter`.
 6. Optional: select `Explain` to open an inline reply composer prefilled as
    `Vote rationale (...)`.
-7. Use the checkboxes beside the artwork, or `Select all` / `Deselect all`,
+7. Select rows by clicking outside their controls, using the checkboxes beside
+   the artwork, or using `Select all` / `Deselect all`,
    then `Reset votes`. Review the selected count in the confirmation dialog
    and confirm to set those votes to `0`, or cancel without changing them.
 8. Scroll to the bottom to load more rows.
@@ -45,8 +47,9 @@ The tab is available only on eligible rank-wave layouts:
 ## Common Scenarios
 
 - Rows use a subtle charcoal background. Hovering an unselected row lightens
-  it further and highlights the title in blue; focusing the title with the
-  keyboard also highlights it in blue.
+  it further. Hovering or focusing the title highlights it in blue.
+- Selecting a row checks its checkbox for reset; it does not change the vote
+  until you confirm `Reset votes`.
 - Vote input accepts numeric text, including temporary empty and `-` while you
   edit.
 - Values outside the row's min/max range are clamped while editing, with a
@@ -59,7 +62,7 @@ The tab is available only on eligible rank-wave layouts:
 - The prefilled reply includes the user's vote total at time of posting. If the
   current session just applied a vote change and that change differs from the
   total, the prefix includes both total and change.
-- During bulk reset, `Select all` and `Reset votes` are disabled.
+- During bulk reset, row selection, `Select all`, and `Reset votes` are disabled.
 - During bulk reset, row vote inputs are disabled and a
   `Resetting votes...` progress bar shows progress.
 - `Available in wave` is shown only when vote context includes a numeric max
@@ -72,6 +75,8 @@ The tab is available only on eligible rank-wave layouts:
   values.
 - If input blurs with empty, `-`, or unchanged value, it resets without submitting.
 - The tab can remain visible even when `Leaderboard` is no longer available.
+- When voting is closed, rows cannot be selected for reset; artwork and title
+  buttons still open the drop.
 - `Select all` affects loaded rows only; rows loaded later are not auto-selected.
 - Bulk reset runs one selected row at a time.
 

--- a/ops/docs/waves/leaderboard/feature-top-voters-lists.md
+++ b/ops/docs/waves/leaderboard/feature-top-voters-lists.md
@@ -46,6 +46,8 @@ either list. Grid cards omit that highlight.
   link, and a compact signed amount on standard leaderboard and memes list
   items. Grid cards omit this highlight to keep the artwork and voting controls
   primary.
+- On Memes list cards, the voters control and available `Vote` button stay
+  together on one row. `Largest vote` appears on a separate line below them.
 - The amount is that voter's current allocation on this drop. `+` means a
   positive vote and `−` means a negative vote. It is not their latest vote
   change or their vote total across the wave.

--- a/ops/docs/waves/leaderboard/feature-winners-tab.md
+++ b/ops/docs/waves/leaderboard/feature-winners-tab.md
@@ -65,10 +65,12 @@ right sidebar, and what users see for loading and empty states.
 
 ## Common Scenarios
 
-- Memes waves show media-rich winner cards with traits and vote context.
+- Memes waves show media-rich winner cards with traits and vote context. Their
+  background, default border, and neutral hover highlight match the leaderboard
+  list cards.
 - In The Memes Main Stage wave, mapped winners show a `The Memes #N` link that
   opens the Meme card minted from that submission. The same link appears when
-  the winning drop is open directly, where the minted outcome and larger Meme
+  the winning drop is open directly, where the minted outcome and compact Meme
   link use their own row below the drop metadata. The frontend uses only the
   explicit mapping returned in the V2 submission context; it never infers a
   Meme ID from winner order. The link is omitted when no mapping is known.

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -6137,7 +6137,7 @@
         "The My Votes tab is documented under wave leaderboard features.",
         "It helps a user inspect their own voting activity where the wave supports it.",
         "Availability depends on wave type, eligibility, and voting state.",
-        "Click a row outside its controls or use its artwork or title buttons to open the drop. The artwork and title buttons support Enter and Space. Checkboxes, vote controls, and profile links keep their own actions. Selecting text does not open the drop. Use the checkbox beside the artwork or Select all to select loaded rows for reset.",
+        "Click a row outside its controls or use the checkbox beside the artwork to select or deselect its vote for reset. Use its artwork or title buttons to open the drop; these buttons support Enter and Space. Vote controls and profile links keep their own actions. Selecting text does not toggle the row. Select all selects loaded rows for reset. Row selection is disabled during reset and when voting is closed.",
         "Reset votes opens a confirmation showing the selected count. Confirming sets those votes to zero; cancelling leaves votes unchanged.",
         "Rows can include an Explain action that opens a normal drop reply prefilled with a vote rationale prefix without submitting or changing the vote."
       ],

--- a/ops/workstreams/i18n-fallbacks/wave-vote-summary-interactive-media.md
+++ b/ops/workstreams/i18n-fallbacks/wave-vote-summary-interactive-media.md
@@ -1,0 +1,21 @@
+# Wave vote summary and interactive media localization fallback debt
+
+- Routes/components: `/waves/{waveId}` leaderboard vote summaries and shared
+  `SandboxedExternalIframe` media banners.
+- Untranslated surface: `waves.leaderboard.voteSummary.*` labels and
+  `media.interactive.untrustedContent`. Source hostnames, URLs, profile handles,
+  and artwork titles remain authored or technical data.
+- Current fallback: these messages resolve through `t()` or `tRich()` with the
+  browser locale. `en-GB`, `fr-FR`, `es-ES`, and `de-DE` fall back to the reviewed
+  `en-US` source messages. Summary vote values use locale-aware formatting;
+  the shared projected-vote tooltip retains legacy number formatting pending
+  its own migration. The largest-vote child is already locale-aware.
+- User impact: the labels remain functional English in non-source locales;
+  the projected-vote tooltip can still use English number separators.
+- Remaining adjacent debt: existing Rep/NIC header copy and winner outcome
+  labels remain English. Their padding, borders, and typography were refined
+  without changing their copy or expanding this migration into those surfaces.
+- Owner/follow-up: frontend wave, media, and profile localization follow-up.
+- Remediation path: add reviewed translations for these keys, localize shared
+  vote summary children and adjacent profile/winner labels, then verify all five
+  supported locales for wrapping, accessible names, and number formatting.

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -6133,7 +6133,7 @@
         "The My Votes tab is documented under wave leaderboard features.",
         "It helps a user inspect their own voting activity where the wave supports it.",
         "Availability depends on wave type, eligibility, and voting state.",
-        "Click a row outside its controls or use its artwork or title buttons to open the drop. The artwork and title buttons support Enter and Space. Checkboxes, vote controls, and profile links keep their own actions. Selecting text does not open the drop. Use the checkbox beside the artwork or Select all to select loaded rows for reset.",
+        "Click a row outside its controls or use the checkbox beside the artwork to select or deselect its vote for reset. Use its artwork or title buttons to open the drop; these buttons support Enter and Space. Vote controls and profile links keep their own actions. Selecting text does not toggle the row. Select all selects loaded rows for reset. Row selection is disabled during reset and when voting is closed.",
         "Reset votes opens a confirmation showing the selected count. Confirming sets those votes to zero; cancelling leaves votes unchanged.",
         "Rows can include an Explain action that opens a normal drop reply prefilled with a vote rationale prefix without submitting or changing the vote."
       ],

--- a/scripts/typecheck-test-baseline.json
+++ b/scripts/typecheck-test-baseline.json
@@ -300,7 +300,6 @@
     "__tests__/components/memes/drops/meme-participation-drop/MemeDropDescription.test.tsx": 1,
     "__tests__/components/memes/drops/meme-participation-drop/MemeDropVoteStats.test.tsx": 2,
     "__tests__/components/memes/drops/MemeParticipationDrop.test.tsx": 13,
-    "__tests__/components/memes/drops/MemesLeaderboardDrop.test.tsx": 2,
     "__tests__/components/memes/drops/MemesLeaderboardDropCard.test.tsx": 1,
     "__tests__/components/memes/drops/MemesLeaderboardDropVoteSummary.test.tsx": 1,
     "__tests__/components/memes/drops/MemeWinnerArtistInfo.test.tsx": 1,

--- a/tests/network-open-data/network-open-data-api-readonly.spec.ts
+++ b/tests/network-open-data/network-open-data-api-readonly.spec.ts
@@ -198,12 +198,22 @@ test.describe("Network, Open Data, and public API read-only coverage @surface @m
       400,
       "address is required"
     );
-    await expectNoStoreJsonError(
-      request,
-      "/api/alchemy/collections?query=",
-      400,
-      "query is required"
-    );
+    const collections = await request.get("/api/alchemy/collections?query=");
+    expect(collections.headers()["cache-control"] ?? "").toContain("no-store");
+    // Both the active and retired endpoint reject this request without caching.
+    expect([
+      { status: 400, body: { error: "query is required" } },
+      {
+        status: 410,
+        body: {
+          error:
+            "Collection name search is no longer available. Use a contract address.",
+        },
+      },
+    ]).toContainEqual({
+      status: collections.status(),
+      body: await collections.json(),
+    });
     await expectNoStoreJsonError(
       request,
       "/api/alchemy/owner-nfts?chainId=not-a-number",


### PR DESCRIPTION
## Issue

Recent styling changes made notifications too light, added unnecessary dividers, and left uneven spacing around chat identities, voting controls, and profile headings. Main Stage cards also had inconsistent borders and oversized minted labels. My Votes rows opened submissions when users expected to select votes for resetting.

## Fix

Restore the darker notification presentation, tighten the affected spacing, and make Main Stage card styling consistent. Clicking a My Votes row now toggles reset selection; the title and artwork still open the submission.

## Changes

- Remove notification dividers and restore compact chat identity spacing.
- Keep media icons beside wrapping titles; align voters with Vote and bring Largest vote closer to the totals.
- Match Winners backgrounds and default/hover borders to leaderboard list cards; restore compact minted text and Meme links.
- Preserve independent checkbox, vote-control, profile-link, title, and artwork actions in My Votes, including closed/resetting states.
- Remove the browser's iframe frame and use an 11px uppercase untrusted-content label; retain the source link and all sandbox restrictions.
- Remove inherited top margins from Rep and NIC headings and descriptions. Update product docs and the Help Bot corpus for the changed workflow.
- Correct an existing staging read-only test to recognize the collection-search endpoint's documented retirement response, while retaining exact status/body and no-cache assertions.

## Validation

- Focused Jest and CI's related tests passed, covering My Votes, leaderboard cards, Winners, minted metadata, iframe handling, and localization.
- `6529 run lint:changed`, `6529 run typecheck:changed`, `6529 run typecheck:tests`, and `6529 run react-doctor:diff` passed; `git diff --check` passed.
- Help index generation, agent-file synchronization, and documentation link checks passed.
- The corrected invalid-input API check passed on desktop and mobile against both the active local endpoint and the retired staging endpoint (four passing checks).
- Browser review covered Main Stage, interactive media, profile cards, and compact minted labels across desktop and narrow layouts. Authenticated checks confirmed aligned voting controls at 1440px, 650px, and 390px. My Votes and Notifications were empty for the QA account; populated-row behavior is covered by tests. Five-locale mobile checks confirmed expected number formatting and no summary/banner overflow.
- [Staging deployment](https://github.com/6529-Collections/6529seize-frontend/actions/runs/34329433184) and [E2E](https://github.com/6529-Collections/6529seize-frontend/actions/runs/34330241549) passed on `e1a4fa29737df2b0e2d9f82e8c0073221ce0430f`: 12 packs, 190 tests, and 26 expected skips. The reviewed UI components match production. Staging browser checks used CI access; supplemental visual review was completed locally and on production.
- [Production deployment](https://github.com/6529-Collections/6529seize-frontend/actions/runs/34332148738) succeeded on merged commit `a59ea3104a027d54a313e59fdda44caaa67dd7ae`, whose tree matches the reviewed PR head. Independent artifact checks, server readiness, and three consecutive HTTP version checks passed. All 13 public UI checks passed against that exact live version, including actual hover, narrow layouts, iframe styling/security, profile spacing, and compact minted labels. Authenticated actions retain the local QA/test coverage above; production verification made no voting or account mutations.
- [Production E2E](https://github.com/6529-Collections/6529seize-frontend/actions/runs/34333822807) passed all 11 packs: 73 tests passed immediately and one passed on automatic retry, with no final failures or skips. The retry was an unchanged ReMemes header-visibility check; no attributable regression was found.

## Risk

- Level: Low.
- Mostly presentation changes. The main behavior risk is accidental selection in My Votes; targeted tests cover nested controls, keyboard checkbox selection, text selection, and disabled states. No API, database, dependency, or iframe-permission changes.
- Rollback: revert the affected focused commits through a reviewed PR and redeploy using the ordinary staging and production workflows.

## Review Notes

- Focus on My Votes click boundaries and narrow-container voting layouts.
- Reset selection does not submit or reset a vote by itself. Vote controls retain their existing actions.
- Preserve the uppercase untrusted-content warning and source link. The iframe change is visual only.
- Independent review found no correctness blockers; voter-avatar links have localized accessible names, visible keyboard focus, and safe identity fallbacks. Follow-up fixes address Sonar and i18n findings. The external responsiveness bot failed before running because it uses a retired dependency-install command; affected layouts were verified directly in the browser.
- Existing staging E2E failed because collection search returns its documented 410 retirement response there while main returns 400 for missing input. The focused test correction accepts only those two exact rejection contracts, preserves `no-store`, and changes no endpoint implementation. Unmerged Alchemy application changes remain outside this PR.
- CodeRabbit's generic docstring-coverage warning is advisory. Comments explain the non-obvious click boundary; blanket JSDoc on straightforward rendering components and handlers would add noise without documenting an additional contract.
- Separate existing observation: a raw Winners avatar URL returned 403 HTML from the QA network, while the single submission loaded it through the image optimizer. Those image-rendering paths were unchanged by this PR; no release regression was established.
