### PR TITLE
Keep GitHub preview metadata public

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -75,7 +75,11 @@ SSR_CLIENT_ID=
 SSR_CLIENT_SECRET=
 
 # GitHub link preview status badges (optional but recommended)
-# Used server-side only to raise GitHub API rate limits.
+# Server-side only. REST rate-limit headroom requires a classic token with NO
+# scopes; GitHub response headers verify this. Other tokens use anonymous REST.
+# Scoped tokens can fetch public discussions, with anonymous REST limits.
+# Scope-free classic tokens cannot fetch GraphQL discussion metadata.
+# Discussion metadata is returned only with same-response public visibility.
 GITHUB_LINK_STATUS_PREVIEW_TOKEN=
 
 # 6529bot usage dashboard (server-side only)

--- a/__tests__/app/api/github-preview.public-access.test.ts
+++ b/__tests__/app/api/github-preview.public-access.test.ts
@@ -24,7 +24,7 @@ type GithubRoute = typeof import("../../../app/api/github-preview/route");
 const API_BASE = "https://api.github.com";
 const PRIVATE_MARKER = "confidential fixture metadata";
 const PUBLIC_TITLE = "Public issue";
-const CLASSIC_TOKEN = "ghp_preview_test_fixture";
+const CLASSIC_TOKEN = "ghp_test";
 const issueUrl = "https://github.com/o/r/issues/1";
 const jsonResponse = (body: unknown, scopes?: string) =>
   new Response(JSON.stringify(body), {
@@ -71,8 +71,8 @@ describe("GitHub preview public access boundary", () => {
   });
 
   it.each([
-    "github_pat_fine_grained_fixture",
-    "ghs_installation_fixture",
+    "github_pat_test",
+    "ghs_test",
     "unrecognized-token-fixture",
   ])("uses anonymous REST for unverified token type %s", async (token) => {
     mockGithubToken = token;

--- a/__tests__/app/api/github-preview.public-access.test.ts
+++ b/__tests__/app/api/github-preview.public-access.test.ts
@@ -1,0 +1,367 @@
+/**
+ * @jest-environment node
+ */
+
+import type { NextRequest } from "next/server";
+
+let mockGithubToken: string | undefined;
+
+jest.mock("@/config/serverEnv", () => ({
+  get serverEnv() {
+    return { GITHUB_LINK_STATUS_PREVIEW_TOKEN: mockGithubToken };
+  },
+}));
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), init),
+  },
+}));
+
+type GithubRoute = typeof import("../../../app/api/github-preview/route");
+
+const API_BASE = "https://api.github.com";
+const PRIVATE_MARKER = "confidential fixture metadata";
+const PUBLIC_TITLE = "Public issue";
+const CLASSIC_TOKEN = "ghp_preview_test_fixture";
+const issueUrl = "https://github.com/o/r/issues/1";
+const jsonResponse = (body: unknown, scopes?: string) =>
+  new Response(JSON.stringify(body), {
+    headers: scopes === undefined ? {} : { "x-oauth-scopes": scopes },
+  });
+const notFoundResponse = () =>
+  new Response(JSON.stringify({ message: "Not Found" }), { status: 404 });
+const requestFor = (url: string, refresh = false): NextRequest =>
+  ({
+    nextUrl: new URL(
+      `https://app.local/api/github-preview?url=${encodeURIComponent(url)}${refresh ? "&refresh=1" : ""}`
+    ),
+  }) as NextRequest;
+const batchRequestFor = (urls: readonly string[]): Request =>
+  new Request("https://app.local/api/github-preview", {
+    method: "POST",
+    body: JSON.stringify({ urls }),
+  });
+const authorization = (init?: RequestInit) =>
+  new Headers(init?.headers).get("authorization");
+const publicIssue = { title: PUBLIC_TITLE, state: "open" };
+const discussion = {
+  title: PRIVATE_MARKER,
+  number: 12,
+  comments: { totalCount: 3 },
+};
+
+describe("GitHub preview public access boundary", () => {
+  const originalFetch = globalThis.fetch;
+  const fetchMock = jest.fn<Promise<Response>, [string, RequestInit?]>();
+  let route: GithubRoute;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    mockGithubToken = undefined;
+    fetchMock.mockReset();
+    globalThis.fetch = fetchMock;
+    route = await import("../../../app/api/github-preview/route");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    globalThis.fetch = originalFetch;
+  });
+
+  it.each([
+    "github_pat_fine_grained_fixture",
+    "ghs_installation_fixture",
+    "unrecognized-token-fixture",
+  ])("uses anonymous REST for unverified token type %s", async (token) => {
+    mockGithubToken = token;
+    fetchMock.mockImplementation(async (_url, init) => {
+      if (authorization(init)) {
+        return jsonResponse({ title: PRIVATE_MARKER });
+      }
+      return notFoundResponse();
+    });
+    const urls = [
+      "https://github.com/o/r",
+      issueUrl,
+      "https://github.com/o/r/pull/1",
+      "https://github.com/o/r/blob/main/secret.txt#L1-L3",
+      "https://github.com/o/r/tree/main/src",
+      "https://github.com/o/r/commit/abc123",
+      "https://github.com/o/r/releases/tag/v1",
+      "https://github.com/o/r/releases/latest",
+      "https://github.com/o/r/actions",
+      "https://github.com/o/r/actions/runs/1",
+      "https://github.com/o/r/actions/workflows/ci.yml",
+    ];
+
+    for (const url of urls) {
+      const response = await route.GET(requestFor(url));
+      expect(await response.text()).not.toContain(PRIVATE_MARKER);
+    }
+    const batch = await route.POST(batchRequestFor(urls.slice(0, 10)));
+    expect(await batch.text()).not.toContain(PRIVATE_MARKER);
+    expect(fetchMock).toHaveBeenCalled();
+    for (const [, init] of fetchMock.mock.calls) {
+      expect(authorization(init)).toBeNull();
+      expect(init?.cache).toBe("no-store");
+    }
+  });
+
+  it.each(["repo", "public_repo", "repo:status", "read:discussion", undefined])(
+    "falls back anonymously when the classic token probe reports %s",
+    async (scopes) => {
+      mockGithubToken = CLASSIC_TOKEN;
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({}, scopes))
+        .mockResolvedValueOnce(jsonResponse(publicIssue));
+
+      const response = await route.GET(requestFor(issueUrl));
+
+      await expect(response.json()).resolves.toMatchObject({
+        title: PUBLIC_TITLE,
+      });
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(`${API_BASE}/rate_limit`);
+      expect(authorization(fetchMock.mock.calls[0]?.[1])).toBe(
+        `Bearer ${CLASSIC_TOKEN}`
+      );
+      expect(authorization(fetchMock.mock.calls[1]?.[1])).toBeNull();
+    }
+  );
+
+  it("retains authenticated rate headroom for a verified no-scope classic token", async () => {
+    mockGithubToken = CLASSIC_TOKEN;
+    fetchMock.mockImplementation(async (url) =>
+      jsonResponse(url.endsWith("/rate_limit") ? {} : publicIssue, "")
+    );
+
+    const responses = await Promise.all([
+      route.GET(requestFor(issueUrl)),
+      route.GET(requestFor("https://github.com/o/r/issues/2")),
+    ]);
+
+    for (const response of responses) {
+      await expect(response.json()).resolves.toMatchObject({
+        title: PUBLIC_TITLE,
+      });
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(
+      fetchMock.mock.calls.filter(([url]) => url.endsWith("/rate_limit"))
+    ).toHaveLength(1);
+    for (const [, init] of fetchMock.mock.calls) {
+      expect(authorization(init)).toBe(`Bearer ${CLASSIC_TOKEN}`);
+    }
+  });
+
+  it.each(["repo", undefined])(
+    "discards the authenticated body if its response scopes become %s",
+    async (scopes) => {
+      mockGithubToken = CLASSIC_TOKEN;
+      const privateResponse = jsonResponse({ title: PRIVATE_MARKER }, scopes);
+      const parsePrivateBody = jest.spyOn(privateResponse, "json");
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({}, ""))
+        .mockResolvedValueOnce(privateResponse)
+        .mockResolvedValueOnce(jsonResponse(publicIssue));
+
+      const first = await route.GET(requestFor(issueUrl));
+      const cached = await route.GET(requestFor(issueUrl));
+
+      await expect(first.json()).resolves.toMatchObject({
+        title: PUBLIC_TITLE,
+      });
+      await expect(cached.json()).resolves.toMatchObject({
+        title: PUBLIC_TITLE,
+      });
+      expect(parsePrivateBody).not.toHaveBeenCalled();
+      expect(authorization(fetchMock.mock.calls[2]?.[1])).toBeNull();
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    }
+  );
+
+  it("does not reuse token eligibility after the configured credential changes", async () => {
+    mockGithubToken = CLASSIC_TOKEN;
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({}, ""))
+      .mockResolvedValueOnce(jsonResponse(publicIssue, ""))
+      .mockResolvedValueOnce(jsonResponse({}, "repo"))
+      .mockResolvedValueOnce(jsonResponse(publicIssue));
+    await route.GET(requestFor(issueUrl));
+
+    mockGithubToken = "ghp_different_fixture";
+    await route.GET(requestFor("https://github.com/o/r/issues/2"));
+
+    expect(fetchMock.mock.calls[2]?.[0]).toBe(`${API_BASE}/rate_limit`);
+    expect(authorization(fetchMock.mock.calls[3]?.[1])).toBeNull();
+  });
+
+  it("uses anonymous REST when the eligibility probe fails", async () => {
+    mockGithubToken = CLASSIC_TOKEN;
+    fetchMock
+      .mockRejectedValueOnce(new Error("network unavailable"))
+      .mockResolvedValueOnce(jsonResponse(publicIssue));
+
+    const response = await route.GET(requestFor(issueUrl));
+
+    await expect(response.json()).resolves.toMatchObject({
+      title: PUBLIC_TITLE,
+    });
+    expect(authorization(fetchMock.mock.calls[1]?.[1])).toBeNull();
+  });
+
+  it.each([true, undefined])(
+    "omits unpublished release metadata with draft=%s",
+    async (draft) => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({
+          draft,
+          name: PRIVATE_MARKER,
+          tag_name: "unpublished-secret-tag",
+          published_at: "2026-09-01T00:00:00Z",
+        })
+      );
+
+      const response = await route.GET(
+        requestFor("https://github.com/o/r/releases/tag/v1")
+      );
+
+      await expect(response.json()).resolves.toMatchObject({
+        title: "v1",
+        tagName: "v1",
+        publishedAt: null,
+      });
+    }
+  );
+
+  it.each([
+    { visibility: "PRIVATE", isPrivate: true },
+    { visibility: "INTERNAL", isPrivate: true },
+    { visibility: "PUBLIC", isPrivate: true },
+    { visibility: "PUBLIC" },
+    { isPrivate: false },
+    {},
+  ])(
+    "rejects discussion visibility %j without caching it",
+    async (visibility) => {
+      mockGithubToken = "github_pat_discussion_fixture";
+      fetchMock.mockImplementation(async () =>
+        jsonResponse({
+          data: {
+            repository: {
+              ...visibility,
+              discussion,
+              discussions: { nodes: [discussion] },
+            },
+          },
+        })
+      );
+      const url = "https://github.com/o/r/discussions/12";
+
+      const first = await route.GET(requestFor(url));
+      const repeated = await route.GET(requestFor(url));
+      const batch = await route.POST(
+        batchRequestFor([url, "https://github.com/o/r/discussions"])
+      );
+
+      expect(first.status).toBe(400);
+      expect(repeated.status).toBe(400);
+      for (const response of [first, repeated, batch]) {
+        expect(await response.text()).not.toContain(PRIVATE_MARKER);
+      }
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+      for (const [, init] of fetchMock.mock.calls) {
+        const requestBody: { query: string } = JSON.parse(String(init?.body));
+        expect(requestBody.query).toContain("visibility");
+        expect(requestBody.query).toContain("isPrivate");
+      }
+    }
+  );
+
+  it("preserves public discussion lists with the visibility decision in the same response", async () => {
+    mockGithubToken = "github_pat_discussion_fixture";
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        data: {
+          repository: {
+            visibility: "PUBLIC",
+            isPrivate: false,
+            discussions: {
+              nodes: [{ ...discussion, title: "Public discussion" }],
+            },
+          },
+        },
+      })
+    );
+
+    const response = await route.GET(
+      requestFor("https://github.com/o/r/discussions")
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      type: "github.discussion",
+      title: "Public discussion",
+      comments: 3,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not expose upstream GraphQL error text", async () => {
+    mockGithubToken = "github_pat_discussion_fixture";
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ errors: [{ message: PRIVATE_MARKER }] })
+    );
+
+    const response = await route.GET(
+      requestFor("https://github.com/o/r/discussions/12")
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "GitHub GraphQL request failed.",
+    });
+  });
+
+  it("expires previously public metadata and rechecks visibility on refresh", async () => {
+    mockGithubToken = "github_pat_discussion_fixture";
+    const now = jest.spyOn(Date, "now").mockReturnValue(1_000);
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: {
+            repository: {
+              visibility: "PUBLIC",
+              isPrivate: false,
+              discussion: { title: "Previously public" },
+            },
+          },
+        })
+      )
+      .mockImplementation(async () =>
+        jsonResponse({
+          data: {
+            repository: { visibility: "PRIVATE", isPrivate: true, discussion },
+          },
+        })
+      );
+    const url = "https://github.com/o/r/discussions/12";
+
+    await route.GET(requestFor(url));
+    now.mockReturnValue(120_000);
+    const cached = await route.GET(requestFor(url));
+    await expect(cached.json()).resolves.toMatchObject({
+      title: "Previously public",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const refreshed = await route.GET(requestFor(url, true));
+    expect(refreshed.status).toBe(400);
+    expect(await refreshed.text()).not.toContain(PRIVATE_MARKER);
+    now.mockReturnValue(121_001);
+    const expired = await route.GET(requestFor(url));
+    expect(expired.status).toBe(400);
+    expect(await expired.text()).not.toContain(PRIVATE_MARKER);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/__tests__/app/api/github-preview.public-access.test.ts
+++ b/__tests__/app/api/github-preview.public-access.test.ts
@@ -54,7 +54,7 @@ const discussion = {
 
 describe("GitHub preview public access boundary", () => {
   const originalFetch = globalThis.fetch;
-  const fetchMock = jest.fn<Promise<Response>, [string, RequestInit?]>();
+  const fetchMock = jest.fn<Promise<Response>, Parameters<typeof fetch>>();
   let route: GithubRoute;
 
   beforeEach(async () => {
@@ -133,7 +133,7 @@ describe("GitHub preview public access boundary", () => {
   it("retains authenticated rate headroom for a verified no-scope classic token", async () => {
     mockGithubToken = CLASSIC_TOKEN;
     fetchMock.mockImplementation(async (url) =>
-      jsonResponse(url.endsWith("/rate_limit") ? {} : publicIssue, "")
+      jsonResponse(String(url).endsWith("/rate_limit") ? {} : publicIssue, "")
     );
 
     const responses = await Promise.all([
@@ -148,7 +148,7 @@ describe("GitHub preview public access boundary", () => {
     }
     expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(
-      fetchMock.mock.calls.filter(([url]) => url.endsWith("/rate_limit"))
+      fetchMock.mock.calls.filter(([url]) => String(url).endsWith("/rate_limit"))
     ).toHaveLength(1);
     for (const [, init] of fetchMock.mock.calls) {
       expect(authorization(init)).toBe(`Bearer ${CLASSIC_TOKEN}`);

--- a/__tests__/app/api/github-preview.route.test.ts
+++ b/__tests__/app/api/github-preview.route.test.ts
@@ -715,6 +715,8 @@ describe("github-preview API route", () => {
       jsonResponse({
         data: {
           repository: {
+            visibility: "PUBLIC",
+            isPrivate: false,
             discussion: {
               title: "Preview all GitHub resources",
               url: "https://github.com/o/r/discussions/12",

--- a/app/api/github-preview/service.ts
+++ b/app/api/github-preview/service.ts
@@ -3,6 +3,8 @@ import type { GithubPreviewResponse } from "@/services/api/github-preview-api";
 import { getResourceCacheKey, parseGithubResource } from "./service/resource";
 import { resolvePreviewForResource } from "./service/previews";
 
+// Only public metadata passes the fetchers/preview gates. Previously public
+// snapshots can remain visible for this TTL after upstream visibility changes.
 const CACHE_TTL_MS = 2 * 60 * 1000;
 const CACHE_MAX_ITEMS = 500;
 

--- a/app/api/github-preview/service/fetchers.ts
+++ b/app/api/github-preview/service/fetchers.ts
@@ -4,6 +4,15 @@ import type { GithubGraphqlResponse } from "./types";
 const GITHUB_API_BASE = "https://api.github.com";
 const GITHUB_GRAPHQL_URL = `${GITHUB_API_BASE}/graphql`;
 const FETCH_TIMEOUT_MS = 5000;
+const TOKEN_CHECK_TTL_MS = 2 * 60 * 1000;
+
+let publicTokenCheck:
+  | {
+      readonly token: string;
+      readonly expiresAt: number;
+      readonly result: Promise<boolean>;
+    }
+  | undefined;
 
 class GithubApiError extends Error {
   constructor(
@@ -43,9 +52,7 @@ export const isGithubApiNotFoundError = (
 ): error is GithubApiError =>
   error instanceof GithubApiError && error.status === 404;
 
-export const fetchGithubJson = async <T>(path: string): Promise<T> => {
-  const { controller, cancel } = createAbortController();
-  const githubToken = serverEnv?.GITHUB_LINK_STATUS_PREVIEW_TOKEN;
+const restHeaders = (githubToken?: string): Record<string, string> => {
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
     "X-GitHub-Api-Version": "2022-11-28",
@@ -56,11 +63,76 @@ export const fetchGithubJson = async <T>(path: string): Promise<T> => {
     headers["Authorization"] = `Bearer ${githubToken}`;
   }
 
+  return headers;
+};
+
+// GitHub documents classic tokens with no scopes as read-only public access.
+// A missing header is not proof: fine-grained and GitHub App tokens use other
+// permission models, and even public_repo permits non-public draft releases.
+const hasNoOauthScopes = (response: Response): boolean =>
+  response.headers.get("x-oauth-scopes")?.trim() === "";
+
+const checkPublicToken = async (githubToken: string): Promise<boolean> => {
+  const { controller, cancel } = createAbortController();
   try {
-    const response = await fetch(`${GITHUB_API_BASE}${path}`, {
-      headers,
+    const response = await fetch(`${GITHUB_API_BASE}/rate_limit`, {
+      headers: restHeaders(githubToken),
       signal: controller.signal,
+      cache: "no-store",
+      redirect: "error",
     });
+    const eligible = response.ok && hasNoOauthScopes(response);
+    await response.body?.cancel();
+    return eligible;
+  } catch {
+    return false;
+  } finally {
+    cancel();
+  }
+};
+
+const getPublicRestToken = async (): Promise<string | undefined> => {
+  const githubToken = serverEnv?.GITHUB_LINK_STATUS_PREVIEW_TOKEN;
+  if (!githubToken?.startsWith("ghp_")) {
+    return undefined;
+  }
+
+  if (
+    publicTokenCheck?.token !== githubToken ||
+    publicTokenCheck.expiresAt <= Date.now()
+  ) {
+    publicTokenCheck = {
+      token: githubToken,
+      expiresAt: Date.now() + TOKEN_CHECK_TTL_MS,
+      result: checkPublicToken(githubToken),
+    };
+  }
+
+  return (await publicTokenCheck.result) ? githubToken : undefined;
+};
+
+export const fetchGithubJson = async <T>(path: string): Promise<T> => {
+  const githubToken = await getPublicRestToken();
+  const { controller, cancel } = createAbortController();
+
+  try {
+    let response = await fetch(`${GITHUB_API_BASE}${path}`, {
+      headers: restHeaders(githubToken),
+      signal: controller.signal,
+      cache: "no-store",
+    });
+
+    // Scopes can change after the eligibility probe. Never parse or cache an
+    // authenticated resource body without checking that same response's scopes.
+    if (githubToken && !hasNoOauthScopes(response)) {
+      await response.body?.cancel();
+      publicTokenCheck = undefined;
+      response = await fetch(`${GITHUB_API_BASE}${path}`, {
+        headers: restHeaders(),
+        signal: controller.signal,
+        cache: "no-store",
+      });
+    }
 
     if (!response.ok) {
       throw new GithubApiError(
@@ -103,6 +175,8 @@ export const fetchGithubGraphql = async <T>(
       },
       body: JSON.stringify({ query, variables }),
       signal: controller.signal,
+      cache: "no-store",
+      redirect: "error",
     });
 
     if (!response.ok) {
@@ -115,7 +189,7 @@ export const fetchGithubGraphql = async <T>(
     const body = (await response.json()) as GithubGraphqlResponse<T>;
     const [firstError] = body.errors ?? [];
     if (firstError) {
-      throw new Error(firstError.message ?? "GitHub GraphQL request failed.");
+      throw new Error("GitHub GraphQL request failed.");
     }
 
     if (!body.data) {

--- a/app/api/github-preview/service/previews.ts
+++ b/app/api/github-preview/service/previews.ts
@@ -487,6 +487,9 @@ const resolveReleasePreview = async (
 
   try {
     const release = await fetchGithubJson<GithubReleaseApiResponse>(endpoint);
+    if (release.draft !== false) {
+      return fallbackReleasePreview(resource);
+    }
     return buildReleasePreview(resource, release);
   } catch (error) {
     if (isGithubApiNotFoundError(error)) {
@@ -612,6 +615,8 @@ const resolveDiscussionPreview = async (
       ? `
         query GithubDiscussionPreview($owner: String!, $repo: String!, $number: Int!) {
           repository(owner: $owner, name: $repo) {
+            visibility
+            isPrivate
             discussion(number: $number) {
               title
               url
@@ -627,6 +632,8 @@ const resolveDiscussionPreview = async (
       : `
         query GithubDiscussionsPreview($owner: String!, $repo: String!) {
           repository(owner: $owner, name: $repo) {
+            visibility
+            isPrivate
             discussions(first: 1, orderBy: { field: UPDATED_AT, direction: DESC }) {
               totalCount
               nodes {
@@ -648,6 +655,15 @@ const resolveDiscussionPreview = async (
       ...(resource.number ? { number: resource.number } : {}),
     }
   );
+
+  // Keep the visibility decision in the response that supplies the metadata;
+  // a separately cached repository preflight cannot authorize this body.
+  if (
+    data.repository?.visibility !== "PUBLIC" ||
+    data.repository.isPrivate !== false
+  ) {
+    throw new Error("GitHub discussion preview metadata is unavailable.");
+  }
 
   const discussion =
     data.repository?.discussion ??

--- a/app/api/github-preview/service/types.ts
+++ b/app/api/github-preview/service/types.ts
@@ -240,6 +240,8 @@ export interface GithubDiscussionGraphqlNode {
 
 export interface GithubDiscussionGraphqlData {
   readonly repository?: {
+    readonly visibility?: string | null;
+    readonly isPrivate?: boolean | null;
     readonly discussion?: GithubDiscussionGraphqlNode | null;
     readonly discussions?: {
       readonly totalCount?: number | null;

--- a/ops/docs/waves/link-previews/feature-external-link-previews.md
+++ b/ops/docs/waves/link-previews/feature-external-link-previews.md
@@ -73,6 +73,9 @@ loading.
   only to backend-uploaded attachments that pass the 6529 attachment pipeline.
 - GitHub file and directory links use the GitHub preview handler, not the generic
   external-card path. GitHub binary, PDF, and large files are also metadata-only.
+- GitHub previews show public metadata only. Private repositories and draft
+  releases do not provide preview metadata. A previously public preview can
+  remain cached for up to two minutes after its visibility changes.
 
 ## Failure and Recovery
 


### PR DESCRIPTION
## Issue

Public GitHub preview cards need a consistent public-data boundary regardless of the server credential's permissions.

## Fix

Restrict REST credential use to verified scope-free classic tokens and check the permission header on each authenticated response. Other credentials use anonymous REST reads. Discussion metadata must explicitly identify a public repository in the same GraphQL response.

## Changes

- Preserve existing preview variants, refresh behavior, and two-minute public snapshot cache.
- Exclude draft release metadata and keep upstream GraphQL errors generic.
- Document credential compatibility and cache freshness.

## Validation

- 65 focused tests across the GitHub preview service, route, and public-access suites passed.
- Changed-file lint and TypeScript checks passed.
- React Doctor: 100/100; documentation links and whitespace checks passed.
- Confidentiality tests use local fixtures; no private live resources were accessed.

## Risk

- Level: Medium
- Why: scoped credentials now use anonymous REST limits. A scope-free classic token retains authenticated REST headroom, while discussion GraphQL requires its own supported credential permissions.
- Rollback: revert the change through the normal reviewed release process; prefer a forward fix for public-access policy regressions.

## Review Notes

Review per-response permission checks, discussion visibility checks, and draft-release handling. Cache entries are snapshots of public metadata and can remain visible for up to two minutes after a repository changes visibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - GitHub link previews now show only publicly accessible metadata.
  - Private repositories, private discussions, and draft releases are excluded from previews.
  - Previews no longer expose detailed GitHub GraphQL errors.
  - Authentication and rate-limit handling are more reliable, including safer fallback behavior for unsupported credentials.
  - Previously public previews may remain cached for up to two minutes after visibility changes.

- **Documentation**
  - Updated token requirements, rate-limit behavior, visibility rules, and discussion metadata limitations for GitHub previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->