### PR TITLE
Bound preview downloads, image work, and mobile return paths

### DIFF
--- a/__tests__/app/api/og-metadata.image.route.test.ts
+++ b/__tests__/app/api/og-metadata.image.route.test.ts
@@ -3,6 +3,8 @@ jest.mock("undici", () => ({
   fetch: jest.fn(),
 }));
 
+jest.mock("sharp", () => jest.fn());
+
 jest.mock("@/lib/security/urlGuard", () => {
   const actual = jest.requireActual("@/lib/security/urlGuard");
   return {
@@ -46,6 +48,14 @@ class MockNextResponse {
 
     return JSON.parse(this.body);
   }
+
+  async arrayBuffer(): Promise<ArrayBuffer> {
+    if (!(this.body instanceof Uint8Array)) {
+      throw new TypeError("Mock binary response body must be a Uint8Array.");
+    }
+
+    return new Uint8Array(this.body).buffer;
+  }
 }
 
 jest.mock("next/server", () => ({
@@ -55,8 +65,11 @@ jest.mock("next/server", () => ({
 import { dynamic, GET } from "@/app/api/og-metadata/image/route";
 import { fetchPublicUrl } from "@/lib/security/urlGuard";
 import type { NextRequest } from "next/server";
+import sharp from "sharp";
 
 const mockFetchPublicUrl = fetchPublicUrl as jest.Mock;
+const mockSharp = jest.mocked(sharp);
+const actualSharp = jest.requireActual<typeof sharp>("sharp");
 const PNG_1X1 = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAADUlEQVQImWP4////fwAJ+wP9CNHoHgAAAABJRU5ErkJggg==",
   "base64"
@@ -66,12 +79,12 @@ const GIF_2_FRAME = Buffer.from(
   "base64"
 );
 
-const createRequest = (sourceUrl: string): NextRequest =>
+const createRequest = (sourceUrl: string, width = "1108"): NextRequest =>
   ({
     nextUrl: new URL(
       `http://localhost:3001/api/og-metadata/image?url=${encodeURIComponent(
         sourceUrl
-      )}&w=1108`
+      )}&w=${width}`
     ),
   }) as NextRequest;
 
@@ -122,6 +135,7 @@ const mockImageResponse = (
 describe("/api/og-metadata/image", () => {
   beforeEach(() => {
     mockFetchPublicUrl.mockReset();
+    mockSharp.mockReset().mockImplementation(actualSharp);
   });
 
   it("is always rendered at request time", () => {
@@ -140,7 +154,7 @@ describe("/api/og-metadata/image", () => {
   });
 
   it("still rejects source images above the proxy cap", async () => {
-    mockImageResponse(51 * 1024 * 1024);
+    const cancel = mockImageResponse(51 * 1024 * 1024);
 
     const response = await GET(
       createRequest("https://d3lqz0a4bldqgf.cloudfront.net/huge.png")
@@ -150,6 +164,290 @@ describe("/api/og-metadata/image", () => {
     await expect(response.json()).resolves.toEqual({
       error: "Failed to normalize image",
     });
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels unsuccessful upstream responses", async () => {
+    const cancel = mockImageResponse(0, "text/html", Buffer.from("Missing"), 404);
+
+    const response = await GET(createRequest("https://cdn.test/missing.png"));
+
+    expect(response.status).toBe(502);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies a finite pixel limit and first-frame selection to every Sharp input", async () => {
+    for (const body of [PNG_1X1, GIF_2_FRAME]) {
+      mockImageResponse(body.byteLength, "application/octet-stream", body);
+      const response = await GET(createRequest("https://cdn.test/art"));
+      expect(response.status).toBe(200);
+    }
+
+    expect(mockSharp).toHaveBeenCalledTimes(2);
+    for (const [, options] of mockSharp.mock.calls) {
+      expect(options).toEqual({
+        limitInputPixels: 512_000_000,
+        page: 0,
+        pages: 1,
+        sequentialRead: true,
+      });
+    }
+  });
+
+  it.each([
+    { width: 32_001, height: 16_000 },
+    { width: 65_537, height: 1 },
+    { width: 1, height: 65_537 },
+    { width: 0, height: 1 },
+    { width: 1, height: Number.NaN },
+    { width: Number.POSITIVE_INFINITY, height: 1 },
+    { width: 1.5, height: 1 },
+  ])(
+    "rejects unsupported decoded dimensions before processing: %j",
+    async (dimensions) => {
+      const image = actualSharp(PNG_1X1);
+      const metadata = await image.metadata();
+      jest
+        .spyOn(image, "metadata")
+        .mockResolvedValue({ ...metadata, ...dimensions });
+      const toBuffer = jest.spyOn(image, "toBuffer");
+      mockSharp.mockReturnValueOnce(image);
+      mockImageResponse(PNG_1X1.byteLength);
+
+      const response = await GET(createRequest("https://cdn.test/art.png"));
+
+      expect(response.status).toBe(502);
+      expect(toBuffer).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    { width: 32_000, height: 16_000 },
+    { width: 65_536, height: 1 },
+    { width: 1, height: 65_536 },
+    { width: 32_000, height: 160_000, pageHeight: 16_000, pages: 10 },
+  ])(
+    "allows boundary dimensions per processed frame without allocating them: %j",
+    async (dimensions) => {
+      const image = actualSharp(PNG_1X1);
+      const metadata = await image.metadata();
+      jest
+        .spyOn(image, "metadata")
+        .mockResolvedValue({ ...metadata, ...dimensions });
+      const timeout = jest.spyOn(image, "timeout");
+      const resize = jest.spyOn(image, "resize");
+      mockSharp.mockReturnValueOnce(image);
+      mockImageResponse(PNG_1X1.byteLength);
+
+      const response = await GET(
+        createRequest("https://cdn.test/art.png", "9999")
+      );
+
+      expect(response.status).toBe(200);
+      expect(timeout).toHaveBeenCalledWith({ seconds: 7 });
+      expect(resize).toHaveBeenCalledWith(1200, 12000, {
+        fit: "inside",
+        withoutEnlargement: true,
+      });
+    }
+  );
+
+  it("rejects a tiny PNG whose header declares more than the decoded pixel budget", async () => {
+    // Valid IHDR CRC for 32,001 x 16,000; keep the tiny original IDAT because
+    // the decoder must reject the dimensions before it processes pixel data.
+    const oversizedHeader = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAfQEAAD6ACAYAAAAHE8IPAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAADUlEQVQImWP4////fwAJ+wP9CNHoHgAAAABJRU5ErkJggg==",
+      "base64"
+    );
+    await expect(
+      actualSharp(oversizedHeader, {
+        limitInputPixels: 512_000_000,
+        pages: 1,
+      }).metadata()
+    ).rejects.toThrow("Input image exceeds pixel limit");
+    mockImageResponse(oversizedHeader.byteLength, "image/png", oversizedHeader);
+
+    const response = await GET(createRequest("https://cdn.test/art.png"));
+
+    expect(response.status).toBe(502);
+  });
+
+  it("sniffs and rasterizes SVG without enlarging small artwork", async () => {
+    const svg = Buffer.from(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="12"><rect width="24" height="12" fill="red"/></svg>'
+    );
+    mockImageResponse(svg.byteLength, "application/octet-stream", svg);
+
+    const response = await GET(createRequest("https://cdn.test/art"));
+    const metadata = await actualSharp(
+      Buffer.from(await response.arrayBuffer())
+    ).metadata();
+
+    expect(response.status).toBe(200);
+    expect(metadata).toMatchObject({ format: "png", width: 24, height: 12 });
+  });
+
+  it("preserves the GIF first-frame colors in a static PNG", async () => {
+    mockImageResponse(GIF_2_FRAME.byteLength, "image/gif", GIF_2_FRAME);
+
+    const response = await GET(createRequest("https://cdn.test/art.gif"));
+    const output = actualSharp(Buffer.from(await response.arrayBuffer()));
+    expect(await output.metadata()).toMatchObject({
+      format: "png",
+      width: 2,
+      height: 2,
+    });
+    const { data, info } = await output
+      .raw()
+      .toBuffer({ resolveWithObject: true });
+    expect([...data.subarray(0, 3)]).toEqual([255, 0, 0]);
+    expect(info.width).toBe(2);
+  });
+
+  it.each([
+    {
+      inputWidth: 2,
+      inputHeight: 24_000,
+      width: "1200",
+      outputWidth: 1,
+      outputHeight: 12_000,
+    },
+    {
+      inputWidth: 2400,
+      inputHeight: 2,
+      width: "9999",
+      outputWidth: 1200,
+      outputHeight: 1,
+    },
+    {
+      inputWidth: 240,
+      inputHeight: 120,
+      width: "60",
+      outputWidth: 60,
+      outputHeight: 30,
+    },
+  ])(
+    "resizes inside both output bounds while preserving aspect ratio: %j",
+    async ({ inputWidth, inputHeight, width, outputWidth, outputHeight }) => {
+      const png = await actualSharp({
+        create: {
+          width: inputWidth,
+          height: inputHeight,
+          channels: 3,
+          background: "red",
+        },
+      })
+        .png()
+        .toBuffer();
+      mockImageResponse(png.byteLength, "image/png", png);
+
+      const response = await GET(
+        createRequest("https://cdn.test/art.png", width)
+      );
+
+      expect(response.status).toBe(200);
+      const metadata = await actualSharp(
+        Buffer.from(await response.arrayBuffer())
+      ).metadata();
+      expect(metadata).toMatchObject({
+        width: outputWidth,
+        height: outputHeight,
+      });
+    }
+  );
+
+  it("applies EXIF rotation before fitting the output bounds", async () => {
+    const jpeg = await actualSharp({
+      create: { width: 60, height: 30, channels: 3, background: "red" },
+    })
+      .withMetadata({ orientation: 6 })
+      .jpeg()
+      .toBuffer();
+    mockImageResponse(jpeg.byteLength, "image/jpeg", jpeg);
+
+    const response = await GET(createRequest("https://cdn.test/art.jpg", "15"));
+
+    expect(response.status).toBe(200);
+    expect(
+      await actualSharp(Buffer.from(await response.arrayBuffer())).metadata()
+    ).toMatchObject({
+      width: 15,
+      height: 30,
+    });
+  });
+
+  it("fails fast before downloading another image and releases admission after failure", async () => {
+    let rejectFetch: (error: Error) => void = () => {
+      throw new Error("Image fetch has not started.");
+    };
+    mockFetchPublicUrl.mockImplementationOnce(
+      () =>
+        new Promise<Response>((_resolve, reject) => {
+          rejectFetch = reject;
+        })
+    );
+    const pending = GET(createRequest("https://cdn.test/pending.png"));
+
+    try {
+      const busy = await GET(createRequest("https://cdn.test/another.png"));
+      expect(busy.status).toBe(503);
+      expect(busy.headers.get("cache-control")).toBe("no-store");
+      expect(busy.headers.get("retry-after")).toBe("1");
+      expect(mockFetchPublicUrl).toHaveBeenCalledTimes(1);
+      // Rejected requests must not release another request's admission.
+      expect(
+        (await GET(createRequest("https://cdn.test/third.png"))).status
+      ).toBe(503);
+      expect(mockFetchPublicUrl).toHaveBeenCalledTimes(1);
+    } finally {
+      rejectFetch(new Error("Upstream failed"));
+      expect((await pending).status).toBe(502);
+    }
+
+    mockImageResponse(PNG_1X1.byteLength);
+    expect(
+      (await GET(createRequest("https://cdn.test/retry.png"))).status
+    ).toBe(200);
+  });
+
+  it("holds admission until native processing completes", async () => {
+    const image = actualSharp(PNG_1X1);
+    const bufferOutput: { toBuffer: () => Promise<Buffer> } = image;
+    let finishProcessing: () => void = () => {
+      throw new Error("Image processing has not started.");
+    };
+    let processingStarted: () => void = () => {
+      throw new Error("Image processing wait has not started.");
+    };
+    const started = new Promise<void>((resolve) => {
+      processingStarted = resolve;
+    });
+    jest.spyOn(bufferOutput, "toBuffer").mockImplementationOnce(
+      () =>
+        new Promise<Buffer>((resolve) => {
+          finishProcessing = () => resolve(PNG_1X1);
+          processingStarted();
+        })
+    );
+    mockSharp.mockReturnValueOnce(image);
+    mockImageResponse(PNG_1X1.byteLength);
+    const pending = GET(createRequest("https://cdn.test/processing.png"));
+    await started;
+
+    try {
+      expect(
+        (await GET(createRequest("https://cdn.test/another.png"))).status
+      ).toBe(503);
+      expect(mockFetchPublicUrl).toHaveBeenCalledTimes(1);
+    } finally {
+      finishProcessing();
+      expect((await pending).status).toBe(200);
+    }
+
+    mockImageResponse(PNG_1X1.byteLength);
+    expect(
+      (await GET(createRequest("https://cdn.test/retry.png"))).status
+    ).toBe(200);
   });
 
   it("uses a bounded range request for oversized GIF previews", async () => {

--- a/__tests__/app/api/og-metadata.image.route.test.ts
+++ b/__tests__/app/api/og-metadata.image.route.test.ts
@@ -79,8 +79,13 @@ const GIF_2_FRAME = Buffer.from(
   "base64"
 );
 
-const createRequest = (sourceUrl: string, width = "1108"): NextRequest =>
+const createRequest = (
+  sourceUrl: string,
+  width = "1108",
+  signal?: AbortSignal
+): NextRequest =>
   ({
+    signal,
     nextUrl: new URL(
       `http://localhost:3001/api/og-metadata/image?url=${encodeURIComponent(
         sourceUrl
@@ -168,7 +173,12 @@ describe("/api/og-metadata/image", () => {
   });
 
   it("cancels unsuccessful upstream responses", async () => {
-    const cancel = mockImageResponse(0, "text/html", Buffer.from("Missing"), 404);
+    const cancel = mockImageResponse(
+      0,
+      "text/html",
+      Buffer.from("Missing"),
+      404
+    );
 
     const response = await GET(createRequest("https://cdn.test/missing.png"));
 
@@ -376,7 +386,7 @@ describe("/api/og-metadata/image", () => {
     });
   });
 
-  it("fails fast before downloading another image and releases admission after failure", async () => {
+  it("admits a waiting image after the active upstream request fails", async () => {
     let rejectFetch: (error: Error) => void = () => {
       throw new Error("Image fetch has not started.");
     };
@@ -387,32 +397,25 @@ describe("/api/og-metadata/image", () => {
         })
     );
     const pending = GET(createRequest("https://cdn.test/pending.png"));
+    mockImageResponse(PNG_1X1.byteLength);
+    const waiting = GET(createRequest("https://cdn.test/another.png"));
+    await Promise.resolve();
 
     try {
-      const busy = await GET(createRequest("https://cdn.test/another.png"));
-      expect(busy.status).toBe(503);
-      expect(busy.headers.get("cache-control")).toBe("no-store");
-      expect(busy.headers.get("retry-after")).toBe("1");
       expect(mockFetchPublicUrl).toHaveBeenCalledTimes(1);
-      // Rejected requests must not release another request's admission.
-      expect(
-        (await GET(createRequest("https://cdn.test/third.png"))).status
-      ).toBe(503);
-      expect(mockFetchPublicUrl).toHaveBeenCalledTimes(1);
+      expect(mockSharp).not.toHaveBeenCalled();
     } finally {
       rejectFetch(new Error("Upstream failed"));
       expect((await pending).status).toBe(502);
+      expect((await waiting).status).toBe(200);
     }
-
-    mockImageResponse(PNG_1X1.byteLength);
-    expect(
-      (await GET(createRequest("https://cdn.test/retry.png"))).status
-    ).toBe(200);
   });
 
-  it("holds admission until native processing completes", async () => {
+  it("normalizes simultaneous small images sequentially without overlapping downloads or decode", async () => {
     const image = actualSharp(PNG_1X1);
     const bufferOutput: { toBuffer: () => Promise<Buffer> } = image;
+    const originalToBuffer = bufferOutput.toBuffer.bind(image);
+    const workOrder: string[] = [];
     let finishProcessing: () => void = () => {
       throw new Error("Image processing has not started.");
     };
@@ -422,32 +425,123 @@ describe("/api/og-metadata/image", () => {
     const started = new Promise<void>((resolve) => {
       processingStarted = resolve;
     });
-    jest.spyOn(bufferOutput, "toBuffer").mockImplementationOnce(
-      () =>
-        new Promise<Buffer>((resolve) => {
-          finishProcessing = () => resolve(PNG_1X1);
-          processingStarted();
-        })
-    );
+    const continueProcessing = new Promise<void>((resolve) => {
+      finishProcessing = resolve;
+    });
+    jest.spyOn(bufferOutput, "toBuffer").mockImplementationOnce(async () => {
+      workOrder.push("first-decode-start");
+      processingStarted();
+      await continueProcessing;
+      const bytes = await originalToBuffer();
+      workOrder.push("first-decode-complete");
+      return bytes;
+    });
     mockSharp.mockReturnValueOnce(image);
     mockImageResponse(PNG_1X1.byteLength);
     const pending = GET(createRequest("https://cdn.test/processing.png"));
     await started;
+    mockFetchPublicUrl.mockImplementationOnce(async () => {
+      workOrder.push("second-fetch");
+      return {
+        body: createReadableBody(PNG_1X1),
+        headers: createHeaders({ "content-type": "image/png" }),
+        ok: true,
+        status: 200,
+      };
+    });
+    const waiting = GET(createRequest("https://cdn.test/another.png"));
+    await Promise.resolve();
 
     try {
-      expect(
-        (await GET(createRequest("https://cdn.test/another.png"))).status
-      ).toBe(503);
       expect(mockFetchPublicUrl).toHaveBeenCalledTimes(1);
+      expect(mockSharp).toHaveBeenCalledTimes(1);
     } finally {
       finishProcessing();
       expect((await pending).status).toBe(200);
+      const secondResponse = await waiting;
+      expect(secondResponse.status).toBe(200);
+      expect(
+        await actualSharp(
+          Buffer.from(await secondResponse.arrayBuffer())
+        ).metadata()
+      ).toMatchObject({ format: "png", width: 1, height: 1 });
     }
+    expect(workOrder).toEqual([
+      "first-decode-start",
+      "first-decode-complete",
+      "second-fetch",
+    ]);
+  });
 
+  it("bounds pending image requests and removes aborted waiters before any download", async () => {
+    let rejectFetch: (error: Error) => void = () => {
+      throw new Error("Image fetch has not started.");
+    };
+    mockFetchPublicUrl.mockImplementationOnce(
+      () =>
+        new Promise<Response>((_resolve, reject) => {
+          rejectFetch = reject;
+        })
+    );
+    const active = GET(createRequest("https://cdn.test/active.png"));
+    const controllers = Array.from({ length: 32 }, () => new AbortController());
+    const waiting = controllers.map((controller) =>
+      GET(
+        createRequest("https://cdn.test/queued.png", "1108", controller.signal)
+      )
+    );
+    await Promise.resolve();
+
+    try {
+      const full = await GET(createRequest("https://cdn.test/full.png"));
+      expect(full.status).toBe(503);
+      expect(full.headers.get("cache-control")).toBe("no-store");
+      expect(full.headers.get("retry-after")).toBe("1");
+      expect(mockFetchPublicUrl).toHaveBeenCalledTimes(1);
+      expect(mockSharp).not.toHaveBeenCalled();
+    } finally {
+      controllers.forEach((controller) => controller.abort());
+      const responses = await Promise.all(waiting);
+      expect(responses.every((response) => response.status === 503)).toBe(true);
+      rejectFetch(new Error("Upstream failed"));
+      expect((await active).status).toBe(502);
+    }
+    expect(mockFetchPublicUrl).toHaveBeenCalledTimes(1);
     mockImageResponse(PNG_1X1.byteLength);
     expect(
       (await GET(createRequest("https://cdn.test/retry.png"))).status
     ).toBe(200);
+  });
+
+  it("expires a queued image after 15 seconds without fetching it", async () => {
+    jest.useFakeTimers();
+    let rejectFetch: (error: Error) => void = () => {
+      throw new Error("Image fetch has not started.");
+    };
+    mockFetchPublicUrl.mockImplementationOnce(
+      () =>
+        new Promise<Response>((_resolve, reject) => {
+          rejectFetch = reject;
+        })
+    );
+    const active = GET(createRequest("https://cdn.test/active.png"));
+    const waiting = GET(createRequest("https://cdn.test/queued.png"));
+    await Promise.resolve();
+
+    try {
+      jest.advanceTimersByTime(15_000);
+      const response = await waiting;
+      expect(response.status).toBe(503);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      expect(response.headers.get("retry-after")).toBe("1");
+      expect(mockFetchPublicUrl).toHaveBeenCalledTimes(1);
+      expect(mockSharp).not.toHaveBeenCalled();
+      expect(jest.getTimerCount()).toBe(0);
+    } finally {
+      rejectFetch(new Error("Upstream failed"));
+      await active;
+      jest.useRealTimers();
+    }
   });
 
   it("uses a bounded range request for oversized GIF previews", async () => {

--- a/__tests__/app/api/open-graph.opensea.service.test.ts
+++ b/__tests__/app/api/open-graph.opensea.service.test.ts
@@ -8,6 +8,7 @@ jest.mock("@/config/alchemyEnv", () => ({
 describe("createOpenSeaPlan", () => {
   const fetchHtml = jest.fn();
   const assertPublicUrl = jest.fn();
+  const fetchTokenMetadata = jest.fn();
   const mockedGetAlchemyApiKey = getAlchemyApiKey as jest.MockedFunction<
     typeof getAlchemyApiKey
   >;
@@ -22,6 +23,13 @@ describe("createOpenSeaPlan", () => {
     mockFetch.mockReset();
     mockedGetAlchemyApiKey.mockReset();
     assertPublicUrl.mockResolvedValue(undefined);
+    fetchTokenMetadata.mockReset();
+    fetchTokenMetadata.mockImplementation(async (url: URL) => {
+      await assertPublicUrl(url);
+      const response = await mockFetch(url.toString());
+      if (!response.ok) throw new Error("Metadata unavailable");
+      return response.json();
+    });
     mockedGetAlchemyApiKey.mockReturnValue("test-alchemy-key");
     global.fetch = mockFetch as unknown as typeof fetch;
   });
@@ -39,6 +47,7 @@ describe("createOpenSeaPlan", () => {
       {
         fetchHtml,
         assertPublicUrl,
+        fetchTokenMetadata,
       }
     );
 
@@ -54,6 +63,7 @@ describe("createOpenSeaPlan", () => {
       {
         fetchHtml,
         assertPublicUrl,
+        fetchTokenMetadata,
       }
     );
 
@@ -66,6 +76,7 @@ describe("createOpenSeaPlan", () => {
       {
         fetchHtml,
         assertPublicUrl,
+        fetchTokenMetadata,
       }
     );
 
@@ -80,6 +91,7 @@ describe("createOpenSeaPlan", () => {
       {
         fetchHtml,
         assertPublicUrl,
+        fetchTokenMetadata,
       }
     );
 
@@ -105,6 +117,7 @@ describe("createOpenSeaPlan", () => {
     const plan = createOpenSeaPlan(new URL(url), {
       fetchHtml,
       assertPublicUrl,
+      fetchTokenMetadata,
     });
     const result = await plan?.execute();
 
@@ -147,6 +160,7 @@ describe("createOpenSeaPlan", () => {
     const plan = createOpenSeaPlan(new URL(url), {
       fetchHtml,
       assertPublicUrl,
+      fetchTokenMetadata,
     });
     const result = await plan?.execute();
 
@@ -191,6 +205,7 @@ describe("createOpenSeaPlan", () => {
     const plan = createOpenSeaPlan(new URL(url), {
       fetchHtml,
       assertPublicUrl,
+      fetchTokenMetadata,
     });
     const result = await plan?.execute();
 
@@ -260,6 +275,7 @@ describe("createOpenSeaPlan", () => {
     const plan = createOpenSeaPlan(new URL(url), {
       fetchHtml,
       assertPublicUrl,
+      fetchTokenMetadata,
     });
     const result = await plan?.execute();
 
@@ -312,6 +328,7 @@ describe("createOpenSeaPlan", () => {
       {
         fetchHtml,
         assertPublicUrl,
+        fetchTokenMetadata,
       }
     );
     const result = await plan?.execute();
@@ -363,6 +380,7 @@ describe("createOpenSeaPlan", () => {
       {
         fetchHtml,
         assertPublicUrl,
+        fetchTokenMetadata,
       }
     );
     const result = await plan?.execute();
@@ -410,6 +428,7 @@ describe("createOpenSeaPlan", () => {
       {
         fetchHtml,
         assertPublicUrl,
+        fetchTokenMetadata,
       }
     );
     const result = await plan?.execute();
@@ -455,6 +474,7 @@ describe("createOpenSeaPlan", () => {
     const plan = createOpenSeaPlan(new URL(url), {
       fetchHtml,
       assertPublicUrl,
+      fetchTokenMetadata,
     });
     const result = await plan?.execute();
 
@@ -502,6 +522,7 @@ describe("createOpenSeaPlan", () => {
     const plan = createOpenSeaPlan(new URL(url), {
       fetchHtml,
       assertPublicUrl,
+      fetchTokenMetadata,
     });
     const result = await plan?.execute();
 

--- a/__tests__/app/api/open-graph.previewCacheBudget.test.ts
+++ b/__tests__/app/api/open-graph.previewCacheBudget.test.ts
@@ -1,0 +1,167 @@
+import {
+  copyPreviewCacheEntry,
+  isPreviewCacheEntryWithinBudget,
+  PREVIEW_CACHE_MAX_ENTRY_BYTES,
+} from "@/app/api/open-graph/previewCacheBudget";
+import { serialize } from "node:v8";
+
+jest.mock("node:v8", () => {
+  const actual = jest.requireActual<typeof import("node:v8")>("node:v8");
+  return { ...actual, serialize: jest.fn(actual.serialize) };
+});
+
+describe("preview cache retention", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("copies accepted data and keys while preserving optional undefined fields", () => {
+    const image = { url: "https://images.example/art.png" };
+    const preview = {
+      title: "Artwork",
+      author: undefined,
+      image,
+      images: [image],
+    };
+    const entry = copyPreviewCacheEntry("preview", preview);
+
+    expect(entry).toEqual({ key: "preview", data: preview });
+    expect(entry?.data).not.toBe(preview);
+    expect(entry?.data.image).not.toBe(image);
+    expect(Object.hasOwn(entry?.data ?? {}, "author")).toBe(true);
+    expect(serialize).toHaveBeenCalledTimes(1);
+
+    preview.title = "Changed";
+    image.url = "https://images.example/changed.png";
+    expect(entry?.data.title).toBe("Artwork");
+    expect(entry?.data.image.url).toBe("https://images.example/art.png");
+  });
+
+  it("does not copy oversized entries", () => {
+    const preview = { image: "x".repeat(512) };
+
+    expect(copyPreviewCacheEntry("preview", preview, 512)).toBeNull();
+    expect(serialize).not.toHaveBeenCalled();
+  });
+
+  it("skips caching if an accepted entry cannot be copied", () => {
+    jest.mocked(serialize).mockImplementationOnce(() => {
+      throw new Error("Copy failed");
+    });
+
+    expect(copyPreviewCacheEntry("preview", { title: "Artwork" })).toBeNull();
+  });
+
+  it("accepts ordinary previews with optional undefined fields and shared media", () => {
+    const image = { url: "https://images.example/art.png", alt: undefined };
+    const preview = {
+      title: "Artwork",
+      description: null,
+      image,
+      images: [image],
+      width: 1200,
+      available: true,
+    };
+
+    expect(isPreviewCacheEntryWithinBudget("preview", preview, 4096)).toBe(
+      true
+    );
+  });
+
+  it("counts UTF-16 strings and the cache key at the exact small-budget boundary", () => {
+    // Entry (64), key string (64 + 2), and surrogate-pair string (64 + 4).
+    expect(isPreviewCacheEntryWithinBudget("k", "😀", 198)).toBe(true);
+    expect(isPreviewCacheEntryWithinBudget("k", "😀", 197)).toBe(false);
+    expect(isPreviewCacheEntryWithinBudget("kk", "😀", 198)).toBe(false);
+  });
+
+  it("charges undefined values without excluding normal optional fields", () => {
+    expect(isPreviewCacheEntryWithinBudget("k", undefined, 146)).toBe(true);
+    expect(isPreviewCacheEntryWithinBudget("k", undefined, 145)).toBe(false);
+  });
+
+  it.each(["title", "description", "image"])(
+    "rejects an oversized %s without copying its string",
+    (property) => {
+      const preview = { [property]: "x".repeat(PREVIEW_CACHE_MAX_ENTRY_BYTES) };
+      expect(isPreviewCacheEntryWithinBudget("preview", preview)).toBe(false);
+    }
+  );
+
+  it("counts property names and many small collection members", () => {
+    expect(
+      isPreviewCacheEntryWithinBudget("preview", { ["x".repeat(256)]: 1 }, 512)
+    ).toBe(false);
+    expect(
+      isPreviewCacheEntryWithinBudget(
+        "preview",
+        { images: Array(32).fill("") },
+        512
+      )
+    ).toBe(false);
+  });
+
+  it("rejects a sparse collection before inspecting its elements", () => {
+    const read = jest.fn();
+    const images = new Array(1_000_000);
+    Object.defineProperty(images, "0", { enumerable: true, get: read });
+
+    expect(isPreviewCacheEntryWithinBudget("preview", { images }, 512)).toBe(
+      false
+    );
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it("stops traversal as soon as the budget is exhausted", () => {
+    const read = jest.fn();
+    const preview = { title: "x".repeat(512) };
+    Object.defineProperty(preview, "image", { enumerable: true, get: read });
+
+    expect(isPreviewCacheEntryWithinBudget("preview", preview, 512)).toBe(
+      false
+    );
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it("refuses cycles and excessive nesting", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic["self"] = cyclic;
+    expect(isPreviewCacheEntryWithinBudget("preview", cyclic)).toBe(false);
+
+    let nested: unknown = "leaf";
+    for (let depth = 0; depth < 65; depth += 1) nested = { nested };
+    expect(isPreviewCacheEntryWithinBudget("preview", nested)).toBe(false);
+  });
+
+  it("refuses hidden and symbol properties that are outside plain JSON data", () => {
+    const hidden = Object.defineProperty({}, "image", { value: "art" });
+    const symbol = { [Symbol("image")]: "art" };
+    expect(isPreviewCacheEntryWithinBudget("preview", hidden)).toBe(false);
+    expect(isPreviewCacheEntryWithinBudget("preview", symbol)).toBe(false);
+  });
+
+  it("refuses accessors without executing them", () => {
+    const read = jest.fn(() => "art");
+    const preview = Object.defineProperty({}, "image", {
+      enumerable: true,
+      get: read,
+    });
+
+    expect(isPreviewCacheEntryWithinBudget("preview", preview)).toBe(false);
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it.each([new Date(0), new Map(), new Set(), () => "art", 1n, Symbol("art")])(
+    "refuses unsupported retained values",
+    (preview) => {
+      expect(isPreviewCacheEntryWithinBudget("preview", preview)).toBe(false);
+    }
+  );
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, 1.5])(
+    "rejects invalid budget %s",
+    (budget) => {
+      expect(isPreviewCacheEntryWithinBudget("preview", {}, budget)).toBe(
+        false
+      );
+    }
+  );
+});

--- a/__tests__/app/api/open-graph.route.test.ts
+++ b/__tests__/app/api/open-graph.route.test.ts
@@ -326,6 +326,7 @@ describe("open-graph API route", () => {
       favicons: [],
       image: null,
       images: [],
+      author: undefined,
     };
 
     const fetchResponse = createResponse(200, {
@@ -415,6 +416,35 @@ describe("open-graph API route", () => {
       "text/html",
       "https://cdn.safe.example/page"
     );
+  });
+
+  it.each([
+    { label: "title", data: { title: "x".repeat(128 * 1024) } },
+    {
+      label: "inline image",
+      data: { image: { url: `data:image/svg+xml,${"x".repeat(128 * 1024)}` } },
+    },
+    {
+      label: "image collection",
+      data: { images: Array.from({ length: 1000 }, () => ({ url: "art.png" })) },
+    },
+  ])("returns oversized $label previews without caching them", async ({ data }) => {
+    const execute = jest.fn().mockResolvedValue({ data });
+    opensea.createOpenSeaPlan.mockReturnValue({ cacheKey: "oversized", execute });
+    const request = {
+      nextUrl: new URL(
+        "https://app.local/api/open-graph?url=https://opensea.io/item/ethereum/art/1"
+      ),
+    } as NextRequest;
+
+    const first = await GET(request);
+    const second = await GET(request);
+
+    expect(first.status).toBe(200);
+    expect(await first.json()).toBe(data);
+    expect(second.status).toBe(200);
+    expect(await second.json()).toBe(data);
+    expect(execute).toHaveBeenCalledTimes(2);
   });
 
   it("passes through richer generic article metadata from the parser", async () => {

--- a/__tests__/app/api/open-graph.tokenUriMetadata.test.ts
+++ b/__tests__/app/api/open-graph.tokenUriMetadata.test.ts
@@ -8,13 +8,18 @@ jest.mock("undici", () => ({
 }));
 
 import { lookup } from "node:dns/promises";
+import type { LookupAddress, LookupAllOptions } from "node:dns";
 import {
   fetchTokenUriJson,
   TOKEN_URI_MAX_BYTES,
 } from "@/app/api/open-graph/tokenUriMetadata";
 import { BodyTooLargeError } from "@/lib/fetch/limitedBody";
 
-const mockLookup = jest.mocked(lookup);
+const lookupAll: (
+  hostname: string,
+  options: LookupAllOptions
+) => Promise<LookupAddress[]> = lookup;
+const mockLookup = jest.mocked(lookupAll);
 const url = new URL("https://metadata.example/nft/1");
 
 describe("NFT metadata transport", () => {
@@ -103,7 +108,37 @@ describe("NFT metadata transport", () => {
     await expect(fetchTokenUriJson(url, {})).rejects.toBeInstanceOf(
       BodyTooLargeError
     );
-    expect(reads).toBe(65);
+    expect(reads).toBe(Math.floor(TOKEN_URI_MAX_BYTES / chunk.byteLength) + 1);
     expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds simultaneous reads and recovers when the admitted body completes", async () => {
+    const stream = new TransformStream<Uint8Array, Uint8Array>();
+    const writer = stream.writable.getWriter();
+    mockFetch.mockResolvedValueOnce(new Response(stream.readable));
+    const admitted = fetchTokenUriJson(url, {});
+    await expect(fetchTokenUriJson(url, {})).rejects.toThrow(
+      "processing is busy"
+    );
+    await expect(fetchTokenUriJson(url, {})).rejects.toThrow(
+      "processing is busy"
+    );
+    await writer.write(new TextEncoder().encode('{"name":"Artwork"}'));
+    await writer.close();
+    await expect(admitted).resolves.toEqual({ name: "Artwork" });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    mockFetch.mockResolvedValueOnce(new Response('{"name":"Next artwork"}'));
+    await expect(fetchTokenUriJson(url, {})).resolves.toEqual({
+      name: "Next artwork",
+    });
+  });
+
+  it("releases metadata admission after a failed fetch", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("upstream unavailable"));
+    await expect(fetchTokenUriJson(url, {})).rejects.toThrow();
+    mockFetch.mockResolvedValueOnce(new Response('{"name":"Artwork"}'));
+    await expect(fetchTokenUriJson(url, {})).resolves.toEqual({
+      name: "Artwork",
+    });
   });
 });

--- a/__tests__/app/api/open-graph.tokenUriMetadata.test.ts
+++ b/__tests__/app/api/open-graph.tokenUriMetadata.test.ts
@@ -112,25 +112,22 @@ describe("NFT metadata transport", () => {
     expect(cancel).toHaveBeenCalledTimes(1);
   });
 
-  it("bounds simultaneous reads and recovers when the admitted body completes", async () => {
+  it("waits for the active metadata body before fetching the next preview", async () => {
     const stream = new TransformStream<Uint8Array, Uint8Array>();
     const writer = stream.writable.getWriter();
-    mockFetch.mockResolvedValueOnce(new Response(stream.readable));
+    mockFetch
+      .mockResolvedValueOnce(new Response(stream.readable))
+      .mockResolvedValueOnce(new Response('{"name":"Next artwork"}'));
     const admitted = fetchTokenUriJson(url, {});
-    await expect(fetchTokenUriJson(url, {})).rejects.toThrow(
-      "processing is busy"
-    );
-    await expect(fetchTokenUriJson(url, {})).rejects.toThrow(
-      "processing is busy"
-    );
+    const queued = fetchTokenUriJson(url, {});
     await writer.write(new TextEncoder().encode('{"name":"Artwork"}'));
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     await writer.close();
     await expect(admitted).resolves.toEqual({ name: "Artwork" });
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    mockFetch.mockResolvedValueOnce(new Response('{"name":"Next artwork"}'));
-    await expect(fetchTokenUriJson(url, {})).resolves.toEqual({
+    await expect(queued).resolves.toEqual({
       name: "Next artwork",
     });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
   it("releases metadata admission after a failed fetch", async () => {

--- a/__tests__/app/api/open-graph.tokenUriMetadata.test.ts
+++ b/__tests__/app/api/open-graph.tokenUriMetadata.test.ts
@@ -1,0 +1,109 @@
+/** @jest-environment node */
+
+jest.mock("node:dns/promises", () => ({ lookup: jest.fn() }));
+const mockFetch = jest.fn();
+jest.mock("undici", () => ({
+  Agent: jest.fn(() => ({ dispatch: jest.fn() })),
+  fetch: (...args: unknown[]) => mockFetch(...args),
+}));
+
+import { lookup } from "node:dns/promises";
+import {
+  fetchTokenUriJson,
+  TOKEN_URI_MAX_BYTES,
+} from "@/app/api/open-graph/tokenUriMetadata";
+import { BodyTooLargeError } from "@/lib/fetch/limitedBody";
+
+const mockLookup = jest.mocked(lookup);
+const url = new URL("https://metadata.example/nft/1");
+
+describe("NFT metadata transport", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockLookup.mockReset();
+    mockLookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+  });
+
+  it("accepts public metadata with a missing or unconventional MIME type", async () => {
+    mockFetch.mockResolvedValue(
+      new Response('{"image":"ipfs://art","name":"Artwork"}', {
+        headers: { "content-type": "application/octet-stream" },
+      })
+    );
+    await expect(fetchTokenUriJson(url, {})).resolves.toEqual({
+      image: "ipfs://art",
+      name: "Artwork",
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      url.toString(),
+      expect.objectContaining({ redirect: "manual" })
+    );
+  });
+
+  it("rejects redirect destinations on private networks before fetching them", async () => {
+    const cancel = jest.fn();
+    mockFetch.mockResolvedValue(
+      new Response(new ReadableStream({ cancel }), {
+        status: 302,
+        headers: { location: "http://169.254.169.254/latest/meta-data/" },
+      })
+    );
+    await expect(fetchTokenUriJson(url, {})).rejects.toMatchObject({
+      kind: "ip-not-allowed",
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies the preview host policy again on each redirect", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://publicly-resolving.internal/metadata" },
+      })
+    );
+    await expect(
+      fetchTokenUriJson(url, { policy: { blockedHostSuffixes: [".internal"] } })
+    ).rejects.toMatchObject({ kind: "host-not-allowed" });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels an oversized declared body before reading any metadata", async () => {
+    const cancel = jest.fn();
+    mockFetch.mockResolvedValue(
+      new Response(new ReadableStream({ cancel }), {
+        headers: { "content-length": String(TOKEN_URI_MAX_BYTES + 1) },
+      })
+    );
+    await expect(fetchTokenUriJson(url, {})).rejects.toBeInstanceOf(
+      BodyTooLargeError
+    );
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("counts decompressed stream bytes even when the server declares a tiny length", async () => {
+    const cancel = jest.fn();
+    const chunk = new TextEncoder().encode(" ".repeat(1024 * 1024));
+    let reads = 0;
+    mockFetch.mockResolvedValue(
+      new Response(
+        new ReadableStream(
+          {
+            pull(controller) {
+              reads += 1;
+              controller.enqueue(chunk);
+            },
+            cancel,
+          },
+          { highWaterMark: 0 }
+        ),
+        { headers: { "content-length": "1", "content-encoding": "gzip" } }
+      )
+    );
+    await expect(fetchTokenUriJson(url, {})).rejects.toBeInstanceOf(
+      BodyTooLargeError
+    );
+    expect(reads).toBe(65);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/app/api/open-graph.transient.service.test.ts
+++ b/__tests__/app/api/open-graph.transient.service.test.ts
@@ -8,6 +8,7 @@ jest.mock("@/config/alchemyEnv", () => ({
 describe("createTransientPlan", () => {
   const fetchHtml = jest.fn();
   const assertPublicUrl = jest.fn();
+  const fetchTokenMetadata = jest.fn();
   const mockedGetAlchemyApiKey = getAlchemyApiKey as jest.MockedFunction<
     typeof getAlchemyApiKey
   >;
@@ -22,6 +23,13 @@ describe("createTransientPlan", () => {
     mockFetch.mockReset();
     mockedGetAlchemyApiKey.mockReset();
     assertPublicUrl.mockResolvedValue(undefined);
+    fetchTokenMetadata.mockReset();
+    fetchTokenMetadata.mockImplementation(async (url: URL) => {
+      await assertPublicUrl(url);
+      const response = await mockFetch(url.toString());
+      if (!response.ok) throw new Error("Metadata unavailable");
+      return response.json();
+    });
     mockedGetAlchemyApiKey.mockReturnValue("test-alchemy-key");
     global.fetch = mockFetch as unknown as typeof fetch;
   });
@@ -48,6 +56,7 @@ describe("createTransientPlan", () => {
       createTransientPlan(new URL("https://www.transient.xyz/about"), {
         fetchHtml,
         assertPublicUrl,
+        fetchTokenMetadata,
       })
     ).toBeNull();
     expect(
@@ -58,6 +67,7 @@ describe("createTransientPlan", () => {
         {
           fetchHtml,
           assertPublicUrl,
+          fetchTokenMetadata,
         }
       )
     ).toBeNull();
@@ -83,6 +93,7 @@ describe("createTransientPlan", () => {
     const plan = createTransientPlan(new URL(url), {
       fetchHtml,
       assertPublicUrl,
+      fetchTokenMetadata,
     });
     const result = await plan?.execute();
 
@@ -140,6 +151,7 @@ describe("createTransientPlan", () => {
     const plan = createTransientPlan(new URL(url), {
       fetchHtml,
       assertPublicUrl,
+      fetchTokenMetadata,
     });
     const result = await plan?.execute();
 
@@ -193,6 +205,7 @@ describe("createTransientPlan", () => {
     const plan = createTransientPlan(new URL(url), {
       fetchHtml,
       assertPublicUrl,
+      fetchTokenMetadata,
     });
     const result = await plan?.execute();
 
@@ -235,6 +248,7 @@ describe("createTransientPlan", () => {
     const plan = createTransientPlan(new URL(url), {
       fetchHtml,
       assertPublicUrl,
+      fetchTokenMetadata,
     });
     const result = await plan?.execute();
 
@@ -281,6 +295,7 @@ describe("createTransientPlan", () => {
     const plan = createTransientPlan(new URL(url), {
       fetchHtml,
       assertPublicUrl,
+      fetchTokenMetadata,
     });
     const result = await plan?.execute();
 
@@ -319,6 +334,7 @@ describe("createTransientPlan", () => {
     const plan = createTransientPlan(new URL(url), {
       fetchHtml,
       assertPublicUrl,
+      fetchTokenMetadata,
     });
     const result = await plan?.execute();
 

--- a/__tests__/app/api/open-graph.transient.service.test.ts
+++ b/__tests__/app/api/open-graph.transient.service.test.ts
@@ -44,7 +44,7 @@ describe("createTransientPlan", () => {
       new URL(
         "https://www.transient.xyz/nfts/ethereum/0xda48f4db41415fc2873efb487eec1068626fad60/7"
       ),
-      { fetchHtml, assertPublicUrl }
+      { fetchHtml, assertPublicUrl, fetchTokenMetadata }
     );
 
     expect(plan).not.toBeNull();

--- a/__tests__/app/openMobile.test.tsx
+++ b/__tests__/app/openMobile.test.tsx
@@ -1,4 +1,5 @@
 import OpenMobilePage from "@/app/open-mobile/page";
+import { MOBILE_APP_ANDROID, MOBILE_APP_IOS } from "@/constants/constants";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useSearchParams } from "next/navigation";
@@ -30,5 +31,111 @@ describe("OpenMobilePage", () => {
 
     await userEvent.click(screen.getByText("Back to 6529.io"));
     expect(openSpy).toHaveBeenCalledWith("http://localhost/foo-bar", "_self");
+  });
+
+  it.each([false, true])(
+    "preserves route query and hash with extra whole-path encoding: %s",
+    async (extraEncoding) => {
+      const destination =
+        "/waves/123?drop=456&search=a%26b%23c&next=%2F%2Fexample.com#drop-456";
+      const path = extraEncoding
+        ? encodeURIComponent(destination)
+        : destination;
+      useSearchParamsMock.mockReturnValue(new URLSearchParams({ path }));
+
+      render(<OpenMobilePage />);
+
+      await waitFor(() => {
+        expect(openSpy).toHaveBeenCalledWith(
+          `testmobile6529://navigate${destination}`,
+          "_self"
+        );
+      });
+      await userEvent.click(
+        screen.getByRole("button", { name: "Back to 6529.io" })
+      );
+      expect(openSpy).toHaveBeenLastCalledWith(
+        `http://localhost${destination}`,
+        "_self"
+      );
+    }
+  );
+
+  it.each([
+    null,
+    "",
+    "/bad%",
+    "%E0%A4%A",
+    "//example.com/path",
+    "%2F%2Fexample.com/path",
+    "/%2Fexample.com/path",
+    "@example.com/path",
+    ".example.com/path",
+    "/\\example.com/path",
+    "/waves/..//example.com/path",
+  ])(
+    "returns home without an app handoff for invalid path %j",
+    async (path) => {
+      useSearchParamsMock.mockReturnValue(
+        new URLSearchParams(path === null ? {} : { path })
+      );
+
+      render(<OpenMobilePage />);
+
+      expect(openSpy).not.toHaveBeenCalled();
+      await userEvent.click(
+        screen.getByRole("button", { name: "Back to 6529.io" })
+      );
+      expect(openSpy).toHaveBeenCalledTimes(1);
+      expect(openSpy).toHaveBeenLastCalledWith("http://localhost/", "_self");
+    }
+  );
+
+  it.each([null, "/bad%", "//example.com/path"])(
+    "discards the previous valid destination when path changes to %j",
+    async (path) => {
+      const { rerender } = render(<OpenMobilePage />);
+      await waitFor(() => {
+        expect(openSpy).toHaveBeenCalledWith(
+          "testmobile6529://navigate/foo-bar",
+          "_self"
+        );
+      });
+      openSpy.mockClear();
+      useSearchParamsMock.mockReturnValue(
+        new URLSearchParams(path === null ? {} : { path })
+      );
+
+      rerender(<OpenMobilePage />);
+
+      expect(openSpy).not.toHaveBeenCalled();
+      await userEvent.click(
+        screen.getByRole("button", { name: "Back to 6529.io" })
+      );
+      expect(openSpy).toHaveBeenCalledTimes(1);
+      expect(openSpy).toHaveBeenLastCalledWith("http://localhost/", "_self");
+    }
+  );
+
+  it.each([
+    { userAgent: "iPhone", expected: [MOBILE_APP_IOS] },
+    { userAgent: "Android", expected: [MOBILE_APP_ANDROID] },
+    { userAgent: "Desktop", expected: [MOBILE_APP_IOS, MOBILE_APP_ANDROID] },
+  ])("preserves store actions for $userAgent", ({ userAgent, expected }) => {
+    const userAgentSpy = jest
+      .spyOn(navigator, "userAgent", "get")
+      .mockReturnValue(userAgent);
+    useSearchParamsMock.mockReturnValue(new URLSearchParams());
+
+    try {
+      render(<OpenMobilePage />);
+      const links = screen.getAllByRole("link");
+      expect(links.map((link) => link.getAttribute("href"))).toEqual(expected);
+      for (const link of links) {
+        expect(link).toHaveAttribute("target", "_self");
+      }
+    } finally {
+      userAgentSpy.mockRestore();
+    }
   });
 });

--- a/__tests__/app/openMobileDestination.test.ts
+++ b/__tests__/app/openMobileDestination.test.ts
@@ -1,0 +1,64 @@
+import { getMobileDestination } from "@/app/open-mobile/mobileDestination";
+
+const ORIGIN = "https://6529.io";
+
+describe("getMobileDestination", () => {
+  it.each([
+    ["/", "/"],
+    ["/waves/123?drop=456#part-2", "/waves/123?drop=456#part-2"],
+    ["/waves/../the-memes/1", "/the-memes/1"],
+    ["/waves/%2e%2e/the-memes/1", "/the-memes/1"],
+    [
+      "/search?q=100%25&value=a%26b%3Dc%23d",
+      "/search?q=100%25&value=a%26b%3Dc%23d",
+    ],
+    [
+      "/search?q=%2F%2Fexample.com&next=%5Cexample",
+      "/search?q=%2F%2Fexample.com&next=%5Cexample",
+    ],
+    [
+      "/some%20profile?query=a+b#part%202",
+      "/some%20profile?query=a+b#part%202",
+    ],
+    ["/café?locale=fr-FR", "/caf%C3%A9?locale=fr-FR"],
+    ["%2Fwaves%2F123%3Fdrop%3D456%23part-2", "/waves/123?drop=456#part-2"],
+  ])("canonicalizes %s to %s", (path, expected) => {
+    expect(getMobileDestination(path, ORIGIN)).toBe(expected);
+  });
+
+  it.each([
+    null,
+    "",
+    "waves/123",
+    "https://example.com/path",
+    "https://6529.io/waves/123",
+    "javascript:alert(1)",
+    "@example.com/path",
+    "%40example.com/path",
+    ".example.com/path",
+    "%2Eexample.com/path",
+    "//example.com/path",
+    "%2F%2Fexample.com/path",
+    "%252F%252Fexample.com/path",
+    "/%2fexample.com/path",
+    "/\\example.com/path",
+    "/%5cexample.com/path",
+    "\\\\example.com/path",
+    "/waves\n/123",
+    "/waves%0a/123",
+    "/waves%00/123",
+    "/waves%7f/123",
+    "/bad%",
+    "/bad%2",
+    "/bad%GG",
+    "/bad%E0%A4%A",
+    "%E0%A4%A",
+    "/search?q=bad%",
+    "/waves#bad%",
+    "/waves/..//example.com/path",
+    "/waves/%2e%2e//example.com/path",
+    "/waves/%2e%2e%2f/example.com/path",
+  ])("rejects invalid destination %j", (path) => {
+    expect(getMobileDestination(path, ORIGIN)).toBeNull();
+  });
+});

--- a/__tests__/lib/fetch/admissionQueue.test.ts
+++ b/__tests__/lib/fetch/admissionQueue.test.ts
@@ -1,0 +1,155 @@
+import {
+  AdmissionQueue,
+  AdmissionQueueError,
+} from "@/lib/fetch/admissionQueue";
+
+describe("AdmissionQueue", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("admits one caller at a time in FIFO order", async () => {
+    const queue = new AdmissionQueue({ maxPending: 2, waitMs: 100 });
+    const order: number[] = [];
+    const releaseFirst = await queue.acquire();
+    const second = queue.acquire().then((release) => {
+      order.push(2);
+      return release;
+    });
+    const third = queue.acquire().then((release) => {
+      order.push(3);
+      return release;
+    });
+    await Promise.resolve();
+    expect(order).toEqual([]);
+
+    releaseFirst();
+    const releaseSecond = await second;
+    expect(order).toEqual([2]);
+    releaseSecond();
+    const releaseThird = await third;
+    expect(order).toEqual([2, 3]);
+    releaseThird();
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("rejects excess pending callers without releasing the active caller", async () => {
+    const queue = new AdmissionQueue({ maxPending: 1, waitMs: 100 });
+    const releaseFirst = await queue.acquire();
+    let admittedSecond = false;
+    const second = queue.acquire().then((release) => {
+      admittedSecond = true;
+      return release;
+    });
+
+    await expect(queue.acquire()).rejects.toMatchObject({
+      name: "AdmissionQueueError",
+      kind: "full",
+    });
+    expect(admittedSecond).toBe(false);
+    releaseFirst();
+    (await second)();
+    (await queue.acquire())();
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("expires a waiter and frees its queue capacity and abort listener", async () => {
+    const queue = new AdmissionQueue({ maxPending: 1, waitMs: 20 });
+    const releaseFirst = await queue.acquire();
+    const controller = new AbortController();
+    const removeListener = jest.spyOn(controller.signal, "removeEventListener");
+    const expired = queue
+      .acquire(controller.signal)
+      .catch((error: unknown) => error);
+    jest.advanceTimersByTime(20);
+
+    expect(await expired).toMatchObject({ kind: "timeout" });
+    expect(removeListener).toHaveBeenCalledWith("abort", expect.any(Function));
+    expect(jest.getTimerCount()).toBe(0);
+    const replacement = queue.acquire();
+    releaseFirst();
+    (await replacement)();
+  });
+
+  it("removes an aborted waiter while preserving the next caller's turn", async () => {
+    const queue = new AdmissionQueue({ maxPending: 2, waitMs: 100 });
+    const releaseFirst = await queue.acquire();
+    const controller = new AbortController();
+    const removeListener = jest.spyOn(controller.signal, "removeEventListener");
+    const aborted = queue
+      .acquire(controller.signal)
+      .catch((error: unknown) => error);
+    const next = queue.acquire();
+    controller.abort();
+
+    expect(await aborted).toBeInstanceOf(AdmissionQueueError);
+    expect(await aborted).toMatchObject({ kind: "aborted" });
+    expect(removeListener).toHaveBeenCalledWith("abort", expect.any(Function));
+    expect(jest.getTimerCount()).toBe(1);
+    releaseFirst();
+    (await next)();
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("does not reserve a slot for an already aborted request", async () => {
+    const queue = new AdmissionQueue({ maxPending: 0, waitMs: 100 });
+    const controller = new AbortController();
+    controller.abort();
+    await expect(queue.acquire(controller.signal)).rejects.toMatchObject({
+      kind: "aborted",
+    });
+    (await queue.acquire())();
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("keeps granted ownership until release, including repeated release and abort", async () => {
+    const queue = new AdmissionQueue({ maxPending: 2, waitMs: 100 });
+    const releaseFirst = await queue.acquire();
+    const controller = new AbortController();
+    const removeListener = jest.spyOn(controller.signal, "removeEventListener");
+    const second = queue.acquire(controller.signal);
+    releaseFirst();
+    const releaseSecond = await second;
+    let admittedThird = false;
+    const third = queue.acquire().then((release) => {
+      admittedThird = true;
+      return release;
+    });
+
+    releaseFirst();
+    controller.abort();
+    await Promise.resolve();
+    expect(admittedThird).toBe(false);
+    expect(removeListener).toHaveBeenCalledWith("abort", expect.any(Function));
+    releaseSecond();
+    (await third)();
+    releaseSecond();
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("rejects elapsed deadlines even before a delayed timer callback runs", async () => {
+    const queue = new AdmissionQueue({ maxPending: 1, waitMs: 100 });
+    const release = await queue.acquire();
+    const pending = queue.acquire().catch((error: unknown) => error);
+    jest.setSystemTime(Date.now() + 100);
+    release();
+
+    expect(await pending).toMatchObject({ kind: "timeout" });
+    expect(jest.getTimerCount()).toBe(0);
+    (await queue.acquire())();
+  });
+
+  it.each([
+    { maxPending: -1, waitMs: 100 },
+    { maxPending: 1.5, waitMs: 100 },
+    { maxPending: 1, waitMs: 0 },
+    { maxPending: 1, waitMs: Number.POSITIVE_INFINITY },
+    { maxPending: 1, waitMs: 2_147_483_648 },
+  ])("rejects invalid bounds: %j", (options) => {
+    expect(() => new AdmissionQueue(options)).toThrow(RangeError);
+  });
+});

--- a/__tests__/lib/security/urlGuard.deadline.test.ts
+++ b/__tests__/lib/security/urlGuard.deadline.test.ts
@@ -8,9 +8,14 @@ jest.mock("undici", () => ({
 }));
 
 import { lookup } from "node:dns/promises";
+import type { LookupAddress, LookupAllOptions } from "node:dns";
 import { fetchPublicUrl } from "@/lib/security/urlGuard";
 
-const mockLookup = jest.mocked(lookup);
+const lookupAll: (
+  hostname: string,
+  options: LookupAllOptions
+) => Promise<LookupAddress[]> = lookup;
+const mockLookup = jest.mocked(lookupAll);
 const options = { timeoutMs: 100, revalidateFinalUrl: false };
 
 describe("public fetch deadline", () => {
@@ -22,6 +27,34 @@ describe("public fetch deadline", () => {
   });
 
   afterEach(() => jest.useRealTimers());
+
+  it("does not start DNS or fetch for an already cancelled caller", async () => {
+    const caller = new AbortController();
+    const reason = new Error("caller disconnected");
+    caller.abort(reason);
+    await expect(
+      fetchPublicUrl("https://example.com", { signal: caller.signal }, options)
+    ).rejects.toBe(reason);
+    expect(mockLookup).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("cleans up when the upstream body fails", async () => {
+    const reason = new Error("upstream disconnected");
+    mockFetch.mockResolvedValue(
+      new Response(
+        new ReadableStream({
+          pull(controller) {
+            controller.error(reason);
+          },
+        })
+      )
+    );
+    const response = await fetchPublicUrl("https://example.com", {}, options);
+    await expect(response.text()).rejects.toBe(reason);
+    expect(jest.getTimerCount()).toBe(0);
+  });
 
   it("ends a body that stalls after headers and cancels the upstream reader", async () => {
     const cancel = jest.fn();

--- a/__tests__/lib/security/urlGuard.deadline.test.ts
+++ b/__tests__/lib/security/urlGuard.deadline.test.ts
@@ -1,0 +1,111 @@
+/** @jest-environment node */
+
+jest.mock("node:dns/promises", () => ({ lookup: jest.fn() }));
+const mockFetch = jest.fn();
+jest.mock("undici", () => ({
+  Agent: jest.fn(() => ({ dispatch: jest.fn() })),
+  fetch: (...args: unknown[]) => mockFetch(...args),
+}));
+
+import { lookup } from "node:dns/promises";
+import { fetchPublicUrl } from "@/lib/security/urlGuard";
+
+const mockLookup = jest.mocked(lookup);
+const options = { timeoutMs: 100, revalidateFinalUrl: false };
+
+describe("public fetch deadline", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockFetch.mockReset();
+    mockLookup.mockReset();
+    mockLookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+  });
+
+  afterEach(() => jest.useRealTimers());
+
+  it("ends a body that stalls after headers and cancels the upstream reader", async () => {
+    const cancel = jest.fn();
+    mockFetch.mockResolvedValue(new Response(new ReadableStream({ cancel })));
+    const response = await fetchPublicUrl("https://example.com", {}, options);
+    const forwarded = new Response(response.body);
+    const result = expect(forwarded.text()).rejects.toMatchObject({
+      kind: "timeout",
+    });
+    await jest.advanceTimersByTimeAsync(101);
+    await result;
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("bounds DNS lookup before opening a connection", async () => {
+    mockLookup.mockReturnValue(new Promise(() => {}));
+    const result = expect(
+      fetchPublicUrl("https://example.com", {}, options)
+    ).rejects.toMatchObject({ kind: "timeout" });
+    await jest.advanceTimersByTimeAsync(101);
+    await result;
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("keeps caller cancellation connected after headers", async () => {
+    const caller = new AbortController();
+    const reason = new Error("caller disconnected");
+    mockFetch.mockResolvedValue(new Response(new ReadableStream()));
+    const response = await fetchPublicUrl(
+      "https://example.com",
+      { signal: caller.signal },
+      options
+    );
+    const result = expect(response.arrayBuffer()).rejects.toBe(reason);
+    caller.abort(reason);
+    await result;
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("streams promptly and preserves response identity metadata through clones", async () => {
+    const upstream = new Response("preview", {
+      status: 201,
+      headers: { "x-preview": "yes" },
+    });
+    Object.defineProperty(upstream, "url", {
+      value: "https://example.com/final",
+    });
+    mockFetch.mockResolvedValue(upstream);
+    const response = await fetchPublicUrl("https://example.com", {}, options);
+    const clone = response.clone();
+    expect(clone.url).toBe(upstream.url);
+    expect(response.status).toBe(201);
+    expect(response.headers.get("x-preview")).toBe("yes");
+    await expect(response.text()).resolves.toBe("preview");
+    await expect(clone.text()).resolves.toBe("preview");
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("releases the deadline and upstream when the consumer cancels", async () => {
+    const cancel = jest.fn();
+    mockFetch.mockResolvedValue(new Response(new ReadableStream({ cancel })));
+    const response = await fetchPublicUrl("https://example.com", {}, options);
+    await response.body?.cancel();
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("uses one time budget across redirects and cancels discarded bodies", async () => {
+    const cancel = jest.fn();
+    mockFetch
+      .mockImplementationOnce(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 60));
+        return new Response(new ReadableStream({ cancel }), {
+          status: 302,
+          headers: { location: "https://cdn.example.com/image" },
+        });
+      })
+      .mockImplementationOnce(() => new Promise(() => {}));
+    const result = expect(
+      fetchPublicUrl("https://example.com", {}, options)
+    ).rejects.toMatchObject({ kind: "timeout" });
+    await jest.advanceTimersByTimeAsync(101);
+    await result;
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/api/og-metadata/image/route.ts
+++ b/app/api/og-metadata/image/route.ts
@@ -6,13 +6,19 @@ import {
 } from "@/lib/security/urlGuard";
 import { OG_IMAGE_PROXY_MAX_BYTES } from "@/app/api/og-metadata/_lib/imageProxyPolicy";
 import { NextResponse, type NextRequest } from "next/server";
-import sharp, { type Sharp } from "sharp";
+import sharp, { type Metadata } from "sharp";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 const DEFAULT_WIDTH = 1200;
 const MAX_WIDTH = 1200;
+const MAX_HEIGHT = 12000;
+const MAX_INPUT_PIXELS = 512_000_000;
+const MAX_INPUT_DIMENSION = 65_536;
+// Admit before fetching to bound both compressed buffers and native image work.
+// Do not queue requests while the process is already handling a large image.
+let imageRequestActive = false;
 const OVERSIZED_GIF_PREVIEW_MAX_BYTES = 8 * 1024 * 1024;
 const PNG_CONTENT_TYPE = "image/png";
 const GIF_CONTENT_TYPE = "image/gif";
@@ -215,6 +221,7 @@ const fetchImageBuffer = async (url: URL): Promise<Buffer> => {
   );
 
   if (!response.ok) {
+    await cancelResponseBody(response);
     throw new Error(`Image request failed: ${response.status}`);
   }
 
@@ -226,7 +233,12 @@ const fetchImageBuffer = async (url: URL): Promise<Buffer> => {
   }
 
   if (contentLength !== null) {
-    ensureAllowedImageSize(contentLength);
+    try {
+      ensureAllowedImageSize(contentLength);
+    } catch (error) {
+      await cancelResponseBody(response);
+      throw error;
+    }
   }
 
   return readImageResponseBuffer(response);
@@ -298,36 +310,40 @@ const normalizeImageToPng = async ({
     throw new Error("Upstream response is not an image.");
   }
 
-  const image =
-    detectedContentType === GIF_CONTENT_TYPE
-      ? await createGifPreviewImage(buffer)
-      : sharp(buffer, {
-          limitInputPixels: false,
-          pages: 1,
-          sequentialRead: true,
-        });
+  const image = sharp(buffer, {
+    limitInputPixels: MAX_INPUT_PIXELS,
+    page: 0,
+    pages: 1,
+    sequentialRead: true,
+  }).timeout({ seconds: 7 });
+  // Read only the first frame, so animation length does not consume the pixel
+  // budget. Sharp enforces its finite pixel limit while opening this metadata.
+  ensureAllowedImageDimensions(await image.metadata());
 
   return image
-    .timeout({ seconds: 7 })
     .rotate()
-    .resize(width, undefined, { withoutEnlargement: true })
+    .resize(width, MAX_HEIGHT, {
+      fit: "inside",
+      withoutEnlargement: true,
+    })
     .png({ quality: 100 })
     .toBuffer();
 };
 
-const createGifPreviewImage = async (buffer: Buffer): Promise<Sharp> => {
-  await sharp(buffer, {
-    animated: true,
-    limitInputPixels: false,
-    sequentialRead: true,
-  }).metadata();
-
-  return sharp(buffer, {
-    limitInputPixels: false,
-    page: 0,
-    pages: 1,
-    sequentialRead: true,
-  });
+const ensureAllowedImageDimensions = (metadata: Metadata): void => {
+  const width = metadata.width;
+  const height = metadata.pageHeight ?? metadata.height;
+  if (
+    !Number.isSafeInteger(width) ||
+    !Number.isSafeInteger(height) ||
+    width < 1 ||
+    height < 1 ||
+    width > MAX_INPUT_DIMENSION ||
+    height > MAX_INPUT_DIMENSION ||
+    width * height > MAX_INPUT_PIXELS
+  ) {
+    throw new Error("Image dimensions exceeded supported limits.");
+  }
 };
 
 const parseImageUrl = (value: string | null): URL => {
@@ -337,9 +353,21 @@ const parseImageUrl = (value: string | null): URL => {
 };
 
 export async function GET(request: NextRequest) {
+  let admitted = false;
   try {
     const imageUrl = parseImageUrl(request.nextUrl.searchParams.get("url"));
     const width = parseWidth(request.nextUrl.searchParams.get("w"));
+    if (imageRequestActive) {
+      return NextResponse.json(
+        { error: "Image processing busy" },
+        {
+          status: 503,
+          headers: { "Cache-Control": "no-store", "Retry-After": "1" },
+        }
+      );
+    }
+    imageRequestActive = true;
+    admitted = true;
     const buffer = await fetchImageBuffer(imageUrl);
     const png = await normalizeImageToPng({ buffer, width });
 
@@ -352,5 +380,9 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     console.error("Unable to normalize OG metadata image.", error);
     return mapErrorToResponse(error);
+  } finally {
+    if (admitted) {
+      imageRequestActive = false;
+    }
   }
 }

--- a/app/api/og-metadata/image/route.ts
+++ b/app/api/og-metadata/image/route.ts
@@ -5,6 +5,10 @@ import {
   type FetchPublicUrlOptions,
 } from "@/lib/security/urlGuard";
 import { OG_IMAGE_PROXY_MAX_BYTES } from "@/app/api/og-metadata/_lib/imageProxyPolicy";
+import {
+  AdmissionQueue,
+  AdmissionQueueError,
+} from "@/lib/fetch/admissionQueue";
 import { NextResponse, type NextRequest } from "next/server";
 import sharp, { type Metadata } from "sharp";
 
@@ -17,8 +21,8 @@ const MAX_HEIGHT = 12000;
 const MAX_INPUT_PIXELS = 512_000_000;
 const MAX_INPUT_DIMENSION = 65_536;
 // Admit before fetching to bound both compressed buffers and native image work.
-// Do not queue requests while the process is already handling a large image.
-let imageRequestActive = false;
+// Ordinary multi-image cards can wait briefly without allocating image buffers.
+const imageAdmission = new AdmissionQueue({ maxPending: 32, waitMs: 15_000 });
 const OVERSIZED_GIF_PREVIEW_MAX_BYTES = 8 * 1024 * 1024;
 const PNG_CONTENT_TYPE = "image/png";
 const GIF_CONTENT_TYPE = "image/gif";
@@ -155,6 +159,15 @@ const cancelResponseBody = async (response: Response): Promise<void> => {
 };
 
 const mapErrorToResponse = (error: unknown): NextResponse => {
+  if (error instanceof AdmissionQueueError) {
+    return NextResponse.json(
+      { error: "Image processing busy" },
+      {
+        status: 503,
+        headers: { "Cache-Control": "no-store", "Retry-After": "1" },
+      }
+    );
+  }
   if (error instanceof UrlGuardError) {
     switch (error.kind) {
       case "missing-url":
@@ -353,21 +366,11 @@ const parseImageUrl = (value: string | null): URL => {
 };
 
 export async function GET(request: NextRequest) {
-  let admitted = false;
+  let releaseAdmission: (() => void) | undefined;
   try {
     const imageUrl = parseImageUrl(request.nextUrl.searchParams.get("url"));
     const width = parseWidth(request.nextUrl.searchParams.get("w"));
-    if (imageRequestActive) {
-      return NextResponse.json(
-        { error: "Image processing busy" },
-        {
-          status: 503,
-          headers: { "Cache-Control": "no-store", "Retry-After": "1" },
-        }
-      );
-    }
-    imageRequestActive = true;
-    admitted = true;
+    releaseAdmission = await imageAdmission.acquire(request.signal);
     const buffer = await fetchImageBuffer(imageUrl);
     const png = await normalizeImageToPng({ buffer, width });
 
@@ -378,11 +381,11 @@ export async function GET(request: NextRequest) {
       },
     });
   } catch (error) {
-    console.error("Unable to normalize OG metadata image.", error);
+    if (!(error instanceof AdmissionQueueError)) {
+      console.error("Unable to normalize OG metadata image.", error);
+    }
     return mapErrorToResponse(error);
   } finally {
-    if (admitted) {
-      imageRequestActive = false;
-    }
+    releaseAdmission?.();
   }
 }

--- a/app/api/open-graph/opensea/service.ts
+++ b/app/api/open-graph/opensea/service.ts
@@ -40,7 +40,6 @@ const OPENSEA_ITEM_PATH_PATTERN =
   /^\/item\/([^/]+)\/(0x[a-f0-9]{40})\/([^/?#]+)\/?$/i;
 const OPENSEA_ASSET_PATH_PATTERN =
   /^\/assets\/([^/]+)\/(0x[a-f0-9]{40})\/([^/?#]+)\/?$/i;
-const TOKEN_URI_FETCH_TIMEOUT_MS = 4000;
 
 const ALCHEMY_NETWORK_BY_OPENSEA_CHAIN: Record<string, string> = {
   arbitrum: "arb-mainnet",
@@ -279,44 +278,11 @@ const fetchTokenUriMetadataCandidate = async (
   deps: CreateOpenSeaPlanDeps
 ): Promise<TokenUriMetadata | null> => {
   try {
-    await deps.assertPublicUrl(candidateUrl);
+    const payload = await deps.fetchTokenMetadata(candidateUrl);
+    return extractTokenUriMetadata(payload).metadata;
   } catch {
     return null;
   }
-
-  const controller = new AbortController();
-  const timeout = setTimeout(
-    () => controller.abort(),
-    TOKEN_URI_FETCH_TIMEOUT_MS
-  );
-
-  let response: Response;
-  try {
-    response = await fetch(candidateUrl.toString(), {
-      headers: { Accept: "application/json" },
-      signal: controller.signal,
-    });
-  } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
-      return null;
-    }
-    return null;
-  } finally {
-    clearTimeout(timeout);
-  }
-
-  if (!response.ok) {
-    return null;
-  }
-
-  let payload: unknown;
-  try {
-    payload = (await response.json()) as unknown;
-  } catch {
-    return null;
-  }
-
-  return extractTokenUriMetadata(payload).metadata;
 };
 
 async function resolveTokenUriFallbackImage(

--- a/app/api/open-graph/opensea/shared.ts
+++ b/app/api/open-graph/opensea/shared.ts
@@ -9,6 +9,7 @@ type FetchHtmlResult = {
 export interface CreateOpenSeaPlanDeps {
   readonly fetchHtml: (url: URL) => Promise<FetchHtmlResult>;
   readonly assertPublicUrl: (url: URL) => Promise<void>;
+  readonly fetchTokenMetadata: (url: URL) => Promise<unknown>;
 }
 
 export type OpenSeaContext = {

--- a/app/api/open-graph/previewCacheBudget.ts
+++ b/app/api/open-graph/previewCacheBudget.ts
@@ -1,0 +1,122 @@
+import { deserialize, serialize } from "node:v8";
+
+export const PREVIEW_CACHE_MAX_ENTRY_BYTES = 128 * 1024;
+
+const ENTRY_BYTES = 64;
+const CONTAINER_BYTES = 64;
+const PROPERTY_BYTES = 64;
+const STRING_BYTES = 64;
+const SLOT_BYTES = 16;
+const MAX_DEPTH = 64;
+
+function primitiveBytes(value: unknown): number | null {
+  if (typeof value === "string") return STRING_BYTES + value.length * 2;
+  if (value === null) return SLOT_BYTES;
+  if (typeof value === "object") return null;
+  if (
+    typeof value === "undefined" ||
+    typeof value === "boolean" ||
+    typeof value === "number"
+  ) {
+    return SLOT_BYTES;
+  }
+  return Number.POSITIVE_INFINITY;
+}
+
+/** Copy only budgeted entries so slices cannot retain a much larger source string. */
+export function copyPreviewCacheEntry<T>(
+  key: string,
+  data: T,
+  maxBytes = PREVIEW_CACHE_MAX_ENTRY_BYTES
+): { readonly key: string; readonly data: T } | null {
+  if (!isPreviewCacheEntryWithinBudget(key, data, maxBytes)) return null;
+  try {
+    // V8 serialization preserves optional undefined values and severs string
+    // backing stores for the key and payload. Oversized previews never reach it.
+    return deserialize(serialize({ key, data })) as { key: string; data: T };
+  } catch {
+    return null;
+  }
+}
+
+function hasPlainPrototype(value: object, array: boolean): boolean {
+  const prototype: unknown = Object.getPrototypeOf(value);
+  if (array) return prototype === Array.prototype;
+  return prototype === Object.prototype || prototype === null;
+}
+
+/**
+ * Estimates retained plain preview data without serializing or copying strings.
+ * Padded container/property charges and UTF-16 string sizes form a conservative
+ * payload budget, not an exact measurement of the JavaScript engine's heap.
+ */
+export function isPreviewCacheEntryWithinBudget(
+  key: string,
+  preview: unknown,
+  maxBytes = PREVIEW_CACHE_MAX_ENTRY_BYTES
+): boolean {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) return false;
+
+  let remaining = maxBytes;
+  const ancestors = new Set<object>();
+  const consume = (bytes: number): boolean => {
+    if (bytes > remaining) return false;
+    remaining -= bytes;
+    return true;
+  };
+
+  const visit = (value: unknown, depth: number): boolean => {
+    const bytes = primitiveBytes(value);
+    if (bytes !== null) return consume(bytes);
+    return visitObject(value as object, depth);
+  };
+
+  const visitProperty = (
+    value: object,
+    property: string,
+    depth: number
+  ): boolean => {
+    const descriptor = Object.getOwnPropertyDescriptor(value, property);
+    return (
+      descriptor !== undefined &&
+      "value" in descriptor &&
+      consume(PROPERTY_BYTES + STRING_BYTES + property.length * 2) &&
+      visit(descriptor.value, depth + 1)
+    );
+  };
+
+  const visitObject = (value: object, depth: number): boolean => {
+    const array = Array.isArray(value);
+    if (
+      !hasPlainPrototype(value, array) ||
+      ancestors.has(value) ||
+      depth >= MAX_DEPTH
+    ) {
+      return false;
+    }
+    // Charge all array slots before enumeration, including holes in sparse arrays.
+    const slots = array ? value.length * SLOT_BYTES : 0;
+    if (!consume(CONTAINER_BYTES + slots)) return false;
+
+    ancestors.add(value);
+    let properties = 0;
+    try {
+      for (const property in value) {
+        if (!Object.hasOwn(value, property)) continue;
+        properties += 1;
+        if (!visitProperty(value, property, depth)) return false;
+      }
+      // JSON-like previews have no hidden or symbol properties. Refuse them
+      // rather than retaining values that the enumerable traversal did not count.
+      return Reflect.ownKeys(value).length === properties + (array ? 1 : 0);
+    } finally {
+      ancestors.delete(value);
+    }
+  };
+
+  try {
+    return consume(ENTRY_BYTES) && visit(key, 0) && visit(preview, 0);
+  } catch {
+    return false;
+  }
+}

--- a/app/api/open-graph/previewCacheBudget.ts
+++ b/app/api/open-graph/previewCacheBudget.ts
@@ -14,7 +14,7 @@ function primitiveBytes(value: unknown): number | null {
   if (value === null) return SLOT_BYTES;
   if (typeof value === "object") return null;
   if (
-    typeof value === "undefined" ||
+    value === undefined ||
     typeof value === "boolean" ||
     typeof value === "number"
   ) {

--- a/app/api/open-graph/route.ts
+++ b/app/api/open-graph/route.ts
@@ -42,6 +42,7 @@ import { buildFarcasterEmbedResponse } from "./farcaster/service";
 import { detectEnsTarget, fetchEnsPreview, EnsPreviewError } from "./ens";
 import { HTML_FETCH_HEADERS, createFetchConfig } from "./fetchConfig";
 import { fetchTokenUriJson } from "./tokenUriMetadata";
+import { copyPreviewCacheEntry } from "./previewCacheBudget";
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const CACHE_MAX_ITEMS = 500;
@@ -624,7 +625,10 @@ async function executePlan(plan: PreviewPlan): Promise<LinkPreviewResponse> {
   }
 
   const { data, ttl } = await plan.execute();
-  cache.set(plan.cacheKey, data, ttl);
+  const cacheEntry = copyPreviewCacheEntry(plan.cacheKey, data);
+  if (cacheEntry) {
+    cache.set(cacheEntry.key, cacheEntry.data, ttl);
+  }
 
   return data;
 }

--- a/app/api/open-graph/route.ts
+++ b/app/api/open-graph/route.ts
@@ -41,6 +41,7 @@ import { createEtherscanPlan } from "./etherscan/service";
 import { buildFarcasterEmbedResponse } from "./farcaster/service";
 import { detectEnsTarget, fetchEnsPreview, EnsPreviewError } from "./ens";
 import { HTML_FETCH_HEADERS, createFetchConfig } from "./fetchConfig";
+import { fetchTokenUriJson } from "./tokenUriMetadata";
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const CACHE_MAX_ITEMS = 500;
@@ -526,10 +527,12 @@ async function resolveLinkPreview(
     createOpenSeaPlan(targetUrl, {
       fetchHtml,
       assertPublicUrl: (url) => assertPublicUrl(url, PUBLIC_URL_OPTIONS),
+      fetchTokenMetadata: (url) => fetchTokenUriJson(url, PUBLIC_URL_OPTIONS),
     }) ??
     createTransientPlan(targetUrl, {
       fetchHtml,
       assertPublicUrl: (url) => assertPublicUrl(url, PUBLIC_URL_OPTIONS),
+      fetchTokenMetadata: (url) => fetchTokenUriJson(url, PUBLIC_URL_OPTIONS),
     }) ??
     createCompoundPlan(targetUrl) ??
     createGenericPlan(targetUrl);

--- a/app/api/open-graph/tokenUriMetadata.ts
+++ b/app/api/open-graph/tokenUriMetadata.ts
@@ -1,0 +1,28 @@
+import { readLimitedJson } from "@/lib/fetch/limitedBody";
+import { discardResponse } from "@/lib/fetch/fetchDeadline";
+import { fetchPublicUrl, type UrlGuardOptions } from "@/lib/security/urlGuard";
+
+// NFT metadata sometimes embeds substantial artwork. Count decoded bytes, not
+// the compressed Content-Length, and keep the existing permissive MIME handling.
+export const TOKEN_URI_MAX_BYTES = 64 * 1024 * 1024;
+const TOKEN_URI_TIMEOUT_MS = 4000;
+
+export async function fetchTokenUriJson(
+  url: URL,
+  options: UrlGuardOptions
+): Promise<unknown> {
+  const response = await fetchPublicUrl(
+    url,
+    { headers: { Accept: "application/json" } },
+    {
+      ...options,
+      timeoutMs: TOKEN_URI_TIMEOUT_MS,
+      maxRedirects: 5,
+    }
+  );
+  if (!response.ok) {
+    discardResponse(response);
+    throw new Error("NFT metadata request failed.");
+  }
+  return readLimitedJson<unknown>(response, TOKEN_URI_MAX_BYTES);
+}

--- a/app/api/open-graph/tokenUriMetadata.ts
+++ b/app/api/open-graph/tokenUriMetadata.ts
@@ -6,23 +6,32 @@ import { fetchPublicUrl, type UrlGuardOptions } from "@/lib/security/urlGuard";
 // the compressed Content-Length, and keep the existing permissive MIME handling.
 export const TOKEN_URI_MAX_BYTES = 64 * 1024 * 1024;
 const TOKEN_URI_TIMEOUT_MS = 4000;
+// Metadata can contain substantial embedded art. Keep the generous byte limit
+// without allowing a batch to buffer and parse several such documents at once.
+let tokenMetadataActive = false;
 
 export async function fetchTokenUriJson(
   url: URL,
   options: UrlGuardOptions
 ): Promise<unknown> {
-  const response = await fetchPublicUrl(
-    url,
-    { headers: { Accept: "application/json" } },
-    {
-      ...options,
-      timeoutMs: TOKEN_URI_TIMEOUT_MS,
-      maxRedirects: 5,
+  if (tokenMetadataActive) throw new Error("NFT metadata processing is busy.");
+  tokenMetadataActive = true;
+  try {
+    const response = await fetchPublicUrl(
+      url,
+      { headers: { Accept: "application/json" } },
+      {
+        ...options,
+        timeoutMs: TOKEN_URI_TIMEOUT_MS,
+        maxRedirects: 5,
+      }
+    );
+    if (!response.ok) {
+      discardResponse(response);
+      throw new Error("NFT metadata request failed.");
     }
-  );
-  if (!response.ok) {
-    discardResponse(response);
-    throw new Error("NFT metadata request failed.");
+    return await readLimitedJson<unknown>(response, TOKEN_URI_MAX_BYTES);
+  } finally {
+    tokenMetadataActive = false;
   }
-  return readLimitedJson<unknown>(response, TOKEN_URI_MAX_BYTES);
 }

--- a/app/api/open-graph/tokenUriMetadata.ts
+++ b/app/api/open-graph/tokenUriMetadata.ts
@@ -1,5 +1,6 @@
 import { readLimitedJson } from "@/lib/fetch/limitedBody";
 import { discardResponse } from "@/lib/fetch/fetchDeadline";
+import { AdmissionQueue } from "@/lib/fetch/admissionQueue";
 import { fetchPublicUrl, type UrlGuardOptions } from "@/lib/security/urlGuard";
 
 // NFT metadata sometimes embeds substantial artwork. Count decoded bytes, not
@@ -8,14 +9,13 @@ export const TOKEN_URI_MAX_BYTES = 64 * 1024 * 1024;
 const TOKEN_URI_TIMEOUT_MS = 4000;
 // Metadata can contain substantial embedded art. Keep the generous byte limit
 // without allowing a batch to buffer and parse several such documents at once.
-let tokenMetadataActive = false;
+const metadataAdmission = new AdmissionQueue({ maxPending: 32, waitMs: 15_000 });
 
 export async function fetchTokenUriJson(
   url: URL,
   options: UrlGuardOptions
 ): Promise<unknown> {
-  if (tokenMetadataActive) throw new Error("NFT metadata processing is busy.");
-  tokenMetadataActive = true;
+  const release = await metadataAdmission.acquire();
   try {
     const response = await fetchPublicUrl(
       url,
@@ -32,6 +32,6 @@ export async function fetchTokenUriJson(
     }
     return await readLimitedJson<unknown>(response, TOKEN_URI_MAX_BYTES);
   } finally {
-    tokenMetadataActive = false;
+    release();
   }
 }

--- a/app/api/open-graph/transient/service.ts
+++ b/app/api/open-graph/transient/service.ts
@@ -48,6 +48,7 @@ type FetchHtmlResult = {
 interface CreateTransientPlanDeps {
   readonly fetchHtml: (url: URL) => Promise<FetchHtmlResult>;
   readonly assertPublicUrl: (url: URL) => Promise<void>;
+  readonly fetchTokenMetadata: (url: URL) => Promise<unknown>;
 }
 
 type TransientContext = {
@@ -286,32 +287,11 @@ const fetchTokenUriMetadataCandidate = async (
   deps: CreateTransientPlanDeps
 ): Promise<TokenUriMetadata | null> => {
   try {
-    await deps.assertPublicUrl(candidateUrl);
+    const payload = await deps.fetchTokenMetadata(candidateUrl);
+    return extractTokenUriMetadata(payload).metadata;
   } catch {
     return null;
   }
-
-  let response: Response;
-  try {
-    response = await fetch(candidateUrl.toString(), {
-      headers: { Accept: "application/json" },
-    });
-  } catch {
-    return null;
-  }
-
-  if (!response.ok) {
-    return null;
-  }
-
-  let payload: unknown;
-  try {
-    payload = (await response.json()) as unknown;
-  } catch {
-    return null;
-  }
-
-  return extractTokenUriMetadata(payload).metadata;
 };
 
 async function resolveTokenUriFallbackImage(

--- a/app/open-mobile/mobileDestination.ts
+++ b/app/open-mobile/mobileDestination.ts
@@ -1,0 +1,53 @@
+const hasUnsafeCharacters = (value: string): boolean =>
+  value.includes("\\") || /[\u0000-\u001f\u007f]/.test(value);
+
+const isRootRelativePath = (value: string): boolean =>
+  value.startsWith("/") && !value.startsWith("//");
+
+export function getMobileDestination(
+  pathParam: string | null,
+  origin: string
+): string | null {
+  if (!pathParam) {
+    return null;
+  }
+
+  try {
+    // URLSearchParams already decodes the query. Retain compatibility with
+    // links that additionally encode the entire route, without decoding its
+    // individual path segments or query values into URL delimiters.
+    const path = pathParam.startsWith("/")
+      ? pathParam
+      : decodeURIComponent(pathParam);
+    if (!isRootRelativePath(path) || hasUnsafeCharacters(path)) {
+      return null;
+    }
+
+    // Reject malformed encoding while preserving escaped query/hash values.
+    decodeURI(path);
+    const destination = new URL(path, origin);
+    const decodedPathname = decodeURIComponent(destination.pathname);
+    if (
+      destination.origin !== origin ||
+      !isRootRelativePath(destination.pathname) ||
+      !isRootRelativePath(decodedPathname) ||
+      hasUnsafeCharacters(decodedPathname)
+    ) {
+      return null;
+    }
+
+    // Native routing may decode path segments. Check that representation too,
+    // including dot segments that would expose a leading double slash.
+    const decodedDestination = new URL(decodedPathname, origin);
+    if (
+      decodedDestination.origin !== origin ||
+      !isRootRelativePath(decodedDestination.pathname)
+    ) {
+      return null;
+    }
+
+    return `${destination.pathname}${destination.search}${destination.hash}`;
+  } catch {
+    return null;
+  }
+}

--- a/app/open-mobile/page.client.tsx
+++ b/app/open-mobile/page.client.tsx
@@ -7,36 +7,35 @@ import { DeepLinkScope } from "@/hooks/useDeepLinkNavigation";
 import { DEFAULT_LOCALE } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
 import { useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
+import { getMobileDestination } from "./mobileDestination";
 
 const APPS_LOCALE = DEFAULT_LOCALE;
 
 export default function OpenMobilePage() {
   const searchParams = useSearchParams();
-  const pathParam = searchParams?.get("path") || "";
-  const [decodedPath, setDecodedPath] = useState<string | null>(null);
+  const pathParam = searchParams.get("path");
+  const destination =
+    typeof window === "undefined"
+      ? null
+      : getMobileDestination(pathParam, window.location.origin);
   const { isAppleMobile } = useDeviceInfo();
 
   useEffect(() => {
-    if (typeof window === "undefined" || !pathParam) {
+    if (!destination) {
       return;
     }
 
     const appScheme = publicEnv.MOBILE_APP_SCHEME ?? "mobile6529";
-    const decoded = decodeURIComponent(pathParam);
-    const deepLink = `${appScheme}://${DeepLinkScope.NAVIGATE}${decoded}`;
+    const deepLink = `${appScheme}://${DeepLinkScope.NAVIGATE}${destination}`;
 
-    setDecodedPath(decoded);
     window.open(deepLink, "_self");
-  }, [pathParam]);
+  }, [destination]);
 
   const handleBack = () => {
-    if (decodedPath) {
-      window.open(`${window.location.origin}${decodedPath}`, "_self");
-    } else {
-      window.open(window.location.origin, "_self");
-    }
+    const returnUrl = new URL(destination ?? "/", window.location.origin);
+    window.open(returnUrl.href, "_self");
   };
 
   const printMobileApps = () => {

--- a/lib/fetch/admissionQueue.ts
+++ b/lib/fetch/admissionQueue.ts
@@ -1,0 +1,114 @@
+type AdmissionQueueOptions = {
+  readonly maxPending: number;
+  readonly waitMs: number;
+};
+
+type AdmissionFailureKind = "full" | "timeout" | "aborted";
+type ReleaseAdmission = () => void;
+type PendingAdmission = {
+  readonly expiresAt: number;
+  readonly grant: () => void;
+  readonly fail: (kind: AdmissionFailureKind) => void;
+};
+
+export class AdmissionQueueError extends Error {
+  readonly kind: AdmissionFailureKind;
+
+  constructor(kind: AdmissionFailureKind) {
+    super("Resource admission unavailable.");
+    this.name = "AdmissionQueueError";
+    this.kind = kind;
+  }
+}
+
+/** Serializes resource-heavy work without starting downloads for queued callers. */
+export class AdmissionQueue {
+  private active = false;
+  private readonly pending: PendingAdmission[] = [];
+  private readonly maxPending: number;
+  private readonly waitMs: number;
+
+  constructor({ maxPending, waitMs }: AdmissionQueueOptions) {
+    if (!Number.isSafeInteger(maxPending) || maxPending < 0) {
+      throw new RangeError("maxPending must be a nonnegative safe integer.");
+    }
+    if (!Number.isSafeInteger(waitMs) || waitMs < 1 || waitMs > 2_147_483_647) {
+      throw new RangeError(
+        "waitMs must be a positive supported timer duration."
+      );
+    }
+    this.maxPending = maxPending;
+    this.waitMs = waitMs;
+  }
+
+  acquire(signal?: AbortSignal): Promise<ReleaseAdmission> {
+    if (signal?.aborted) {
+      return Promise.reject(new AdmissionQueueError("aborted"));
+    }
+    if (!this.active) {
+      this.active = true;
+      return Promise.resolve(this.createRelease());
+    }
+    if (this.pending.length >= this.maxPending) {
+      return Promise.reject(new AdmissionQueueError("full"));
+    }
+
+    return new Promise((resolve, reject) => {
+      const pending: PendingAdmission = {
+        expiresAt: Date.now() + this.waitMs,
+        grant: () => {
+          cleanup();
+          resolve(this.createRelease());
+        },
+        fail: (kind) => {
+          cleanup();
+          reject(new AdmissionQueueError(kind));
+        },
+      };
+      const timeout = setTimeout(() => {
+        this.removePending(pending, "timeout");
+      }, this.waitMs);
+      const onAbort = () => this.removePending(pending, "aborted");
+      const cleanup = () => {
+        clearTimeout(timeout);
+        signal?.removeEventListener("abort", onAbort);
+      };
+      this.pending.push(pending);
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
+  }
+
+  private removePending(
+    pending: PendingAdmission,
+    kind: AdmissionFailureKind
+  ): void {
+    const index = this.pending.indexOf(pending);
+    if (index !== -1) {
+      this.pending.splice(index, 1);
+      pending.fail(kind);
+    }
+  }
+
+  private createRelease(): ReleaseAdmission {
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+
+      let pending = this.pending.shift();
+      while (pending) {
+        // Enforce the deadline even if a busy event loop delayed its timer.
+        if (pending.expiresAt <= Date.now()) {
+          pending.fail("timeout");
+          pending = this.pending.shift();
+          continue;
+        }
+        pending.grant();
+        return;
+      }
+      this.active = false;
+    };
+  }
+}

--- a/lib/fetch/fetchDeadline.ts
+++ b/lib/fetch/fetchDeadline.ts
@@ -1,0 +1,128 @@
+/** One deadline covers DNS, redirects, and consumption of the final body. */
+export function createFetchDeadline(
+  caller: AbortSignal | null | undefined,
+  timeoutMs: number | undefined,
+  timeoutError: () => Error
+) {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const forwardAbort = () => controller.abort(caller?.reason);
+  const dispose = () => {
+    clearTimeout(timer);
+    caller?.removeEventListener("abort", forwardAbort);
+    controller.signal.removeEventListener("abort", dispose);
+  };
+
+  if (timeoutMs !== undefined) {
+    timer = setTimeout(() => controller.abort(timeoutError()), timeoutMs);
+  }
+  controller.signal.addEventListener("abort", dispose, { once: true });
+  if (caller?.aborted) forwardAbort();
+  else caller?.addEventListener("abort", forwardAbort, { once: true });
+
+  async function run<T>(operation: () => Promise<T>): Promise<T> {
+    controller.signal.throwIfAborted();
+    let onAbort: () => void = () => undefined;
+    const aborted = new Promise<never>((_resolve, reject) => {
+      onAbort = () => reject(controller.signal.reason);
+      controller.signal.addEventListener("abort", onAbort, { once: true });
+    });
+    try {
+      return await Promise.race([operation(), aborted]);
+    } finally {
+      controller.signal.removeEventListener("abort", onAbort);
+    }
+  }
+
+  return { signal: controller.signal, dispose, run };
+}
+
+type FetchDeadline = ReturnType<typeof createFetchDeadline>;
+
+/** Discarded responses must release their connection even on error paths. */
+export function discardResponse(response: Response): void {
+  void response.body?.cancel().catch(() => undefined);
+}
+
+function preserveResponseMetadata(
+  response: Response,
+  original: Response
+): Response {
+  Object.defineProperties(response, {
+    url: { value: original.url },
+    redirected: { value: original.redirected },
+    type: { value: original.type },
+  });
+  const clone = response.clone.bind(response);
+  response.clone = () => preserveResponseMetadata(clone(), original);
+  return response;
+}
+
+/** Wrap without buffering, so a route can still proxy response.body directly. */
+export function bindResponseDeadline(
+  response: Response,
+  deadline: FetchDeadline
+): Response {
+  if (!response.body) {
+    deadline.dispose();
+    return response;
+  }
+
+  const reader = response.body.getReader();
+  let finished = false;
+  let onAbort: () => void = () => undefined;
+  const finish = () => {
+    finished = true;
+    deadline.signal.removeEventListener("abort", onAbort);
+    deadline.dispose();
+  };
+  const cancel = (reason?: unknown) => {
+    void reader.cancel(reason).catch(() => undefined);
+  };
+  const body = new ReadableStream<Uint8Array>(
+    {
+      start(controller) {
+        onAbort = () => {
+          if (finished) return;
+          finish();
+          controller.error(deadline.signal.reason);
+          cancel(deadline.signal.reason);
+        };
+        deadline.signal.addEventListener("abort", onAbort, { once: true });
+        if (deadline.signal.aborted) onAbort();
+      },
+      async pull(controller) {
+        try {
+          const { done, value } = await reader.read();
+          if (finished) return;
+          if (done) {
+            finish();
+            reader.releaseLock();
+            controller.close();
+          } else {
+            controller.enqueue(value);
+          }
+        } catch (error) {
+          if (finished) return;
+          finish();
+          reader.releaseLock();
+          controller.error(error);
+        }
+      },
+      cancel(reason) {
+        finish();
+        cancel(reason);
+      },
+    },
+    { highWaterMark: 0 }
+  );
+
+  return preserveResponseMetadata(
+    new Response(body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    }),
+    response
+  );
+}

--- a/lib/fetch/limitedBody.ts
+++ b/lib/fetch/limitedBody.ts
@@ -160,9 +160,8 @@ export async function readLimitedText(
   source: BodySource,
   maxBytes: number
 ): Promise<string> {
-  assertReadableSize(source.headers, maxBytes);
-
   if (!source.body) {
+    assertReadableSize(source.headers, maxBytes);
     return "";
   }
 
@@ -172,6 +171,12 @@ export async function readLimitedText(
   let text = "";
 
   try {
+    try {
+      assertReadableSize(source.headers, maxBytes);
+    } catch (error) {
+      await cancelReader(reader);
+      throw error;
+    }
     while (true) {
       const { done, value } = await reader.read();
       if (done) {

--- a/lib/security/urlGuard.ts
+++ b/lib/security/urlGuard.ts
@@ -5,6 +5,11 @@ import { isIP } from "node:net";
 import { toASCII } from "node:punycode";
 import { Agent, fetch as undiciFetch } from "undici";
 import type { RequestInit as UndiciRequestInit } from "undici";
+import {
+  bindResponseDeadline,
+  createFetchDeadline,
+  discardResponse,
+} from "@/lib/fetch/fetchDeadline";
 
 type UrlGuardErrorKind =
   | "missing-url"
@@ -581,45 +586,24 @@ export async function fetchPublicUrl(
 
   let currentUrl = initialUrl;
   let redirectCount = 0;
+  const deadline = createFetchDeadline(
+    init.signal,
+    options.timeoutMs,
+    () => new UrlGuardError("Request timed out.", "timeout", 504)
+  );
+  let response: Response | undefined;
 
-  while (true) {
-    const validatedUrl = await validatePublicUrl(currentUrl, options);
+  try {
+    for (;;) {
+      const validatedUrl = await deadline.run(() =>
+        validatePublicUrl(currentUrl, options)
+      );
 
-    const headers = new Headers(init.headers);
-    if (options.userAgent && !headers.has("user-agent")) {
-      headers.set("user-agent", options.userAgent);
-    }
-
-    let timeoutId: NodeJS.Timeout | undefined;
-    let abortedByTimeout = false;
-    const controller = new AbortController();
-    const signals: AbortSignal[] = [];
-    if (init.signal) {
-      signals.push(init.signal);
-    }
-
-    const abortHandler = (event: Event) => {
-      const target = event.target as AbortSignal;
-      controller.abort(target.reason);
-    };
-
-    for (const signal of signals) {
-      if (signal.aborted) {
-        controller.abort(signal.reason);
-      } else {
-        signal.addEventListener("abort", abortHandler, { once: true });
+      const headers = new Headers(init.headers);
+      if (options.userAgent && !headers.has("user-agent")) {
+        headers.set("user-agent", options.userAgent);
       }
-    }
 
-    if (options.timeoutMs !== undefined) {
-      timeoutId = setTimeout(() => {
-        abortedByTimeout = true;
-        controller.abort();
-      }, options.timeoutMs);
-    }
-
-    let response: Response;
-    try {
       const baseRequestInit: RequestInit = {
         ...init,
         headers,
@@ -630,91 +614,69 @@ export async function fetchPublicUrl(
             baseRequestInit
           )
         : baseRequestInit;
-      response = await fetchWithValidatedAddresses(
-        currentUrl,
-        {
-          ...requestInit,
-          redirect: "manual",
-          signal: controller.signal,
-        },
-        validatedUrl
+      response = await deadline.run(() =>
+        fetchWithValidatedAddresses(
+          currentUrl,
+          {
+            ...requestInit,
+            redirect: "manual",
+            signal: deadline.signal,
+          },
+          validatedUrl
+        )
       );
-    } catch (error) {
-      if (abortedByTimeout) {
-        throw new UrlGuardError("Request timed out.", "timeout", 504, {
-          cause: error,
-        });
-      }
 
-      if (error instanceof UrlGuardError) {
-        throw error;
-      }
-
-      throw new UrlGuardError("Failed to fetch URL.", "fetch-failed", 502, {
-        cause: error,
-      });
-    } finally {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-      for (const signal of signals) {
-        signal.removeEventListener("abort", abortHandler);
-      }
-    }
-
-    if (redirectStatusCodes.has(response.status)) {
-      if (redirectCount >= maxRedirects) {
-        throw new UrlGuardError(
-          "Too many redirects.",
-          "too-many-redirects",
-          502
-        );
-      }
-
-      const location = response.headers.get("location");
-      if (!location) {
-        throw new UrlGuardError(
-          "Redirect response missing location header.",
-          "redirect-location-missing",
-          502
-        );
-      }
-
-      let nextUrl: URL;
-      try {
-        nextUrl = new URL(location, currentUrl);
-      } catch (error) {
-        throw new UrlGuardError(
-          "Redirect response has invalid location.",
-          "redirect-location-invalid",
-          502,
-          { cause: error }
-        );
-      }
-
-      currentUrl = nextUrl;
-      redirectCount += 1;
-      continue;
-    }
-
-    if (options.revalidateFinalUrl !== false && response.url) {
-      try {
-        const finalUrl = new URL(response.url);
-        await assertPublicUrl(finalUrl, options);
-      } catch (error) {
-        if (error instanceof UrlGuardError) {
-          throw error;
+      if (redirectStatusCodes.has(response.status)) {
+        discardResponse(response);
+        if (redirectCount >= maxRedirects) {
+          throw new UrlGuardError(
+            "Too many redirects.",
+            "too-many-redirects",
+            502
+          );
         }
-        throw new UrlGuardError(
-          "Failed to validate final URL.",
-          "fetch-failed",
-          502,
-          { cause: error }
-        );
-      }
-    }
 
-    return response;
+        const location = response.headers.get("location");
+        if (!location) {
+          throw new UrlGuardError(
+            "Redirect response missing location header.",
+            "redirect-location-missing",
+            502
+          );
+        }
+
+        let nextUrl: URL;
+        try {
+          nextUrl = new URL(location, currentUrl);
+        } catch (error) {
+          throw new UrlGuardError(
+            "Redirect response has invalid location.",
+            "redirect-location-invalid",
+            502,
+            { cause: error }
+          );
+        }
+
+        currentUrl = nextUrl;
+        redirectCount += 1;
+        continue;
+      }
+
+      if (options.revalidateFinalUrl !== false && response.url) {
+        const finalUrl = new URL(response.url);
+        await deadline.run(() => assertPublicUrl(finalUrl, options));
+      }
+
+      return bindResponseDeadline(response, deadline);
+    }
+  } catch (error) {
+    deadline.dispose();
+    if (response) discardResponse(response);
+    if (deadline.signal.aborted) throw deadline.signal.reason;
+    if (error instanceof UrlGuardError) throw error;
+    throw new UrlGuardError("Failed to fetch URL.", "fetch-failed", 502, {
+      cause: error,
+    });
   }
 }
 
@@ -726,6 +688,7 @@ export async function fetchPublicJson<T>(
   const response = await fetchPublicUrl(input, init, options);
 
   if (!response.ok) {
+    discardResponse(response);
     throw new UrlGuardError(
       `Request failed with status ${response.status}`,
       "fetch-failed",

--- a/ops/docs/navigation/feature-mobile-app-landing.md
+++ b/ops/docs/navigation/feature-mobile-app-landing.md
@@ -3,8 +3,8 @@
 ## Overview
 
 `/open-mobile` is a web handoff page for the 6529 mobile app.
-When `path` is provided, it tries an app deep link first and keeps store and
-return actions visible.
+When a valid internal `path` is provided, it tries an app deep link first and
+keeps store and return actions visible.
 
 ## Location in the Site
 
@@ -23,19 +23,19 @@ return actions visible.
 ## User Journey
 
 1. Open `/open-mobile`.
-2. If `path` exists, the page decodes it and builds
-   `<MOBILE_APP_SCHEME>://navigate<decoded-path>`.
+2. If `path` identifies an internal route beginning with a single `/`, the page
+   prepares an app deep link to that route, including its query and fragment.
 3. The browser attempts to open that deep link.
 4. If the app does not open, use the iOS/Android store action.
-5. Use `Back to 6529.io` to return to `<origin><decoded-path>`, or `/` when no
-   decoded path is available.
+5. Use `Back to 6529.io` to return to that route on the current website, or `/`
+   when `path` is missing or invalid.
 
 ## Common Scenarios
 
 - Apple mobile clients (including iPad touch-desktop UA): show only iOS action.
 - Android clients: show only Android action.
 - Desktop and unclassified environments: show both store actions.
-- Missing `path`: no deep-link attempt; `Back to 6529.io` returns to `/`.
+- Missing or invalid `path`: no deep-link attempt; `Back to 6529.io` returns to `/`.
 
 ## Edge Cases
 
@@ -43,7 +43,9 @@ return actions visible.
 - Deep-link redirect runs after first client render, so the landing UI can flash
   briefly before app handoff.
 - Store actions force top-level full-page redirects to app-store URLs.
-- `path` must be valid URL encoding and should decode to an app/web route.
+- `path` must use valid URL encoding and identify an internal route. External
+  URLs and malformed route values use the home-page fallback.
+- A new missing or invalid `path` clears the previous return destination.
 
 ## Failure and Recovery
 
@@ -56,8 +58,8 @@ return actions visible.
 - App handoff depends on browser/device support for custom URL schemes.
 - The page does not show explicit in-page error or retry UI for failed
   deep-link handoff.
-- Route validation is limited to URL decoding; invalid route shapes are not
-  corrected on this page.
+- The page checks the destination format; it does not check whether the route
+  exists or whether the user has access to its content.
 
 ## Related Pages
 

--- a/ops/docs/navigation/troubleshooting-navigation-and-shell-controls.md
+++ b/ops/docs/navigation/troubleshooting-navigation-and-shell-controls.md
@@ -94,7 +94,7 @@ handoff does not behave as expected.
 - `/open-mobile` only shows one store action:
   expected on detected iOS (App Store only) or Android (Play Store only).
 - `Back to 6529.io` on `/open-mobile` returns to `/`:
-  happens when no decoded `path` is available.
+  happens when `path` is missing or is not a valid internal route.
 
 ## Edge Cases
 

--- a/ops/docs/shared/feature-social-card-and-open-graph-metadata.md
+++ b/ops/docs/shared/feature-social-card-and-open-graph-metadata.md
@@ -45,8 +45,10 @@ the `1200x630` image dimensions and `summary_large_image` Twitter card.
   - Each processed frame must be at most 512 million pixels, with neither
     dimension exceeding 65,536 pixels. Sources outside these limits do not
     produce a normalized preview.
-  - When image processing is busy, the image endpoint returns a temporary
-    `503` response with a one-second retry interval.
+  - Images are processed one at a time per server process. Up to 32 requests can
+    wait for at most 15 seconds before downloading, so a card's banner, avatar,
+    and artwork can all render. A full queue or expired wait produces a
+    temporary `503` response with a one-second retry interval.
 
 ## Standard Route Contract
 

--- a/ops/docs/shared/feature-social-card-and-open-graph-metadata.md
+++ b/ops/docs/shared/feature-social-card-and-open-graph-metadata.md
@@ -36,7 +36,17 @@ the `1200x630` image dimensions and `summary_large_image` Twitter card.
   overrides for `artist`, `badge`, `collection`, `image`, `subtitle`, and
   `title`.
 - `/api/og-metadata/image?url={url}&w={width}` safely normalizes allowed remote
-  images for card rendering.
+  images to PNG for card rendering. Images retain their aspect ratio and fit
+  within the requested width (at most 1,200 pixels) and 12,000 pixels high,
+  without cropping or enlarging smaller originals. GIF previews use the first
+  frame, and SVG artwork is supported.
+  - Source downloads are limited to 50 MiB. Larger GIFs can still produce a
+    preview when the source supports a partial download of the first 8 MiB.
+  - Each processed frame must be at most 512 million pixels, with neither
+    dimension exceeding 65,536 pixels. Sources outside these limits do not
+    produce a normalized preview.
+  - When image processing is busy, the image endpoint returns a temporary
+    `503` response with a one-second retry interval.
 
 ## Standard Route Contract
 

--- a/ops/docs/waves/link-previews/feature-web3-preview-cards.md
+++ b/ops/docs/waves/link-previews/feature-web3-preview-cards.md
@@ -142,6 +142,11 @@ Only `https://` URLs match. Host must be apex or `www`.
   to non-public destinations are skipped; the existing preview fallback remains
   available. Embedded artwork and missing or unusual JSON content types remain
   supported within that limit.
+- NFT token metadata is read one document at a time per server process. When
+  that reader is busy, the existing preview fallback is used; refreshing later
+  can retry the metadata lookup.
+- Large previews can still be returned, but previews exceeding the in-memory
+  cache budget are fetched again on subsequent requests.
 - Art Blocks cards show project/token context with `View live` and
   `Open on Art Blocks`.
 - Etherscan transaction cards show status, inferred action, participants,

--- a/ops/docs/waves/link-previews/feature-web3-preview-cards.md
+++ b/ops/docs/waves/link-previews/feature-web3-preview-cards.md
@@ -142,9 +142,10 @@ Only `https://` URLs match. Host must be apex or `www`.
   to non-public destinations are skipped; the existing preview fallback remains
   available. Embedded artwork and missing or unusual JSON content types remain
   supported within that limit.
-- NFT token metadata is read one document at a time per server process. When
-  that reader is busy, the existing preview fallback is used; refreshing later
-  can retry the metadata lookup.
+- NFT token metadata is read one document at a time per server process. Up to
+  32 other lookups can wait for at most 15 seconds before their download starts.
+  If that queue is full or the wait expires, the existing preview fallback is
+  used; refreshing later can retry the metadata lookup.
 - Large previews can still be returned, but previews exceeding the in-memory
   cache budget are fetched again on subsequent requests.
 - Art Blocks cards show project/token context with `View live` and

--- a/ops/docs/waves/link-previews/feature-web3-preview-cards.md
+++ b/ops/docs/waves/link-previews/feature-web3-preview-cards.md
@@ -137,6 +137,11 @@ Only `https://` URLs match. Host must be apex or `www`.
   variants), marketplace preview interactions stay within the preview and do not
   trigger parent-card navigation.
 - OpenSea cards filter blocked OpenGraph-overlay image URLs.
+- OpenSea and Transient NFT previews can read public token metadata as a fallback.
+  Metadata larger than 64 MiB after decompression, slow downloads, or redirects
+  to non-public destinations are skipped; the existing preview fallback remains
+  available. Embedded artwork and missing or unusual JSON content types remain
+  supported within that limit.
 - Art Blocks cards show project/token context with `View live` and
   `Open on Art Blocks`.
 - Etherscan transaction cards show status, inferred action, participants,

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -4570,6 +4570,7 @@
       "facts": [
         "The open-mobile route handles mobile app handoff and landing behavior.",
         "Use /open-mobile when users ask how to open the 6529 app from the web.",
+        "A valid internal path is used for the app handoff and Back to 6529.io, including query and fragment. A missing or invalid path skips app handoff and Back to 6529.io returns home.",
         "Mobile navigation and push notification behavior are documented separately."
       ],
       "canonical_path": "/open-mobile",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -4566,6 +4566,7 @@
       "facts": [
         "The open-mobile route handles mobile app handoff and landing behavior.",
         "Use /open-mobile when users ask how to open the 6529 app from the web.",
+        "A valid internal path is used for the app handoff and Back to 6529.io, including query and fragment. A missing or invalid path skips app handoff and Back to 6529.io returns home.",
         "Mobile navigation and push notification behavior are documented separately."
       ],
       "canonical_path": "/open-mobile",


### PR DESCRIPTION
## Issue

Public previews need bounded downloads and image work throughout response processing, and the mobile landing page needs a consistent internal return destination.

## Fix

Keep NFT metadata on the validated public-URL transport, retain its deadline through the response body, and limit decoded metadata and image dimensions. Validate one mobile destination for both native handoff and browser return.

## Changes

- Apply the existing preview host policy and pinned connection handling to OpenSea and Transient token metadata, including redirects.
- Cap token metadata at 64 MiB after decompression, preserving embedded artwork, token templates, gateways, and permissive content types.
- Admit one token-metadata document per process at a time, with bounded waiting before download so ordinary parallel previews can complete.
- Retain only preview cache entries within a conservative 128 KiB payload budget. Copy accepted entries after the budget check to detach backing strings; return larger previews normally without caching them.
- Keep one deadline across DNS, redirects, and body completion or cancellation, while retaining streaming responses and response metadata.
- Limit images to 512 million pixels per processed frame and 65,536 pixels per axis. Fit output inside 1200×12000 without cropping or enlargement. Admit one image request per process, allowing a card's avatar, banner, and artwork to wait before downloading.
- Each admission queue allows at most 32 waiting requests for at most 15 seconds; waiting requests hold no downloaded media. Full or expired queues retain the existing metadata fallback or temporary uncached image busy response.
- Preserve 50 MiB image downloads, the 8 MiB GIF range fallback, first-frame GIF previews, SVG, and rotation.
- Preserve valid mobile route/query/fragment encoding and clear invalid or missing destinations. Update user documentation and the help corpus.

## Validation

- 191 focused tests passed across transport, metadata, provider, image, and mobile suites. Direct streaming-response forwarding is covered.
- The stalled-body regression reproduced before the fix and passes afterward.
- Scoped TypeScript, documentation links, help-index generation, and whitespace checks passed.
- Combined lint and the full local build passed. The metadata/cache follow-up passed 101 focused tests across five suites, changed-source TypeScript, and the Jest typecheck ratchet; the latest PR checks validate the final head.
- The bounded-queue follow-up passed 50 focused tests across three suites, including simultaneous image rendering without overlapping downloads or decoding. Changed-source TypeScript, the Jest typecheck ratchet, lint, and whitespace passed.
- Mobile React Doctor: 99/100; its Suspense warning is covered by the unchanged server page boundary.
- Tests use modest image fixtures and synthetic dimensions; no extreme image allocation or live load test was run.

## Risk

- Level: Medium
- Why: the shared fetch lifecycle affects several preview routes. Full or expired image queues return 503 with Retry-After. Individual images within the generous ceiling can still be expensive; the pixel cap is not a strict memory limit.
- Rollback: use the normal reviewed revert and deployment process; prefer a focused forward fix for any compatibility regression.

## Review Notes

Focus on cancellation and redirect cleanup, response cloning/stream forwarding, per-frame GIF dimensions, image admission cleanup, and mobile encoding compatibility. Sharp's seven-second timeout applies to pipeline evaluation, not a hard metadata-parser deadline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Open Graph and NFT preview reliability with safer metadata fetching, size limits, caching safeguards, and fallback behavior.
  * Added protection against overloaded image and metadata processing; temporary `503` responses include retry guidance when capacity is reached.
  * Mobile app handoffs now safely preserve valid internal paths, query strings, and fragments.

* **Bug Fixes**
  * Invalid, malformed, external, or unsafe mobile destinations now return users to the homepage instead of attempting app handoff.

* **Documentation**
  * Updated guidance for mobile navigation, social-card image limits, and Web3 preview behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->