### PR TITLE
fix(cms): resolve published pages with display-case handles

### DIFF
--- a/__tests__/lib/profile-cms/runtime/routes.test.ts
+++ b/__tests__/lib/profile-cms/runtime/routes.test.ts
@@ -46,6 +46,25 @@ describe("profile CMS runtime routes", () => {
     }
   );
 
+  it.each([false, true])(
+    "rejects canonical route collisions regardless of order (reversed: %s)",
+    (reversed) => {
+      const routes: CmsPackageV1["payload"]["routes"] = [
+        { path: "/Punk6529/index.html", kind: "page", page_id: "page-home" },
+        {
+          path: "/punk6529/index.html",
+          kind: "redirect",
+          target: "/punk6529/Other/index.html",
+        },
+      ];
+      const cmsPackage = withRoutes(reversed ? routes.toReversed() : routes);
+      expect(resolveCmsRoute(cmsPackage, "/punk6529/index.html")).toEqual({
+        kind: "not_found",
+        reason: "route_missing",
+      });
+    }
+  );
+
   it("normalizes path aliases and detects cycles across handle casing", () => {
     const cmsPackage = withRoutes([
       {

--- a/__tests__/lib/profile-cms/runtime/routes.test.ts
+++ b/__tests__/lib/profile-cms/runtime/routes.test.ts
@@ -13,6 +13,132 @@ const minimalCmsPackage = minimalPackage as unknown as CmsPackageV1;
 const galleryCmsPackage = walletGalleryPackage as unknown as CmsPackageV1;
 
 describe("profile CMS runtime routes", () => {
+  const withRoutes = (
+    routes: CmsPackageV1["payload"]["routes"]
+  ): CmsPackageV1 => ({
+    ...minimalCmsPackage,
+    payload: { ...minimalCmsPackage.payload, routes },
+  });
+
+  it.each(["/punk6529/Gallery/index.html", "/Punk6529/Gallery/index.html"])(
+    "resolves display-case manifest handles for %s without changing page slugs",
+    (path) => {
+      const cmsPackage = withRoutes([
+        {
+          path: "/PUNK6529/Gallery/index.html",
+          kind: "page",
+          page_id: "page-home",
+        },
+      ]);
+      expect(resolveCmsRoute(cmsPackage, path).kind).toBe("page");
+      expect(
+        resolveCmsRoute(cmsPackage, "/punk6529/gallery/index.html")
+      ).toEqual({
+        kind: "not_found",
+        reason: "route_missing",
+      });
+      expect(getCmsPagePath(cmsPackage, "page-home")).toBe(
+        "/punk6529/Gallery/index.html"
+      );
+      expect(cmsPackage.payload.routes[0]?.path).toBe(
+        "/PUNK6529/Gallery/index.html"
+      );
+    }
+  );
+
+  it("normalizes path aliases and detects cycles across handle casing", () => {
+    const cmsPackage = withRoutes([
+      {
+        path: "/Punk6529/index.html",
+        kind: "alias",
+        target: "/PUNK6529/Home/index.html",
+      },
+      { path: "/punk6529/Home/index.html", kind: "alias", target: "page-home" },
+      {
+        path: "/Punk6529/loop/index.html",
+        kind: "alias",
+        target: "/punk6529/loop/index.html",
+      },
+    ]);
+    expect(resolveCmsRoute(cmsPackage, "/punk6529/index.html").kind).toBe(
+      "page"
+    );
+    expect(resolveCmsRoute(cmsPackage, "/PUNK6529/loop/index.html")).toEqual({
+      kind: "not_found",
+      reason: "route_missing",
+    });
+  });
+
+  it.each([
+    [
+      "/Punk6529/Gallery/index.html?view=Grid#Artwork",
+      "/punk6529/Gallery/index.html?view=Grid#Artwork",
+    ],
+    ["/Punk6529?view=Grid#Artwork", "/punk6529?view=Grid#Artwork"],
+    ["/Punk6529#Artwork", "/punk6529#Artwork"],
+  ])(
+    "preserves query and fragment casing in redirects to %s",
+    (target, expected) => {
+      const cmsPackage = withRoutes([
+        { path: "/Punk6529/go/index.html", kind: "redirect", target },
+      ]);
+      expect(
+        resolveCmsRoute(cmsPackage, "/punk6529/go/index.html")
+      ).toMatchObject({
+        kind: "redirect",
+        target: expected,
+      });
+    }
+  );
+
+  it("normalizes fallback page paths without changing the package", () => {
+    const cmsPackage: CmsPackageV1 = {
+      ...minimalCmsPackage,
+      payload: {
+        ...minimalCmsPackage.payload,
+        routes: [],
+        pages: minimalCmsPackage.payload.pages.map((page) => ({
+          ...page,
+          path: "/Punk6529/Home/index.html",
+        })),
+      },
+    };
+    expect(getCmsPagePath(cmsPackage, "page-home")).toBe(
+      "/punk6529/Home/index.html"
+    );
+    expect(getCmsPagePath(cmsPackage, "missing")).toBeNull();
+    expect(cmsPackage.payload.pages[0]?.path).toBe("/Punk6529/Home/index.html");
+  });
+
+  it("normalizes nested internal navigation without rewriting external URLs or anchors", () => {
+    const urls = [
+      "/Punk6529/Gallery/index.html?view=Grid#Artwork",
+      "/Punk6529?view=Grid#Artwork",
+      "https://Example.com/Gallery?view=Grid#Artwork",
+      "//Example.com/Gallery",
+      "#Artwork",
+    ];
+    const items = [
+      { label: "Gallery", children: urls.map((url) => ({ label: url, url })) },
+    ];
+    const cmsPackage: CmsPackageV1 = {
+      ...minimalCmsPackage,
+      site: { ...minimalCmsPackage.site, navigation_id: "navigation-test" },
+      payload: {
+        ...minimalCmsPackage.payload,
+        navigation: [{ id: "navigation-test", items }],
+      },
+    };
+    expect(
+      getCmsNavigationItems(cmsPackage)[0]?.children?.map((item) => item.url)
+    ).toEqual([
+      "/punk6529/Gallery/index.html?view=Grid#Artwork",
+      "/punk6529?view=Grid#Artwork",
+      ...urls.slice(2),
+    ]);
+    expect(items[0]?.children.map((item) => item.url)).toEqual(urls);
+  });
+
   it("only treats index.html paths as CMS routes", () => {
     expect(isProfileCmsIndexSegments(undefined)).toBe(false);
     expect(isProfileCmsIndexSegments([])).toBe(false);

--- a/lib/profile-cms/runtime/routes.ts
+++ b/lib/profile-cms/runtime/routes.ts
@@ -58,7 +58,11 @@ export function resolveCmsRoute(
   cmsPackage: CmsPackageV1,
   path: string
 ): CmsRouteResolution {
-  return resolveCmsRouteInternal(cmsPackage, path, new Set<string>());
+  return resolveCmsRouteInternal(
+    cmsPackage,
+    normalizeCmsHandleSegment(path),
+    new Set<string>()
+  );
 }
 
 export function getCmsPagePath(
@@ -69,23 +73,50 @@ export function getCmsPagePath(
     (candidate) => candidate.page_id === pageId && candidate.kind === "page"
   );
   if (route) {
-    return route.path;
+    return normalizeCmsHandleSegment(route.path);
   }
 
-  return (
-    cmsPackage.payload.pages.find((candidate) => candidate.id === pageId)
-      ?.path ?? null
+  const page = cmsPackage.payload.pages.find(
+    (candidate) => candidate.id === pageId
   );
+  return page ? normalizeCmsHandleSegment(page.path) : null;
 }
 
 export function getCmsNavigationItems(
   cmsPackage: CmsPackageV1
 ): CmsNavigationItemV1[] {
-  return (
+  const items =
     cmsPackage.payload.navigation.find(
       (navigation) => navigation.id === cmsPackage.site.navigation_id
-    )?.items ?? []
-  );
+    )?.items ?? [];
+  return items.map((item) => normalizeCmsNavigationItem(item));
+}
+
+/**
+ * Published packages may retain display-case handles, while runtime requests
+ * use canonical lowercase handles. Preserve page slugs, queries, and fragments.
+ */
+function normalizeCmsHandleSegment(path: string): string {
+  if (!isSafeCmsRelativeUri(path)) {
+    return path;
+  }
+  return path.replace(/^\/[^/?#]+/, (handle) => handle.toLowerCase());
+}
+
+function normalizeCmsNavigationItem(
+  item: CmsNavigationItemV1
+): CmsNavigationItemV1 {
+  return {
+    ...item,
+    ...(item.url ? { url: normalizeCmsHandleSegment(item.url) } : {}),
+    ...(item.children
+      ? {
+          children: item.children.map((child) =>
+            normalizeCmsNavigationItem(child)
+          ),
+        }
+      : {}),
+  };
 }
 
 function resolveCmsRouteInternal(
@@ -99,7 +130,7 @@ function resolveCmsRouteInternal(
   seenPaths.add(path);
 
   const route = cmsPackage.payload.routes.find(
-    (candidate) => candidate.path === path
+    (candidate) => normalizeCmsHandleSegment(candidate.path) === path
   );
   if (!route) {
     return { kind: "not_found", reason: "route_missing" };
@@ -109,7 +140,11 @@ function resolveCmsRouteInternal(
     if (!route.target || !isSafeCmsRelativeUri(route.target)) {
       return { kind: "not_found", reason: "unsafe_redirect" };
     }
-    return { kind: "redirect", route, target: route.target };
+    return {
+      kind: "redirect",
+      route,
+      target: normalizeCmsHandleSegment(route.target),
+    };
   }
 
   if (route.kind === "alias") {
@@ -117,7 +152,11 @@ function resolveCmsRouteInternal(
       return { kind: "not_found", reason: "route_missing" };
     }
     if (route.target.startsWith("/")) {
-      return resolveCmsRouteInternal(cmsPackage, route.target, seenPaths);
+      return resolveCmsRouteInternal(
+        cmsPackage,
+        normalizeCmsHandleSegment(route.target),
+        seenPaths
+      );
     }
     const page = cmsPackage.payload.pages.find(
       (candidate) => candidate.id === route.target

--- a/lib/profile-cms/runtime/routes.ts
+++ b/lib/profile-cms/runtime/routes.ts
@@ -129,9 +129,11 @@ function resolveCmsRouteInternal(
   }
   seenPaths.add(path);
 
-  const route = cmsPackage.payload.routes.find(
+  const matchingRoutes = cmsPackage.payload.routes.filter(
     (candidate) => normalizeCmsHandleSegment(candidate.path) === path
   );
+  // Never let manifest ordering choose between conflicting canonical routes.
+  const route = matchingRoutes.length === 1 ? matchingRoutes[0] : undefined;
   if (!route) {
     return { kind: "not_found", reason: "route_missing" };
   }

--- a/ops/docs/profiles/troubleshooting/troubleshooting-routes-and-tabs.md
+++ b/ops/docs/profiles/troubleshooting/troubleshooting-routes-and-tabs.md
@@ -73,6 +73,13 @@ Scope:
   - Meaning: canonical-handle normalization.
   - Action: save the canonical URL.
 
+- Symptom: a published custom profile page ending in `/index.html` cannot be found.
+  - Meaning: the profile handle is case-insensitive, but page names after the
+    handle remain case-sensitive. The page must exist in the published site.
+  - Action: use the published page or navigation link and preserve its page-name
+    capitalization. Changing only the handle capitalization does not select a
+    different page.
+
 - Symptom: `/{user}/stats` shows `USER OR PAGE`.
   - Meaning: the standalone `Stats` route was removed.
   - Action: open `/{user}/collected` and use `Details` for profile stats behavior.

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -7476,6 +7476,37 @@
       "related_paths": ["/restricted"],
       "tags": ["access", "navigation"],
       "source_refs": ["app/access/page.tsx", "app/access/page.client.tsx"]
+    },
+    {
+      "id": "profiles.cms-pages",
+      "kind": "business_rule",
+      "title": "Published custom profile pages",
+      "aliases": [
+        "custom profile page",
+        "profile website",
+        "published CMS page"
+      ],
+      "keywords": [
+        "profile",
+        "cms",
+        "published",
+        "page",
+        "route",
+        "capitalization"
+      ],
+      "facts": [
+        "Published custom profile pages use paths ending in /index.html under the profile handle.",
+        "Profile handles in custom page links are case-insensitive; page names after the handle remain case-sensitive.",
+        "If a custom page is not found, use a link from the published site and preserve its page-name capitalization."
+      ],
+      "canonical_path": "/{user}",
+      "related_paths": ["/{user}/cms/builder"],
+      "tags": ["profiles", "cms"],
+      "source_refs": [
+        "app/[user]/[...cmsPath]/page.tsx",
+        "lib/profile-cms/runtime/routes.ts",
+        "ops/docs/profiles/troubleshooting/troubleshooting-routes-and-tabs.md"
+      ]
     }
   ]
 }

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -7472,6 +7472,37 @@
       "related_paths": ["/restricted"],
       "tags": ["access", "navigation"],
       "source_refs": ["app/access/page.tsx", "app/access/page.client.tsx"]
+    },
+    {
+      "id": "profiles.cms-pages",
+      "kind": "business_rule",
+      "title": "Published custom profile pages",
+      "aliases": [
+        "custom profile page",
+        "profile website",
+        "published CMS page"
+      ],
+      "keywords": [
+        "profile",
+        "cms",
+        "published",
+        "page",
+        "route",
+        "capitalization"
+      ],
+      "facts": [
+        "Published custom profile pages use paths ending in /index.html under the profile handle.",
+        "Profile handles in custom page links are case-insensitive; page names after the handle remain case-sensitive.",
+        "If a custom page is not found, use a link from the published site and preserve its page-name capitalization."
+      ],
+      "canonical_path": "/{user}",
+      "related_paths": ["/{user}/cms/builder"],
+      "tags": ["profiles", "cms"],
+      "source_refs": [
+        "app/[user]/[...cmsPath]/page.tsx",
+        "lib/profile-cms/runtime/routes.ts",
+        "ops/docs/profiles/troubleshooting/troubleshooting-routes-and-tabs.md"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Issue
Published custom profile packages can retain display-case handles, while requests use the canonical lowercase handle. A valid page such as `/Punk6529/Gallery/index.html` can consequently return not found.

## Fix
Normalize only the profile-handle segment when matching routes and producing internal links. Preserve case-sensitive page names, query values, and fragments.

## Changes
- Apply the same handle normalization to aliases, safe redirects, page links, and nested navigation.
- Preserve alias-cycle detection, unsafe-redirect rejection, external URLs, and the original package objects; reject conflicting canonical routes independently of manifest order.
- Add regression tests and update profile troubleshooting and the Help Bot corpus.

## Validation
- All four CMS runtime suites passed: 32 tests, including 17 route tests.
- Help index synchronization and documentation link validation passed (299 files).
- Whitespace check passed.
- Changed-file type check passed; React Doctor found no issues in the two changed source files.
- CI passed changed-file lint, quality/contracts, production build, Playwright smoke and critical shell, CodeQL, SonarCloud, Snyk, and DCO.

## Risk
Low: scoped to custom profile route matching and generated links. No package format, backend, or data migration changes. Revert this change to roll back.

## Review Notes
Check that only the handle is normalized, including handle-only links with queries or fragments, and that aliases retain cycle protection.

