### PR TITLE
chore(lint): cover configuration and CMS runtime tests

### DIFF
--- a/config/version.ts
+++ b/config/version.ts
@@ -4,6 +4,7 @@ export function logOnceConfig(label: string, message: string) {
   if (!process.env[`__LOG_${label}_ONCE__`]) {
     process.env[`__LOG_${label}_ONCE__`] = "1";
     process.env["__LOG_ENV_ONCE__"] = "1";
+    // eslint-disable-next-line no-console -- deliberate build-time version banner, emitted once
     console.log(`${label}: ${message}`);
   }
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -469,12 +469,15 @@ export const baseGlobalIgnores = Object.freeze([
   "**/public",
   "**/coverage",
   "**/generated",
-  "**/__tests__/**",
+  // Expand test lint coverage one subtree at a time; keep directory traversal
+  // enabled so the selected runtime tests can be reached.
+  "**/__tests__/**/*",
+  "!**/__tests__/**/",
+  "!**/__tests__/lib/profile-cms/runtime/**",
   "**/tests/**",
   "**/__mocks__/**",
   "**/e2e/**",
   "**/test-results/**",
-  "config/**",
   "*.js",
   "*.mjs",
   "*.ts",
@@ -495,10 +498,6 @@ export const typeCheckedFileIgnores = Object.freeze([
   "scripts/**",
   "**/next.config.*",
   "**/.next-static-export/**",
-  "config/env.ts",
-  "config/serverEnv.ts",
-  "config/alchemyEnv.ts",
-  "config/reviewbotUsageEnv.ts",
   "__tests__/config/env.base-endpoint.test.ts",
   "**/playwright.config.ts",
   "tests/**",
@@ -593,6 +592,27 @@ export const createEslintConfig = ({
               "Accessing process.env is restricted. Use environment variables safely.",
           },
         ],
+      },
+    },
+
+    // These existing adapters form the raw environment boundary. Keep them
+    // type-checked, and keep the env-access restriction on other config files.
+    {
+      files: [
+        "config/alchemyEnv.ts",
+        "config/assets.ts",
+        "config/deploymentEnv.ts",
+        "config/env.ts",
+        "config/museumPublicationEnv.server.ts",
+        "config/nextConfig.ts",
+        "config/publicReviewDestinationEnv.server.ts",
+        "config/reviewbotUsageEnv.ts",
+        "config/runtimeConfig.ts",
+        "config/serverEnv.ts",
+        "config/version.ts",
+      ],
+      rules: {
+        "no-restricted-syntax": "off",
       },
     },
 

--- a/eslint.config.tight.mjs
+++ b/eslint.config.tight.mjs
@@ -1,9 +1,12 @@
 import reactYouMightNotNeedAnEffect from "eslint-plugin-react-you-might-not-need-an-effect";
 import { baseGlobalIgnores, createEslintConfig } from "./eslint.config.mjs";
 
-const tightGlobalIgnores = baseGlobalIgnores.filter(
-  (pattern) => pattern !== "**/test-results/**"
-);
+// Roll out the existing base rules first, preserving the tighter ruleset's scope.
+const tightGlobalIgnores = [
+  ...baseGlobalIgnores.filter((pattern) => pattern !== "**/test-results/**"),
+  "**/__tests__/**",
+  "config/**",
+];
 
 const tightRuleOverrides = {
   // Preserve every rule explicitly enabled by the legacy tight config. Some of


### PR DESCRIPTION
## Issue
The base ESLint configuration skips the entire `config` and `__tests__` trees, leaving environment adapters and CMS runtime regression tests outside normal base lint coverage.

## Fix
Enable base lint for configuration files and the four CMS runtime test suites. Keep type information for environment adapters and allow raw environment reads only in the existing adapter files.

## Changes
- Add a bounded test-directory rollout without enabling unrelated test subtrees.
- Replace the broad config exclusion with eleven explicit raw-environment adapter exceptions.
- Preserve the current tight/diff lint scope and existing application rules.
- Document the intentional once-only build version banner with a local console-rule exception.

## Validation
- Effective ESLint configuration probe passed: selected files are linted with type information; unrelated tests and tight exclusions remain unchanged.
- A raw `process.env` probe still fails in feature configuration.
- Four CMS runtime suites passed: 22 tests.
- Changed-file type check and whitespace check passed.
- Direct base lint passed for configuration; the JSON report confirms all four CMS runtime test files were analyzed with zero errors or warnings. Changed-file lint passed.
- CI passed quality/contracts, production build, Playwright smoke and critical shell, CodeQL, SonarCloud, Snyk, and DCO.

## Risk
Low runtime risk: no behavior or dependency changes. Base lint gains coverage; tight/diff lint remains unchanged. Revert the config change to restore the previous lint scope.

## Review Notes
Focus on ignore traversal, typed parser coverage, and the narrow environment-adapter exceptions. This is an incremental rollout of the base rules, not a broad test cleanup or a new CI gate.


