### PR TITLE
Ensure single-submission views show complete media

### DIFF
--- a/__tests__/components/waves/drops/WaveDropQuoteWithDropId.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropQuoteWithDropId.test.tsx
@@ -11,10 +11,8 @@ jest.mock("@/components/waves/drops/WaveDropQuote", () => (props: any) => {
 });
 
 const useQuery = jest.fn();
-const getQueryData = jest.fn();
 jest.mock("@tanstack/react-query", () => ({
   useQuery: (opts: any) => useQuery(opts),
-  useQueryClient: () => ({ getQueryData }),
   keepPreviousData: "keep",
 }));
 
@@ -43,7 +41,6 @@ describe("WaveDropQuoteWithDropId", () => {
   beforeEach(() => {
     capturedProps = undefined;
     jest.clearAllMocks();
-    getQueryData.mockReturnValue(undefined);
     useMyStreamOptional.mockReturnValue(null);
   });
 
@@ -77,9 +74,7 @@ describe("WaveDropQuoteWithDropId", () => {
       wave: { id: "old-wave" },
       hide_link_preview: true,
     };
-    useQuery.mockImplementation((opts: any) => {
-      return { data: opts.initialData };
-    });
+    useQuery.mockReturnValue({ data: undefined });
 
     render(
       <WaveDropQuoteWithDropId
@@ -96,17 +91,14 @@ describe("WaveDropQuoteWithDropId", () => {
     const call = useQuery.mock.calls[0][0];
     expect(call.queryKey).toEqual([QueryKey.DROP, { drop_id: "d1" }]);
     expect(call.enabled).toBe(false);
-    expect(call.initialData).toBe(maybeDrop);
+    expect(call).not.toHaveProperty("initialData");
     expect(call).not.toHaveProperty("initialDataUpdatedAt");
     expect(fetchDropByIdBatchedMock).not.toHaveBeenCalled();
   });
 
-  it("uses an already cached drop without fetching fresh data", () => {
+  it("uses an already cached detail drop without reseeding the query", () => {
     const cachedDrop = { id: "d1", wave: { id: "cached-wave" } };
-    getQueryData.mockReturnValue(cachedDrop);
-    useQuery.mockImplementation((opts: any) => {
-      return { data: opts.initialData };
-    });
+    useQuery.mockReturnValue({ data: cachedDrop });
 
     render(
       <WaveDropQuoteWithDropId
@@ -119,8 +111,8 @@ describe("WaveDropQuoteWithDropId", () => {
 
     expect(capturedProps.drop).toBe(cachedDrop);
     const call = useQuery.mock.calls[0][0];
-    expect(call.enabled).toBe(false);
-    expect(call.initialData).toBe(cachedDrop);
+    expect(call.enabled).toBe(true);
+    expect(call).not.toHaveProperty("initialData");
   });
 
   it("uses a full drop from wave messages without fetching by id", () => {
@@ -140,9 +132,7 @@ describe("WaveDropQuoteWithDropId", () => {
         unsubscribe: jest.fn(),
       },
     });
-    useQuery.mockImplementation((opts: any) => {
-      return { data: opts.initialData };
-    });
+    useQuery.mockReturnValue({ data: undefined });
 
     render(
       <WaveDropQuoteWithDropId
@@ -157,7 +147,7 @@ describe("WaveDropQuoteWithDropId", () => {
     expect(capturedProps.drop).toBe(waveDrop);
     const call = useQuery.mock.calls[0][0];
     expect(call.enabled).toBe(false);
-    expect(call.initialData).toBe(waveDrop);
+    expect(call).not.toHaveProperty("initialData");
   });
 
   it("keeps active-wave hydration neutral until the moderated record arrives", () => {
@@ -174,7 +164,6 @@ describe("WaveDropQuoteWithDropId", () => {
       type: "FULL",
       moderation: { status: "MODERATOR_REMOVED", can_view: false },
     };
-    getQueryData.mockReturnValue(staleCachedDrop);
     useMyStreamOptional.mockReturnValue({
       activeWave: { id: "w1" },
       waveMessagesStore: {

--- a/__tests__/components/waves/drops/useDropContent.test.tsx
+++ b/__tests__/components/waves/drops/useDropContent.test.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { useDropContent } from "@/components/waves/drops/useDropContent";
 import type { ApiDrop } from "@/generated/models/ApiDrop";
 import { ApiDropModerationStatus } from "@/generated/models/ApiDropModerationStatus";
-import { fetchDropByIdBatched } from "@/services/api/drop-api";
+import { fetchDropByIdBatched, getDropQueryKey } from "@/services/api/drop-api";
 
 // Mock dependencies
 jest.mock("@/services/api/drop-api", () => {
@@ -53,8 +53,8 @@ const mockFetchDropByIdBatched = fetchDropByIdBatched as jest.MockedFunction<
 >;
 
 // Test wrapper with QueryClient
-const createWrapper = () => {
-  const queryClient = new QueryClient({
+const createQueryClient = () =>
+  new QueryClient({
     defaultOptions: {
       queries: {
         retry: false,
@@ -63,6 +63,7 @@ const createWrapper = () => {
     },
   });
 
+const createWrapper = (queryClient = createQueryClient()) => {
   const Wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
@@ -418,10 +419,44 @@ describe("useDropContent", () => {
 
   describe("Query behavior", () => {
     it("disables query when maybeDrop is provided", () => {
-      renderHook(() => useDropContent("drop-123", 1, mockDrop), {
-        wrapper: createWrapper(),
-      });
+      const queryClient = createQueryClient();
+      const { result } = renderHook(
+        () => useDropContent("drop-123", 1, mockDrop),
+        { wrapper: createWrapper(queryClient) }
+      );
 
+      expect(result.current.drop).toBe(mockDrop);
+      expect(
+        queryClient.getQueryData(getDropQueryKey("drop-123"))
+      ).toBeUndefined();
+      expect(mockFetchDropByIdBatched).not.toHaveBeenCalled();
+    });
+
+    it("does not let a reply preview replace cached full drop details", () => {
+      const queryClient = createQueryClient();
+      queryClient.setQueryData(getDropQueryKey("drop-123"), mockDrop);
+      const replyPreview = {
+        ...mockDrop,
+        created_at: 0,
+        parts: [
+          {
+            part_id: 1,
+            content: "Test content",
+            quoted_drop: null,
+            media: [],
+          },
+        ],
+      } as unknown as ApiDrop;
+
+      const { result } = renderHook(
+        () => useDropContent("drop-123", 1, replyPreview),
+        { wrapper: createWrapper(queryClient) }
+      );
+
+      expect(result.current.drop).toBe(mockDrop);
+      expect(queryClient.getQueryData(getDropQueryKey("drop-123"))).toBe(
+        mockDrop
+      );
       expect(mockFetchDropByIdBatched).not.toHaveBeenCalled();
     });
 

--- a/components/waves/drops/WaveDropQuoteWithDropId.tsx
+++ b/components/waves/drops/WaveDropQuoteWithDropId.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import React, { useCallback, useSyncExternalStore } from "react";
-import {
-  keepPreviousData,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import type { ApiDrop } from "@/generated/models/ApiDrop";
 import { ApiDropModerationStatus } from "@/generated/models/ApiDropModerationStatus";
 import { useMyStreamOptional } from "@/contexts/wave/MyStreamContext";
@@ -113,13 +109,9 @@ const WaveDropQuoteWithDropId: React.FC<WaveDropQuoteWithDropIdProps> = ({
   onLinkCardActionsActiveChange,
 }) => {
   const normalizedDropId = dropId.trim();
-  const queryClient = useQueryClient();
   const myStream = useMyStreamOptional();
   const targetWaveId = waveId ?? myStream?.activeWave.id ?? null;
   const waveMessages = useOptionalWaveMessages(myStream, targetWaveId);
-  const cachedDrop = queryClient.getQueryData<ApiDrop>(
-    getDropQueryKey(normalizedDropId)
-  );
   const waveMessagesDrop =
     (targetWaveId
       ? waveMessages?.drops.find(
@@ -139,18 +131,15 @@ const WaveDropQuoteWithDropId: React.FC<WaveDropQuoteWithDropIdProps> = ({
     authoritativeModeratedDrop = waveMessagesDrop;
   }
 
-  let initialDrop = currentPresentationDrop;
-  if (initialDrop === null && !isActiveWaveHydrating) {
-    initialDrop = cachedDrop ?? null;
-  }
-
   const { data: drop, error } = useQuery<ApiDrop | undefined>({
     queryKey: getDropQueryKey(normalizedDropId),
     queryFn: () => fetchDropByIdBatched(normalizedDropId),
     placeholderData: keepPreviousData,
-    enabled: normalizedDropId.length > 0 && initialDrop === null,
+    enabled:
+      normalizedDropId.length > 0 &&
+      currentPresentationDrop === null &&
+      !isActiveWaveHydrating,
     staleTime: DROP_DETAIL_STALE_TIME_MS,
-    ...(initialDrop === null ? {} : { initialData: initialDrop }),
   });
 
   const isNotFound =

--- a/components/waves/drops/useDropContent.ts
+++ b/components/waves/drops/useDropContent.ts
@@ -51,12 +51,9 @@ export const useDropContent = (
     placeholderData: (previousDrop) => maybeDrop ?? previousDrop,
     enabled: shouldFetchDrop,
     staleTime: DROP_DETAIL_STALE_TIME_MS,
-    ...(!shouldFetchDrop && maybeDrop !== null
-      ? { initialData: maybeDrop }
-      : {}),
   });
   const resolvedDrop: ApiDrop | null =
-    authoritativeModeratedDrop ?? drop ?? null;
+    authoritativeModeratedDrop ?? drop ?? maybeDrop ?? null;
 
   const content = useMemo<ProcessedContent>(() => {
     if (isFetching && resolvedDrop === null) {


### PR DESCRIPTION
## Issue

Single-submission views could render a partial reply or quote preview instead of the complete drop. Affected panels could omit media, show author level 0, and display a 1970 timestamp even though separately fetched metadata still appeared.

## Fix

Keep reply and quote previews as local presentation data rather than seeding them into the shared full-drop React Query cache. Complete cached drops still take precedence, and single-submission views can now fetch authoritative drop details normally.

## Notable changes

- Stop reply previews from becoming `initialData` for the canonical drop-detail query.
- Stop quote previews and wave-message presentation records from seeding that query.
- Preserve immediate reply/quote rendering and moderated-drop behavior.
- Add regression coverage proving previews neither populate nor replace complete cached drop details.

## Validation

- `./bin/6529 run test --runInBand --forceExit --testPathPatterns='__tests__/components/waves/drops/(useDropContent|WaveDropQuoteWithDropId)\.test\.tsx$'` — 32 tests passed.
- `./bin/6529 run check:changed` — passed on the latest rebased head.
- `./bin/6529 run react-doctor:diff` — 100/100 on the changed React sources before commit; no findings.
- Read-only browser matrix against production API data through the fixed local app — 8/8 desktop Chromium and Pixel 7 tests passed.
- Confirmed the reported WA-NGMI drop renders its MP4, Arthr level 37, and the real timestamp; Legacy of Wisdom remains correct.
- Confirmed an image submission and a chat image render by deep link, and image/video submissions render when opened from the leaderboard on desktop and mobile.

## Risk

Low. The change is limited to preview-to-query-cache behavior. Preview components continue to render the same local data, while the shared query key is reserved for complete drop records.

## Rollback

Revert the fix commit to restore the previous preview cache seeding behavior.

## Review notes

Please focus on the distinction between presentation-only preview data and authoritative drop-detail cache data, including moderated and active-wave hydration cases.

No user-facing documentation changes are needed because this restores the intended existing behavior without changing routes, controls, or terminology.
