### PR TITLE
Fix CMS gallery snapshot sign-in guidance

### DIFF
--- a/__tests__/components/profile-cms-builder/ProfileCmsBuilder.test.tsx
+++ b/__tests__/components/profile-cms-builder/ProfileCmsBuilder.test.tsx
@@ -29,6 +29,8 @@ jest.mock("@/components/auth/Auth", () => ({
 }));
 
 jest.mock("@/services/api/common-api", () => ({
+  getStructuredApiErrorStatus: jest.requireActual("@/services/api/common-api")
+    .getStructuredApiErrorStatus,
   commonApiPost: jest.fn(),
   commonApiFetch: jest.fn(async () => []),
 }));
@@ -109,6 +111,7 @@ describe("ProfileCmsBuilder", () => {
     useAuthMock.mockReturnValue({
       activeProfileProxy: null,
       connectedProfile: null,
+      isAuthenticated: false,
     });
   });
 
@@ -375,6 +378,10 @@ describe("ProfileCmsBuilder", () => {
     await user.click(screen.getByRole("button", { name: "Request snapshot" }));
 
     expect(await screen.findByText("Fixture snapshot")).toBeInTheDocument();
+    expect(commonApiPostMock).not.toHaveBeenCalled();
+    expect(
+      screen.queryByText("Sign in to request a wallet snapshot.")
+    ).not.toBeInTheDocument();
     expect(screen.getByText("The Memes #1")).toBeInTheDocument();
     expect(screen.getAllByText("Media pending").length).toBeGreaterThan(0);
 
@@ -418,6 +425,7 @@ describe("ProfileCmsBuilder", () => {
     useAuthMock.mockReturnValue({
       activeProfileProxy: null,
       connectedProfile: { id: "profile" },
+      isAuthenticated: true,
     });
     const snapshot = {
       ...createMockWalletGallerySnapshot({ handle: "punk6529", sources: [] }),

--- a/__tests__/components/profile-cms-builder/ProfileCmsBuilderGalleryAuth.test.tsx
+++ b/__tests__/components/profile-cms-builder/ProfileCmsBuilderGalleryAuth.test.tsx
@@ -1,0 +1,181 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { useAuth } from "@/components/auth/Auth";
+import ProfileCmsBuilder from "@/components/profile-cms-builder/ProfileCmsBuilder";
+import * as editor from "@/components/profile-cms-builder/ProfileCmsBuilderEditorPanel";
+import { publicEnv } from "@/config/env";
+import {
+  ApiProfileCmsWalletGallerySnapshotSourceEnum,
+  type ApiProfileCmsWalletGallerySnapshot,
+} from "@/generated/models/ApiProfileCmsWalletGallerySnapshot";
+import { commonApiPost } from "@/services/api/common-api";
+
+jest.mock("@/config/env", () => {
+  const actual = jest.requireActual("@/config/env");
+  return { ...actual, publicEnv: { ...actual.publicEnv } };
+});
+jest.mock("@/components/auth/Auth", () => ({ useAuth: jest.fn() }));
+jest.mock("@/services/api/common-api", () => ({
+  getStructuredApiErrorStatus: jest.requireActual("@/services/api/common-api")
+    .getStructuredApiErrorStatus,
+  commonApiPost: jest.fn(),
+  commonApiFetch: jest.fn(async () => []),
+}));
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+jest.mock("@/components/profile-cms/CmsSiteRenderer", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("@/components/auth/SeizeConnectContext", () => ({
+  useSeizeConnectContext: () => ({ address: undefined, isConnected: false }),
+}));
+jest.mock("@/hooks/profile-cms/useProfileCmsPublishSign", () => ({
+  useProfileCmsPublishSign: () => ({
+    isConnected: false,
+    chainId: 1,
+    isSafe: false,
+    signTypedData: jest.fn(),
+  }),
+}));
+
+const auth = useAuth as jest.Mock;
+const post = jest.mocked(commonApiPost);
+
+async function openGallery() {
+  const user = userEvent.setup();
+  render(
+    <ProfileCmsBuilder
+      handle="punk6529"
+      profileId="target-profile"
+      title="Profile CMS builder"
+    />
+  );
+  await user.click(screen.getByRole("button", { name: "Wallet gallery" }));
+  return user;
+}
+
+describe("CMS wallet snapshot authentication", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    publicEnv.PROFILE_CMS_BUILDER_API_ENABLED = "true";
+    delete publicEnv.NEXT_PUBLIC_PROFILE_CMS_BUILDER_API_ENABLED;
+    auth.mockReturnValue({
+      isAuthenticated: false,
+      connectedProfile: null,
+      activeProfileProxy: null,
+    });
+    post.mockResolvedValue({
+      generated_at: Date.parse("2026-09-10T12:00:00Z"),
+      source: ApiProfileCmsWalletGallerySnapshotSourceEnum.IndexedOwnership,
+      block_reference: 0,
+      wallets: [],
+      assets: [],
+      excluded_assets: [],
+      totals: {
+        requested_wallets: 1,
+        resolved_wallets: 1,
+        unresolved_wallets: 0,
+        indexed_assets: 0,
+        visible_assets: 0,
+        excluded_assets: 0,
+        spam_assets: 0,
+        truncated: false,
+      },
+    } satisfies ApiProfileCmsWalletGallerySnapshot);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it.each([false, undefined])(
+    "requires an authenticated session even when a profile is present (%s)",
+    async (isAuthenticated) => {
+      auth.mockReturnValue({
+        isAuthenticated,
+        connectedProfile: { id: "target-profile" },
+        activeProfileProxy: null,
+      });
+      const user = await openGallery();
+      const request = screen.getByRole("button", { name: "Request snapshot" });
+      expect(request).toBeDisabled();
+      expect(request).toHaveAccessibleDescription(
+        "Sign in to request a wallet snapshot."
+      );
+      await user.click(request);
+      expect(post).not.toHaveBeenCalled();
+    }
+  );
+
+  it("guards a direct snapshot handler call while signed out", async () => {
+    const originalEditor = editor.EditorPanel;
+    let requestSnapshot: (() => void) | undefined;
+    jest.spyOn(editor, "EditorPanel").mockImplementation((props) => {
+      requestSnapshot = props.onRequestGallerySnapshot;
+      return originalEditor(props);
+    });
+    await openGallery();
+    expect(requestSnapshot).toBeDefined();
+    await act(async () => requestSnapshot?.());
+    expect(post).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Sign in to request a wallet snapshot."
+    );
+  });
+
+  it.each([null, { id: "different-profile" }])(
+    "allows any authenticated session without target-profile ownership (%j)",
+    async (connectedProfile) => {
+      auth.mockReturnValue({
+        isAuthenticated: true,
+        connectedProfile,
+        activeProfileProxy: null,
+      });
+      const user = await openGallery();
+      const request = screen.getByRole("button", { name: "Request snapshot" });
+      expect(request).toBeEnabled();
+      await user.click(request);
+      await waitFor(() => expect(post).toHaveBeenCalledTimes(1));
+      expect(post).toHaveBeenCalledWith({
+        endpoint: "profile-cms/wallet-gallery/snapshot",
+        body: { wallets: ["punk6529.eth"] },
+        errorMode: "structured",
+      });
+      expect(await screen.findByText("Backend snapshot")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Save draft" })).toBeDisabled();
+    }
+  );
+
+  it.each([
+    [
+      401,
+      "Your session could not be verified. Sign in again to request a wallet snapshot.",
+    ],
+    [503, "Gallery snapshot could not be created."],
+  ])(
+    "shows the safe actionable message for HTTP %i",
+    async (status, message) => {
+      auth.mockReturnValue({
+        isAuthenticated: true,
+        connectedProfile: null,
+        activeProfileProxy: null,
+      });
+      post.mockRejectedValueOnce(
+        Object.assign(new Error("Internal response details"), { status })
+      );
+      const user = await openGallery();
+      await user.click(
+        screen.getByRole("button", { name: "Request snapshot" })
+      );
+      expect(await screen.findByText(message)).toHaveAttribute("role", "alert");
+      expect(
+        screen.getByRole("button", { name: "Request snapshot" })
+      ).toHaveAccessibleDescription(message);
+      expect(
+        screen.queryByText("Internal response details")
+      ).not.toBeInTheDocument();
+    }
+  );
+});

--- a/components/profile-cms-builder/ProfileCmsBuilder.tsx
+++ b/components/profile-cms-builder/ProfileCmsBuilder.tsx
@@ -63,6 +63,7 @@ import {
   updateCmsBuilderState,
 } from "@/lib/profile-cms/builder/editor";
 import { getProfileCmsPackageById } from "@/lib/profile-cms/builder/api";
+import { getStructuredApiErrorStatus } from "@/services/api/common-api";
 
 export default function ProfileCmsBuilder(
   props: ComponentProps<typeof ProfileCmsBuilderWorkspace>
@@ -117,7 +118,7 @@ function ProfileCmsBuilderWorkspace({
   const actionRequestIdRef = useRef(0);
   const gallerySnapshotRequestIdRef = useRef(0);
   const stateVersionRef = useRef(0);
-  const { activeProfileProxy, connectedProfile } = useAuth();
+  const { activeProfileProxy, connectedProfile, isAuthenticated } = useAuth();
   const { address } = useSeizeConnectContext();
 
   const validation = useMemo(() => validateCmsBuilderState(state), [state]);
@@ -130,6 +131,8 @@ function ProfileCmsBuilderWorkspace({
     connectedProfile?.id,
     !!activeProfileProxy
   );
+  const canRequestGallerySnapshot =
+    !isProfileCmsBuilderApiEnabledEnv() || isAuthenticated === true;
   const busy = isCmsBuilderBusy(
     isSubmitting,
     isPublishing,
@@ -244,6 +247,13 @@ function ProfileCmsBuilderWorkspace({
   };
 
   const requestGallerySnapshot = async () => {
+    if (!canRequestGallerySnapshot) {
+      setGallerySnapshotStatus("error");
+      setGallerySnapshotError(
+        t(locale, "profileCms.builder.gallery.snapshot.signInRequired")
+      );
+      return;
+    }
     const parsed = parseWalletGallerySources(state.gallery.walletInput);
     if (!parsed.ok) {
       setGallerySnapshotStatus("error");
@@ -280,13 +290,18 @@ function ProfileCmsBuilderWorkspace({
       );
       clearActionResult();
       setGallerySnapshotStatus("ready");
-    } catch {
+    } catch (error) {
       if (requestId !== gallerySnapshotRequestIdRef.current) {
         return;
       }
       setGallerySnapshotStatus("error");
       setGallerySnapshotError(
-        t(locale, "profileCms.builder.gallery.snapshot.failed")
+        t(
+          locale,
+          getStructuredApiErrorStatus(error) === 401
+            ? "profileCms.builder.gallery.snapshot.sessionExpired"
+            : "profileCms.builder.gallery.snapshot.failed"
+        )
       );
     }
   };
@@ -560,6 +575,7 @@ function ProfileCmsBuilderWorkspace({
             {activeTab === "editor" && canVisuallyEditCmsPackage(state) ? (
               <EditorPanel
                 addBlock={addBlock}
+                canRequestGallerySnapshot={canRequestGallerySnapshot}
                 gallerySnapshotError={gallerySnapshotError}
                 gallerySnapshotStatus={gallerySnapshotStatus}
                 locale={locale}

--- a/components/profile-cms-builder/ProfileCmsBuilderControls.tsx
+++ b/components/profile-cms-builder/ProfileCmsBuilderControls.tsx
@@ -154,11 +154,13 @@ export function TabButton({
 }
 
 export function BuilderActionButton({
+  describedBy,
   disabled,
   label,
   onClick,
   variant = "secondary",
 }: {
+  readonly describedBy?: string | undefined;
   readonly disabled: boolean;
   readonly label: string;
   readonly onClick: () => void;
@@ -166,6 +168,7 @@ export function BuilderActionButton({
 }) {
   return (
     <button
+      aria-describedby={describedBy}
       className={`tw-min-h-10 tw-border tw-border-solid tw-px-3 tw-text-sm tw-font-semibold disabled:tw-cursor-not-allowed disabled:tw-opacity-50 ${
         variant === "primary"
           ? "tw-border-primary-400 tw-bg-primary-500 tw-text-white"

--- a/components/profile-cms-builder/ProfileCmsBuilderControls.tsx
+++ b/components/profile-cms-builder/ProfileCmsBuilderControls.tsx
@@ -171,7 +171,7 @@ export function BuilderActionButton({
       aria-describedby={describedBy}
       className={`tw-min-h-10 tw-border tw-border-solid tw-px-3 tw-text-sm tw-font-semibold disabled:tw-cursor-not-allowed disabled:tw-opacity-50 ${
         variant === "primary"
-          ? "tw-border-primary-400 tw-bg-primary-500 tw-text-white"
+          ? "tw-border-primary-400 tw-bg-primary-600 tw-text-white"
           : "tw-border-iron-700 tw-bg-iron-950 tw-text-iron-100 hover:tw-border-primary-400"
       }`}
       disabled={disabled}

--- a/components/profile-cms-builder/ProfileCmsBuilderEditorPanel.tsx
+++ b/components/profile-cms-builder/ProfileCmsBuilderEditorPanel.tsx
@@ -35,6 +35,7 @@ const BLOCK_OPTIONS: ReadonlyArray<{
 
 export function EditorPanel({
   addBlock,
+  canRequestGallerySnapshot,
   gallerySnapshotError,
   gallerySnapshotStatus,
   locale,
@@ -47,6 +48,7 @@ export function EditorPanel({
   updateState,
 }: {
   readonly addBlock: (kind: CmsBuilderBlockKind) => void;
+  readonly canRequestGallerySnapshot: boolean;
   readonly gallerySnapshotError: string;
   readonly gallerySnapshotStatus: GallerySnapshotStatus;
   readonly locale: SupportedLocale;
@@ -104,6 +106,7 @@ export function EditorPanel({
 
       {state.template === "wallet_gallery" ? (
         <WalletGalleryPanel
+          canRequestSnapshot={canRequestGallerySnapshot}
           gallery={state.gallery}
           locale={locale}
           onRequestSnapshot={onRequestGallerySnapshot}

--- a/components/profile-cms-builder/ProfileCmsBuilderGalleryPanel.tsx
+++ b/components/profile-cms-builder/ProfileCmsBuilderGalleryPanel.tsx
@@ -24,6 +24,7 @@ import {
 import type { GallerySnapshotStatus } from "@/components/profile-cms-builder/ProfileCmsBuilderEditorPanel";
 
 export function WalletGalleryPanel({
+  canRequestSnapshot,
   gallery,
   locale,
   onRequestSnapshot,
@@ -33,6 +34,7 @@ export function WalletGalleryPanel({
   updateGallery,
   updateState,
 }: {
+  readonly canRequestSnapshot: boolean;
   readonly gallery: WalletGalleryBuilderState;
   readonly locale: SupportedLocale;
   readonly onRequestSnapshot: () => void;
@@ -43,6 +45,13 @@ export function WalletGalleryPanel({
   readonly updateState: (patch: Partial<CmsBuilderState>) => void;
 }) {
   const snapshot = gallery.snapshot;
+  const snapshotDescription =
+    [
+      !canRequestSnapshot ? "cms-builder-gallery-sign-in" : null,
+      snapshotError ? "cms-builder-gallery-snapshot-error" : null,
+    ]
+      .filter(Boolean)
+      .join(" ") || undefined;
   const orderedAssets = snapshot
     ? orderGalleryAssets(snapshot.assets, gallery.orderedAssetIds)
     : [];
@@ -118,7 +127,8 @@ export function WalletGalleryPanel({
         <div className="tw-flex tw-flex-col tw-gap-2 md:tw-col-span-2">
           <div>
             <BuilderActionButton
-              disabled={snapshotStatus === "loading"}
+              describedBy={snapshotDescription}
+              disabled={!canRequestSnapshot || snapshotStatus === "loading"}
               label={
                 snapshotStatus === "loading"
                   ? t(locale, "profileCms.builder.gallery.snapshot.loading")
@@ -128,6 +138,14 @@ export function WalletGalleryPanel({
               variant="primary"
             />
           </div>
+          {!canRequestSnapshot ? (
+            <p
+              className="tw-text-sm tw-leading-6 tw-text-iron-300"
+              id="cms-builder-gallery-sign-in"
+            >
+              {t(locale, "profileCms.builder.gallery.snapshot.signInRequired")}
+            </p>
+          ) : null}
           <p className="tw-text-sm tw-leading-6 tw-text-iron-400">
             {t(locale, "profileCms.builder.gallery.wallets.help")}
           </p>
@@ -142,6 +160,7 @@ export function WalletGalleryPanel({
           {snapshotError ? (
             <p
               className="tw-border tw-border-solid tw-border-red tw-bg-red/10 tw-p-3 tw-text-sm tw-text-red"
+              id="cms-builder-gallery-snapshot-error"
               role="alert"
             >
               {snapshotError}

--- a/i18n/messages/de-DE.ts
+++ b/i18n/messages/de-DE.ts
@@ -438,6 +438,10 @@ export const DE_DE_MESSAGES = {
   "profileCms.builder.gallery.review.title": "Snapshot-Überprüfung",
   "profileCms.builder.gallery.settings": "Galerieeinstellungen",
   "profileCms.builder.gallery.snapshot.api": "Server-Snapshot",
+  "profileCms.builder.gallery.snapshot.signInRequired":
+    "Melden Sie sich an, um einen Wallet-Snapshot anzufordern.",
+  "profileCms.builder.gallery.snapshot.sessionExpired":
+    "Ihre Sitzung konnte nicht bestätigt werden. Melden Sie sich erneut an, um einen Wallet-Snapshot anzufordern.",
   "profileCms.builder.gallery.snapshot.failed":
     "Galerie-Snapshot konnte nicht erstellt werden.",
   "profileCms.builder.gallery.snapshot.fixture": "Fixture-Snapshot",

--- a/i18n/messages/en-GB.ts
+++ b/i18n/messages/en-GB.ts
@@ -412,6 +412,10 @@ export const EN_GB_MESSAGES = {
   "profileCms.builder.gallery.review.title": "Snapshot review",
   "profileCms.builder.gallery.settings": "Gallery settings",
   "profileCms.builder.gallery.snapshot.api": "Backend snapshot",
+  "profileCms.builder.gallery.snapshot.signInRequired":
+    "Sign in to request a wallet snapshot.",
+  "profileCms.builder.gallery.snapshot.sessionExpired":
+    "Your session could not be verified. Sign in again to request a wallet snapshot.",
   "profileCms.builder.gallery.snapshot.failed":
     "Gallery snapshot could not be created.",
   "profileCms.builder.gallery.snapshot.fixture": "Fixture snapshot",

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -3546,6 +3546,10 @@ export const EN_US_MESSAGES = {
   "profileCms.builder.gallery.snapshot.loading": "Requesting...",
   "profileCms.builder.gallery.snapshot.loadingDetail":
     "Collecting holdings and media candidates for review.",
+  "profileCms.builder.gallery.snapshot.signInRequired":
+    "Sign in to request a wallet snapshot.",
+  "profileCms.builder.gallery.snapshot.sessionExpired":
+    "Your session could not be verified. Sign in again to request a wallet snapshot.",
   "profileCms.builder.gallery.snapshot.failed":
     "Gallery snapshot could not be created.",
   "profileCms.builder.gallery.snapshot.fixture": "Fixture snapshot",

--- a/i18n/messages/es-ES.ts
+++ b/i18n/messages/es-ES.ts
@@ -433,6 +433,10 @@ export const ES_ES_MESSAGES = {
   "profileCms.builder.gallery.review.title": "Revisión de instantánea",
   "profileCms.builder.gallery.settings": "Configuración de la galería",
   "profileCms.builder.gallery.snapshot.api": "Instantánea del servidor",
+  "profileCms.builder.gallery.snapshot.signInRequired":
+    "Inicia sesión para solicitar una instantánea de la cartera.",
+  "profileCms.builder.gallery.snapshot.sessionExpired":
+    "No se pudo verificar tu sesión. Vuelve a iniciar sesión para solicitar una instantánea de la cartera.",
   "profileCms.builder.gallery.snapshot.failed":
     "No se pudo crear la instantánea de la galería.",
   "profileCms.builder.gallery.snapshot.fixture": "Instantánea fija",

--- a/i18n/messages/fr-FR.ts
+++ b/i18n/messages/fr-FR.ts
@@ -440,6 +440,10 @@ export const FR_FR_MESSAGES = {
   "profileCms.builder.gallery.review.title": "Examen de la copie d'écran",
   "profileCms.builder.gallery.settings": "Paramètres de la galerie",
   "profileCms.builder.gallery.snapshot.api": "Copie d'écran du serveur",
+  "profileCms.builder.gallery.snapshot.signInRequired":
+    "Connectez-vous pour demander un instantané de portefeuille.",
+  "profileCms.builder.gallery.snapshot.sessionExpired":
+    "Votre session n’a pas pu être vérifiée. Reconnectez-vous pour demander un instantané de portefeuille.",
   "profileCms.builder.gallery.snapshot.failed":
     "Impossible de créer la copie d'écran de la galerie.",
   "profileCms.builder.gallery.snapshot.fixture":

--- a/ops/docs/profiles/feature-profile-cms-builder.md
+++ b/ops/docs/profiles/feature-profile-cms-builder.md
@@ -14,8 +14,10 @@ published website uses `/{user}/index.html` and the additional paths in its pack
 ## Entry Points
 
 Open the builder URL directly. There is no public profile navigation link.
-Connect the wallet for the profile you want to edit. Server actions require the
-owner profile; a proxy session cannot save or publish.
+Connect the wallet for the profile you want to edit. Saving, server validation,
+and publishing require the owner profile; a proxy session cannot save or publish.
+Requesting a live gallery snapshot requires a signed-in session, but you can
+request holdings for another wallet.
 
 ## User Journey
 
@@ -38,10 +40,11 @@ owner profile; a proxy session cannot save or publish.
 - **Recover local work:** the builder keeps a browser recovery copy scoped to the
   profile. Use the recovery prompt to restore or discard it. Save to the server
   for access from another browser or device.
-- **Create a gallery:** request a wallet snapshot, choose supported collection
-  filters, then select and order artworks. A snapshot records the returned set;
-  request another snapshot to update it. Saving or publishing a gallery requires
-  a real snapshot; offline example holdings are for preview.
+- **Create a gallery:** sign in, enter wallet addresses or ENS names, and request
+  a wallet snapshot. Choose supported collection filters, then select and order
+  artworks. A snapshot records the returned set; request another snapshot to
+  update it. Saving or publishing a gallery requires a real snapshot; offline
+  example holdings are for preview.
 - **Restore a previous publication:** choose the version in history and confirm
   the restore. If another session changed the active version, refresh history
   before trying again.
@@ -68,6 +71,11 @@ owner profile; a proxy session cannot save or publish.
   the snapshot to try again.
 
 ## Failure and Recovery
+
+**Request snapshot** is disabled while signed out, with a sign-in explanation.
+If a session can no longer be verified, sign in again and retry. An ENS name
+without a resolved address appears as an unresolved wallet; check the name or
+enter the wallet address directly.
 
 Validation findings identify issues in the package. Fix them, save, and validate
 again. A rejected wallet signature does not publish the draft; retry signing when

--- a/ops/docs/specs/2026-06-19-6529-help-bot-knowledge-index.md
+++ b/ops/docs/specs/2026-06-19-6529-help-bot-knowledge-index.md
@@ -33,9 +33,10 @@ current pages; those guides are not invented as historical snapshot routes.
 The EMMA record covers the five fixed collection shortcuts, Memes season
 selection, Intern JPG token IDs, and the manual contract path in Create Snapshots.
 
-The profile CMS builder record covers direct route access, owner-only server
-actions, draft recovery, gallery snapshots, wallet-signed publishing, version
-restoration, and unpublishing. It distinguishes removing the active website
+The profile CMS builder record covers direct route access, owner-only save and
+publish actions, draft recovery, signed-in gallery snapshots for wallet addresses
+and ENS names, wallet-signed publishing, version restoration, and unpublishing.
+It distinguishes removing the active website
 pointer from deleting immutable storage and links to the builder's user guide.
 
 ## Goals

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -5415,6 +5415,7 @@
       "facts": [
         "Open /{user}/cms/builder directly to edit a profile-owned website; there is no public profile navigation link.",
         "Saving, server validation, and publishing require the connected non-proxy owner profile. Publishing uploads content and asks the wallet to sign.",
+        "Request snapshot requires a signed-in session and can load another wallet's indexed holdings from an ETH address or ENS name. If the session cannot be verified, sign in again and retry.",
         "The builder supports saved drafts, browser recovery, gallery snapshots, full-package JSON and Agent editing, and published version history.",
         "Restore selects a previous publication. Unpublish removes the active website pointer but does not delete immutable content or version history.",
         "Published CMS pages use /{user}/index.html and additional package paths. Keep the signed publication manifest for independent recovery."

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -5411,6 +5411,7 @@
       "facts": [
         "Open /{user}/cms/builder directly to edit a profile-owned website; there is no public profile navigation link.",
         "Saving, server validation, and publishing require the connected non-proxy owner profile. Publishing uploads content and asks the wallet to sign.",
+        "Request snapshot requires a signed-in session and can load another wallet's indexed holdings from an ETH address or ENS name. If the session cannot be verified, sign in again and retry.",
         "The builder supports saved drafts, browser recovery, gallery snapshots, full-package JSON and Agent editing, and published version history.",
         "Restore selects a previous publication. Unpublish removes the active website pointer but does not delete immutable content or version history.",
         "Published CMS pages use /{user}/index.html and additional package paths. Keep the signed publication manifest for independent recovery."


### PR DESCRIPTION
## Issue

The CMS gallery enables Request snapshot while signed out, then hides the API's authentication rejection behind a generic failure message.

## Fix

Require an authenticated session for live snapshots and show sign-in guidance beside the disabled control. A rejected session receives a specific retry message. Authenticated users can still request another wallet's holdings; offline example snapshots remain available.

## Changes

Add a defensive handler guard, accessible button descriptions, five-locale messages and updated CMS/Help Bot guidance. Use the existing darker primary-button color to meet contrast requirements. Saving and publishing retain their existing owner requirements.

## Validation

- CMS tests: 32 suites / 300 tests passed, including signed-out requests, authenticated non-owners, rejected sessions and offline examples.
- Translation tests: 22 passed. Changed-file typecheck, lint, formatting and whitespace checks passed.
- React Doctor: 99; two existing workspace size/state advisories.
- Help Bot sync: 217 records; documentation link validation: 302 files.
- Production reproduction confirmed an anonymous snapshot request receives HTTP401.
- Controlled browser integration passed 20 states across five locales and desktop/narrow widths, with zero axe violations or horizontal overflow. Keyboard, focus and hover checks passed. These tests use actual builder components and the HTTP error mapper with explicit authentication fixtures.
- Real staging and production browser checks passed at desktop and phone widths: the disabled snapshot control has clear accessible sign-in guidance, makes no snapshot request, and has no scoped accessibility, overflow or runtime errors.
- Latest-head production build, quality/contracts and security checks passed. [Production deployment](https://github.com/6529-Collections/6529seize-frontend/actions/runs/34539466058) passed artifact, exact-version and health checks at `5048a8488976f43d97ffc2382e76bb4178c33407`.

## Risk

Low. The change affects snapshot controls and messaging; it preserves backend authentication, snapshot contracts and publication behavior. Rollback is a normal revert and frontend deployment.

## Review Notes

Snapshot authentication is independent of target-profile ownership. Companion 6529-Collections/6529seize-backend#1989 resolves valid forward ENS aliases missing from indexed display names.
