### PR TITLE
Fix stalled shared session refresh recovery

### DIFF
--- a/__tests__/components/waves/CreateDropContent.refocus.test.tsx
+++ b/__tests__/components/waves/CreateDropContent.refocus.test.tsx
@@ -15,6 +15,7 @@ const mockSetDrop = jest.fn();
 const mockSetIsStormMode = jest.fn();
 const mockOnDropModeChange = jest.fn();
 const mockAddOptimisticDrop = jest.fn();
+let mockIsApp = false;
 
 jest.mock("next/dynamic", () => () => () => null);
 
@@ -66,7 +67,7 @@ jest.mock("@/contexts/EditingDropContext", () => ({
 
 jest.mock("@/hooks/useDeviceInfo", () => ({
   __esModule: true,
-  default: jest.fn(() => ({ isApp: false })),
+  default: jest.fn(() => ({ isApp: mockIsApp })),
 }));
 
 jest.mock("@/components/waves/CreateDropReplyingWrapper", () => () => (
@@ -275,6 +276,8 @@ describe("CreateDropContent chat refocus", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRequestAuth.mockReset().mockResolvedValue({ success: true });
+    mockIsApp = false;
     globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
       callback(0);
       return 1;
@@ -311,6 +314,68 @@ describe("CreateDropContent chat refocus", () => {
       throw new Error("Expected clear and focus to be called");
     }
     expect(clearOrder).toBeLessThan(focusOrder);
+  });
+
+  describe.each([
+    { surface: "web", isApp: false },
+    { surface: "native app", isApp: true },
+  ])("authentication recovery in $surface", ({ isApp }) => {
+    it.each([
+      {
+        failure: "rejects with Safari's Load failed error",
+        authenticate: async () => {
+          throw new TypeError("Load failed");
+        },
+        expectedToasts: [
+          [
+            {
+              type: "error",
+              title: "Couldn't submit this drop.",
+              description: "Please try again.",
+              details: "Load failed.",
+            },
+          ],
+        ],
+      },
+      {
+        failure: "returns an unsuccessful result",
+        authenticate: async () => ({ success: false }),
+        expectedToasts: [],
+      },
+    ])(
+      "preserves the draft and allows retry when authentication $failure",
+      async ({ authenticate, expectedToasts }) => {
+        mockIsApp = isApp;
+        mockRequestAuth.mockImplementationOnce(authenticate);
+        const { submitDrop } = renderSubject();
+        const submitButton = screen.getByRole("button", { name: "submit" });
+
+        await userEvent.click(submitButton);
+
+        await waitFor(() => expect(submitButton).toBeEnabled());
+        expect(mockRequestAuth).toHaveBeenCalledTimes(1);
+        expect(submitDrop).not.toHaveBeenCalled();
+        expect(mockInputClear).not.toHaveBeenCalled();
+        expect(mockSetDrop).not.toHaveBeenCalled();
+        expect(mockInputFocus).not.toHaveBeenCalled();
+        expect(mockSetToast.mock.calls).toEqual(expectedToasts);
+
+        await userEvent.click(submitButton);
+
+        await waitFor(() => expect(submitDrop).toHaveBeenCalledTimes(1));
+        expect(mockRequestAuth).toHaveBeenCalledTimes(2);
+        expect(submitDrop).toHaveBeenCalledWith(
+          expect.objectContaining({
+            drop: expect.objectContaining({
+              drop_type: ApiDropType.Chat,
+              parts: [expect.objectContaining({ content: "queued part" })],
+            }),
+          })
+        );
+        await waitFor(() => expect(mockInputFocus).toHaveBeenCalledTimes(1));
+        expect(mockInputClear).toHaveBeenCalled();
+      }
+    );
   });
 
   it("does not submit, reset, or focus while slow-mode chat is blocked", async () => {

--- a/__tests__/services/auth/session-v2.utils.test.ts
+++ b/__tests__/services/auth/session-v2.utils.test.ts
@@ -440,7 +440,7 @@ describe("session-v2.utils", () => {
         client_type: "web",
         client_address: "0xabc",
       },
-      signal: undefined,
+      signal: expect.any(AbortSignal),
       credentials: "include",
       errorMode: "structured",
       includeWalletAuth: false,
@@ -490,7 +490,7 @@ describe("session-v2.utils", () => {
 
     expect(requestLock).toHaveBeenCalledWith(
       "6529:auth-session-refresh:web:0xabc",
-      { mode: "exclusive" },
+      { mode: "exclusive", signal: expect.any(AbortSignal) },
       expect.any(Function)
     );
     expect(commonApiPost).toHaveBeenCalledWith(
@@ -608,7 +608,7 @@ describe("session-v2.utils", () => {
         client_type: "web",
         client_address: "0xabc",
       },
-      signal: undefined,
+      signal: expect.any(AbortSignal),
       credentials: "include",
       errorMode: "structured",
       includeWalletAuth: false,
@@ -714,6 +714,204 @@ describe("session-v2.utils", () => {
       "success",
     ]);
     expectNoSensitiveRefreshTelemetry(getSessionRefreshInfoTelemetry());
+  });
+
+  it("expires a stalled background refresh so later actions can start a fresh request", async () => {
+    jest.useFakeTimers();
+    const sessionResponse = {
+      client_type: "web",
+      address: "0xabc",
+      role: null,
+      access_token: "access-token",
+      access_token_expires_at: "2026-06-10T00:00:00.000Z",
+    };
+    const manualController = new AbortController();
+    let backgroundError: unknown;
+    let internalSignal: AbortSignal | undefined;
+    (commonApiPost as jest.Mock)
+      .mockImplementationOnce(
+        ({ signal }: { readonly signal?: AbortSignal }) => {
+          internalSignal = signal;
+          return new Promise(() => {});
+        }
+      )
+      .mockResolvedValueOnce(sessionResponse);
+
+    try {
+      const backgroundRefresh = refreshSessionV2({ address: "0xabc" }).catch(
+        (error: unknown) => {
+          backgroundError = error;
+        }
+      );
+      const manualRefresh = refreshSessionV2({
+        address: "0xABC",
+        abortSignal: manualController.signal,
+      });
+      manualController.abort();
+      await expect(manualRefresh).rejects.toMatchObject({ name: "AbortError" });
+      expect(commonApiPost).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(30_000);
+
+      expect(backgroundError).toMatchObject({ name: "TimeoutError" });
+      expect(internalSignal?.aborted).toBe(true);
+      await backgroundRefresh;
+      const retry = refreshSessionV2({ address: "0xabc" });
+      expect(commonApiPost).toHaveBeenCalledTimes(1);
+      await jest.advanceTimersByTimeAsync(250);
+      await expect(retry).resolves.toBe(sessionResponse);
+      expect(commonApiPost).toHaveBeenCalledTimes(2);
+      expect(jest.getTimerCount()).toBe(0);
+    } finally {
+      __resetSessionRefreshStateForTests();
+      jest.useRealTimers();
+    }
+  });
+
+  it.each(["success", "unauthorized", "rate-limit"] as const)(
+    "ignores a timed-out refresh's late %s settlement while a replacement request is active",
+    async (lateOutcome) => {
+      jest.useFakeTimers();
+      const sessionResponse = {
+        client_type: "web",
+        address: "0xabc",
+        role: null,
+        access_token: "access-token",
+        access_token_expires_at: "2026-06-10T00:00:00.000Z",
+      };
+      let resolveStalled!: (value: typeof sessionResponse) => void;
+      let rejectStalled!: (error: Error) => void;
+      let resolveReplacement!: (value: typeof sessionResponse) => void;
+      const stalled = new Promise<typeof sessionResponse>((resolve, reject) => {
+        resolveStalled = resolve;
+        rejectStalled = reject;
+      });
+      const replacement = new Promise<typeof sessionResponse>((resolve) => {
+        resolveReplacement = resolve;
+      });
+      (commonApiPost as jest.Mock)
+        .mockReturnValueOnce(stalled)
+        .mockReturnValueOnce(replacement)
+        .mockResolvedValueOnce(sessionResponse);
+
+      try {
+        let timeoutError: unknown;
+        const expired = refreshSessionV2({ address: "0xabc" }).catch(
+          (error: unknown) => {
+            timeoutError = error;
+          }
+        );
+        await jest.advanceTimersByTimeAsync(30_000);
+        expect(timeoutError).toMatchObject({ name: "TimeoutError" });
+        await expired;
+
+        const fresh = refreshSessionV2({ address: "0xabc" });
+        await jest.advanceTimersByTimeAsync(250);
+        expect(commonApiPost).toHaveBeenCalledTimes(2);
+        if (lateOutcome === "success") {
+          resolveStalled(sessionResponse);
+        } else {
+          rejectStalled(
+            Object.assign(new Error(lateOutcome), {
+              status: lateOutcome === "unauthorized" ? 401 : 429,
+            })
+          );
+        }
+        await jest.advanceTimersByTimeAsync(0);
+
+        const joined = refreshSessionV2({ address: "0xABC" });
+        expect(commonApiPost).toHaveBeenCalledTimes(2);
+        resolveReplacement(sessionResponse);
+        await expect(fresh).resolves.toBe(sessionResponse);
+        await expect(joined).resolves.toBe(sessionResponse);
+        await expect(refreshSessionV2({ address: "0xabc" })).resolves.toBe(
+          sessionResponse
+        );
+        expect(commonApiPost).toHaveBeenCalledTimes(3);
+      } finally {
+        __resetSessionRefreshStateForTests();
+        jest.useRealTimers();
+      }
+    }
+  );
+
+  it.each(["waiting", "acquired"] as const)(
+    "expires a stalled refresh with its cross-tab lock %s",
+    async (lockState) => {
+      jest.useFakeTimers();
+      let lockSignal: AbortSignal | undefined;
+      let lockReleased = false;
+      let timeoutError: unknown;
+      const requestLock = jest.fn(
+        async <T>(
+          _name: string,
+          options: LockOptions,
+          callback: (lock: Lock | null) => Promise<T>
+        ): Promise<T> => {
+          lockSignal = options.signal;
+          if (lockState === "waiting") {
+            return await new Promise<T>(() => {});
+          }
+          try {
+            return await callback(null);
+          } finally {
+            lockReleased = true;
+          }
+        }
+      );
+      setNavigatorLocks({ request: requestLock } as unknown as LockManager);
+      (commonApiPost as jest.Mock).mockReturnValueOnce(new Promise(() => {}));
+
+      try {
+        const refresh = refreshSessionV2({ address: "0xabc" }).catch(
+          (error: unknown) => {
+            timeoutError = error;
+          }
+        );
+        await jest.advanceTimersByTimeAsync(30_000);
+
+        expect(timeoutError).toMatchObject({ name: "TimeoutError" });
+        await refresh;
+        expect(lockSignal?.aborted).toBe(true);
+        expect(lockReleased).toBe(lockState === "acquired");
+        expect(commonApiPost).toHaveBeenCalledTimes(
+          lockState === "acquired" ? 1 : 0
+        );
+      } finally {
+        __resetSessionRefreshStateForTests();
+        jest.useRealTimers();
+      }
+    }
+  );
+
+  it("does not send a native refresh if token storage resolves after the deadline", async () => {
+    jest.useFakeTimers();
+    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(true);
+    let resolveStoredToken!: (token: string) => void;
+    let timeoutError: unknown;
+    (getNativeRefreshToken as jest.Mock).mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        resolveStoredToken = resolve;
+      })
+    );
+
+    try {
+      const refresh = refreshSessionV2({ address: "0xabc" }).catch(
+        (error: unknown) => {
+          timeoutError = error;
+        }
+      );
+      await jest.advanceTimersByTimeAsync(30_000);
+
+      expect(timeoutError).toMatchObject({ name: "TimeoutError" });
+      await refresh;
+      resolveStoredToken("native-refresh-token");
+      await jest.advanceTimersByTimeAsync(0);
+      expect(commonApiPost).not.toHaveBeenCalled();
+    } finally {
+      __resetSessionRefreshStateForTests();
+      jest.useRealTimers();
+    }
   });
 
   it("blocks invalid web session refreshes until persisted auth clears the block", async () => {
@@ -1043,7 +1241,7 @@ describe("session-v2.utils", () => {
         client_type: "web",
         client_address: "0xabc",
       },
-      signal: undefined,
+      signal: expect.any(AbortSignal),
       credentials: "include",
       errorMode: "structured",
       includeWalletAuth: false,
@@ -1175,7 +1373,7 @@ describe("session-v2.utils", () => {
         client_address: "0xabc",
         native_refresh_token: "native-refresh-token",
       },
-      signal: undefined,
+      signal: expect.any(AbortSignal),
       credentials: "include",
       errorMode: "structured",
       includeWalletAuth: false,

--- a/__tests__/services/auth/session-v2.utils.test.ts
+++ b/__tests__/services/auth/session-v2.utils.test.ts
@@ -809,7 +809,10 @@ describe("session-v2.utils", () => {
         await jest.advanceTimersByTimeAsync(250);
         expect(commonApiPost).toHaveBeenCalledTimes(2);
         if (lateOutcome === "success") {
-          resolveStalled(sessionResponse);
+          resolveStalled({
+            ...sessionResponse,
+            access_token: "stale-access-token",
+          });
         } else {
           rejectStalled(
             Object.assign(new Error(lateOutcome), {

--- a/ops/docs/waves/troubleshooting-wave-navigation-and-posting.md
+++ b/ops/docs/waves/troubleshooting-wave-navigation-and-posting.md
@@ -77,6 +77,11 @@ is blocked.
 
 ## Posting and Submission Checks
 
+- Post waits for a session check, then shows a connection or timeout error:
+  the draft stays in the composer. Wait for the loading state to finish, check
+  your connection, complete sign-in if prompted, then retry Post. A stalled
+  session check expires so a later attempt can check the session again; the
+  failed attempt does not automatically post your draft.
 - Footer shows `Connect your wallet to participate in this wave`:
   both chat and submission are blocked because the current viewer is signed out.
 - Footer shows `Create a profile to participate in this wave`:

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -1328,12 +1328,16 @@
         "On desktop web, the collapsed sidebar account avatar highlights on hover but opens its account dropdown only when activated; the dropdown stays aligned with the sidebar on centered wide-screen layouts.",
         "Sign out all clears every connected profile in one visible transition without switching through the remaining profiles.",
         "If wallet connection is not working, retry from the header wallet controls and confirm the wallet modal is completed before using write actions.",
+        "If Post cannot finish its session check, the draft stays in the composer. Wait for loading to finish, check the connection, complete sign-in if prompted, then retry Post. A stalled session check expires so a later attempt can check again; it does not automatically post the draft.",
         "Some write actions, settings, and subscriptions require a connected profile."
       ],
       "canonical_path": "/",
       "related_paths": ["/access"],
       "tags": ["auth", "wallet", "profiles"],
-      "source_refs": ["ops/docs/navigation/feature-wallet-account-controls.md"]
+      "source_refs": [
+        "ops/docs/navigation/feature-wallet-account-controls.md",
+        "ops/docs/waves/troubleshooting-wave-navigation-and-posting.md"
+      ]
     },
     {
       "id": "wallet.connection-sharing",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -1324,12 +1324,16 @@
         "On desktop web, the collapsed sidebar account avatar highlights on hover but opens its account dropdown only when activated; the dropdown stays aligned with the sidebar on centered wide-screen layouts.",
         "Sign out all clears every connected profile in one visible transition without switching through the remaining profiles.",
         "If wallet connection is not working, retry from the header wallet controls and confirm the wallet modal is completed before using write actions.",
+        "If Post cannot finish its session check, the draft stays in the composer. Wait for loading to finish, check the connection, complete sign-in if prompted, then retry Post. A stalled session check expires so a later attempt can check again; it does not automatically post the draft.",
         "Some write actions, settings, and subscriptions require a connected profile."
       ],
       "canonical_path": "/",
       "related_paths": ["/access"],
       "tags": ["auth", "wallet", "profiles"],
-      "source_refs": ["ops/docs/navigation/feature-wallet-account-controls.md"]
+      "source_refs": [
+        "ops/docs/navigation/feature-wallet-account-controls.md",
+        "ops/docs/waves/troubleshooting-wave-navigation-and-posting.md"
+      ]
     },
     {
       "id": "wallet.connection-sharing",

--- a/services/auth/session-refresh-coordination.utils.ts
+++ b/services/auth/session-refresh-coordination.utils.ts
@@ -1,6 +1,13 @@
 const WEB_SESSION_REFRESH_LOCK_PREFIX = "6529:auth-session-refresh:";
+const SESSION_REFRESH_TIMEOUT_MS = 30_000;
 
 export type AuthSessionClientType = "web" | "native" | "desktop";
+
+export type SessionRefreshEntry<T> = {
+  readonly controller: AbortController;
+  readonly promise: Promise<T>;
+  activeConsumers: number;
+};
 
 type NavigatorWithOptionalLocks = {
   readonly locks?: LockManager | undefined;
@@ -50,6 +57,71 @@ export async function withSessionRefreshAbort<T>({
   } finally {
     abortSignal.removeEventListener("abort", onAbort);
   }
+}
+
+export function createSessionRefreshEntry<T>(
+  task: (abortSignal: AbortSignal) => Promise<T>
+): SessionRefreshEntry<T> {
+  // Background consumers must not keep every later action on a stalled request.
+  const controller = new AbortController();
+  let timeoutId: ReturnType<typeof globalThis.setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timeoutId = globalThis.setTimeout(() => {
+      const error = new Error("Session refresh timed out. Please try again.");
+      error.name = "TimeoutError";
+      // Reject first so cancellation cannot replace the timeout's retry semantics.
+      reject(error);
+      controller.abort();
+    }, SESSION_REFRESH_TIMEOUT_MS);
+  });
+  const request = withSessionRefreshAbort({
+    abortSignal: controller.signal,
+    task: () => task(controller.signal),
+  });
+
+  return {
+    controller,
+    activeConsumers: 1,
+    promise: Promise.race([request, timeout]).finally(() => {
+      globalThis.clearTimeout(timeoutId);
+    }),
+  };
+}
+
+export async function waitForSessionRefreshRetryCooldown({
+  cooldown,
+  abortSignal,
+}: {
+  readonly cooldown: { readonly expiresAtMs: number };
+  readonly abortSignal?: AbortSignal | undefined;
+}): Promise<void> {
+  const delayMs = Math.max(0, cooldown.expiresAtMs - Date.now());
+  if (delayMs === 0) {
+    return;
+  }
+  if (abortSignal?.aborted) {
+    throw createAbortError();
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined = undefined;
+    const cleanup = () => {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+      abortSignal?.removeEventListener("abort", onAbort);
+    };
+    const onAbort = () => {
+      cleanup();
+      reject(createAbortError());
+    };
+
+    timeoutId = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, delayMs);
+    abortSignal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 export async function withCrossTabWebSessionRefreshLock<T>({

--- a/services/auth/session-refresh-coordination.utils.ts
+++ b/services/auth/session-refresh-coordination.utils.ts
@@ -26,6 +26,32 @@ export const isAbortError = (error: unknown): boolean =>
   "name" in error &&
   error.name === "AbortError";
 
+export async function withSessionRefreshAbort<T>({
+  abortSignal,
+  task,
+}: {
+  readonly abortSignal: AbortSignal;
+  readonly task: () => Promise<T>;
+}): Promise<T> {
+  if (abortSignal.aborted) {
+    throw createAbortError();
+  }
+
+  let rejectOnAbort: ((error: DOMException) => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectOnAbort = reject;
+  });
+  const onAbort = () => rejectOnAbort?.(createAbortError());
+  abortSignal.addEventListener("abort", onAbort, { once: true });
+
+  try {
+    // Release callers and held Web Locks even if the transport ignores abort.
+    return await Promise.race([task(), aborted]);
+  } finally {
+    abortSignal.removeEventListener("abort", onAbort);
+  }
+}
+
 export async function withCrossTabWebSessionRefreshLock<T>({
   refreshKey,
   abortSignal,
@@ -35,10 +61,9 @@ export async function withCrossTabWebSessionRefreshLock<T>({
   readonly abortSignal?: AbortSignal | undefined;
   readonly task: () => Promise<T>;
 }): Promise<T> {
-  const runtimeNavigator = Reflect.get(
-    globalThis,
-    "navigator"
-  ) as NavigatorWithOptionalLocks | undefined;
+  const runtimeNavigator = Reflect.get(globalThis, "navigator") as
+    | NavigatorWithOptionalLocks
+    | undefined;
   const lockManager = runtimeNavigator?.locks;
   if (!lockManager) {
     return await task();

--- a/services/auth/session-v2.utils.ts
+++ b/services/auth/session-v2.utils.ts
@@ -26,11 +26,14 @@ import {
 } from "./session-refresh-rate-limit.utils";
 import {
   createAbortError,
+  createSessionRefreshEntry,
   getSessionRefreshKey,
   isAbortError,
+  waitForSessionRefreshRetryCooldown,
   withCrossTabWebSessionRefreshLock,
   withSessionRefreshAbort,
   type AuthSessionClientType,
+  type SessionRefreshEntry,
 } from "./session-refresh-coordination.utils";
 
 type RefreshTokenSessionClientType = Exclude<AuthSessionClientType, "web">;
@@ -67,11 +70,8 @@ type SessionRefreshFailureCooldown = {
   readonly type: SessionRefreshFailureCooldownType;
   readonly expiresAtMs: number;
 };
-type SessionRefreshInFlight = {
-  readonly controller: AbortController;
-  readonly promise: Promise<SessionRefreshResponse | null>;
-  activeConsumers: number;
-};
+type SessionRefreshInFlight =
+  SessionRefreshEntry<SessionRefreshResponse | null>;
 
 interface CreateConnectionShareResponse {
   readonly connection_share_code: string;
@@ -106,7 +106,6 @@ interface NativeConnectionShareSourceProof {
 }
 
 const sessionRefreshInFlight = new Map<string, SessionRefreshInFlight>();
-const SESSION_REFRESH_TIMEOUT_MS = 30_000;
 const sessionRefreshFailureCooldowns = new Map<
   string,
   SessionRefreshFailureCooldown
@@ -157,42 +156,6 @@ function clearSessionRefreshFailureForSession(
       clientType: response.client_type,
     })
   );
-}
-
-async function waitForSessionRefreshRetryCooldown({
-  cooldown,
-  abortSignal,
-}: {
-  readonly cooldown: SessionRefreshFailureCooldown;
-  readonly abortSignal?: AbortSignal | undefined;
-}): Promise<void> {
-  const delayMs = Math.max(0, cooldown.expiresAtMs - Date.now());
-  if (delayMs === 0) {
-    return;
-  }
-  if (abortSignal?.aborted) {
-    throw createAbortError();
-  }
-
-  await new Promise<void>((resolve, reject) => {
-    let timeoutId: ReturnType<typeof setTimeout> | undefined = undefined;
-    const cleanup = () => {
-      if (timeoutId !== undefined) {
-        clearTimeout(timeoutId);
-      }
-      abortSignal?.removeEventListener("abort", onAbort);
-    };
-    const onAbort = () => {
-      cleanup();
-      reject(createAbortError());
-    };
-
-    timeoutId = setTimeout(() => {
-      cleanup();
-      resolve();
-    }, delayMs);
-    abortSignal?.addEventListener("abort", onAbort, { once: true });
-  });
 }
 
 function settleSessionRefreshConsumer(
@@ -455,46 +418,6 @@ async function executeSessionRefreshRequest<T extends SessionRefreshResponse>({
   }
 }
 
-function createSessionRefreshEntry({
-  address,
-  clientType,
-  refreshKey,
-}: {
-  readonly address: string;
-  readonly clientType: AuthSessionClientType;
-  readonly refreshKey: string;
-}): SessionRefreshInFlight {
-  // Background consumers must not keep every later action on a stalled request.
-  const controller = new AbortController();
-  let timeoutId: ReturnType<typeof globalThis.setTimeout> | undefined;
-  const timeout = new Promise<never>((_resolve, reject) => {
-    timeoutId = globalThis.setTimeout(() => {
-      const error = new Error("Session refresh timed out. Please try again.");
-      error.name = "TimeoutError";
-      reject(error);
-      controller.abort();
-    }, SESSION_REFRESH_TIMEOUT_MS);
-  });
-  const request = withSessionRefreshAbort({
-    abortSignal: controller.signal,
-    task: () =>
-      executeSessionRefreshV2({
-        address,
-        abortSignal: controller.signal,
-        clientType,
-        refreshKey,
-      }),
-  });
-
-  return {
-    controller,
-    activeConsumers: 1,
-    promise: Promise.race([request, timeout]).finally(() => {
-      globalThis.clearTimeout(timeoutId);
-    }),
-  };
-}
-
 export async function refreshSessionV2({
   address,
   abortSignal,
@@ -561,11 +484,14 @@ export async function refreshSessionV2({
     });
   }
 
-  const entry = createSessionRefreshEntry({
-    address,
-    clientType,
-    refreshKey: key,
-  });
+  const entry = createSessionRefreshEntry((signal) =>
+    executeSessionRefreshV2({
+      address,
+      abortSignal: signal,
+      clientType,
+      refreshKey: key,
+    })
+  );
   sessionRefreshInFlight.set(key, entry);
 
   void (async () => {

--- a/services/auth/session-v2.utils.ts
+++ b/services/auth/session-v2.utils.ts
@@ -29,6 +29,7 @@ import {
   getSessionRefreshKey,
   isAbortError,
   withCrossTabWebSessionRefreshLock,
+  withSessionRefreshAbort,
   type AuthSessionClientType,
 } from "./session-refresh-coordination.utils";
 
@@ -62,7 +63,10 @@ interface SessionNativeResponse {
 
 type SessionLoginResponse = SessionWebResponse | SessionNativeResponse;
 type SessionRefreshResponse = SessionWebResponse | SessionNativeResponse;
-type SessionRefreshFailureCooldown = { readonly type: SessionRefreshFailureCooldownType; readonly expiresAtMs: number };
+type SessionRefreshFailureCooldown = {
+  readonly type: SessionRefreshFailureCooldownType;
+  readonly expiresAtMs: number;
+};
 type SessionRefreshInFlight = {
   readonly controller: AbortController;
   readonly promise: Promise<SessionRefreshResponse | null>;
@@ -102,6 +106,7 @@ interface NativeConnectionShareSourceProof {
 }
 
 const sessionRefreshInFlight = new Map<string, SessionRefreshInFlight>();
+const SESSION_REFRESH_TIMEOUT_MS = 30_000;
 const sessionRefreshFailureCooldowns = new Map<
   string,
   SessionRefreshFailureCooldown
@@ -135,8 +140,7 @@ function rememberSessionRefreshFailure(
   sessionRefreshFailureCooldowns.set(key, {
     type,
     expiresAtMs:
-      Date.now() +
-      getSessionRefreshFailureCooldownMs(type, cooldownMsOverride),
+      Date.now() + getSessionRefreshFailureCooldownMs(type, cooldownMsOverride),
   });
 }
 
@@ -339,12 +343,15 @@ async function executeSessionRefreshV2({
   refreshKey,
 }: {
   readonly address: string;
-  readonly abortSignal?: AbortSignal | undefined;
+  readonly abortSignal: AbortSignal;
   readonly clientType: AuthSessionClientType;
   readonly refreshKey: string;
 }): Promise<SessionRefreshResponse | null> {
   if (clientType !== "web") {
     const nativeRefreshToken = await getNativeRefreshToken(address);
+    if (abortSignal.aborted) {
+      throw createAbortError();
+    }
     if (!nativeRefreshToken) {
       recordSessionRefreshOutcome({
         clientType,
@@ -354,6 +361,7 @@ async function executeSessionRefreshV2({
     }
 
     return await executeSessionRefreshRequest({
+      abortSignal,
       clientType,
       request: () =>
         commonApiPost<
@@ -383,6 +391,7 @@ async function executeSessionRefreshV2({
     abortSignal,
     task: async () =>
       await executeSessionRefreshRequest({
+        abortSignal,
         clientType,
         request: () =>
           commonApiPost<
@@ -407,9 +416,11 @@ async function executeSessionRefreshV2({
 }
 
 async function executeSessionRefreshRequest<T extends SessionRefreshResponse>({
+  abortSignal,
   clientType,
   request,
 }: {
+  readonly abortSignal: AbortSignal;
   readonly clientType: AuthSessionClientType;
   readonly request: () => Promise<T>;
 }): Promise<T | null> {
@@ -420,7 +431,10 @@ async function executeSessionRefreshRequest<T extends SessionRefreshResponse>({
   });
 
   try {
-    const response = await request();
+    const response = await withSessionRefreshAbort({
+      abortSignal,
+      task: request,
+    });
     recordSessionRefreshOutcome({
       clientType,
       outcome: "success",
@@ -439,6 +453,46 @@ async function executeSessionRefreshRequest<T extends SessionRefreshResponse>({
     }
     throw error;
   }
+}
+
+function createSessionRefreshEntry({
+  address,
+  clientType,
+  refreshKey,
+}: {
+  readonly address: string;
+  readonly clientType: AuthSessionClientType;
+  readonly refreshKey: string;
+}): SessionRefreshInFlight {
+  // Background consumers must not keep every later action on a stalled request.
+  const controller = new AbortController();
+  let timeoutId: ReturnType<typeof globalThis.setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timeoutId = globalThis.setTimeout(() => {
+      const error = new Error("Session refresh timed out. Please try again.");
+      error.name = "TimeoutError";
+      reject(error);
+      controller.abort();
+    }, SESSION_REFRESH_TIMEOUT_MS);
+  });
+  const request = withSessionRefreshAbort({
+    abortSignal: controller.signal,
+    task: () =>
+      executeSessionRefreshV2({
+        address,
+        abortSignal: controller.signal,
+        clientType,
+        refreshKey,
+      }),
+  });
+
+  return {
+    controller,
+    activeConsumers: 1,
+    promise: Promise.race([request, timeout]).finally(() => {
+      globalThis.clearTimeout(timeoutId);
+    }),
+  };
 }
 
 export async function refreshSessionV2({
@@ -477,8 +531,7 @@ export async function refreshSessionV2({
     });
     await withSessionRefreshAbortTelemetry({
       clientType,
-      task: () =>
-        waitForSessionRefreshRetryCooldown({ cooldown, abortSignal }),
+      task: () => waitForSessionRefreshRetryCooldown({ cooldown, abortSignal }),
     });
     if (sessionRefreshFailureCooldowns.get(key) === cooldown) {
       sessionRefreshFailureCooldowns.delete(key);
@@ -508,22 +561,19 @@ export async function refreshSessionV2({
     });
   }
 
-  const controller = new AbortController();
-  const entry: SessionRefreshInFlight = {
-    controller,
-    activeConsumers: 1,
-    promise: executeSessionRefreshV2({
-      address,
-      abortSignal: abortSignal ? controller.signal : undefined,
-      clientType,
-      refreshKey: key,
-    }),
-  };
+  const entry = createSessionRefreshEntry({
+    address,
+    clientType,
+    refreshKey: key,
+  });
   sessionRefreshInFlight.set(key, entry);
 
   void (async () => {
     try {
       const response = await entry.promise;
+      if (sessionRefreshInFlight.get(key) !== entry) {
+        return;
+      }
       if (response) {
         clearSessionRefreshFailure(key);
         return;
@@ -531,6 +581,9 @@ export async function refreshSessionV2({
 
       rememberSessionRefreshFailure(key, "empty");
     } catch (error: unknown) {
+      if (sessionRefreshInFlight.get(key) !== entry) {
+        return;
+      }
       if (isAbortError(error)) {
         return;
       }


### PR DESCRIPTION
## Issue

A stalled background session refresh can remain in the shared in-flight cache indefinitely. Later Post attempts and reaction authentication recovery join that same request, even after an individual action's timeout. This reproduces a failure mode consistent with a report of inactive posting and failed reactions; the original iPad network error has not been independently reproduced on hardware.

## Fix

Bound each shared refresh to 30 seconds, abort its transport, and settle its consumers independently of whether the transport honors cancellation. Subsequent attempts can start a fresh refresh after the existing retry cooldown.

## Changes

- Release held Web Locks on cancellation and prevent late native token-storage reads from starting expired requests.
- Keep late responses from modifying the replacement request's state.
- Preserve existing iPad/Surface input handling, caller cancellation, authentication checks, and explicit submission behavior.
- Add session and composer recovery regressions; update troubleshooting and Help Bot guidance.

## Validation

- Reproduced the new stalled-background regression against the unchanged base: it fails before the fix and passes afterward.
- 274 tests passed across session, authentication, JWT, composer, reaction, device, and touch suites.
- Application typecheck, Jest typecheck ratchet, changed typecheck, changed lint, React Doctor (100/100), formatting, and whitespace passed.
- Help index regenerated; documentation link validation passed.
- Physical iPad confirmation remains outstanding. No visual/device classification changes.

## Risk

- Level: Medium, because the shared authentication refresh path serves web and native clients.
- A lost native refresh response may still require reconnecting under the existing token-rotation protocol. Writes are not automatically replayed.
- Rollback: revert this PR and redeploy the frontend. No database or backend changes.

## Review Notes

Focus on cancellation ownership, timeout cleanup, cross-tab lock release, and late responses. Existing Surface and native iPad handling must remain intact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session validation and refresh handling to prevent stalled requests from blocking users indefinitely.
  - Authentication failures now preserve drafts and avoid submitting, resetting, or changing focus after an unsuccessful attempt.
  - Users can re-authenticate and retry successfully without losing their draft.
  - Posts are not submitted automatically when session checks fail or expire.
  - Added clearer error feedback for rejected authentication attempts.

- **Documentation**
  - Added troubleshooting guidance for connection, timeout, session validation, draft preservation, and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->