### PR TITLE
feat: QR-based community app device authorization flow

### DIFF
--- a/app/auth/device/approve/page.client.tsx
+++ b/app/auth/device/approve/page.client.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { useAuth } from "@/components/auth/Auth";
+import { Spinner } from "@/components/dotLoader/DotLoader";
+import { approveDeviceCode, type ApproveResponse } from "@/services/auth/community-app-auth.utils";
+
+type ApproveStatus = "loading" | "confirm" | "approving" | "approved" | "error";
+
+export default function AuthDeviceApprovePageClient() {
+  const searchParams = useSearchParams();
+  const { connectedProfile } = useAuth();
+  const userCode = searchParams.get("user_code");
+
+  const [status, setStatus] = useState<ApproveStatus>("loading");
+  const [message, setMessage] = useState("");
+  const [approveResult, setApproveResult] = useState<ApproveResponse | null>(
+    null
+  );
+
+  useEffect(() => {
+    if (!userCode) {
+      setStatus("error");
+      setMessage("Missing user code. Please scan the QR code again.");
+      return;
+    }
+    setStatus("confirm");
+  }, [userCode]);
+
+  async function handleApprove() {
+    if (!userCode) return;
+    setStatus("approving");
+    try {
+      const result = await approveDeviceCode(userCode);
+      setApproveResult(result);
+      setStatus("approved");
+    } catch (err) {
+      setStatus("error");
+      setMessage(
+        err instanceof Error
+          ? err.message
+          : "Authorization failed. The code may be invalid or expired."
+      );
+    }
+  }
+
+  if (status === "loading") {
+    return (
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          minHeight: "100vh",
+          backgroundColor: "#000",
+        }}
+      >
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: "100vh",
+        padding: "2rem",
+        backgroundColor: "#000000",
+        color: "#ffffff",
+        fontFamily: "sans-serif",
+      }}
+    >
+      <h1
+        style={{
+          fontSize: "1.5rem",
+          marginBottom: "1.5rem",
+          textAlign: "center",
+        }}
+      >
+        Authorize Community App
+      </h1>
+
+      {/* User profile card */}
+      {connectedProfile && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "1rem",
+            marginBottom: "1.5rem",
+            padding: "1rem",
+            borderRadius: "12px",
+            background: "#111",
+            border: "1px solid #333",
+          }}
+        >
+          {connectedProfile.pfp?.url && (
+            <img
+              src={connectedProfile.pfp.url}
+              alt="PFP"
+              style={{
+                width: 48,
+                height: 48,
+                borderRadius: "50%",
+                objectFit: "cover",
+              }}
+            />
+          )}
+          <div>
+            <p style={{ fontWeight: "bold", margin: 0 }}>
+              {connectedProfile.handle ?? connectedProfile.display ?? "User"}
+            </p>
+            {connectedProfile.level && (
+              <p style={{ color: "#888", fontSize: "0.85rem", margin: 0 }}>
+                Level {connectedProfile.level}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {status === "confirm" && (
+        <div style={{ textAlign: "center", maxWidth: "400px" }}>
+          <p
+            style={{
+              marginBottom: "1rem",
+              color: "#ccc",
+            }}
+          >
+            A community app is requesting access to your 6529 identity
+            (read-only). Your wallet address and profile will be shared with
+            the app.
+          </p>
+          <p
+            style={{
+              fontSize: "0.85rem",
+              color: "#888",
+              marginBottom: "1.5rem",
+            }}
+          >
+            Scope: <code style={{ color: "#fff" }}>identity:read</code>
+          </p>
+          <p
+            style={{
+              fontSize: "0.85rem",
+              color: "#888",
+              marginBottom: "1.5rem",
+            }}
+          >
+            User code:{" "}
+            <code
+              style={{
+                fontSize: "1.1rem",
+                fontWeight: "bold",
+                letterSpacing: "0.15em",
+                color: "#fff",
+                background: "#222",
+                padding: "0.25rem 0.5rem",
+                borderRadius: "4px",
+              }}
+            >
+              {userCode}
+            </code>
+          </p>
+          <button
+            onClick={handleApprove}
+            style={{
+              background: "#22c55e",
+              color: "#000",
+              border: "none",
+              padding: "0.75rem 2.5rem",
+              borderRadius: "8px",
+              fontSize: "1.1rem",
+              fontWeight: "bold",
+              cursor: "pointer",
+            }}
+          >
+            Authorize
+          </button>
+        </div>
+      )}
+
+      {status === "approving" && (
+        <div style={{ textAlign: "center" }}>
+          <Spinner />
+          <p style={{ color: "#888", marginTop: "1rem" }}>Authorizing…</p>
+        </div>
+      )}
+
+      {status === "approved" && approveResult && (
+        <div style={{ textAlign: "center", maxWidth: "400px" }}>
+          <p style={{ fontSize: "1.3rem", marginBottom: "0.5rem" }}>✓</p>
+          <p style={{ fontSize: "1.2rem", marginBottom: "0.5rem" }}>
+            Authorized!
+          </p>
+          <p style={{ color: "#ccc", marginBottom: "0.5rem" }}>
+            {approveResult.client_name}
+          </p>
+          <p style={{ color: "#888", fontSize: "0.9rem" }}>
+            You can close this tab and return to the community app.
+          </p>
+        </div>
+      )}
+
+      {status === "error" && (
+        <div style={{ textAlign: "center", maxWidth: "400px" }}>
+          <p style={{ color: "#e74c3c", marginBottom: "1rem" }}>{message}</p>
+          <button
+            onClick={() => window.location.reload()}
+            style={{
+              background: "#fff",
+              color: "#000",
+              border: "none",
+              padding: "0.75rem 2rem",
+              borderRadius: "8px",
+              fontSize: "1rem",
+              cursor: "pointer",
+            }}
+          >
+            Try Again
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/auth/device/approve/page.tsx
+++ b/app/auth/device/approve/page.tsx
@@ -1,0 +1,18 @@
+import { getAppMetadata } from "@/components/providers/metadata";
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import AuthDeviceApprovePageClient from "./page.client";
+
+export default function AuthDeviceApprovePage() {
+  return (
+    <Suspense fallback={null}>
+      <AuthDeviceApprovePageClient />
+    </Suspense>
+  );
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  return getAppMetadata({
+    title: "Approve Community App",
+  });
+}

--- a/app/auth/device/page.client.tsx
+++ b/app/auth/device/page.client.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { toDataURL } from "qrcode";
+import {
+  createDeviceCode,
+  approveDeviceCode,
+  type DeviceCodeResponse,
+  type ApproveResponse,
+} from "@/services/auth/community-app-auth.utils";
+import { generatePkcePairBrowser } from "@/services/auth/pkce.utils";
+
+type DeviceAuthStatus =
+  | "loading"
+  | "qr-ready"
+  | "approved"
+  | "redirecting"
+  | "error";
+
+interface DeviceAuthState {
+  readonly status: DeviceAuthStatus;
+  readonly message: string;
+  readonly qrSrc: string;
+  readonly userCode: string;
+  readonly approveResult: ApproveResponse | null;
+  readonly pkceVerifier: string;
+  readonly deviceCode: string;
+}
+
+const POLL_INTERVAL_MS = 3000;
+const QR_SIZE = 400;
+
+export default function AuthDevicePageClient() {
+  const searchParams = useSearchParams();
+  const [state, setState] = useState<DeviceAuthState>({
+    status: "loading",
+    message: "",
+    qrSrc: "",
+    userCode: "",
+    approveResult: null,
+    pkceVerifier: "",
+    deviceCode: "",
+  });
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const clientId = searchParams.get("client_id");
+  const redirectUri = searchParams.get("redirect_uri");
+  const scope = searchParams.get("scope") ?? "identity:read";
+  const stateParam = searchParams.get("state");
+  const codeChallenge = searchParams.get("code_challenge");
+
+  const handleRedirect = useCallback(
+    (deviceCode: string) => {
+      setState((prev) => ({
+        ...prev,
+        status: "redirecting",
+      }));
+
+      const callbackUrl = new URL(redirectUri!);
+      callbackUrl.searchParams.set("device_code", deviceCode);
+      callbackUrl.searchParams.set("state", stateParam ?? "");
+      window.location.href = callbackUrl.toString();
+    },
+    [redirectUri, stateParam]
+  );
+
+  useEffect(() => {
+    if (!clientId || !redirectUri) {
+      setState({
+        status: "error",
+        message:
+          "Missing required parameters (client_id, redirect_uri). Please return to the community app and try again.",
+        qrSrc: "",
+        userCode: "",
+        approveResult: null,
+        pkceVerifier: "",
+        deviceCode: "",
+      });
+      return;
+    }
+
+    let cancelled = false;
+    const abortController = new AbortController();
+
+    async function initDeviceAuth() {
+      try {
+        let pkceVerifier = "";
+        let challenge = codeChallenge;
+
+        // If community app didn't pass code_challenge, generate our own PKCE pair
+        if (!challenge) {
+          const pkcePair = await generatePkcePairBrowser();
+          pkceVerifier = pkcePair.verifier;
+          challenge = pkcePair.challenge;
+        }
+
+        const response: DeviceCodeResponse = await createDeviceCode({
+          clientId: clientId!,
+          redirectUri: redirectUri!,
+          scope,
+          codeChallenge: challenge!,
+          codeChallengeMethod: "S256",
+        });
+
+        if (cancelled) return;
+
+        // Build QR payload — encodes 6529.io approval page with user_code
+        const qrPayload = `${window.location.origin}/auth/device/approve?user_code=${response.user_code}`;
+        const qrSrc = await toDataURL(qrPayload, {
+          width: QR_SIZE,
+          margin: 4,
+          color: {
+            dark: "#000000",
+            light: "#ffffff",
+          },
+        });
+
+        if (cancelled) return;
+
+        setState({
+          status: "qr-ready",
+          message:
+            "Scan this QR code with your phone to authorize the community app.",
+          qrSrc,
+          userCode: response.user_code,
+          approveResult: null,
+          pkceVerifier,
+          deviceCode: response.device_code,
+        });
+
+        // Start polling for approval
+        pollIntervalRef.current = setInterval(async () => {
+          if (cancelled) return;
+          try {
+            const approveResult = await approveDeviceCode(response.user_code);
+            if (approveResult && !cancelled) {
+              if (pollIntervalRef.current) {
+                clearInterval(pollIntervalRef.current);
+                pollIntervalRef.current = null;
+              }
+              setState((prev) => ({
+                ...prev,
+                status: "approved",
+                approveResult,
+              }));
+              // Redirect after short delay so user sees the approval confirmation
+              setTimeout(() => {
+                if (!cancelled) handleRedirect(response.device_code);
+              }, 1500);
+            }
+          } catch {
+            // Approval not yet given — continue polling
+          }
+        }, POLL_INTERVAL_MS);
+      } catch (err) {
+        if (cancelled) return;
+        setState({
+          status: "error",
+          message:
+            err instanceof Error
+              ? err.message
+              : "Failed to start authorization. Please try again.",
+          qrSrc: "",
+          userCode: "",
+          approveResult: null,
+          pkceVerifier: "",
+          deviceCode: "",
+        });
+      }
+    }
+
+    initDeviceAuth();
+
+    return () => {
+      cancelled = true;
+      abortController.abort();
+      if (pollIntervalRef.current) {
+        clearInterval(pollIntervalRef.current);
+        pollIntervalRef.current = null;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clientId, redirectUri, scope, stateParam, codeChallenge]);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: "100vh",
+        padding: "2rem",
+        backgroundColor: "#000000",
+        color: "#ffffff",
+        fontFamily: "sans-serif",
+      }}
+    >
+      <h1
+        style={{
+          fontSize: "1.75rem",
+          marginBottom: "1rem",
+          textAlign: "center",
+        }}
+      >
+        6529 Community App Authorization
+      </h1>
+
+      {state.status === "loading" && (
+        <p style={{ color: "#888" }}>Preparing authorization…</p>
+      )}
+
+      {state.status === "qr-ready" && (
+        <>
+          <p
+            style={{
+              marginBottom: "1.5rem",
+              textAlign: "center",
+              maxWidth: "500px",
+              color: "#ccc",
+            }}
+          >
+            {state.message}
+          </p>
+          {state.qrSrc && (
+            <img
+              src={state.qrSrc}
+              alt="QR Code"
+              style={{
+                borderRadius: "12px",
+                border: "2px solid #333",
+                marginBottom: "1rem",
+              }}
+            />
+          )}
+          <p
+            style={{
+              fontSize: "0.9rem",
+              color: "#888",
+              marginTop: "0.5rem",
+            }}
+          >
+            Or enter code manually:{" "}
+            <code
+              style={{
+                fontSize: "1.2rem",
+                fontWeight: "bold",
+                letterSpacing: "0.15em",
+                color: "#fff",
+                background: "#222",
+                padding: "0.25rem 0.5rem",
+                borderRadius: "4px",
+              }}
+            >
+              {state.userCode}
+            </code>
+          </p>
+        </>
+      )}
+
+      {state.status === "approved" && (
+        <div style={{ textAlign: "center" }}>
+          {state.approveResult && (
+            <>
+              <p style={{ fontSize: "1.2rem", marginBottom: "0.5rem" }}>
+                ✓ Authorized
+              </p>
+              <p style={{ color: "#ccc", marginBottom: "0.5rem" }}>
+                {state.approveResult.client_name}
+              </p>
+              <p style={{ color: "#888", fontSize: "0.9rem" }}>
+                Redirecting you back…
+              </p>
+            </>
+          )}
+        </div>
+      )}
+
+      {state.status === "redirecting" && (
+        <p style={{ color: "#888" }}>Redirecting…</p>
+      )}
+
+      {state.status === "error" && (
+        <div style={{ textAlign: "center", maxWidth: "500px" }}>
+          <p style={{ color: "#e74c3c", marginBottom: "1rem" }}>
+            {state.message}
+          </p>
+          <button
+            onClick={() => window.location.reload()}
+            style={{
+              background: "#fff",
+              color: "#000",
+              border: "none",
+              padding: "0.75rem 2rem",
+              borderRadius: "8px",
+              fontSize: "1rem",
+              cursor: "pointer",
+            }}
+          >
+            Try Again
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/auth/device/page.tsx
+++ b/app/auth/device/page.tsx
@@ -1,0 +1,18 @@
+import { getAppMetadata } from "@/components/providers/metadata";
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import AuthDevicePageClient from "./page.client";
+
+export default function AuthDevicePage() {
+  return (
+    <Suspense fallback={null}>
+      <AuthDevicePageClient />
+    </Suspense>
+  );
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  return getAppMetadata({
+    title: "Community App Authorization",
+  });
+}

--- a/services/auth/community-app-auth.utils.ts
+++ b/services/auth/community-app-auth.utils.ts
@@ -1,0 +1,83 @@
+import { commonApiPost } from "@/services/api/common-api";
+
+export interface DeviceCodeResponse {
+  readonly device_code: string;
+  readonly user_code: string;
+  readonly expires_in: number;
+  readonly redirect_uri: string;
+}
+
+export interface ApproveResponse {
+  readonly client_id: string;
+  readonly client_name: string;
+  readonly client_description: string;
+  readonly redirect_uri: string;
+  readonly scope: string;
+}
+
+export interface TokenResponse {
+  readonly access_token: string;
+  readonly token_type: "Bearer";
+  readonly expires_in: number;
+  readonly scope: string;
+  readonly address: string;
+}
+
+export async function createDeviceCode(params: {
+  clientId: string;
+  redirectUri: string;
+  scope: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+}): Promise<DeviceCodeResponse> {
+  return commonApiPost<
+    {
+      readonly client_id: string;
+      readonly redirect_uri: string;
+      readonly scope: string;
+      readonly code_challenge: string;
+      readonly code_challenge_method: string;
+    },
+    DeviceCodeResponse
+  >({
+    endpoint: "auth/community-app/device-code",
+    body: {
+      client_id: params.clientId,
+      redirect_uri: params.redirectUri,
+      scope: params.scope,
+      code_challenge: params.codeChallenge,
+      code_challenge_method: params.codeChallengeMethod,
+    },
+  });
+}
+
+export async function approveDeviceCode(
+  userCode: string
+): Promise<ApproveResponse> {
+  return commonApiPost<
+    { readonly user_code: string },
+    ApproveResponse
+  >({
+    endpoint: "auth/community-app/approve",
+    body: { user_code: userCode },
+  });
+}
+
+export async function exchangeDeviceCode(params: {
+  deviceCode: string;
+  codeVerifier: string;
+}): Promise<TokenResponse> {
+  return commonApiPost<
+    {
+      readonly device_code: string;
+      readonly code_verifier: string;
+    },
+    TokenResponse
+  >({
+    endpoint: "auth/community-app/token",
+    body: {
+      device_code: params.deviceCode,
+      code_verifier: params.codeVerifier,
+    },
+  });
+}

--- a/services/auth/pkce.utils.ts
+++ b/services/auth/pkce.utils.ts
@@ -1,0 +1,24 @@
+export interface PkcePair {
+  readonly verifier: string;
+  readonly challenge: string;
+  readonly method: string;
+}
+
+function base64urlEncode(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+export async function generatePkcePairBrowser(): Promise<PkcePair> {
+  const array = new Uint8Array(32);
+  crypto.getRandomValues(array);
+  const verifier = base64urlEncode(array);
+  const challengeBuffer = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(verifier)
+  );
+  const challenge = base64urlEncode(new Uint8Array(challengeBuffer));
+  return { verifier, challenge, method: "S256" };
+}


### PR DESCRIPTION
## Summary

Replaces the rejected auth-bridge approach (PR #3706) with a proper OAuth 2.0 Device Authorization Grant (RFC 8628) pattern that uses QR codes and scoped, audience-bound JWTs.

**This PR closes #3706.**

## What Changed

### New Pages
- **`/auth/device`** — Community app entry point. Shows QR code + user_code. Polls for approval. Redirects to community app callback with device_code when approved.
- **`/auth/device/approve`** — Mobile approval page (opens when user scans QR). Shows user's 6529 profile card, requested scope (`identity:read`), and an Authorize button.

### New Services
- **`services/auth/community-app-auth.utils.ts`** — API wrappers for three backend endpoints: `createDeviceCode`, `approveDeviceCode`, `exchangeDeviceCode`
- **`services/auth/pkce.utils.ts`** — Browser PKCE (S256) code verifier/challenge generation using Web Crypto API

## How the Flow Works

1. Community app generates PKCE pair, redirects to `6529.io/auth/device?client_id=...&redirect_uri=...&scope=identity:read&code_challenge=...&state=...`
2. 6529.io shows QR code encoding `/auth/device/approve?user_code=XXXX`
3. User scans QR on phone → sees profile card + scope → taps Authorize
4. `/auth/device` page polls `/community-app/approve` → detects approval
5. Redirects to community app callback with `device_code` + `state`
6. Community app exchanges `device_code` + PKCE verifier for scoped JWT via `POST /community-app/token`

## Security Improvements vs. Auth-Bridge (#3706)

| Concern (from @GelatoGenesis review) | Auth-Bridge | Device Auth (this PR) |
|---|---|---|
| Raw JWT exposed to third party | ✗ Yes | ✓ No — only scoped token |
| Token scope | Full session | `identity:read` only |
| Token audience | Unbound | Bound to `client_id` |
| Token lifetime | Session-length | 15 minutes, no refresh |
| Interception protection | None | PKCE S256 |
| User consent | Implicit | Explicit (tap Authorize) |

## Backend Dependency

Requires backend PR **#1990** ([6529seize-backend](https://github.com/6529-Collections/6529seize-backend/pull/1990)) for the API endpoints, DB tables, and scoped JWT issuance.

## Test Plan

- [ ] Navigate to `/auth/device?client_id=ar-community-platform&redirect_uri=https://arweave.net/6529-ar/auth/callback&scope=identity:read&code_challenge=test&state=abc`
- [ ] Verify QR code is displayed with user code
- [ ] Scan QR on phone → verify approval page shows profile + scope
- [ ] Tap Authorize → verify `/auth/device` detects approval
- [ ] Verify redirect to community app callback with device_code + state
- [ ] Test error states: missing params, invalid client_id, expired code
- [ ] Verify existing auth flows are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added community app authorization using device codes.
  - Users can generate a QR code, review requested read-only identity access, and approve authorization.
  - Added approval status, success, loading, error, and retry states.
  - Added secure PKCE-based authorization and automatic redirect after approval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->