### PR TITLE
Guide artists through publication-only artwork records

### DIFF
--- a/__tests__/components/artwork-documentation/DocumentationFeedback.test.tsx
+++ b/__tests__/components/artwork-documentation/DocumentationFeedback.test.tsx
@@ -120,6 +120,6 @@ it("sends publication drafting questions outside the artwork revision and preser
   );
   await waitFor(() => expect(input).toHaveValue(""));
   expect(context.latest_revision_id).toBe("confirmed-artwork");
-  expect(context.modules.context!.answers).toEqual({});
+  expect(context.modules["context"]!.answers).toEqual({});
   client.clear();
 });

--- a/__tests__/components/artwork-documentation/DocumentationFeedback.test.tsx
+++ b/__tests__/components/artwork-documentation/DocumentationFeedback.test.tsx
@@ -123,3 +123,67 @@ it("sends publication drafting questions outside the artwork revision and preser
   expect(context.modules["context"]!.answers).toEqual({});
   client.clear();
 });
+
+it("keeps resolved publication questions available without mixing revision feedback into the conversation", async () => {
+  const context = documentationFixture();
+  context.profile.intake_mode = "publication_only" as never;
+  context.profile.version = 2;
+  jest.mocked(getDocumentationThreads).mockResolvedValue({
+    data: [
+      {
+        id: "answered-question",
+        context_id: context.id,
+        field_path: null,
+        revision_id: null,
+        thread_version: 2,
+        resolved: true,
+        audience: "artist_and_reviewers",
+        restricted_class: "ordinary",
+        comments: [
+          {
+            id: "answer",
+            actor_profile_id: "artist-a",
+            text: "The team clarified which display instructions to use.",
+            created_at: 1788998400000,
+          },
+        ],
+      },
+      {
+        id: "revision-feedback",
+        context_id: context.id,
+        field_path: "artwork.title",
+        revision_id: "confirmed-artwork",
+        thread_version: 1,
+        resolved: false,
+        audience: "artist_and_reviewers",
+        restricted_class: "ordinary",
+        comments: [
+          {
+            id: "revision-comment",
+            actor_profile_id: "artist-a",
+            text: "Feedback about the prior artwork title.",
+            created_at: 1788998400000,
+          },
+        ],
+      },
+    ],
+  } as never);
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <DocumentationFeedback context={context} />
+    </QueryClientProvider>
+  );
+  await screen.findByText(
+    "The team clarified which display instructions to use."
+  );
+  expect(
+    screen.getByRole("button", { name: "Reopen conversation" })
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByText("Feedback about the prior artwork title.")
+  ).not.toBeInTheDocument();
+  client.clear();
+});

--- a/__tests__/components/artwork-documentation/DocumentationFeedback.test.tsx
+++ b/__tests__/components/artwork-documentation/DocumentationFeedback.test.tsx
@@ -5,6 +5,7 @@ import { documentationFixture } from "@/__tests__/fixtures/artwork-documentation
 import {
   getDocumentationThreads,
   resolveDocumentationThread,
+  createDocumentationThread,
 } from "@/services/api/artwork-documentation-api";
 
 jest.mock("@/hooks/useBrowserLocale", () => ({
@@ -20,34 +21,33 @@ jest.mock("@/services/api/artwork-documentation-api", () => ({
   ...jest.requireActual("@/services/api/artwork-documentation-api"),
   getDocumentationThreads: jest.fn(),
   resolveDocumentationThread: jest.fn().mockResolvedValue({}),
+  createDocumentationThread: jest.fn().mockResolvedValue({}),
 }));
 
 it.each([false, true])(
   "preserves an unsent comment when toggling resolved=%s",
   async (resolved) => {
     jest.mocked(resolveDocumentationThread).mockClear();
-    jest
-      .mocked(getDocumentationThreads)
-      .mockResolvedValue({
-        data: [
-          {
-            id: "thread",
-            context_id: "context",
-            thread_version: 1,
-            resolved,
-            audience: "artist_and_reviewers",
-            restricted_class: "ordinary",
-            comments: [
-              {
-                id: "comment",
-                text: "Prior discussion",
-                actor_profile_id: "artist-a",
-                created_at: 1788998400000,
-              },
-            ],
-          },
-        ],
-      } as never);
+    jest.mocked(getDocumentationThreads).mockResolvedValue({
+      data: [
+        {
+          id: "thread",
+          context_id: "context",
+          thread_version: 1,
+          resolved,
+          audience: "artist_and_reviewers",
+          restricted_class: "ordinary",
+          comments: [
+            {
+              id: "comment",
+              text: "Prior discussion",
+              actor_profile_id: "artist-a",
+              created_at: 1788998400000,
+            },
+          ],
+        },
+      ],
+    } as never);
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
@@ -76,3 +76,50 @@ it.each([false, true])(
     client.clear();
   }
 );
+
+it("sends publication drafting questions outside the artwork revision and preserves a failed question", async () => {
+  const context = documentationFixture();
+  context.profile.intake_mode = "publication_only" as never;
+  context.profile.version = 2;
+  context.latest_revision_id = "confirmed-artwork";
+  jest.mocked(getDocumentationThreads).mockResolvedValue({ data: [] } as never);
+  jest
+    .mocked(createDocumentationThread)
+    .mockRejectedValueOnce(new Error("offline"))
+    .mockResolvedValueOnce({});
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <DocumentationFeedback context={context} />
+    </QueryClientProvider>
+  );
+  await screen.findByText(
+    "No questions yet. You can return here whenever you need help."
+  );
+  expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  const input = screen.getByRole("textbox", {
+    name: "What would you like to ask?",
+  });
+  fireEvent.change(input, {
+    target: { value: "Which final file should I choose?" },
+  });
+  fireEvent.click(
+    screen.getByRole("button", { name: "Send question to the team" })
+  );
+  await screen.findByRole("alert");
+  expect(input).toHaveValue("Which final file should I choose?");
+  expect(createDocumentationThread).toHaveBeenLastCalledWith(context.id, {
+    text: "Which final file should I choose?",
+    audience: "artist_and_reviewers",
+    restricted_class: "ordinary",
+  });
+  fireEvent.click(
+    screen.getByRole("button", { name: "Send question to the team" })
+  );
+  await waitFor(() => expect(input).toHaveValue(""));
+  expect(context.latest_revision_id).toBe("confirmed-artwork");
+  expect(context.modules.context!.answers).toEqual({});
+  client.clear();
+});

--- a/__tests__/components/artwork-documentation/DocumentationGuidance.test.tsx
+++ b/__tests__/components/artwork-documentation/DocumentationGuidance.test.tsx
@@ -137,7 +137,7 @@ describe("worked artwork documentation examples", () => {
       <DocumentationNarrativeStarter
         id="caption"
         label="Caption"
-        structure="I made [your own account]."
+        structure="I made [[your own account]]."
         editor={{ kind: "localized", max: 3000 }}
         disabled={false}
         hasAnswer={false}
@@ -182,7 +182,7 @@ describe("worked artwork documentation examples", () => {
     const props = {
       id: "description",
       label: "Description",
-      structure: "[My account]",
+      structure: "[[My account]]",
       editor: { kind: "text" as const, multiline: true },
       disabled: false,
       hasAnswer: false,
@@ -204,13 +204,51 @@ describe("worked artwork documentation examples", () => {
     expect(props.onApply).not.toHaveBeenCalled();
   });
 
+  it.each([
+    "I made [[a renamed prompt]].",
+    "I made [[an unfinished prompt.",
+    "I made an unfinished prompt]].",
+  ])("keeps a remaining reserved prompt unsaved: %s", (text) => {
+    const onApply = jest.fn();
+    render(
+      <DocumentationNarrativeStarter
+        id="description"
+        label="Description"
+        structure="I made [[my account]]."
+        editor={{ kind: "text", multiline: true }}
+        disabled={false}
+        hasAnswer={false}
+        validate={() => true}
+        onApply={onApply}
+      />
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Adapt this writing structure" })
+    );
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: text },
+    });
+    const apply = screen.getByRole("button", { name: "Use my answer" });
+    expect(apply).toBeDisabled();
+    fireEvent.click(apply);
+    expect(onApply).not.toHaveBeenCalled();
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "I refer to the catalogue [1] in my account." },
+    });
+    expect(apply).toBeEnabled();
+    fireEvent.click(apply);
+    expect(onApply).toHaveBeenCalledWith(
+      "I refer to the catalogue [1] in my account."
+    );
+  });
+
   it("leaves rejected or discarded working text out of the form", () => {
     const onApply = jest.fn();
     render(
       <DocumentationNarrativeStarter
         id="description"
         label="Description"
-        structure="[My account]"
+        structure="[[My account]]"
         editor={{ kind: "text", multiline: true }}
         disabled={false}
         hasAnswer={false}

--- a/__tests__/components/artwork-documentation/DocumentationGuidance.test.tsx
+++ b/__tests__/components/artwork-documentation/DocumentationGuidance.test.tsx
@@ -1,0 +1,235 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import DocumentationWorkedExample from "@/components/artwork-documentation/DocumentationWorkedExample";
+import DocumentationModules from "@/components/artwork-documentation/DocumentationModules";
+import DocumentationNarrativeStarter from "@/components/artwork-documentation/DocumentationNarrativeStarter";
+import { documentationFixture } from "@/__tests__/fixtures/artwork-documentation";
+import {
+  MODULE_FIELDS,
+  MODULE_IDS,
+  SECTIONS,
+} from "@/lib/artwork-documentation/registry";
+import { documentationExampleFields } from "@/lib/artwork-documentation/examples";
+import { ARTWORK_DOCUMENTATION_EXAMPLE_MESSAGES } from "@/i18n/messages/artwork-documentation-examples";
+
+jest.mock("@/hooks/useBrowserLocale", () => ({
+  useBrowserLocale: () => "en-US",
+}));
+
+function completeProfile() {
+  const context = documentationFixture();
+  context.profile.interview_instrument = {
+    id: "artwork-documentation-artist-interview-v1",
+    version: 1,
+    language: "en",
+    prompts: [{ id: "q5", text: "What does a gate mean in this image?" }],
+  };
+  context.profile.modules = context.profile.modules.map((module) => ({
+    ...module,
+    fields: MODULE_FIELDS[module.id].map((field) => ({
+      ...context.profile.modules[1]!.fields[0]!,
+      id: field.id,
+    })),
+  }));
+  return context;
+}
+
+describe("worked artwork documentation examples", () => {
+  it("covers all eight modules and every publication field, with a separate review example", () => {
+    const context = completeProfile();
+    const excluded = new Set([
+      "identity.private_contact",
+      "files.source_availability",
+      "rights.people_depicted",
+      "rights.consent_status",
+      "rights.consent_asset_ids",
+      "rights.identifiability_note",
+      "rights.sensitive_context_note",
+    ]);
+    const fields = SECTIONS.flatMap((section) =>
+      documentationExampleFields(context.profile, section)
+    );
+    expect(new Set(fields.map((entry) => entry.moduleId))).toEqual(
+      new Set(MODULE_IDS)
+    );
+    expect(
+      fields.map(({ moduleId, field }) => `${moduleId}.${field.id}`).sort()
+    ).toEqual(
+      MODULE_IDS.flatMap((moduleId) =>
+        MODULE_FIELDS[moduleId].map((field) => `${moduleId}.${field.id}`)
+      )
+        .filter((path) => !excluded.has(path))
+        .sort()
+    );
+    expect(
+      ARTWORK_DOCUMENTATION_EXAMPLE_MESSAGES[
+        "artworkDocumentation.examples.review"
+      ]
+    ).toContain("before finalizing");
+  });
+
+  it("opens an empty section's complete fictional example without adding any answers", () => {
+    const context = documentationFixture();
+    context.modules.artwork!.answers = {};
+    const before = JSON.stringify(context);
+    render(
+      <DocumentationWorkedExample
+        context={context}
+        edits={[]}
+        section="artwork"
+      />
+    );
+    expect(
+      screen
+        .getByText("See a complete example for this section")
+        .closest("details")
+    ).toHaveAttribute("open");
+    expect(screen.getByText("The Space Between")).toBeInTheDocument();
+    expect(JSON.stringify(context)).toBe(before);
+  });
+
+  it("keeps the example discoverable after a section has an answer, and filters unsupported fields", () => {
+    render(
+      <DocumentationWorkedExample
+        context={documentationFixture()}
+        edits={[]}
+        section="artwork"
+      />
+    );
+    expect(
+      screen
+        .getByText("See a complete example for this section")
+        .closest("details")
+    ).not.toHaveAttribute("open");
+    expect(
+      screen.queryByText("12 May 2025; exact day.")
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not attach known interview answers to an unknown pinned instrument", () => {
+    const context = completeProfile();
+    context.profile.interview_instrument.id = "another-instrument";
+    expect(
+      documentationExampleFields(context.profile, "preservation").some(
+        ({ field }) => field.id === "q5"
+      )
+    ).toBe(false);
+  });
+
+  it("does not offer a factual title or location template for insertion", () => {
+    const onChange = jest.fn();
+    render(
+      <DocumentationModules
+        context={documentationFixture()}
+        edits={[]}
+        section="artwork"
+        onChange={onChange}
+      />
+    );
+    expect(
+      screen.queryByRole("button", { name: "Adapt this writing structure" })
+    ).not.toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps writing structures unsaved until the artist replaces prompts and explicitly applies a schema-valid answer", () => {
+    const onApply = jest.fn();
+    render(
+      <DocumentationNarrativeStarter
+        id="caption"
+        label="Caption"
+        structure="I made [your own account]."
+        editor={{ kind: "localized", max: 3000 }}
+        disabled={false}
+        hasAnswer={false}
+        validate={() => true}
+        onApply={onApply}
+      />
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Adapt this writing structure" })
+    );
+    expect(onApply).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "Use my answer" })
+    ).toBeDisabled();
+    fireEvent.change(
+      screen.getByRole("textbox", { name: "Your answer for Caption" }),
+      { target: { value: "I photographed the trees after the rain." } }
+    );
+    expect(
+      screen.getByRole("button", { name: "Use my answer" })
+    ).toBeDisabled();
+    fireEvent.change(
+      screen.getByLabelText("Language of your answer (for example, en or es)"),
+      { target: { value: "en" } }
+    );
+    expect(onApply).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Use my answer" }));
+    expect(onApply).toHaveBeenCalledWith({
+      primary_language: "en",
+      versions: [
+        {
+          language: "en",
+          text: "I photographed the trees after the rain.",
+          authorship: "original",
+          approved_by_artist: false,
+        },
+      ],
+    });
+  });
+
+  it("does not overwrite an answer that arrives while the artist writes a starter", () => {
+    const props = {
+      id: "description",
+      label: "Description",
+      structure: "[My account]",
+      editor: { kind: "text" as const, multiline: true },
+      disabled: false,
+      hasAnswer: false,
+      validate: () => true,
+      onApply: jest.fn(),
+    };
+    const { rerender } = render(<DocumentationNarrativeStarter {...props} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Adapt this writing structure" })
+    );
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "My own work." },
+    });
+    rerender(<DocumentationNarrativeStarter {...props} hasAnswer />);
+    expect(screen.getByDisplayValue("My own work.")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Use my answer" })
+    ).toBeDisabled();
+    expect(props.onApply).not.toHaveBeenCalled();
+  });
+
+  it("leaves rejected or discarded working text out of the form", () => {
+    const onApply = jest.fn();
+    render(
+      <DocumentationNarrativeStarter
+        id="description"
+        label="Description"
+        structure="[My account]"
+        editor={{ kind: "text", multiline: true }}
+        disabled={false}
+        hasAnswer={false}
+        validate={() => false}
+        onApply={onApply}
+      />
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Adapt this writing structure" })
+    );
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Too long for this schema." },
+    });
+    expect(
+      screen.getByRole("button", { name: "Use my answer" })
+    ).toBeDisabled();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Discard this working text" })
+    );
+    expect(onApply).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/artwork-documentation/DocumentationGuidance.test.tsx
+++ b/__tests__/components/artwork-documentation/DocumentationGuidance.test.tsx
@@ -69,7 +69,7 @@ describe("worked artwork documentation examples", () => {
 
   it("opens an empty section's complete fictional example without adding any answers", () => {
     const context = documentationFixture();
-    context.modules.artwork!.answers = {};
+    context.modules["artwork"]!.answers = {};
     const before = JSON.stringify(context);
     render(
       <DocumentationWorkedExample

--- a/__tests__/components/artwork-documentation/DocumentationModules.test.tsx
+++ b/__tests__/components/artwork-documentation/DocumentationModules.test.tsx
@@ -8,6 +8,43 @@ jest.mock("@/hooks/useBrowserLocale", () => ({
 }));
 
 describe("artwork documentation modules", () => {
+  it("uses publication intent without exposing per-field privacy choices in the new intake", () => {
+    const context = documentationFixture();
+    context.profile.version = 2;
+    context.profile.intake_mode = "publication_only" as never;
+    context.profile.modules[1]!.fields[1]!.allowed_statuses = [
+      "provided",
+      "unknown",
+    ] as never;
+    const onChange = jest.fn();
+    render(
+      <DocumentationModules
+        context={context}
+        edits={[]}
+        section="artwork"
+        onChange={onChange}
+      />
+    );
+    expect(
+      screen.queryByRole("option", { name: "Restricted" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "Withheld" })
+    ).not.toBeInTheDocument();
+    fireEvent.change(screen.getByRole("textbox", { name: "Location" }), {
+      target: { value: "A studio" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith(
+      "artwork",
+      expect.objectContaining({
+        answer: {
+          status: "provided",
+          value: "A studio",
+          intended_visibility: "public_record",
+        },
+      })
+    );
+  });
   it("renders the original script without rewriting the artist title", () => {
     render(
       <DocumentationModules

--- a/__tests__/components/artwork-documentation/DocumentationPublicationUploads.test.tsx
+++ b/__tests__/components/artwork-documentation/DocumentationPublicationUploads.test.tsx
@@ -100,7 +100,7 @@ describe("publication-only artwork uploads", () => {
       received_parts: [],
       policy: {},
     } as Awaited<ReturnType<typeof startDocumentationUpload>>);
-    jest.mocked(transferDocumentationFile).mockResolvedValue(undefined);
+    jest.mocked(transferDocumentationFile).mockResolvedValue({ asset });
     render(<DocumentationUpload context={context} controller={controller} />);
     fireEvent.change(screen.getByLabelText("Select file"), {
       target: {

--- a/__tests__/components/artwork-documentation/DocumentationPublicationUploads.test.tsx
+++ b/__tests__/components/artwork-documentation/DocumentationPublicationUploads.test.tsx
@@ -1,12 +1,25 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import DocumentationUpload from "@/components/artwork-documentation/DocumentationUpload";
 import DocumentationAssetDetails from "@/components/artwork-documentation/DocumentationAssetDetails";
 import { documentationFixture } from "@/__tests__/fixtures/artwork-documentation";
 import { DocumentationDraftController } from "@/lib/artwork-documentation/draft-controller";
 import { canPublishDocumentationAsset } from "@/lib/artwork-documentation/asset-roles";
 import { ApiArtworkDocumentationAnswerStatusEnum } from "@/generated/models/ApiArtworkDocumentationAnswer";
+import type { ApiArtworkDocumentationAsset } from "@/generated/models/ApiArtworkDocumentationAsset";
+import type { ApiArtworkDocumentationAssetLink } from "@/generated/models/ApiArtworkDocumentationAssetLink";
+import type { ApiArtworkDocumentationUploadSession } from "@/generated/models/ApiArtworkDocumentationUploadSession";
+import { ApiArtworkDocumentationAssetTermsKindEnum } from "@/generated/models/ApiArtworkDocumentationAssetTerms";
 import {
+  cancelDocumentationUpload,
+  getDocumentationUpload,
   linkDocumentationAsset,
+  patchDocumentationAssetLink,
   startDocumentationUpload,
 } from "@/services/api/artwork-documentation-assets-api";
 import { transferDocumentationFile } from "@/lib/artwork-documentation/upload";
@@ -24,6 +37,54 @@ jest.mock("@/lib/artwork-documentation/poll-processing", () => ({
 }));
 
 const controllers: DocumentationDraftController[] = [];
+function uploadSession(
+  overrides: Partial<ApiArtworkDocumentationAsset> = {}
+): ApiArtworkDocumentationUploadSession {
+  return {
+    asset: {
+      id: "asset-1",
+      filename: "final.png",
+      size_bytes: 5,
+      role: "artwork_final",
+      intended_visibility: "public_record",
+      state: "uploading",
+      ...overrides,
+    },
+    upload_id: "asset-1",
+    expires_at: Date.now() + 60_000,
+    received_parts: [],
+    policy: {},
+  };
+}
+function assetLink(
+  asset: ApiArtworkDocumentationAsset,
+  overrides: Partial<ApiArtworkDocumentationAssetLink> = {}
+): ApiArtworkDocumentationAssetLink {
+  return {
+    id: "link-1",
+    asset_id: asset.id,
+    role: asset.role,
+    label: "Original label",
+    description: "",
+    intended_visibility: asset.intended_visibility,
+    source_of_asset: "unknown",
+    source_credit: "",
+    derived_from_asset_ids: [],
+    deposit_note: "",
+    intended_terms: {
+      kind: ApiArtworkDocumentationAssetTermsKindEnum.Unspecified,
+    },
+    manifest: asset,
+    ...overrides,
+  };
+}
+function selectFile() {
+  fireEvent.change(screen.getByLabelText("Select file"), {
+    target: {
+      files: [new File(["image"], "final.png", { type: "image/png" })],
+    },
+  });
+}
 function setup(publicationOnly = true) {
   const context = documentationFixture();
   if (publicationOnly)
@@ -46,6 +107,12 @@ function setup(publicationOnly = true) {
 afterEach(() => {
   controllers.splice(0).forEach((controller) => controller.dispose());
   jest.clearAllMocks();
+});
+beforeEach(() => {
+  jest.mocked(startDocumentationUpload).mockReset();
+  jest.mocked(getDocumentationUpload).mockReset();
+  jest.mocked(cancelDocumentationUpload).mockReset();
+  jest.mocked(transferDocumentationFile).mockReset();
 });
 
 describe("publication-only artwork uploads", () => {
@@ -184,6 +251,264 @@ describe("publication-only artwork uploads", () => {
         }),
         expect.any(AbortSignal)
       )
+    );
+  });
+  it("resumes an existing artwork upload independently of the new-file interview role", async () => {
+    const { context, controller } = setup();
+    const session = uploadSession();
+    context.assets = [session.asset];
+    jest.mocked(getDocumentationUpload).mockResolvedValue(session);
+    jest
+      .mocked(transferDocumentationFile)
+      .mockResolvedValue({ asset: session.asset });
+    render(<DocumentationUpload context={context} controller={controller} />);
+    fireEvent.change(
+      screen.getByRole("combobox", { name: "What is this file for?" }),
+      {
+        target: { value: "interview_recording" },
+      }
+    );
+    selectFile();
+    expect(screen.getByRole("button", { name: "Upload file" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    await waitFor(() =>
+      expect(transferDocumentationFile).toHaveBeenCalledWith(
+        expect.objectContaining({ session, contextId: context.id })
+      )
+    );
+    expect(startDocumentationUpload).not.toHaveBeenCalled();
+    expect(cancelDocumentationUpload).not.toHaveBeenCalled();
+  });
+  it("retries its retained session even after an unrelated form role is selected", async () => {
+    const props = setup();
+    const session = uploadSession();
+    jest.mocked(startDocumentationUpload).mockResolvedValue(session);
+    jest.mocked(getDocumentationUpload).mockResolvedValue(session);
+    jest
+      .mocked(transferDocumentationFile)
+      .mockRejectedValueOnce(new Error("network"))
+      .mockResolvedValue({ asset: session.asset });
+    render(<DocumentationUpload {...props} />);
+    selectFile();
+    fireEvent.click(screen.getByRole("button", { name: "Upload file" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Try again" })).toBeEnabled()
+    );
+    fireEvent.change(
+      screen.getByRole("combobox", { name: "What is this file for?" }),
+      {
+        target: { value: "interview_recording" },
+      }
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    await waitFor(() =>
+      expect(transferDocumentationFile).toHaveBeenCalledTimes(2)
+    );
+    expect(getDocumentationUpload).toHaveBeenCalledWith(
+      props.context.id,
+      session.upload_id,
+      expect.any(AbortSignal)
+    );
+    expect(startDocumentationUpload).toHaveBeenCalledTimes(1);
+    expect(cancelDocumentationUpload).not.toHaveBeenCalled();
+  });
+  it.each([
+    { role: "consent_instrument" },
+    { intended_visibility: "restricted" },
+  ])(
+    "cancels a newly returned incompatible session and renews its start key: %j",
+    async (overrides) => {
+      const props = setup();
+      const rejected = uploadSession(overrides);
+      const accepted = uploadSession();
+      jest
+        .mocked(startDocumentationUpload)
+        .mockResolvedValueOnce(rejected)
+        .mockResolvedValueOnce(accepted);
+      jest.mocked(cancelDocumentationUpload).mockResolvedValue(undefined);
+      jest
+        .mocked(transferDocumentationFile)
+        .mockResolvedValue({ asset: accepted.asset });
+      render(<DocumentationUpload {...props} />);
+      selectFile();
+      fireEvent.click(screen.getByRole("button", { name: "Upload file" }));
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: "Upload file" })
+        ).toBeEnabled()
+      );
+      expect(cancelDocumentationUpload).toHaveBeenCalledWith(
+        props.context.id,
+        rejected.upload_id,
+        expect.any(AbortSignal)
+      );
+      expect(transferDocumentationFile).not.toHaveBeenCalled();
+      const firstKey = jest.mocked(startDocumentationUpload).mock.calls[0]![2];
+      fireEvent.click(screen.getByRole("button", { name: "Upload file" }));
+      await waitFor(() =>
+        expect(transferDocumentationFile).toHaveBeenCalledTimes(1)
+      );
+      expect(jest.mocked(startDocumentationUpload).mock.calls[1]![2]).not.toBe(
+        firstKey
+      );
+    }
+  );
+  it("retains a rejected reservation when automatic or explicit cancellation fails", async () => {
+    const props = setup();
+    const rejected = uploadSession({ role: "rights_instrument" });
+    jest.mocked(startDocumentationUpload).mockResolvedValue(rejected);
+    jest
+      .mocked(cancelDocumentationUpload)
+      .mockRejectedValueOnce(new Error("network"))
+      .mockRejectedValueOnce(new Error("network"))
+      .mockResolvedValueOnce(undefined);
+    render(<DocumentationUpload {...props} />);
+    selectFile();
+    fireEvent.click(screen.getByRole("button", { name: "Upload file" }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Cancel upload" })
+      ).toBeEnabled()
+    );
+    expect(screen.getByRole("button", { name: "Try again" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel upload" }));
+    await waitFor(() =>
+      expect(cancelDocumentationUpload).toHaveBeenCalledTimes(2)
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Cancel upload" })
+      ).toBeEnabled()
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Cancel upload" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Upload file" })).toBeEnabled()
+    );
+    expect(cancelDocumentationUpload).toHaveBeenCalledTimes(3);
+    expect(cancelDocumentationUpload).toHaveBeenLastCalledWith(
+      props.context.id,
+      rejected.upload_id,
+      expect.any(AbortSignal)
+    );
+    expect(transferDocumentationFile).not.toHaveBeenCalled();
+  });
+  it("preserves a resumed interview session if publication permission changes while loading it", async () => {
+    const props = setup();
+    const session = uploadSession({ role: "interview_recording" });
+    props.context.assets = [session.asset];
+    props.context.modules["interview"]!.answers["recording_permission"] = {
+      status: ApiArtworkDocumentationAnswerStatusEnum.Provided,
+      value: "intended_public_record",
+    };
+    jest.mocked(getDocumentationUpload).mockImplementation(async () => {
+      delete props.context.modules["interview"]!.answers[
+        "recording_permission"
+      ];
+      return session;
+    });
+    render(<DocumentationUpload {...props} />);
+    selectFile();
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Cancel upload" })
+      ).toBeEnabled()
+    );
+    expect(transferDocumentationFile).not.toHaveBeenCalled();
+    expect(cancelDocumentationUpload).not.toHaveBeenCalled();
+    expect(startDocumentationUpload).not.toHaveBeenCalled();
+  });
+  it("aborts cancellation on unmount without starting a replacement upload", async () => {
+    const props = setup();
+    const session = uploadSession();
+    jest.mocked(startDocumentationUpload).mockResolvedValue(session);
+    jest
+      .mocked(transferDocumentationFile)
+      .mockRejectedValue(new Error("network"));
+    let finishCancel: (() => void) | undefined;
+    jest.mocked(cancelDocumentationUpload).mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishCancel = resolve;
+        })
+    );
+    const view = render(<DocumentationUpload {...props} />);
+    selectFile();
+    fireEvent.click(screen.getByRole("button", { name: "Upload file" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Try again" })).toBeEnabled()
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Cancel upload" }));
+    const signal = jest.mocked(cancelDocumentationUpload).mock.calls[0]![2];
+    view.unmount();
+    expect(signal?.aborted).toBe(true);
+    await act(async () => {
+      finishCancel?.();
+    });
+    expect(startDocumentationUpload).toHaveBeenCalledTimes(1);
+  });
+  it.each([
+    { role: "consent_instrument" },
+    { role: "rights_instrument" },
+    { intended_visibility: "restricted" },
+  ])(
+    "blocks incompatible existing links instead of republishing their metadata: %j",
+    (overrides) => {
+      const props = setup();
+      const asset = uploadSession({ state: "ready" }).asset;
+      props.context.assets = [asset];
+      props.context.asset_links = [assetLink(asset, overrides)];
+      render(<DocumentationAssetDetails {...props} assetId={asset.id} />);
+      expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Add entry" })
+      ).not.toBeInTheDocument();
+      expect(props.controller.snapshot().contentEdits).toHaveLength(0);
+      expect(patchDocumentationAssetLink).not.toHaveBeenCalled();
+      expect(linkDocumentationAsset).not.toHaveBeenCalled();
+    }
+  );
+  it("rechecks the stored asset when a role addition reaches the mutation queue", async () => {
+    const props = setup();
+    const asset = uploadSession({ state: "ready" }).asset;
+    props.context.assets = [asset];
+    render(<DocumentationAssetDetails {...props} assetId={asset.id} />);
+    fireEvent.click(screen.getByText("File details and integrity"));
+    asset.intended_visibility = "restricted";
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Add entry" }));
+    });
+    expect(linkDocumentationAsset).not.toHaveBeenCalled();
+  });
+  it("keeps legacy consent metadata restricted when editing a label", async () => {
+    const props = setup(false);
+    const asset = uploadSession({
+      state: "ready",
+      role: "consent_instrument",
+      intended_visibility: "restricted",
+    }).asset;
+    props.context.assets = [asset];
+    props.context.asset_links = [assetLink(asset)];
+    jest.mocked(patchDocumentationAssetLink).mockResolvedValue(props.context);
+    render(<DocumentationAssetDetails {...props} assetId={asset.id} />);
+    fireEvent.click(
+      screen.getByText("File details and integrity", { selector: "summary" })
+    );
+    fireEvent.change(screen.getByDisplayValue("Original label"), {
+      target: { value: "Updated label" },
+    });
+    await act(async () => {
+      await props.controller.flush();
+    });
+    expect(patchDocumentationAssetLink).toHaveBeenCalledWith(
+      props.context,
+      "link-1",
+      expect.objectContaining({
+        label: "Updated label",
+        intended_visibility: "restricted",
+      }),
+      expect.any(AbortSignal),
+      expect.any(String)
     );
   });
 });

--- a/__tests__/components/artwork-documentation/DocumentationPublicationUploads.test.tsx
+++ b/__tests__/components/artwork-documentation/DocumentationPublicationUploads.test.tsx
@@ -1,0 +1,189 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import DocumentationUpload from "@/components/artwork-documentation/DocumentationUpload";
+import DocumentationAssetDetails from "@/components/artwork-documentation/DocumentationAssetDetails";
+import { documentationFixture } from "@/__tests__/fixtures/artwork-documentation";
+import { DocumentationDraftController } from "@/lib/artwork-documentation/draft-controller";
+import { canPublishDocumentationAsset } from "@/lib/artwork-documentation/asset-roles";
+import { ApiArtworkDocumentationAnswerStatusEnum } from "@/generated/models/ApiArtworkDocumentationAnswer";
+import {
+  linkDocumentationAsset,
+  startDocumentationUpload,
+} from "@/services/api/artwork-documentation-assets-api";
+import { transferDocumentationFile } from "@/lib/artwork-documentation/upload";
+
+jest.mock("@/hooks/useBrowserLocale", () => ({
+  useBrowserLocale: () => "en-US",
+}));
+jest.mock("@/services/api/artwork-documentation-assets-api");
+jest.mock("@/lib/artwork-documentation/upload", () => ({
+  DocumentationFileChangedError: class extends Error {},
+  transferDocumentationFile: jest.fn(),
+}));
+jest.mock("@/lib/artwork-documentation/poll-processing", () => ({
+  pollDocumentationProcessing: jest.fn(() => jest.fn()),
+}));
+
+const controllers: DocumentationDraftController[] = [];
+function setup(publicationOnly = true) {
+  const context = documentationFixture();
+  if (publicationOnly)
+    Object.assign(context.profile, {
+      intake_mode: "publication_only",
+      version: 2,
+    });
+  const controller = new DocumentationDraftController(
+    context,
+    {
+      save: jest.fn(async () => context),
+      read: jest.fn(async () => context),
+    },
+    jest.fn()
+  );
+  controllers.push(controller);
+  jest.mocked(linkDocumentationAsset).mockResolvedValue(context);
+  return { context, controller };
+}
+afterEach(() => {
+  controllers.splice(0).forEach((controller) => controller.dispose());
+  jest.clearAllMocks();
+});
+
+describe("publication-only artwork uploads", () => {
+  it("shows the final artwork first and omits private upload roles and visibility controls", () => {
+    render(<DocumentationUpload {...setup()} />);
+    expect(
+      screen.getByRole("heading", {
+        name: "Add the final artwork or public supporting material",
+      })
+    ).toBeInTheDocument();
+    const roles = screen.getByRole("combobox", {
+      name: "What is this file for?",
+    });
+    expect(roles).toHaveValue("artwork_final");
+    expect(
+      Array.from((roles as HTMLSelectElement).options, (option) => option.value)
+    ).toEqual([
+      "artwork_final",
+      "preservation_master",
+      "process_evidence",
+      "display_derivative",
+      "interview_recording",
+      "interview_transcript",
+      "other_supporting",
+    ]);
+    expect(screen.getAllByRole("combobox")).toHaveLength(1);
+  });
+  it("preserves legacy upload visibility and private-source role choices", () => {
+    render(<DocumentationUpload {...setup(false)} />);
+    expect(screen.getAllByRole("combobox")).toHaveLength(2);
+    expect(
+      screen.getByRole("option", { name: "Camera original / RAW" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Consent document" })
+    ).toBeInTheDocument();
+  });
+  it("starts the exact final file with public-record intention without granting a license", async () => {
+    const { context, controller } = setup();
+    const asset = {
+      id: "asset-1",
+      filename: "final.png",
+      size_bytes: 5,
+      role: "artwork_final",
+      intended_visibility: "public_record",
+      state: "uploading",
+    };
+    jest.mocked(startDocumentationUpload).mockResolvedValue({
+      asset,
+      upload_id: asset.id,
+      expires_at: Date.now() + 60_000,
+      received_parts: [],
+      policy: {},
+    } as Awaited<ReturnType<typeof startDocumentationUpload>>);
+    jest.mocked(transferDocumentationFile).mockResolvedValue(undefined);
+    render(<DocumentationUpload context={context} controller={controller} />);
+    fireEvent.change(screen.getByLabelText("Select file"), {
+      target: {
+        files: [new File(["image"], "final.png", { type: "image/png" })],
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Upload file" }));
+    await waitFor(() =>
+      expect(startDocumentationUpload).toHaveBeenCalledWith(
+        context.id,
+        {
+          filename: "final.png",
+          size_bytes: 5,
+          declared_mime: "image/png",
+          role: "artwork_final",
+          intended_visibility: "public_record",
+        },
+        expect.any(String),
+        expect.any(AbortSignal)
+      )
+    );
+    expect(linkDocumentationAsset).not.toHaveBeenCalled();
+  });
+  it("requires the matching interview publication permission before transfer", () => {
+    const { context, controller } = setup();
+    render(<DocumentationUpload context={context} controller={controller} />);
+    fireEvent.change(
+      screen.getByRole("combobox", { name: "What is this file for?" }),
+      { target: { value: "interview_recording" } }
+    );
+    fireEvent.change(screen.getByLabelText("Select file"), {
+      target: {
+        files: [new File(["audio"], "interview.wav", { type: "audio/wav" })],
+      },
+    });
+    expect(screen.getByRole("button", { name: "Upload file" })).toBeDisabled();
+    expect(
+      screen.getByText(/Before uploading this interview material/)
+    ).toBeInTheDocument();
+    context.modules["interview"]!.answers["recording_permission"] = {
+      status: ApiArtworkDocumentationAnswerStatusEnum.Provided,
+      value: "intended_public_record",
+    };
+    expect(canPublishDocumentationAsset(context, "interview_recording")).toBe(
+      true
+    );
+    expect(canPublishDocumentationAsset(context, "interview_transcript")).toBe(
+      false
+    );
+    expect(startDocumentationUpload).not.toHaveBeenCalled();
+  });
+  it("adds a public preservation role without private-deposit terms or an automatic license", async () => {
+    const { context, controller } = setup();
+    context.assets = [
+      {
+        id: "asset-1",
+        filename: "final.png",
+        size_bytes: 5,
+        state: "ready",
+        role: "artwork_final",
+        intended_visibility: "public_record",
+      },
+    ];
+    render(
+      <DocumentationAssetDetails
+        context={context}
+        controller={controller}
+        assetId="asset-1"
+      />
+    );
+    fireEvent.click(screen.getByText("File details and integrity"));
+    fireEvent.click(screen.getByRole("button", { name: "Add entry" }));
+    await waitFor(() =>
+      expect(linkDocumentationAsset).toHaveBeenCalledWith(
+        context,
+        expect.objectContaining({
+          asset_id: "asset-1",
+          role: "preservation_master",
+          intended_visibility: "public_record",
+          intended_terms: { kind: "unspecified" },
+        }),
+        expect.any(AbortSignal)
+      )
+    );
+  });
+});

--- a/__tests__/components/artwork-documentation/DocumentationPublicationUploads.test.tsx
+++ b/__tests__/components/artwork-documentation/DocumentationPublicationUploads.test.tsx
@@ -371,6 +371,9 @@ describe("publication-only artwork uploads", () => {
       ).toBeEnabled()
     );
     expect(screen.getByRole("button", { name: "Try again" })).toBeDisabled();
+    expect(
+      screen.getByText(/This upload is still pending/)
+    ).toHaveTextContent("Cancel upload to release it");
     fireEvent.click(screen.getByRole("button", { name: "Cancel upload" }));
     await waitFor(() =>
       expect(cancelDocumentationUpload).toHaveBeenCalledTimes(2)

--- a/__tests__/lib/artwork-documentation/intake.test.ts
+++ b/__tests__/lib/artwork-documentation/intake.test.ts
@@ -27,7 +27,7 @@ describe("publication intake boundaries", () => {
   it("cannot copy restricted or unsupported source answers into a publication record", () => {
     const context = documentationFixture();
     context.profile.intake_mode = "publication_only" as never;
-    const publicAnswer = context.modules.artwork!.answers.title!;
+    const publicAnswer = context.modules["artwork"]!.answers["title"]!;
     expect(
       canImportDocumentationAnswer(
         context.profile,

--- a/__tests__/lib/artwork-documentation/intake.test.ts
+++ b/__tests__/lib/artwork-documentation/intake.test.ts
@@ -1,0 +1,92 @@
+import { documentationFixture } from "@/__tests__/fixtures/artwork-documentation";
+import {
+  canImportDocumentationAnswer,
+  documentationChoiceEditor,
+  isPublicationOnly,
+  latestDocumentationProfiles,
+} from "@/lib/artwork-documentation/intake";
+import { confirmationCopyMatches } from "@/lib/artwork-documentation/confirmation";
+import { ARTWORK_DOCUMENTATION_MESSAGES } from "@/i18n/messages/artwork-documentation";
+
+describe("publication intake boundaries", () => {
+  it("selects the newest profile without rewriting existing contexts", () => {
+    const legacy = documentationFixture().profile;
+    const latest = {
+      ...legacy,
+      version: 2,
+      intake_mode: "publication_only" as never,
+    };
+    const another = { ...latest, program_id: "another-program" };
+    expect(latestDocumentationProfiles([legacy, latest, another])).toEqual([
+      latest,
+      another,
+    ]);
+    expect(isPublicationOnly(legacy)).toBe(false);
+    expect(legacy.version).toBe(1);
+  });
+  it("cannot copy restricted or unsupported source answers into a publication record", () => {
+    const context = documentationFixture();
+    context.profile.intake_mode = "publication_only" as never;
+    const publicAnswer = context.modules.artwork!.answers.title!;
+    expect(
+      canImportDocumentationAnswer(
+        context.profile,
+        "artwork.title",
+        publicAnswer
+      )
+    ).toBe(true);
+    expect(
+      canImportDocumentationAnswer(
+        context.profile,
+        "identity.private_contact",
+        publicAnswer
+      )
+    ).toBe(false);
+    expect(
+      canImportDocumentationAnswer(context.profile, "artwork.title", {
+        ...publicAnswer,
+        intended_visibility: "restricted" as never,
+      })
+    ).toBe(false);
+    expect(
+      canImportDocumentationAnswer(context.profile, "artwork.title", {
+        ...publicAnswer,
+        status: "withheld" as never,
+      })
+    ).toBe(false);
+    expect(
+      canImportDocumentationAnswer(context.profile, "artwork.title", {
+        ...publicAnswer,
+        value: { wrong: "shape" },
+      })
+    ).toBe(false);
+  });
+  it("uses the server's permitted interview choices rather than legacy client options", () => {
+    expect(
+      documentationChoiceEditor(
+        {
+          kind: "choice",
+          options: [
+            "not_requested",
+            "private_review",
+            "intended_public_record",
+          ],
+        },
+        { type: "string", enum: ["intended_public_record"] } as never
+      )
+    ).toEqual({ kind: "choice", options: ["intended_public_record"] });
+  });
+  it("accepts only the exact reviewed confirmation copy for either version", () => {
+    const profile = documentationFixture().profile;
+    expect(confirmationCopyMatches(profile)).toBe(true);
+    profile.confirmation_copy_version = "artwork-documentation-confirmation-v2";
+    expect(confirmationCopyMatches(profile)).toBe(false);
+    profile.confirmation_copy =
+      ARTWORK_DOCUMENTATION_MESSAGES[
+        "artworkDocumentation.publication.confirmCopy"
+      ];
+    expect(confirmationCopyMatches(profile)).toBe(true);
+    profile.confirmation_copy += " Changed.";
+    expect(confirmationCopyMatches(profile)).toBe(false);
+  });
+});

--- a/components/artwork-documentation/ArtworkDocumentationInline.tsx
+++ b/components/artwork-documentation/ArtworkDocumentationInline.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { isPublicationOnly } from "@/lib/artwork-documentation/intake";
+
 import Link from "next/link";
 import {
   forwardRef,
@@ -216,7 +218,13 @@ const InlineEditor = forwardRef<
   );
   return (
     <div className="tw-space-y-4">
-      <DocumentationNotice>{msg("privacy")}</DocumentationNotice>
+      <DocumentationNotice>
+        {msg(
+          isPublicationOnly(draft.context.profile)
+            ? "publication.help"
+            : "privacy"
+        )}
+      </DocumentationNotice>
       <p className="tw-text-xs tw-text-iron-400">{msg("sourceProposal")}</p>
       <DocumentationSaveStatus snapshot={draft} controller={controller} />
       <DocumentationModules

--- a/components/artwork-documentation/ArtworkDocumentationList.tsx
+++ b/components/artwork-documentation/ArtworkDocumentationList.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/services/api/artwork-documentation-api";
 import { documentationOptionLabel } from "@/i18n/messages/artwork-documentation-fields";
 import { formatDate } from "@/i18n/format";
+import { isPublicationOnly } from "@/lib/artwork-documentation/intake";
 import DocumentationAuthGate, {
   useDocumentationActor,
 } from "./DocumentationAuthGate";
@@ -139,7 +140,13 @@ function DocumentationListContent({
           {msg("stages")}
         </p>
       </header>
-      <DocumentationNotice>{msg("privacy")}</DocumentationNotice>
+      <DocumentationNotice>
+        {msg(
+          selected && isPublicationOnly(selected)
+            ? "publication.help"
+            : "privacy"
+        )}
+      </DocumentationNotice>
       {sourceDropId && (
         <DocumentationNotice>{msg("sourceHelp")}</DocumentationNotice>
       )}

--- a/components/artwork-documentation/ArtworkDocumentationWorkspace.tsx
+++ b/components/artwork-documentation/ArtworkDocumentationWorkspace.tsx
@@ -46,6 +46,8 @@ import DocumentationSources from "./DocumentationSources";
 import DocumentationArtistPin from "./DocumentationArtistPin";
 import DocumentationArtworkPreview from "./DocumentationArtworkPreview";
 import DocumentationNewContext from "./DocumentationNewContext";
+import DocumentationWorkedExample from "./DocumentationWorkedExample";
+import { isPublicationOnly } from "@/lib/artwork-documentation/intake";
 
 interface Props {
   readonly workId: string;
@@ -120,6 +122,7 @@ function WorkspaceEditor({
   const router = useRouter();
   const draft = useDocumentationDraft(initial);
   const { context, controller } = draft;
+  const publicationOnly = isPublicationOnly(context.profile);
   const [section, setSection] = useState(initialSection);
   const counts = Object.values(context.modules).reduce(
     (total, module) => ({
@@ -183,6 +186,17 @@ function WorkspaceEditor({
         </p>
       </header>
       <DocumentationSaveStatus snapshot={draft} controller={controller} />
+      <DocumentationNotice>
+        <p className="tw-m-0 tw-font-semibold">
+          {msg(publicationOnly ? "publication.intro" : "publication.legacy")}
+        </p>
+        {publicationOnly && (
+          <>
+            <p className="tw-mt-2">{msg("publication.help")}</p>
+            <p className="tw-m-0">{msg("publication.draft")}</p>
+          </>
+        )}
+      </DocumentationNotice>
       {context.confirmation_status ===
         ApiArtworkDocumentationContextConfirmationStatusEnum.NewerDraft && (
         <DocumentationNotice>{msg("newerDraft")}</DocumentationNotice>
@@ -199,7 +213,7 @@ function WorkspaceEditor({
             : msg("description")}
         </p>
         <p className="tw-m-0 tw-text-xs tw-leading-relaxed tw-text-iron-400">
-          {msg("privacy")}
+          {msg(publicationOnly ? "publication.draft" : "privacy")}
         </p>
       </details>
       <DocumentationSources context={context} controller={controller} />
@@ -254,10 +268,27 @@ function WorkspaceEditor({
                 {msg("why")}
               </summary>
               <p className="tw-mt-2 tw-leading-relaxed">
-                {msg(`why.${section}`)}
+                {msg(
+                  publicationOnly && section === "rights"
+                    ? "publication.whyRights"
+                    : `why.${section}`
+                )}
               </p>
             </details>
           </div>
+          <DocumentationWorkedExample
+            key={`${context.id}-${section}`}
+            context={context}
+            edits={draft.edits}
+            section={section}
+          />
+          <h3
+            id={`documentation-answers-${context.id}-${section}`}
+            tabIndex={-1}
+            className="tw-text-lg tw-font-semibold tw-text-iron-100 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-primary-400"
+          >
+            {msg("examples.yourRecord")}
+          </h3>
           {section === "artwork" && (
             <>
               <DocumentationArtworkPreview context={context} />
@@ -281,7 +312,11 @@ function WorkspaceEditor({
             </DocumentationNotice>
           )}
           {section === "preservation" && (
-            <DocumentationNotice>{msg("interviewHelp")}</DocumentationNotice>
+            <DocumentationNotice>
+              {msg(
+                publicationOnly ? "publication.interviewHelp" : "interviewHelp"
+              )}
+            </DocumentationNotice>
           )}
           {section === "review" ? (
             <>
@@ -290,12 +325,12 @@ function WorkspaceEditor({
                 controller={controller}
                 saveState={draft.state}
               />
-              <DocumentationFeedback context={context} />
               <DocumentationAccess context={context} />
               <DocumentationNewContext
                 context={context}
                 controller={controller}
               />
+              <DocumentationFeedback context={context} />
             </>
           ) : (
             <DocumentationModules

--- a/components/artwork-documentation/DocumentationAccess.tsx
+++ b/components/artwork-documentation/DocumentationAccess.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/services/api/artwork-documentation-api";
 import { documentationOptionLabel } from "@/i18n/messages/artwork-documentation-fields";
 import { MODULE_IDS } from "@/lib/artwork-documentation/registry";
+import { isPublicationOnly } from "@/lib/artwork-documentation/intake";
 import { useDocumentationActor } from "./DocumentationAuthGate";
 import {
   DocumentationButton,
@@ -35,6 +36,7 @@ export default function DocumentationAccess({
     null
   );
   const artist = context.owner_profile_id === connectedProfile?.id;
+  const publicationOnly = isPublicationOnly(context.profile);
   const [modules, setModules] = useState<string[]>([]);
   const [evidence, setEvidence] = useState<string[]>([]);
   const [role, setRole] = useState("curatorial");
@@ -76,11 +78,13 @@ export default function DocumentationAccess({
         read_archival_files: artist
           ? evidence.includes("archival")
           : role === "technical",
-        read_rights_evidence: artist
-          ? evidence.includes("rights")
-          : role === "rights",
-        read_source_receipts: artist && evidence.includes("sources"),
-        read_contact: artist && evidence.includes("contact"),
+        read_rights_evidence:
+          !publicationOnly &&
+          (artist ? evidence.includes("rights") : role === "rights"),
+        read_source_receipts:
+          !publicationOnly && artist && evidence.includes("sources"),
+        read_contact:
+          !publicationOnly && artist && evidence.includes("contact"),
         confirm_as_artist: false,
         review_lanes: artist ? [] : [role],
         manage_assignments: false,
@@ -148,9 +152,14 @@ export default function DocumentationAccess({
             ))}
           </div>
           <p className="tw-text-xs tw-text-iron-400">
-            {msg("evidencePermissions")}
+            {msg(
+              publicationOnly ? "publication.fileAccess" : "evidencePermissions"
+            )}
           </p>
-          {["archival", "rights", "sources", "contact"].map((id) => (
+          {(publicationOnly
+            ? ["archival"]
+            : ["archival", "rights", "sources", "contact"]
+          ).map((id) => (
             <label
               key={id}
               className="tw-flex tw-items-center tw-gap-3 tw-text-sm tw-text-iron-300"
@@ -167,7 +176,11 @@ export default function DocumentationAccess({
                   )
                 }
               />
-              {msg(`evidence.${id}`)}
+              {msg(
+                publicationOnly
+                  ? "publication.originalAccess"
+                  : `evidence.${id}`
+              )}
             </label>
           ))}
         </fieldset>

--- a/components/artwork-documentation/DocumentationArtistPin.tsx
+++ b/components/artwork-documentation/DocumentationArtistPin.tsx
@@ -5,6 +5,11 @@ import type { DocumentationDraftController } from "@/lib/artwork-documentation/d
 import { pinDocumentationArtistRecord } from "@/services/api/artwork-documentation-api";
 import { DocumentationValueSummary } from "./DocumentationSummary";
 import {
+  canImportDocumentationAnswer,
+  isPublicationOnly,
+} from "@/lib/artwork-documentation/intake";
+import { isRedacted } from "@/lib/artwork-documentation/answers";
+import {
   DocumentationButton,
   panelClass,
   useDocumentationMessages,
@@ -21,10 +26,28 @@ export default function DocumentationArtistPin({
   const candidate = context.available_artist_record;
   const revisionId = candidate?.id;
   if (
+    !candidate ||
     typeof revisionId !== "string" ||
     revisionId === context.artist_record_revision_id
   )
     return null;
+  if (
+    isPublicationOnly(context.profile) &&
+    Object.entries(candidate.answers).some(
+      ([field, answer]) =>
+        isRedacted(answer) ||
+        !canImportDocumentationAnswer(
+          context.profile,
+          `identity.${field}`,
+          answer
+        )
+    )
+  )
+    return (
+      <p className="tw-text-sm tw-leading-relaxed tw-text-iron-300">
+        {msg("publication.pinBlocked")}
+      </p>
+    );
   return (
     <details className={panelClass}>
       <summary className="tw-cursor-pointer tw-py-2 tw-text-sm tw-font-medium">
@@ -46,7 +69,7 @@ export default function DocumentationArtistPin({
           <h3 className="tw-text-sm tw-font-semibold">
             {msg("conflict.server")}
           </h3>
-          <DocumentationValueSummary value={candidate?.answers} />
+          <DocumentationValueSummary value={candidate.answers} />
         </div>
       </div>
       <DocumentationButton

--- a/components/artwork-documentation/DocumentationAssetDetails.tsx
+++ b/components/artwork-documentation/DocumentationAssetDetails.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import type { ApiArtworkDocumentationContext } from "@/generated/models/ApiArtworkDocumentationContext";
 import type { ApiArtworkDocumentationAssetLink } from "@/generated/models/ApiArtworkDocumentationAssetLink";
 import type { ApiArtworkDocumentationAssetLinkRequest } from "@/generated/models/ApiArtworkDocumentationAssetLinkRequest";
+import { ApiArtworkDocumentationAssetTermsKindEnum } from "@/generated/models/ApiArtworkDocumentationAssetTerms";
 import type { DocumentationDraftController } from "@/lib/artwork-documentation/draft-controller";
 import type {
   FieldValue,
@@ -23,6 +24,7 @@ import { isPublicationOnly } from "@/lib/artwork-documentation/intake";
 import DocumentationValueEditor from "./DocumentationValueEditor";
 import {
   DocumentationButton,
+  DocumentationNotice,
   inputClass,
   useDocumentationMessages,
 } from "./DocumentationControls";
@@ -59,6 +61,33 @@ const detailsEditor = (publicationOnly: boolean): ValueEditor => ({
   },
 });
 
+function canEditAssetDetails(
+  context: ApiArtworkDocumentationContext,
+  assetId: string
+): boolean {
+  if (!isPublicationOnly(context.profile)) return true;
+  const allowed = (asset: {
+    readonly role: string;
+    readonly intended_visibility: string;
+  }) =>
+    asset.intended_visibility === "public_record" &&
+    canPublishDocumentationAsset(context, asset.role);
+  const asset = context.assets.find((item) => item.id === assetId);
+  return (
+    asset !== undefined &&
+    allowed(asset) &&
+    context.asset_links
+      .filter((link) => link.asset_id === assetId)
+      .every(
+        (link) =>
+          allowed(link) &&
+          allowed(link.manifest) &&
+          link.intended_terms.kind !==
+            ApiArtworkDocumentationAssetTermsKindEnum.PrivateDeposit
+      )
+  );
+}
+
 export default function DocumentationAssetDetails({
   context,
   assetId,
@@ -76,21 +105,24 @@ export default function DocumentationAssetDetails({
     : DOCUMENTATION_ASSET_ROLES;
   const rolePermitted = canPublishDocumentationAsset(context, role);
   const links = context.asset_links.filter((link) => link.asset_id === assetId);
-  const asset = context.assets.find((item) => item.id === assetId);
   const addRole = () =>
     controller.mutate((current, signal) => {
-      if (!canPublishDocumentationAsset(current, role))
-        throw new Error("INTERVIEW_PUBLICATION_PERMISSION_REQUIRED");
+      if (
+        !canEditAssetDetails(current, assetId) ||
+        !canPublishDocumentationAsset(current, role)
+      )
+        throw new Error("PUBLICATION_ASSET_ROLE_REQUIRED");
+      const asset = current.assets.find((item) => item.id === assetId);
       return linkDocumentationAsset(
         current,
         {
           asset_id: assetId,
           role,
-          intended_visibility: publicationOnly
-            ? "public_record"
-            : (asset?.intended_visibility ?? "restricted"),
+          intended_visibility: asset?.intended_visibility ?? "restricted",
           intended_terms: {
-            kind: publicationOnly ? "unspecified" : "private_deposit",
+            kind: isPublicationOnly(current.profile)
+              ? "unspecified"
+              : "private_deposit",
           },
         } as ApiArtworkDocumentationAssetLinkRequest,
         signal
@@ -103,6 +135,12 @@ export default function DocumentationAssetDetails({
       return msg("publicationProcessRole");
     return documentationOptionLabel(value);
   };
+  if (!canEditAssetDetails(context, assetId))
+    return (
+      <DocumentationNotice error>
+        {msg("publicationAssetUnavailable")}
+      </DocumentationNotice>
+    );
   return (
     <details className="tw-mt-3">
       <summary className="tw-cursor-pointer tw-py-2 tw-text-xs tw-text-iron-300">
@@ -183,7 +221,6 @@ function ManifestEditor({
       (next as Record<string, FieldValue>)["intended_visibility"] ??
       link.intended_visibility;
     if (restricted) nextVisibility = "restricted";
-    if (publicationOnly) nextVisibility = "public_record";
     const body = {
       ...(next as Record<string, FieldValue>),
       intended_visibility: nextVisibility,
@@ -191,8 +228,15 @@ function ManifestEditor({
     controller.queueContent(
       `asset-link:${link.id}`,
       body,
-      (current, key, signal) =>
-        patchDocumentationAssetLink(current, link.id, body, signal, key)
+      (current, key, signal) => {
+        if (
+          !canEditAssetDetails(current, link.asset_id) ||
+          (isPublicationOnly(current.profile) &&
+            body.intended_visibility !== "public_record")
+        )
+          throw new Error("PUBLICATION_ASSET_ROLE_REQUIRED");
+        return patchDocumentationAssetLink(current, link.id, body, signal, key);
+      }
     );
   };
   const intendedVisibility =

--- a/components/artwork-documentation/DocumentationAssetDetails.tsx
+++ b/components/artwork-documentation/DocumentationAssetDetails.tsx
@@ -14,7 +14,12 @@ import {
   patchDocumentationAssetLink,
 } from "@/services/api/artwork-documentation-assets-api";
 import { documentationOptionLabel } from "@/i18n/messages/artwork-documentation-fields";
-import { DOCUMENTATION_ASSET_ROLES } from "@/lib/artwork-documentation/asset-roles";
+import {
+  canPublishDocumentationAsset,
+  DOCUMENTATION_ASSET_ROLES,
+  PUBLICATION_DOCUMENTATION_ASSET_ROLES,
+} from "@/lib/artwork-documentation/asset-roles";
+import { isPublicationOnly } from "@/lib/artwork-documentation/intake";
 import DocumentationValueEditor from "./DocumentationValueEditor";
 import {
   DocumentationButton,
@@ -22,7 +27,7 @@ import {
   useDocumentationMessages,
 } from "./DocumentationControls";
 
-const detailsEditor: ValueEditor = {
+const detailsEditor = (publicationOnly: boolean): ValueEditor => ({
   kind: "object",
   fields: {
     label: { kind: "text", max: 160 },
@@ -38,19 +43,21 @@ const detailsEditor: ValueEditor = {
       fields: {
         kind: {
           kind: "choice",
-          options: [
-            "unspecified",
-            "private_deposit",
-            "proposed_license",
-            "already_licensed",
-          ],
+          options: publicationOnly
+            ? ["unspecified", "proposed_license", "already_licensed"]
+            : [
+                "unspecified",
+                "private_deposit",
+                "proposed_license",
+                "already_licensed",
+              ],
         },
         license_uri: { kind: "text", max: 2048 },
         note: { kind: "text", max: 2000, multiline: true },
       },
     },
   },
-};
+});
 
 export default function DocumentationAssetDetails({
   context,
@@ -62,22 +69,40 @@ export default function DocumentationAssetDetails({
   readonly controller: DocumentationDraftController;
 }) {
   const { msg } = useDocumentationMessages();
+  const publicationOnly = isPublicationOnly(context.profile);
   const [role, setRole] = useState("preservation_master");
+  const roles = publicationOnly
+    ? PUBLICATION_DOCUMENTATION_ASSET_ROLES
+    : DOCUMENTATION_ASSET_ROLES;
+  const rolePermitted = canPublishDocumentationAsset(context, role);
   const links = context.asset_links.filter((link) => link.asset_id === assetId);
   const asset = context.assets.find((item) => item.id === assetId);
   const addRole = () =>
-    controller.mutate((current, signal) =>
-      linkDocumentationAsset(
+    controller.mutate((current, signal) => {
+      if (!canPublishDocumentationAsset(current, role))
+        throw new Error("INTERVIEW_PUBLICATION_PERMISSION_REQUIRED");
+      return linkDocumentationAsset(
         current,
         {
           asset_id: assetId,
           role,
-          intended_visibility: asset?.intended_visibility ?? "restricted",
-          intended_terms: { kind: "private_deposit" },
+          intended_visibility: publicationOnly
+            ? "public_record"
+            : (asset?.intended_visibility ?? "restricted"),
+          intended_terms: {
+            kind: publicationOnly ? "unspecified" : "private_deposit",
+          },
         } as ApiArtworkDocumentationAssetLinkRequest,
         signal
-      )
-    );
+      );
+    });
+  const roleLabel = (value: string) => {
+    if (publicationOnly && value === "preservation_master")
+      return msg("publicationMasterRole");
+    if (publicationOnly && value === "process_evidence")
+      return msg("publicationProcessRole");
+    return documentationOptionLabel(value);
+  };
   return (
     <details className="tw-mt-3">
       <summary className="tw-cursor-pointer tw-py-2 tw-text-xs tw-text-iron-300">
@@ -85,7 +110,13 @@ export default function DocumentationAssetDetails({
       </summary>
       <div className="tw-space-y-4">
         {links.map((link) => (
-          <ManifestEditor key={link.id} link={link} controller={controller} />
+          <ManifestEditor
+            key={link.id}
+            link={link}
+            controller={controller}
+            publicationOnly={publicationOnly}
+            roleLabel={roleLabel(link.role)}
+          />
         ))}
         <label className="tw-block tw-text-xs tw-text-iron-400">
           {msg("uploadRole")}
@@ -94,16 +125,21 @@ export default function DocumentationAssetDetails({
             value={role}
             onChange={(event) => setRole(event.target.value)}
           >
-            {DOCUMENTATION_ASSET_ROLES.map((option) => (
+            {roles.map((option) => (
               <option key={option} value={option}>
-                {documentationOptionLabel(option)}
+                {roleLabel(option)}
               </option>
             ))}
           </select>
         </label>
+        {!rolePermitted && (
+          <p className="tw-text-sm tw-text-iron-300">
+            {msg("publicationInterviewPermission")}
+          </p>
+        )}
         <DocumentationButton
           secondary
-          disabled={links.some((link) => link.role === role)}
+          disabled={!rolePermitted || links.some((link) => link.role === role)}
           onClick={() => {
             void addRole();
           }}
@@ -118,9 +154,13 @@ export default function DocumentationAssetDetails({
 function ManifestEditor({
   link,
   controller,
+  publicationOnly,
+  roleLabel,
 }: {
   readonly link: ApiArtworkDocumentationAssetLink;
   readonly controller: DocumentationDraftController;
+  readonly publicationOnly: boolean;
+  readonly roleLabel: string;
 }) {
   const { msg } = useDocumentationMessages();
   const pending = controller
@@ -139,12 +179,14 @@ function ManifestEditor({
     link.role
   );
   const change = (next: FieldValue) => {
+    let nextVisibility =
+      (next as Record<string, FieldValue>)["intended_visibility"] ??
+      link.intended_visibility;
+    if (restricted) nextVisibility = "restricted";
+    if (publicationOnly) nextVisibility = "public_record";
     const body = {
       ...(next as Record<string, FieldValue>),
-      intended_visibility: restricted
-        ? "restricted"
-        : ((next as Record<string, FieldValue>)["intended_visibility"] ??
-          link.intended_visibility),
+      intended_visibility: nextVisibility,
     };
     controller.queueContent(
       `asset-link:${link.id}`,
@@ -159,30 +201,30 @@ function ManifestEditor({
       : "restricted";
   return (
     <div className="tw-space-y-3 tw-rounded-lg tw-border tw-border-solid tw-border-iron-800 tw-p-3">
-      <p className="tw-text-sm tw-font-medium">
-        {documentationOptionLabel(link.role)}
-      </p>
+      <p className="tw-text-sm tw-font-medium">{roleLabel}</p>
       <DocumentationValueEditor
         id={`manifest-${link.id}`}
         label={msg("fileDetails")}
-        editor={detailsEditor}
+        editor={detailsEditor(publicationOnly)}
         value={value}
         onChange={change}
       />
-      <label className="tw-block tw-text-xs tw-text-iron-400">
-        {msg("visibility")}
-        <select
-          className={`${inputClass} tw-mt-2`}
-          value={intendedVisibility}
-          disabled={restricted}
-          onChange={(event) =>
-            change({ ...value, intended_visibility: event.target.value })
-          }
-        >
-          <option value="restricted">{msg("restricted")}</option>
-          <option value="public_record">{msg("publicIntent")}</option>
-        </select>
-      </label>
+      {!publicationOnly && (
+        <label className="tw-block tw-text-xs tw-text-iron-400">
+          {msg("visibility")}
+          <select
+            className={`${inputClass} tw-mt-2`}
+            value={intendedVisibility}
+            disabled={restricted}
+            onChange={(event) =>
+              change({ ...value, intended_visibility: event.target.value })
+            }
+          >
+            <option value="restricted">{msg("restricted")}</option>
+            <option value="public_record">{msg("publicIntent")}</option>
+          </select>
+        </label>
+      )}
       <DocumentationButton
         secondary
         onClick={() => {

--- a/components/artwork-documentation/DocumentationFeedback.tsx
+++ b/components/artwork-documentation/DocumentationFeedback.tsx
@@ -13,6 +13,11 @@ import {
 } from "@/services/api/artwork-documentation-api";
 import { documentationOptionLabel } from "@/i18n/messages/artwork-documentation-fields";
 import { formatDate } from "@/i18n/format";
+import { isPublicationOnly } from "@/lib/artwork-documentation/intake";
+import {
+  ApiArtworkDocumentationThreadAudienceEnum,
+  ApiArtworkDocumentationThreadRestrictedClassEnum,
+} from "@/generated/models/ApiArtworkDocumentationThread";
 import { useDocumentationActor } from "./DocumentationAuthGate";
 import {
   DocumentationButton,
@@ -28,6 +33,7 @@ export default function DocumentationFeedback({
   readonly context: ApiArtworkDocumentationContext;
 }) {
   const { msg } = useDocumentationMessages();
+  const questions = isPublicationOnly(context.profile);
   const { connectedProfile, actorKey } = useDocumentationActor();
   const [text, setText] = useState("");
   const [audience, setAudience] = useState("artist_and_reviewers");
@@ -52,9 +58,9 @@ export default function DocumentationFeedback({
     try {
       await createDocumentationThread(context.id, {
         text,
-        audience,
-        restricted_class: restrictedClass,
-        ...(context.latest_revision_id
+        audience: questions ? "artist_and_reviewers" : audience,
+        restricted_class: questions ? "ordinary" : restrictedClass,
+        ...(!questions && context.latest_revision_id
           ? { revision_id: context.latest_revision_id }
           : {}),
       });
@@ -66,13 +72,31 @@ export default function DocumentationFeedback({
       setBusy(false);
     }
   };
+  const threads =
+    query.data?.data.filter(
+      (thread) =>
+        !questions ||
+        (!thread.field_path &&
+          !thread.revision_id &&
+          thread.audience ===
+            ApiArtworkDocumentationThreadAudienceEnum.ArtistAndReviewers &&
+          thread.restricted_class ===
+            ApiArtworkDocumentationThreadRestrictedClassEnum.Ordinary)
+    ) ?? [];
   return (
     <section className={`${panelClass} tw-space-y-4`}>
-      <h3 className="tw-m-0 tw-text-lg tw-font-semibold">{msg("feedback")}</h3>
+      <h3 className="tw-m-0 tw-text-lg tw-font-semibold">
+        {msg(questions ? "questions.title" : "feedback")}
+      </h3>
+      {questions && (
+        <p className="tw-text-sm tw-leading-relaxed tw-text-iron-300">
+          {msg("questions.help")}
+        </p>
+      )}
       {(error || query.isError) && (
         <DocumentationNotice error>{msg("error")}</DocumentationNotice>
       )}
-      {query.data?.data.map((thread) => (
+      {threads.map((thread) => (
         <FeedbackThread
           key={thread.id}
           contextId={context.id}
@@ -82,32 +106,50 @@ export default function DocumentationFeedback({
           }}
         />
       ))}
-      {!query.isLoading && (query.data?.data.length ?? 0) === 0 && (
-        <p className="tw-text-sm tw-text-iron-400">{msg("noFeedback")}</p>
+      {!query.isLoading && threads.length === 0 && (
+        <p className="tw-text-sm tw-text-iron-400">
+          {msg(questions ? "questions.empty" : "noFeedback")}
+        </p>
       )}
       <label className="tw-block tw-text-sm tw-text-iron-300">
-        {msg("comment")}
+        {msg(questions ? "questions.label" : "comment")}
         <textarea
           rows={3}
           className={`${inputClass} tw-mt-2`}
           value={text}
+          disabled={busy}
+          aria-describedby={
+            questions ? "documentation-question-help" : undefined
+          }
           onChange={(event) => setText(event.target.value)}
         />
       </label>
-      <label className="tw-block tw-text-sm tw-text-iron-300">
-        {msg("audience")}
-        <select
-          className={`${inputClass} tw-mt-2`}
-          value={audience}
-          onChange={(event) => setAudience(event.target.value)}
+      {questions && (
+        <p
+          id="documentation-question-help"
+          className="tw-text-sm tw-leading-relaxed tw-text-iron-400"
         >
-          <option value="artist_and_reviewers">{msg("artistReviewers")}</option>
-          {context.capabilities.review_lanes.length > 0 && (
-            <option value="reviewers_only">{msg("reviewersOnly")}</option>
-          )}
-        </select>
-      </label>
-      {context.capabilities.read_rights_evidence && (
+          {msg("questions.hint")} {msg("questions.notSaved")}
+        </p>
+      )}
+      {!questions && (
+        <label className="tw-block tw-text-sm tw-text-iron-300">
+          {msg("audience")}
+          <select
+            className={`${inputClass} tw-mt-2`}
+            value={audience}
+            onChange={(event) => setAudience(event.target.value)}
+          >
+            <option value="artist_and_reviewers">
+              {msg("artistReviewers")}
+            </option>
+            {context.capabilities.review_lanes.length > 0 && (
+              <option value="reviewers_only">{msg("reviewersOnly")}</option>
+            )}
+          </select>
+        </label>
+      )}
+      {!questions && context.capabilities.read_rights_evidence && (
         <label className="tw-block tw-text-sm tw-text-iron-300">
           {msg("visibility")}
           <select
@@ -126,7 +168,7 @@ export default function DocumentationFeedback({
           void create();
         }}
       >
-        {msg("sendComment")}
+        {msg(questions ? "questions.send" : "sendComment")}
       </DocumentationButton>
     </section>
   );

--- a/components/artwork-documentation/DocumentationFieldExample.tsx
+++ b/components/artwork-documentation/DocumentationFieldExample.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import type { ApiArtworkDocumentationProfile } from "@/generated/models/ApiArtworkDocumentationProfile";
+import { documentationExampleKey } from "@/lib/artwork-documentation/examples";
+import type {
+  DocumentationField,
+  FieldValue,
+  ModuleId,
+} from "@/lib/artwork-documentation/registry";
+import DocumentationNarrativeStarter from "./DocumentationNarrativeStarter";
+import { useDocumentationMessages } from "./DocumentationControls";
+
+export default function DocumentationFieldExample(props: {
+  readonly profile: ApiArtworkDocumentationProfile;
+  readonly moduleId: ModuleId;
+  readonly field: DocumentationField;
+  readonly label: string;
+  readonly disabled: boolean;
+  readonly hasAnswer: boolean;
+  readonly validate: (value: FieldValue) => boolean;
+  readonly onApply: (value: FieldValue) => void;
+}) {
+  const { msg } = useDocumentationMessages();
+  const answer = documentationExampleKey(
+    props.profile,
+    props.moduleId,
+    props.field.id,
+    "answer"
+  );
+  if (!answer) return null;
+  const why = documentationExampleKey(
+    props.profile,
+    props.moduleId,
+    props.field.id,
+    "why"
+  );
+  const starter = documentationExampleKey(
+    props.profile,
+    props.moduleId,
+    props.field.id,
+    "starter"
+  );
+  const canAdapt =
+    starter !== undefined &&
+    (props.field.editor.kind === "localized" ||
+      (props.field.editor.kind === "text" &&
+        props.field.editor.multiline === true));
+  return (
+    <div className="tw-mb-4">
+      <details className="tw-text-sm">
+        <summary
+          id={`documentation-${props.moduleId}-${props.field.id}-example`}
+          className="tw-flex tw-min-h-11 tw-cursor-pointer tw-items-center tw-text-primary-300 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-primary-400"
+        >
+          {msg("examples.field")}
+        </summary>
+        <p className="tw-mt-1 tw-text-xs tw-font-semibold tw-text-iron-400">
+          {msg("examples.fiction")}
+        </p>
+        <p className="tw-whitespace-pre-wrap tw-break-words tw-leading-relaxed tw-text-iron-200">
+          {msg(answer)}
+        </p>
+        {why && (
+          <p className="tw-leading-relaxed tw-text-iron-400">
+            {msg("examples.why")}: {msg(why)}
+          </p>
+        )}
+        {canAdapt && (
+          <DocumentationNarrativeStarter
+            id={`documentation-${props.moduleId}-${props.field.id}`}
+            label={props.label}
+            structure={msg(starter)}
+            editor={props.field.editor}
+            disabled={props.disabled}
+            hasAnswer={props.hasAnswer}
+            validate={props.validate}
+            onApply={props.onApply}
+          />
+        )}
+      </details>
+    </div>
+  );
+}

--- a/components/artwork-documentation/DocumentationModules.tsx
+++ b/components/artwork-documentation/DocumentationModules.tsx
@@ -34,6 +34,11 @@ import DocumentationValueEditor, {
   type AssetChoice,
 } from "./DocumentationValueEditor";
 import { validDocumentationOperation } from "@/lib/artwork-documentation/validation";
+import {
+  documentationChoiceEditor,
+  isPublicationOnly,
+} from "@/lib/artwork-documentation/intake";
+import DocumentationFieldExample from "./DocumentationFieldExample";
 
 interface Props {
   readonly context: ApiArtworkDocumentationContext;
@@ -142,6 +147,7 @@ function DocumentationAnswerField(
     answer?.intended_visibility ?? definition.default_visibility;
   const status =
     answer?.status ?? ApiArtworkDocumentationAnswerStatusEnum.Provided;
+  const publicationOnly = isPublicationOnly(context.profile);
   const update = (next: Partial<ApiArtworkDocumentationAnswer>) => {
     const merged = {
       status,
@@ -179,13 +185,38 @@ function DocumentationAnswerField(
           id={`${id}-help`}
           className="tw-mb-4 tw-text-sm tw-leading-relaxed tw-text-iron-300"
         >
-          {msg(field.help)}
+          {msg(fieldHelpKey(field.help, publicationOnly))}
         </p>
       )}
       {redacted ? (
         <p className="tw-m-0 tw-text-sm tw-text-iron-400">{msg("redacted")}</p>
       ) : (
         <>
+          <DocumentationFieldExample
+            profile={context.profile}
+            moduleId={moduleId}
+            field={field}
+            label={label}
+            disabled={disabled}
+            hasAnswer={!!answer}
+            validate={(value) =>
+              validDocumentationOperation(context, moduleId, {
+                op: "set",
+                field: field.id,
+                answer: {
+                  status: ApiArtworkDocumentationAnswerStatusEnum.Provided,
+                  value,
+                  intended_visibility: visibility,
+                },
+              } as ApiArtworkDocumentationOperation)
+            }
+            onApply={(value) =>
+              update({
+                status: ApiArtworkDocumentationAnswerStatusEnum.Provided,
+                value,
+              })
+            }
+          />
           {field.id === "canonical_asset_id" &&
             context.latest_revision_id &&
             !disabled && (
@@ -234,7 +265,10 @@ function DocumentationAnswerField(
             <DocumentationValueEditor
               id={id}
               label={label}
-              editor={field.editor}
+              editor={documentationChoiceEditor(
+                field.editor,
+                definition.value_schema
+              )}
               value={
                 (answer?.value as FieldValue | undefined) ??
                 initialValue(field.editor)
@@ -265,33 +299,15 @@ function DocumentationAnswerField(
             </p>
           )}
           <div className="tw-mt-4 tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-3">
-            {definition.locked_restricted ? (
-              <span
-                className="tw-text-xs tw-text-iron-400"
-                title={msg("restrictedHelp")}
-              >
-                {msg("restricted")}
-              </span>
-            ) : (
-              <label className="tw-flex tw-flex-wrap tw-items-center tw-gap-2 tw-text-xs tw-text-iron-400">
-                {msg("visibility")}
-                <select
-                  className={`${inputClass} !tw-w-auto !tw-max-w-full !tw-py-2 !tw-text-xs`}
-                  disabled={disabled || !answer}
-                  value={visibility}
-                  onChange={(event) =>
-                    update({
-                      intended_visibility: event.target.value as NonNullable<
-                        ApiArtworkDocumentationAnswer["intended_visibility"]
-                      >,
-                    })
-                  }
-                >
-                  <option value="public_record">{msg("publicIntent")}</option>
-                  <option value="restricted">{msg("restricted")}</option>
-                </select>
-              </label>
-            )}
+            <AnswerVisibility
+              publicationOnly={publicationOnly}
+              lockedRestricted={definition.locked_restricted}
+              disabled={disabled || !answer}
+              value={visibility}
+              onChange={(intended_visibility) =>
+                update({ intended_visibility })
+              }
+            />
             {answer && !disabled && (
               <DocumentationButton
                 secondary
@@ -309,5 +325,65 @@ function DocumentationAnswerField(
         </>
       )}
     </section>
+  );
+}
+
+function fieldHelpKey(help: string, publicationOnly: boolean): string {
+  return publicationOnly &&
+    ["locationHelp", "masterHelp", "interviewEvidenceHelp"].includes(help)
+    ? `publication.${help}`
+    : help;
+}
+
+function AnswerVisibility({
+  publicationOnly,
+  lockedRestricted,
+  disabled,
+  value,
+  onChange,
+}: {
+  readonly publicationOnly: boolean;
+  readonly lockedRestricted: boolean;
+  readonly disabled: boolean;
+  readonly value: string;
+  readonly onChange: (
+    value: NonNullable<ApiArtworkDocumentationAnswer["intended_visibility"]>
+  ) => void;
+}) {
+  const { msg } = useDocumentationMessages();
+  if (publicationOnly)
+    return (
+      <span className="tw-text-xs tw-text-iron-400">
+        {msg("publication.field")}
+      </span>
+    );
+  if (lockedRestricted)
+    return (
+      <span
+        className="tw-text-xs tw-text-iron-400"
+        title={msg("restrictedHelp")}
+      >
+        {msg("restricted")}
+      </span>
+    );
+  return (
+    <label className="tw-flex tw-flex-wrap tw-items-center tw-gap-2 tw-text-xs tw-text-iron-400">
+      {msg("visibility")}
+      <select
+        className={`${inputClass} !tw-w-auto !tw-max-w-full !tw-py-2 !tw-text-xs`}
+        disabled={disabled}
+        value={value}
+        onChange={(event) =>
+          onChange(
+            event.target.value as NonNullable<
+              ApiArtworkDocumentationAnswer["intended_visibility"]
+            >
+          )
+        }
+      >
+        <option value="public_record">{msg("publicIntent")}</option>
+        <option value="restricted">{msg("restricted")}</option>
+      </select>
+    </label>
   );
 }

--- a/components/artwork-documentation/DocumentationNarrativeStarter.tsx
+++ b/components/artwork-documentation/DocumentationNarrativeStarter.tsx
@@ -45,9 +45,8 @@ export default function DocumentationNarrativeStarter(props: Props) {
     : text.trim();
   const valid =
     text.trim().length > 0 &&
-    !(props.structure.match(/\[[^\]]+\]/g) ?? []).some((prompt) =>
-      text.includes(prompt)
-    ) &&
+    !text.includes("[[") &&
+    !text.includes("]]") &&
     (!localized || language.trim().length > 0) &&
     props.validate(value);
   if (!open && (props.disabled || props.hasAnswer))

--- a/components/artwork-documentation/DocumentationNarrativeStarter.tsx
+++ b/components/artwork-documentation/DocumentationNarrativeStarter.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState } from "react";
+import type {
+  FieldValue,
+  ValueEditor,
+} from "@/lib/artwork-documentation/registry";
+import {
+  DocumentationButton,
+  inputClass,
+  useDocumentationMessages,
+} from "./DocumentationControls";
+
+interface Props {
+  readonly id: string;
+  readonly label: string;
+  readonly structure: string;
+  readonly editor: ValueEditor;
+  readonly disabled: boolean;
+  readonly hasAnswer: boolean;
+  readonly validate: (value: FieldValue) => boolean;
+  readonly onApply: (value: FieldValue) => void;
+}
+
+/** The working text stays in memory and never enters autosave before explicit application. */
+export default function DocumentationNarrativeStarter(props: Props) {
+  const { msg } = useDocumentationMessages();
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState("");
+  const [language, setLanguage] = useState("");
+  const [applied, setApplied] = useState(false);
+  const localized = props.editor.kind === "localized";
+  const value: FieldValue = localized
+    ? {
+        primary_language: language.trim(),
+        versions: [
+          {
+            language: language.trim(),
+            text: text.trim(),
+            authorship: "original",
+            approved_by_artist: false,
+          },
+        ],
+      }
+    : text.trim();
+  const valid =
+    text.trim().length > 0 &&
+    !(props.structure.match(/\[[^\]]+\]/g) ?? []).some((prompt) =>
+      text.includes(prompt)
+    ) &&
+    (!localized || language.trim().length > 0) &&
+    props.validate(value);
+  if (!open && (props.disabled || props.hasAnswer))
+    return applied ? (
+      <p role="status" className="tw-mt-3 tw-text-sm tw-text-iron-300">
+        {msg("examples.applied")}
+      </p>
+    ) : null;
+  return (
+    <div className="tw-mt-3">
+      {!open ? (
+        <DocumentationButton
+          secondary
+          onClick={() => {
+            setText(props.structure);
+            setOpen(true);
+            setApplied(false);
+          }}
+        >
+          {msg("examples.adapt")}
+        </DocumentationButton>
+      ) : (
+        <div className="tw-space-y-3 tw-border-l-2 tw-border-solid tw-border-primary-400 tw-pl-4">
+          <p
+            id={`${props.id}-starter-help`}
+            className="tw-m-0 tw-text-sm tw-leading-relaxed tw-text-iron-300"
+          >
+            {msg("examples.unsaved")}
+          </p>
+          <label
+            className="tw-block tw-text-sm tw-text-iron-200"
+            htmlFor={`${props.id}-starter`}
+          >
+            {msg("examples.yourAnswer", { field: props.label })}
+          </label>
+          <textarea
+            id={`${props.id}-starter`}
+            rows={6}
+            className={inputClass}
+            value={text}
+            aria-describedby={`${props.id}-starter-help`}
+            onChange={(event) => setText(event.target.value)}
+          />
+          {localized && (
+            <label className="tw-block tw-text-sm tw-text-iron-300">
+              {msg("examples.language")}
+              <input
+                className={`${inputClass} tw-mt-2`}
+                value={language}
+                placeholder="en"
+                onChange={(event) => setLanguage(event.target.value)}
+              />
+            </label>
+          )}
+          {props.hasAnswer && (
+            <p role="status" className="tw-text-sm tw-text-amber-200">
+              {msg("examples.answerChanged")}
+            </p>
+          )}
+          <div className="tw-flex tw-flex-wrap tw-gap-2">
+            <DocumentationButton
+              disabled={props.disabled || props.hasAnswer || !valid}
+              onClick={() => {
+                if (props.disabled || props.hasAnswer || !valid) return;
+                (
+                  document.getElementById(props.id) ??
+                  document.getElementById(`${props.id}-primary`)
+                )?.focus();
+                props.onApply(value);
+                setText("");
+                setOpen(false);
+                setApplied(true);
+              }}
+            >
+              {msg("examples.apply")}
+            </DocumentationButton>
+            <DocumentationButton
+              secondary
+              onClick={() => {
+                setText("");
+                setOpen(false);
+                document.getElementById(`${props.id}-example`)?.focus();
+              }}
+            >
+              {msg("examples.discard")}
+            </DocumentationButton>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/artwork-documentation/DocumentationNewContext.tsx
+++ b/components/artwork-documentation/DocumentationNewContext.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { isPublicationOnly } from "@/lib/artwork-documentation/intake";
+
 import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { ApiArtworkDocumentationContext } from "@/generated/models/ApiArtworkDocumentationContext";
@@ -66,7 +68,11 @@ export default function DocumentationNewContext({
         {msg("newContext")}
       </summary>
       <p className="tw-text-sm tw-leading-relaxed tw-text-iron-400">
-        {msg("newContextHelp")}
+        {msg(
+          isPublicationOnly(context.profile)
+            ? "publication.newContextHelp"
+            : "newContextHelp"
+        )}
       </p>
       {error && <DocumentationNotice error>{msg("error")}</DocumentationNotice>}
       <label className="tw-block tw-text-sm tw-text-iron-300">

--- a/components/artwork-documentation/DocumentationReview.tsx
+++ b/components/artwork-documentation/DocumentationReview.tsx
@@ -13,6 +13,7 @@ import type {
   SaveState,
 } from "@/lib/artwork-documentation/draft-controller";
 import { confirmationCopyMatches } from "@/lib/artwork-documentation/confirmation";
+import { isPublicationOnly } from "@/lib/artwork-documentation/intake";
 import { documentationQueryKey } from "@/hooks/artwork-documentation/useArtworkDocumentationAccess";
 import {
   confirmDocumentation,
@@ -44,6 +45,8 @@ export default function DocumentationReview({
   readonly saveState: SaveState;
 }) {
   const { msg, locale } = useDocumentationMessages();
+  const publicationOnly = isPublicationOnly(context.profile);
+  const reviewAllKey = publicationOnly ? "publication.reviewAll" : "reviewAll";
   const { connectedProfile, actorKey } = useDocumentationActor();
   const [acknowledged, setAcknowledged] = useState(false);
   const [preview, setPreview] = useState(false);
@@ -107,10 +110,12 @@ export default function DocumentationReview({
   return (
     <div className="tw-space-y-5">
       <DocumentationButton secondary onClick={() => setPreview(!preview)}>
-        {preview ? msg("reviewAll") : msg("preview")}
+        {msg(preview ? reviewAllKey : "preview")}
       </DocumentationButton>
       {preview && (
-        <DocumentationNotice>{msg("previewNotice")}</DocumentationNotice>
+        <DocumentationNotice>
+          {msg(publicationOnly ? "publication.previewNotice" : "previewNotice")}
+        </DocumentationNotice>
       )}
       {preview ? (
         <>
@@ -159,7 +164,9 @@ export default function DocumentationReview({
               </p>
             )}
             <p className="tw-text-sm tw-leading-relaxed tw-text-iron-200">
-              {msg("confirmCopy")}
+              {confirmationCopyMatches(context.profile)
+                ? context.profile.confirmation_copy
+                : msg("upgrade")}
             </p>
             <p className="tw-text-sm tw-leading-relaxed tw-text-iron-400">
               {msg("confirmHelp")}

--- a/components/artwork-documentation/DocumentationSources.tsx
+++ b/components/artwork-documentation/DocumentationSources.tsx
@@ -14,6 +14,10 @@ import { useDocumentationActor } from "./DocumentationAuthGate";
 import { DocumentationValueSummary } from "./DocumentationSummary";
 import { readAnswer } from "@/lib/artwork-documentation/answers";
 import {
+  canImportDocumentationAnswer,
+  isPublicationOnly,
+} from "@/lib/artwork-documentation/intake";
+import {
   DocumentationButton,
   DocumentationNotice,
   panelClass,
@@ -39,7 +43,11 @@ export default function DocumentationSources({
         {msg("sourceTitle")}
       </summary>
       <p className="tw-text-sm tw-leading-relaxed tw-text-iron-300">
-        {msg("sourceHelp")}
+        {msg(
+          isPublicationOnly(context.profile)
+            ? "publication.sourceHelp"
+            : "sourceHelp"
+        )}
       </p>
       {context.source_links.map((source) => (
         <SourceReceipt
@@ -80,6 +88,14 @@ function SourceReceipt({
     gcTime: 0,
     meta: { persist: false },
   });
+  const fields =
+    query.data?.fields.filter((field) =>
+      canImportDocumentationAnswer(
+        context.profile,
+        field.target_field,
+        field.answer
+      )
+    ) ?? [];
   if (query.isError)
     return (
       <DocumentationNotice>{msg("sourceUnavailable")}</DocumentationNotice>
@@ -97,12 +113,12 @@ function SourceReceipt({
         importDocumentationSource(
           current,
           receiptId,
-          query.data?.fields
+          fields
             .filter((field) => selected.includes(field.target_field))
             .map(({ source_path, target_field }) => ({
               source_path,
               target_field,
-            })) ?? [],
+            })),
           signal
         )
       );
@@ -121,7 +137,7 @@ function SourceReceipt({
           {query.data?.receipt_text}
         </p>
       </details>
-      {query.data?.fields.map((field) => (
+      {fields.map((field) => (
         <div
           key={field.target_field}
           className="tw-space-y-2 tw-border-t tw-border-solid tw-border-iron-800 tw-pt-3"

--- a/components/artwork-documentation/DocumentationUpload.tsx
+++ b/components/artwork-documentation/DocumentationUpload.tsx
@@ -32,7 +32,12 @@ import {
   useDocumentationMessages,
 } from "./DocumentationControls";
 import DocumentationAssetDetails from "./DocumentationAssetDetails";
-import { DOCUMENTATION_ASSET_ROLES } from "@/lib/artwork-documentation/asset-roles";
+import {
+  canPublishDocumentationAsset,
+  DOCUMENTATION_ASSET_ROLES,
+  PUBLICATION_DOCUMENTATION_ASSET_ROLES,
+} from "@/lib/artwork-documentation/asset-roles";
+import { isPublicationOnly } from "@/lib/artwork-documentation/intake";
 
 const restrictedRoles = new Set([
   "consent_instrument",
@@ -55,6 +60,7 @@ function canContinueUpload(
 
 export default function DocumentationUpload({ context, controller }: Props) {
   const { msg, locale } = useDocumentationMessages();
+  const publicationOnly = isPublicationOnly(context.profile);
   const [file, setFile] = useState<File | null>(null);
   const [role, setRole] = useState<string>("artwork_final");
   const [visibility, setVisibility] = useState("restricted");
@@ -78,6 +84,30 @@ export default function DocumentationUpload({ context, controller }: Props) {
   const sizeLabel = (size: number) =>
     `${formatNumber(locale, size / (1024 * 1024), { maximumFractionDigits: 1 })} MiB`;
   const busy = status === "uploading" || status === "processing";
+  const roles = publicationOnly
+    ? PUBLICATION_DOCUMENTATION_ASSET_ROLES
+    : DOCUMENTATION_ASSET_ROLES;
+  const rolePermitted = canPublishDocumentationAsset(context, role);
+  const chosenVisibility = publicationOnly ? "public_record" : visibility;
+  const uploadVisibility =
+    !publicationOnly && restrictedRoles.has(role)
+      ? "restricted"
+      : chosenVisibility;
+  const visibleAssets = context.assets.filter(
+    (asset) =>
+      !publicationOnly ||
+      (asset.intended_visibility === "public_record" &&
+        PUBLICATION_DOCUMENTATION_ASSET_ROLES.some(
+          (allowedRole) => allowedRole === asset.role
+        ))
+  );
+  const roleLabel = (value: string) => {
+    if (publicationOnly && value === "preservation_master")
+      return msg("publicationMasterRole");
+    if (publicationOnly && value === "process_evidence")
+      return msg("publicationProcessRole");
+    return documentationOptionLabel(value);
+  };
   const canUpload =
     context.capabilities.edit_modules.includes(
       ApiArtworkDocumentationCapabilitiesEditModulesEnum.Files
@@ -91,28 +121,38 @@ export default function DocumentationUpload({ context, controller }: Props) {
       assetVisibility: string,
       filename: string
     ) =>
-      controller.mutate((current, signal) =>
-        linkDocumentationAsset(
+      controller.mutate((current, signal) => {
+        if (!canPublishDocumentationAsset(current, assetRole))
+          throw new Error("INTERVIEW_PUBLICATION_PERMISSION_REQUIRED");
+        return linkDocumentationAsset(
           current,
           {
             asset_id: assetId,
             role: assetRole,
             label: filename,
             description: "",
-            intended_visibility: assetVisibility,
-            source_of_asset: "self",
+            intended_visibility: isPublicationOnly(current.profile)
+              ? "public_record"
+              : assetVisibility,
+            source_of_asset: isPublicationOnly(current.profile)
+              ? "unknown"
+              : "self",
             source_credit: "",
             derived_from_asset_ids: [],
             deposit_note: "",
-            intended_terms: { kind: "private_deposit" },
+            intended_terms: {
+              kind: isPublicationOnly(current.profile)
+                ? "unspecified"
+                : "private_deposit",
+            },
           } as ApiArtworkDocumentationAssetLinkRequest,
           signal
-        )
-      ),
+        );
+      }),
     [controller]
   );
   const run = async (resumeId?: string) => {
-    if (!file) return;
+    if (!file || !rolePermitted) return;
     const controllerAbort = new AbortController();
     abort.current = controllerAbort;
     setStatus("uploading");
@@ -131,14 +171,14 @@ export default function DocumentationUpload({ context, controller }: Props) {
               size_bytes: file.size,
               declared_mime: file.type || "application/octet-stream",
               role,
-              intended_visibility: restrictedRoles.has(role)
-                ? "restricted"
-                : visibility,
+              intended_visibility: uploadVisibility,
             },
             startKey.current,
             controllerAbort.signal
           );
       if (!canContinueUpload(controllerAbort.signal, mounted)) return;
+      if (!canPublishDocumentationAsset(context, upload.asset.role))
+        throw new Error("PUBLICATION_ASSET_ROLE_REQUIRED");
       setSession(upload);
       await transferDocumentationFile({
         contextId: context.id,
@@ -241,13 +281,13 @@ export default function DocumentationUpload({ context, controller }: Props) {
         id="documentation-upload-title"
         className="tw-m-0 tw-text-lg tw-font-semibold"
       >
-        {msg("upload")}
+        {msg(publicationOnly ? "publicationUpload" : "upload")}
       </h3>
       <p className="tw-m-0 tw-text-sm tw-leading-relaxed tw-text-iron-300">
-        {msg("uploadHelp")}
+        {msg(publicationOnly ? "publicationUploadHelp" : "uploadHelp")}
       </p>
       <p className="tw-m-0 tw-text-xs tw-leading-relaxed tw-text-iron-400">
-        {msg("uploadPrivacy")}
+        {msg(publicationOnly ? "publicationUploadStorage" : "uploadPrivacy")}
       </p>
       {canUpload && (
         <div className="tw-space-y-4">
@@ -262,25 +302,32 @@ export default function DocumentationUpload({ context, controller }: Props) {
                 startKey.current = crypto.randomUUID();
               }}
             >
-              {DOCUMENTATION_ASSET_ROLES.map((value) => (
+              {roles.map((value) => (
                 <option key={value} value={value}>
-                  {documentationOptionLabel(value)}
+                  {roleLabel(value)}
                 </option>
               ))}
             </select>
           </label>
-          <label className="tw-block tw-text-sm tw-text-iron-300">
-            {msg("visibility")}
-            <select
-              className={`${inputClass} tw-mt-2`}
-              disabled={busy || restrictedRoles.has(role)}
-              value={restrictedRoles.has(role) ? "restricted" : visibility}
-              onChange={(event) => setVisibility(event.target.value)}
-            >
-              <option value="restricted">{msg("restricted")}</option>
-              <option value="public_record">{msg("publicIntent")}</option>
-            </select>
-          </label>
+          {!publicationOnly && (
+            <label className="tw-block tw-text-sm tw-text-iron-300">
+              {msg("visibility")}
+              <select
+                className={`${inputClass} tw-mt-2`}
+                disabled={busy || restrictedRoles.has(role)}
+                value={restrictedRoles.has(role) ? "restricted" : visibility}
+                onChange={(event) => setVisibility(event.target.value)}
+              >
+                <option value="restricted">{msg("restricted")}</option>
+                <option value="public_record">{msg("publicIntent")}</option>
+              </select>
+            </label>
+          )}
+          {!rolePermitted && (
+            <DocumentationNotice>
+              {msg("publicationInterviewPermission")}
+            </DocumentationNotice>
+          )}
           <label className="tw-block tw-text-sm tw-text-iron-300">
             {msg("uploadSelect")}
             <input
@@ -317,6 +364,7 @@ export default function DocumentationUpload({ context, controller }: Props) {
               disabled={
                 !file ||
                 busy ||
+                !rolePermitted ||
                 file.size >
                   (context.profile.limits["asset_bytes"] ?? 4294967296)
               }
@@ -378,7 +426,7 @@ export default function DocumentationUpload({ context, controller }: Props) {
         <DocumentationNotice error>{msg("error")}</DocumentationNotice>
       )}
       <ul className="tw-m-0 tw-list-none tw-space-y-3 tw-p-0">
-        {context.assets.map((asset) => (
+        {visibleAssets.map((asset) => (
           <li
             key={asset.id}
             className="tw-rounded-lg tw-border tw-border-solid tw-border-iron-800 tw-p-4"
@@ -387,8 +435,7 @@ export default function DocumentationUpload({ context, controller }: Props) {
               {asset.filename}
             </p>
             <p className="tw-my-2 tw-text-xs tw-text-iron-400">
-              {documentationOptionLabel(asset.role)} ·{" "}
-              {sizeLabel(asset.size_bytes)} ·{" "}
+              {roleLabel(asset.role)} · {sizeLabel(asset.size_bytes)} ·{" "}
               {documentationOptionLabel(asset.state)}
             </p>
             {asset.state === "ready" && (
@@ -404,7 +451,8 @@ export default function DocumentationUpload({ context, controller }: Props) {
                 {!context.asset_links.some(
                   (link) => link.asset_id === asset.id
                 ) &&
-                  canUpload && (
+                  canUpload &&
+                  canPublishDocumentationAsset(context, asset.role) && (
                     <DocumentationButton
                       secondary
                       onClick={() => {
@@ -443,7 +491,11 @@ export default function DocumentationUpload({ context, controller }: Props) {
                 </p>
                 <DocumentationButton
                   secondary
-                  disabled={!file || busy}
+                  disabled={
+                    !file ||
+                    busy ||
+                    !canPublishDocumentationAsset(context, asset.role)
+                  }
                   onClick={() => {
                     void run(asset.id);
                   }}
@@ -455,8 +507,10 @@ export default function DocumentationUpload({ context, controller }: Props) {
           </li>
         ))}
       </ul>
-      {context.assets.length === 0 && (
-        <p className="tw-text-sm tw-text-iron-400">{msg("noFiles")}</p>
+      {visibleAssets.length === 0 && (
+        <p className="tw-text-sm tw-text-iron-400">
+          {msg(publicationOnly ? "publicationNoFiles" : "noFiles")}
+        </p>
       )}
     </section>
   );

--- a/components/artwork-documentation/DocumentationUpload.tsx
+++ b/components/artwork-documentation/DocumentationUpload.tsx
@@ -58,6 +58,17 @@ function canContinueUpload(
   return mounted.current && !signal.aborted;
 }
 
+function canUseUpload(
+  context: ApiArtworkDocumentationContext,
+  asset: { readonly role: string; readonly intended_visibility: string }
+): boolean {
+  return (
+    canPublishDocumentationAsset(context, asset.role) &&
+    (!isPublicationOnly(context.profile) ||
+      asset.intended_visibility === "public_record")
+  );
+}
+
 export default function DocumentationUpload({ context, controller }: Props) {
   const { msg, locale } = useDocumentationMessages();
   const publicationOnly = isPublicationOnly(context.profile);
@@ -68,7 +79,7 @@ export default function DocumentationUpload({ context, controller }: Props) {
     useState<ApiArtworkDocumentationUploadSession | null>(null);
   const [sent, setSent] = useState(0);
   const [status, setStatus] = useState<
-    "idle" | "uploading" | "processing" | "failed" | "changed"
+    "idle" | "uploading" | "processing" | "cancelling" | "failed" | "changed"
   >("idle");
   const abort = useRef<AbortController | null>(null);
   const startKey = useRef(crypto.randomUUID());
@@ -83,11 +94,17 @@ export default function DocumentationUpload({ context, controller }: Props) {
   }, []);
   const sizeLabel = (size: number) =>
     `${formatNumber(locale, size / (1024 * 1024), { maximumFractionDigits: 1 })} MiB`;
-  const busy = status === "uploading" || status === "processing";
+  const busy =
+    status === "uploading" ||
+    status === "processing" ||
+    status === "cancelling";
   const roles = publicationOnly
     ? PUBLICATION_DOCUMENTATION_ASSET_ROLES
     : DOCUMENTATION_ASSET_ROLES;
   const rolePermitted = canPublishDocumentationAsset(context, role);
+  const transferPermitted = session
+    ? canUseUpload(context, session.asset)
+    : rolePermitted;
   const chosenVisibility = publicationOnly ? "public_record" : visibility;
   const uploadVisibility =
     !publicationOnly && restrictedRoles.has(role)
@@ -122,8 +139,13 @@ export default function DocumentationUpload({ context, controller }: Props) {
       filename: string
     ) =>
       controller.mutate((current, signal) => {
-        if (!canPublishDocumentationAsset(current, assetRole))
-          throw new Error("INTERVIEW_PUBLICATION_PERMISSION_REQUIRED");
+        if (
+          !canUseUpload(current, {
+            role: assetRole,
+            intended_visibility: assetVisibility,
+          })
+        )
+          throw new Error("PUBLICATION_ASSET_ROLE_REQUIRED");
         return linkDocumentationAsset(
           current,
           {
@@ -131,9 +153,7 @@ export default function DocumentationUpload({ context, controller }: Props) {
             role: assetRole,
             label: filename,
             description: "",
-            intended_visibility: isPublicationOnly(current.profile)
-              ? "public_record"
-              : assetVisibility,
+            intended_visibility: assetVisibility,
             source_of_asset: isPublicationOnly(current.profile)
               ? "unknown"
               : "self",
@@ -152,7 +172,7 @@ export default function DocumentationUpload({ context, controller }: Props) {
     [controller]
   );
   const run = async (resumeId?: string) => {
-    if (!file || !rolePermitted) return;
+    if (!file || (!resumeId && !rolePermitted)) return;
     const controllerAbort = new AbortController();
     abort.current = controllerAbort;
     setStatus("uploading");
@@ -177,9 +197,22 @@ export default function DocumentationUpload({ context, controller }: Props) {
             controllerAbort.signal
           );
       if (!canContinueUpload(controllerAbort.signal, mounted)) return;
-      if (!canPublishDocumentationAsset(context, upload.asset.role))
-        throw new Error("PUBLICATION_ASSET_ROLE_REQUIRED");
       setSession(upload);
+      if (!canUseUpload(controller.snapshot().context, upload.asset)) {
+        // Keep a resumed session intact: its permission may only need correcting.
+        // A newly rejected reservation is forgotten only after cancellation succeeds.
+        if (!resumeId) {
+          await cancelDocumentationUpload(
+            context.id,
+            upload.upload_id,
+            controllerAbort.signal
+          );
+          if (!canContinueUpload(controllerAbort.signal, mounted)) return;
+          setSession(null);
+          startKey.current = crypto.randomUUID();
+        }
+        throw new Error("PUBLICATION_ASSET_ROLE_REQUIRED");
+      }
       await transferDocumentationFile({
         contextId: context.id,
         session: upload,
@@ -194,6 +227,30 @@ export default function DocumentationUpload({ context, controller }: Props) {
         setStatus(
           error instanceof DocumentationFileChangedError ? "changed" : "failed"
         );
+    }
+  };
+  const cancel = async () => {
+    abort.current?.abort();
+    const controllerAbort = new AbortController();
+    abort.current = controllerAbort;
+    setStatus("cancelling");
+    setActionError(false);
+    try {
+      if (session)
+        await cancelDocumentationUpload(
+          context.id,
+          session.upload_id,
+          controllerAbort.signal
+        );
+      if (!canContinueUpload(controllerAbort.signal, mounted)) return;
+      setStatus("idle");
+      setSession(null);
+      startKey.current = crypto.randomUUID();
+    } catch {
+      if (canContinueUpload(controllerAbort.signal, mounted)) {
+        setStatus("failed");
+        setActionError(true);
+      }
     }
   };
   useEffect(() => {
@@ -364,7 +421,7 @@ export default function DocumentationUpload({ context, controller }: Props) {
               disabled={
                 !file ||
                 busy ||
-                !rolePermitted ||
+                !transferPermitted ||
                 file.size >
                   (context.profile.limits["asset_bytes"] ?? 4294967296)
               }
@@ -374,19 +431,12 @@ export default function DocumentationUpload({ context, controller }: Props) {
             >
               {session ? msg("retry") : msg("uploadStart")}
             </DocumentationButton>
-            {busy && (
+            {(busy || session !== null) && (
               <DocumentationButton
                 secondary
+                disabled={status === "cancelling"}
                 onClick={() => {
-                  abort.current?.abort();
-                  if (session)
-                    void cancelDocumentationUpload(
-                      context.id,
-                      session.upload_id
-                    ).catch(() => setActionError(true));
-                  setStatus("idle");
-                  setSession(null);
-                  startKey.current = crypto.randomUUID();
+                  void cancel();
                 }}
               >
                 {msg("uploadCancel")}
@@ -494,6 +544,7 @@ export default function DocumentationUpload({ context, controller }: Props) {
                   disabled={
                     !file ||
                     busy ||
+                    (session !== null && session.upload_id !== asset.id) ||
                     !canPublishDocumentationAsset(context, asset.role)
                   }
                   onClick={() => {

--- a/components/artwork-documentation/DocumentationUpload.tsx
+++ b/components/artwork-documentation/DocumentationUpload.tsx
@@ -105,6 +105,8 @@ export default function DocumentationUpload({ context, controller }: Props) {
   const transferPermitted = session
     ? canUseUpload(context, session.asset)
     : rolePermitted;
+  const failureMessage =
+    session && !transferPermitted ? "uploadBlockedRecovery" : "uploadFailed";
   const chosenVisibility = publicationOnly ? "public_record" : visibility;
   const uploadVisibility =
     !publicationOnly && restrictedRoles.has(role)
@@ -469,7 +471,7 @@ export default function DocumentationUpload({ context, controller }: Props) {
       )}
       {(status === "failed" || status === "changed") && (
         <DocumentationNotice error>
-          {msg(status === "changed" ? "uploadMismatch" : "uploadFailed")}
+          {msg(status === "changed" ? "uploadMismatch" : failureMessage)}
         </DocumentationNotice>
       )}
       {actionError && (

--- a/components/artwork-documentation/DocumentationWorkedExample.tsx
+++ b/components/artwork-documentation/DocumentationWorkedExample.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useRef, useState } from "react";
+import type { ApiArtworkDocumentationContext } from "@/generated/models/ApiArtworkDocumentationContext";
+import { documentationFieldLabel } from "@/i18n/messages/artwork-documentation-fields";
+import { readAnswer } from "@/lib/artwork-documentation/answers";
+import type { PendingEdit } from "@/lib/artwork-documentation/draft-controller";
+import {
+  documentationExampleFields,
+  documentationExampleKey,
+} from "@/lib/artwork-documentation/examples";
+import {
+  MODULE_IDS,
+  type DocumentationSection,
+} from "@/lib/artwork-documentation/registry";
+import {
+  DocumentationButton,
+  useDocumentationMessages,
+} from "./DocumentationControls";
+
+export default function DocumentationWorkedExample({
+  context,
+  edits,
+  section,
+}: {
+  readonly context: ApiArtworkDocumentationContext;
+  readonly edits: readonly PendingEdit[];
+  readonly section: DocumentationSection;
+}) {
+  const { msg } = useDocumentationMessages();
+  const fields = documentationExampleFields(context.profile, section);
+  const [open, setOpen] = useState(
+    () =>
+      section !== "review" &&
+      fields.length > 0 &&
+      fields.every(
+        ({ moduleId, field }) => !readAnswer(context, moduleId, field.id, edits)
+      )
+  );
+  const summary = useRef<HTMLElement>(null);
+  const close = () => {
+    setOpen(false);
+    const target = document.getElementById(
+      `documentation-answers-${context.id}-${section}`
+    );
+    (target ?? summary.current)?.focus();
+  };
+  if (!fields.length && section !== "review") return null;
+  return (
+    <details
+      open={open}
+      onToggle={(event) => setOpen(event.currentTarget.open)}
+      className="tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900 tw-p-4 sm:tw-p-6"
+    >
+      <summary
+        ref={summary}
+        className="tw-min-h-11 tw-cursor-pointer tw-text-base tw-font-semibold tw-text-iron-100 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-primary-400"
+      >
+        {msg("examples.title")}
+      </summary>
+      <div className="tw-mt-3 tw-space-y-5">
+        <DocumentationButton secondary onClick={close}>
+          {msg("examples.close")}
+        </DocumentationButton>
+        <div>
+          <p className="tw-m-0 tw-text-xs tw-font-semibold tw-uppercase tw-tracking-wide tw-text-primary-300">
+            {msg("examples.fiction")}
+          </p>
+          <p className="tw-mt-3 tw-text-sm tw-leading-relaxed tw-text-iron-200">
+            {msg("examples.notice")}
+          </p>
+          <p className="tw-m-0 tw-text-sm tw-leading-relaxed tw-text-iron-300">
+            {msg("examples.scenario")}
+          </p>
+        </div>
+        {section === "review" ? (
+          <p className="tw-text-sm tw-leading-relaxed tw-text-iron-200">
+            {msg("examples.review")}
+          </p>
+        ) : (
+          MODULE_IDS.map((moduleId) => {
+            const moduleFields = fields.filter(
+              (entry) => entry.moduleId === moduleId
+            );
+            if (!moduleFields.length) return null;
+            return (
+              <section key={moduleId}>
+                <h3 className="tw-text-base tw-font-semibold tw-text-iron-100">
+                  {msg(`module.${moduleId}`)}
+                </h3>
+                <p className="tw-text-sm tw-leading-relaxed tw-text-iron-400">
+                  {msg(`examples.module.${moduleId}`)}
+                </p>
+                <dl className="tw-m-0 tw-divide-y tw-divide-solid tw-divide-iron-800">
+                  {moduleFields.map(({ field }) => {
+                    const key = documentationExampleKey(
+                      context.profile,
+                      moduleId,
+                      field.id,
+                      "answer"
+                    )!;
+                    const why = documentationExampleKey(
+                      context.profile,
+                      moduleId,
+                      field.id,
+                      "why"
+                    );
+                    const label =
+                      (moduleId === "interview"
+                        ? context.profile.interview_instrument.prompts.find(
+                            (prompt) => prompt.id === field.id
+                          )?.text
+                        : undefined) ?? documentationFieldLabel(field.id);
+                    return (
+                      <div key={field.id} className="tw-py-4">
+                        <dt className="tw-text-sm tw-font-semibold tw-text-iron-100">
+                          {label}
+                        </dt>
+                        <dd className="tw-m-0 tw-mt-2 tw-whitespace-pre-wrap tw-break-words tw-text-sm tw-leading-relaxed tw-text-iron-200">
+                          {msg(key)}
+                        </dd>
+                        {why && (
+                          <dd className="tw-m-0 tw-mt-2 tw-text-sm tw-leading-relaxed tw-text-iron-400">
+                            {msg("examples.why")}: {msg(why)}
+                          </dd>
+                        )}
+                      </div>
+                    );
+                  })}
+                </dl>
+              </section>
+            );
+          })
+        )}
+        <p className="tw-text-xs tw-leading-relaxed tw-text-iron-400">
+          {msg("examples.scope")}
+        </p>
+        <DocumentationButton secondary onClick={close}>
+          {msg("examples.close")}
+        </DocumentationButton>
+      </div>
+    </details>
+  );
+}

--- a/generated/models/ApiArtworkDocumentationCapabilities.ts
+++ b/generated/models/ApiArtworkDocumentationCapabilities.ts
@@ -19,6 +19,10 @@ export class ApiArtworkDocumentationCapabilities {
     'read_rights_evidence': boolean;
     'read_source_receipts': boolean;
     'read_contact': boolean;
+    /**
+    * Read restricted answers beyond individually permissioned contact and locked rights evidence. Defaults to false when absent; does not grant originals, source receipts, editing or artist confirmation.
+    */
+    'read_restricted_fields'?: boolean;
     'confirm_as_artist': boolean;
     'manage_assignments': boolean;
     'manage_context': boolean;
@@ -57,6 +61,12 @@ export class ApiArtworkDocumentationCapabilities {
         {
             "name": "read_contact",
             "baseName": "read_contact",
+            "type": "boolean",
+            "format": ""
+        },
+        {
+            "name": "read_restricted_fields",
+            "baseName": "read_restricted_fields",
             "type": "boolean",
             "format": ""
         },

--- a/generated/models/ApiArtworkDocumentationProfile.ts
+++ b/generated/models/ApiArtworkDocumentationProfile.ts
@@ -16,6 +16,10 @@ import { ApiArtworkDocumentationProfileModule } from '../models/ApiArtworkDocume
 import { HttpFile } from '../http/http';
 
 export class ApiArtworkDocumentationProfile {
+    /**
+    * All artwork answers and selected files are intended for public publication. Absent on legacy private-intake profiles. Team questions are separate drafting discussion and never part of the confirmed artwork record.
+    */
+    'intake_mode'?: ApiArtworkDocumentationProfileIntakeModeEnum;
     'profile_id': string;
     'version': number;
     'program_id': string | null;
@@ -37,6 +41,12 @@ export class ApiArtworkDocumentationProfile {
     static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
+        {
+            "name": "intake_mode",
+            "baseName": "intake_mode",
+            "type": "ApiArtworkDocumentationProfileIntakeModeEnum",
+            "format": ""
+        },
         {
             "name": "profile_id",
             "baseName": "profile_id",
@@ -136,6 +146,9 @@ export class ApiArtworkDocumentationProfile {
     }
 }
 
+export enum ApiArtworkDocumentationProfileIntakeModeEnum {
+    PublicationOnly = 'publication_only'
+}
 export enum ApiArtworkDocumentationProfileReviewLanesEnum {
     Curatorial = 'curatorial',
     Technical = 'technical',

--- a/generated/models/ObjectSerializer.ts
+++ b/generated/models/ObjectSerializer.ts
@@ -724,7 +724,7 @@ import { ApiArtworkDocumentationAssetLinkRequest } from '../models/ApiArtworkDoc
 import { ApiArtworkDocumentationAssetResponse } from '../models/ApiArtworkDocumentationAssetResponse';
 import { ApiArtworkDocumentationAssetTerms, ApiArtworkDocumentationAssetTermsKindEnum     } from '../models/ApiArtworkDocumentationAssetTerms';
 import { ApiArtworkDocumentationAvailableArtistRecord } from '../models/ApiArtworkDocumentationAvailableArtistRecord';
-import { ApiArtworkDocumentationCapabilities        , ApiArtworkDocumentationCapabilitiesEditModulesEnum  , ApiArtworkDocumentationCapabilitiesReviewLanesEnum   } from '../models/ApiArtworkDocumentationCapabilities';
+import { ApiArtworkDocumentationCapabilities         , ApiArtworkDocumentationCapabilitiesEditModulesEnum  , ApiArtworkDocumentationCapabilitiesReviewLanesEnum   } from '../models/ApiArtworkDocumentationCapabilities';
 import { ApiArtworkDocumentationComment } from '../models/ApiArtworkDocumentationComment';
 import { ApiArtworkDocumentationCommentRequest } from '../models/ApiArtworkDocumentationCommentRequest';
 import { ApiArtworkDocumentationCompletePart } from '../models/ApiArtworkDocumentationCompletePart';
@@ -755,7 +755,7 @@ import { ApiArtworkDocumentationOperation, ApiArtworkDocumentationOperationOpEnu
 import { ApiArtworkDocumentationPatchModule } from '../models/ApiArtworkDocumentationPatchModule';
 import { ApiArtworkDocumentationPatchThread } from '../models/ApiArtworkDocumentationPatchThread';
 import { ApiArtworkDocumentationPreviewModule } from '../models/ApiArtworkDocumentationPreviewModule';
-import { ApiArtworkDocumentationProfile     , ApiArtworkDocumentationProfileReviewLanesEnum            } from '../models/ApiArtworkDocumentationProfile';
+import { ApiArtworkDocumentationProfile, ApiArtworkDocumentationProfileIntakeModeEnum       , ApiArtworkDocumentationProfileReviewLanesEnum            } from '../models/ApiArtworkDocumentationProfile';
 import { ApiArtworkDocumentationProfileModule, ApiArtworkDocumentationProfileModuleIdEnum     } from '../models/ApiArtworkDocumentationProfileModule';
 import { ApiArtworkDocumentationProfilesResponse } from '../models/ApiArtworkDocumentationProfilesResponse';
 import { ApiArtworkDocumentationPublicPreview } from '../models/ApiArtworkDocumentationPublicPreview';
@@ -1442,6 +1442,7 @@ let enumsMap: Set<string> = new Set<string>([
     "ApiArtworkDocumentationDownloadRequestVariantEnum",
     "ApiArtworkDocumentationLifecycleRequestLifecycleEnum",
     "ApiArtworkDocumentationOperationOpEnum",
+    "ApiArtworkDocumentationProfileIntakeModeEnum",
     "ApiArtworkDocumentationProfileReviewLanesEnum",
     "ApiArtworkDocumentationProfileModuleIdEnum",
     "ApiArtworkDocumentationReviewLaneEnum",

--- a/hooks/artwork-documentation/useArtworkDocumentationAccess.ts
+++ b/hooks/artwork-documentation/useArtworkDocumentationAccess.ts
@@ -3,6 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useAuth } from "@/components/auth/Auth";
 import { getDocumentationProfiles } from "@/services/api/artwork-documentation-api";
+import { latestDocumentationProfiles } from "@/lib/artwork-documentation/intake";
 
 export const documentationQueryKey = (
   profileId: string | null | undefined,
@@ -28,7 +29,7 @@ export function useArtworkDocumentationAccess() {
   return {
     ...query,
     enabled: query.data?.enabled === true,
-    profiles: query.data?.profiles ?? [],
+    profiles: latestDocumentationProfiles(query.data?.profiles ?? []),
     selfServiceEnabled: query.data?.self_service_enabled === true,
   };
 }

--- a/i18n/messages/artwork-documentation-examples.ts
+++ b/i18n/messages/artwork-documentation-examples.ts
@@ -30,7 +30,7 @@ export const ARTWORK_DOCUMENTATION_EXAMPLE_MESSAGES = {
   "artworkDocumentation.examples.artwork.visual_description.answer":
     "“A pale cardboard gate stands across a dark tabletop in a horizontal black-and-white image. A narrow opening just right of center reveals a bright strip of light. The gate's uneven edge and folded supports are visible. The background fades to black, with no people or lettering in the frame.”",
   "artworkDocumentation.examples.artwork.visual_description.starter":
-    "The image shows [main subject and its position]. [Important surrounding objects, light, color and spatial relationships]. [Visible text, if relevant].",
+    "The image shows [[main subject and its position]]. [[Important surrounding objects, light, color and spatial relationships]]. [[Visible text, if relevant]].",
   "artworkDocumentation.examples.artwork.series_title.answer":
     "Small Thresholds",
   "artworkDocumentation.examples.artwork.canonical_asset_id.answer":
@@ -46,15 +46,15 @@ export const ARTWORK_DOCUMENTATION_EXAMPLE_MESSAGES = {
   "artworkDocumentation.examples.context.caption.answer":
     "I built this gate from cardboard on a studio table. Its narrow opening lets light through but reveals nothing beyond it. I photographed the set twice, changing the light, and combined the exposures to hold detail in both the opening and the gate. I kept the rough edges visible because I wanted the barrier to remain something made, rather than a permanent fact. For Keys and Gates, the image asks what an opening promises when we cannot see where it leads. No figure occupies the scene. I leave that position to the viewer, between the possibility of entering and hesitation.",
   "artworkDocumentation.examples.context.caption.starter":
-    "I made this photograph when [specific circumstance]. [What is happening in the frame]. I chose [one important decision] because [why]. For me, [what the image leaves open or asks the viewer to consider].",
+    "I made this photograph when [[specific circumstance]]. [[What is happening in the frame]]. I chose [[one important decision]] because [[why]]. For me, [[what the image leaves open or asks the viewer to consider]].",
   "artworkDocumentation.examples.context.artist_statement.answer":
     "The Space Between began with a small practical problem: I wanted to photograph a gate that could be seen clearly while the space beyond it remained unreadable. I built it from plain cardboard rather than looking for an existing doorway. Working at this scale let me change the structure with my hands, but I did not want the model to disappear into the illusion of a real place. I kept the folded edges and the supports visible.\n\nI made two photographs with the camera held in the same position. In one, the light describes the front of the gate. In the other, it comes through the opening. I combined those exposures to arrive at a relationship between the surface and the light that a single exposure did not give me. This is a constructed image, and I want that construction to stay part of its record.\n\nThe work belongs to Small Thresholds, a group of photographs in which I use ordinary materials to think about boundaries. I am interested in the moment when an object seems to offer a simple instruction—enter, wait, keep out—but the image gives us too little information to obey it. In this photograph, the gate is handmade and visibly fragile, yet it still organizes the whole space.\n\nFor Keys and Gates, I think of the opening as a promise whose conditions are missing. Light suggests that there might be something on the other side, but it does not tell us who can reach it. I did not include a figure because I wanted the viewer's position to remain unsettled. I hope the image allows both hesitation and possibility. It is not a picture of one particular border or a substitute for anyone's lived account of exclusion. It is a small scene I made to keep that question open.",
   "artworkDocumentation.examples.context.artist_statement.starter":
-    "This work began with [observation or question]. I [what you did]. The decision that mattered most was [choice], because [reason]. [How it relates to your practice]. I want viewers to have room to [encounter or interpret the work in their own way].",
+    "This work began with [[observation or question]]. I [[what you did]]. The decision that mattered most was [[choice]], because [[reason]]. [[How it relates to your practice]]. I want viewers to have room to [[encounter or interpret the work in their own way]].",
   "artworkDocumentation.examples.context.making_context.answer":
     "“I built the gate from unprinted cardboard left over from studio packaging. I worked on a table with a fixed camera and moved the light between exposures. The model was dismantled after I photographed it. The finished work is the image, not the temporary set.”",
   "artworkDocumentation.examples.context.making_context.starter":
-    "Before making the image, [circumstances]. During the work, [what happened]. Afterward, [relevant changes or what survives].",
+    "Before making the image, [[circumstances]]. During the work, [[what happened]]. Afterward, [[relevant changes or what survives]].",
   "artworkDocumentation.examples.context.theme_connection.answer":
     "The gate offers an opening but no view of what comes after it. For Keys and Gates, I was interested in access as a promise: a boundary can appear simple while leaving the terms of entry uncertain.",
   "artworkDocumentation.examples.context.theme_connection.why":
@@ -62,7 +62,7 @@ export const ARTWORK_DOCUMENTATION_EXAMPLE_MESSAGES = {
   "artworkDocumentation.examples.context.misunderstandings.answer":
     "“This is a constructed tabletop scene, not a photograph of a real checkpoint. The opening is made from two exposures of the same set. I am not documenting a particular border or a person's experience of crossing it.”",
   "artworkDocumentation.examples.context.misunderstandings.starter":
-    "A viewer might assume [likely reading]. I want the record to make clear that [relevant fact or distinction].",
+    "A viewer might assume [[likely reading]]. I want the record to make clear that [[relevant fact or distinction]].",
   "artworkDocumentation.examples.context.history.answer":
     "None known. I have not previously published, exhibited, issued a print edition of or minted this work. It has not received an award.",
   "artworkDocumentation.examples.context.prior_mint_status.answer":
@@ -107,35 +107,35 @@ export const ARTWORK_DOCUMENTATION_EXAMPLE_MESSAGES = {
   "artworkDocumentation.examples.preservation.significant_properties.answer":
     "“The relationship between the bright opening and the dark space is essential. The gate must still read as handmade: its folds, rough edges and supports should remain visible. Preserve the full horizontal composition and the subtle detail in the dark tabletop. The work is a still image, with no sound or timed sequence.”",
   "artworkDocumentation.examples.preservation.significant_properties.starter":
-    "The work depends on [specific visual or other properties]. [What a viewer needs to be able to perceive]. [Which features are secondary or flexible].",
+    "The work depends on [[specific visual or other properties]]. [[What a viewer needs to be able to perceive]]. [[Which features are secondary or flexible]].",
   "artworkDocumentation.examples.preservation.display_orientation_crop.answer":
     "“Show the complete horizontal 3:2 frame. Keep its orientation and proportions. If the display has a different shape, fit the image within it instead of cutting off the gate or stretching the frame. I did not include an added border in the image.”",
   "artworkDocumentation.examples.preservation.display_orientation_crop.starter":
-    "Show the work [orientation and full frame/crop]. [Treatment of any border]. On a differently shaped display, [your preferred adaptation].",
+    "Show the work [[orientation and full frame/crop]]. [[Treatment of any border]]. On a differently shaped display, [[your preferred adaptation]].",
   "artworkDocumentation.examples.preservation.color_and_tone.answer":
     "“The intended image is neutral black and white. Keep separation in the dark tabletop and texture in the bright opening; neither should become a featureless block. Avoid a warm or cool tint. Compare a reproduction with the approved final image rather than adding contrast for impact.”",
   "artworkDocumentation.examples.preservation.color_and_tone.starter":
-    "The intended color or tonal balance is [specific description]. Pay particular attention to [highlight, shadow or color relationships]. [Reference the actual approved version].",
+    "The intended color or tonal balance is [[specific description]]. Pay particular attention to [[highlight, shadow or color relationships]]. [[Reference the actual approved version]].",
   "artworkDocumentation.examples.preservation.screen_preferences.answer":
     "“Use a still display with the whole frame visible. Avoid automatic zooms, motion effects or filters. A neutral surround is preferred. Adjust the viewing setup so that the dark surface remains legible; I do not specify one screen model or an invented brightness target.”",
   "artworkDocumentation.examples.preservation.screen_preferences.starter":
-    "On screen, I prefer [framing, surround or viewing conditions]. [Effects to avoid]. [What is flexible or not specified].",
+    "On screen, I prefer [[framing, surround or viewing conditions]]. [[Effects to avoid]]. [[What is flexible or not specified]].",
   "artworkDocumentation.examples.preservation.print_preferences.answer":
     "“I have not approved a physical print edition or a single required print size. For an exhibition reproduction, I would prefer a matte surface and a test proof checked against the final image. Keep the full frame and assess shadow detail before choosing the final size. This is a preference for reproduction, not a record of a print being acquired.”",
   "artworkDocumentation.examples.preservation.print_preferences.starter":
-    "For a print or exhibition reproduction, [size/material preferences, if known]. [Proofing priorities]. [Whether a print edition or physical object is actually part of this work].",
+    "For a print or exhibition reproduction, [[size/material preferences, if known]]. [[Proofing priorities]]. [[Whether a print edition or physical object is actually part of this work]].",
   "artworkDocumentation.examples.preservation.acceptable_changes.answer":
     "Make separately identified file-format or display-size derivatives when needed, while retaining the original final file. Keep the full frame, tonal relationships and visible cardboard detail. Record which file was used and what changed. A change to the composition, added content or a new color treatment would be another version of the work in my account.",
   "artworkDocumentation.examples.preservation.acceptable_changes.starter":
-    "For preservation or display, I consider [specific conversions or adaptations] acceptable if [what remains intact]. Treat [material alterations] as another version and record [the information needed to distinguish it].",
+    "For preservation or display, I consider [[specific conversions or adaptations]] acceptable if [[what remains intact]]. Treat [[material alterations]] as another version and record [[the information needed to distinguish it]].",
   "artworkDocumentation.examples.preservation.avoid_changes.answer":
     "Avoid cropping, stretching, colorization, added animation and replacing or smoothing the rough cardboard edges. Do not invent detail when enlarging the image. Keep any restoration or experimental variation separate from the original final file.",
   "artworkDocumentation.examples.preservation.avoid_changes.starter":
-    "Avoid [specific changes], because [what they would alter about the work]. [How to distinguish an experimental or altered version].",
+    "Avoid [[specific changes]], because [[what they would alter about the work]]. [[How to distinguish an experimental or altered version]].",
   "artworkDocumentation.examples.preservation.physical_materials.answer":
     "“The cardboard gate was a temporary photographic set and was dismantled after capture. It is not an acquired object or a reconstruction instruction. No physical print or model is included in this proposed digital work.”",
   "artworkDocumentation.examples.preservation.physical_materials.starter":
-    "[Related set, model, print or other material]. It [survives / no longer survives / is unknown]. It is [part of the artwork / supporting material / a separate object], as far as this record describes.",
+    "[[Related set, model, print or other material]]. It [[survives / no longer survives / is unknown]]. It is [[part of the artwork / supporting material / a separate object]], as far as this record describes.",
   "artworkDocumentation.examples.interview.mode.answer": "Written reflection.",
   "artworkDocumentation.examples.interview.date.answer": "20 May 2025.",
   "artworkDocumentation.examples.interview.participants.answer":
@@ -144,35 +144,35 @@ export const ARTWORK_DOCUMENTATION_EXAMPLE_MESSAGES = {
   "artworkDocumentation.examples.interview.q1.answer":
     "“I first noticed how much a narrow strip of light could change a simple piece of cardboard. I wanted to make an opening that felt possible without showing a destination.”",
   "artworkDocumentation.examples.interview.q1.starter":
-    "It began when [observation or experience]. What stayed with me was [specific detail].",
+    "It began when [[observation or experience]]. What stayed with me was [[specific detail]].",
   "artworkDocumentation.examples.interview.q2.answer":
     "“The gate is standing on a studio table. Outside the frame are the camera, lighting and the rest of the work surface. There is no building or passage behind it. I made the two exposures without moving the camera or the set.”",
   "artworkDocumentation.examples.interview.q2.starter":
-    "In the image, [what is happening]. Outside the frame, [relevant context].",
+    "In the image, [[what is happening]]. Outside the frame, [[relevant context]].",
   "artworkDocumentation.examples.interview.q3.answer":
     "“Keeping the handmade edges visible was the most important choice. Combining two exposures let me hold detail in both the gate and the opening. I wanted construction to remain visible instead of making the model pass for a real place.”",
   "artworkDocumentation.examples.interview.q3.starter":
-    "The choice that changed the work most was [decision]. I made it because [reason].",
+    "The choice that changed the work most was [[decision]]. I made it because [[reason]].",
   "artworkDocumentation.examples.interview.q4.answer":
     "“Small Thresholds uses small constructed spaces to question how objects direct us. This work is related to the others through that method, but it is the one in which the destination is most completely withheld.”",
   "artworkDocumentation.examples.interview.q4.starter":
-    "This connects to my wider work through [specific concern or method]. It differs in [what is distinctive].",
+    "This connects to my wider work through [[specific concern or method]]. It differs in [[what is distinctive]].",
   "artworkDocumentation.examples.interview.q5.answer":
     "“Here the gate separates the promise of access from the experience of passing through. The light offers a possibility, but the image does not tell us whether an opening is enough.”",
   "artworkDocumentation.examples.interview.q5.starter":
-    "The key or gate in this work is [literal or figurative idea]. I am interested in [your particular connection].",
+    "The key or gate in this work is [[literal or figurative idea]]. I am interested in [[your particular connection]].",
   "artworkDocumentation.examples.interview.q6.answer":
     "“I would not want this read as evidence of an actual checkpoint or an account of a particular person's exclusion. It is an invented space made from two photographs of a model.”",
   "artworkDocumentation.examples.interview.q6.starter":
-    "Someone might read this as [possible misunderstanding]. The distinction I want to retain is [what is actually true].",
+    "Someone might read this as [[possible misunderstanding]]. The distinction I want to retain is [[what is actually true]].",
   "artworkDocumentation.examples.interview.q7.answer":
     "“Keep the full frame, the separation between light and dark, and the roughness of the cardboard. Those qualities hold the image between a convincing space and a visibly made object. A new display format can change; that balance should remain.”",
   "artworkDocumentation.examples.interview.q7.starter":
-    "What needs to remain is [essential properties]. [What can adapt without changing your account of the work].",
+    "What needs to remain is [[essential properties]]. [[What can adapt without changing your account of the work]].",
   "artworkDocumentation.examples.interview.q8.answer":
     "“I made this with ordinary materials and no certainty about how the question should end. I would like someone finding it later to know that the unresolved opening is deliberate. It does not hide a lost answer.”",
   "artworkDocumentation.examples.interview.q8.starter":
-    "Years from now, I would want someone to know [context, uncertainty or intention that might otherwise disappear].",
+    "Years from now, I would want someone to know [[context, uncertainty or intention that might otherwise disappear]].",
   "artworkDocumentation.examples.interview.recording_asset_id.answer":
     "I have answered in writing here and have not supplied a separate recording or transcript.",
   "artworkDocumentation.examples.interview.transcript_asset_id.answer":
@@ -184,7 +184,7 @@ export const ARTWORK_DOCUMENTATION_EXAMPLE_MESSAGES = {
   "artworkDocumentation.examples.interview.correction_note.answer":
     "“I clarified that the final image combines two photographs of the same set, so the word ‘composite’ is not mistaken for borrowed imagery.”",
   "artworkDocumentation.examples.interview.correction_note.starter":
-    "On [actual date, if useful], I corrected or clarified [point]. [What changed and why].",
+    "On [[actual date, if useful]], I corrected or clarified [[point]]. [[What changed and why]].",
   "artworkDocumentation.examples.module.identity":
     "Show how you want to be credited and introduce your practice in your own words.",
   "artworkDocumentation.examples.module.artwork":

--- a/i18n/messages/artwork-documentation-examples.ts
+++ b/i18n/messages/artwork-documentation-examples.ts
@@ -1,0 +1,202 @@
+export const ARTWORK_DOCUMENTATION_EXAMPLE_MESSAGES = {
+  "artworkDocumentation.examples.scenario":
+    "A horizontal black-and-white photographic composite of two exposures of the same handmade cardboard gate. No people are depicted in the fictional scene. The final 6000 × 4000 PNG is also the preservation file. Source files are not part of this public documentation.",
+  "artworkDocumentation.examples.review":
+    "For this fictional work I would check that the title and Ari Example credit are correct; the caption describes two exposures of one handmade set; the actual final PNG is selected; the full 3:2 composition and neutral black-and-white treatment are documented; and the proposed release is not mistaken for an already effective declaration. I would remove any remaining starter prompts and resolve questions with the team before finalizing. This example does not tick any confirmation box.",
+  "artworkDocumentation.examples.identity.display_name.answer": "Ari Example",
+  "artworkDocumentation.examples.identity.preferred_credit.answer":
+    "Ari Example",
+  "artworkDocumentation.examples.identity.record_language.answer":
+    "English (en)",
+  "artworkDocumentation.examples.identity.biography.answer":
+    "I make photographs of small spaces and ordinary objects, often building temporary scenes from paper and cardboard. I am interested in how a familiar object can change when its scale or surroundings become uncertain. My process moves between making things by hand and working with the camera: I build a simple set, watch how light moves through it, and make several versions before choosing a frame. Black-and-white photography lets me concentrate on edges, surfaces and the distance between objects. I use the artist name Ari Example. I prefer a direct description of what I made to a fixed explanation of what viewers should feel.",
+  "artworkDocumentation.examples.identity.links.answer":
+    "I do not have a public website or authority reference to add.",
+  "artworkDocumentation.examples.identity.languages.answer": "English (en)",
+  "artworkDocumentation.examples.artwork.title.answer": "The Space Between",
+  "artworkDocumentation.examples.artwork.title_language.answer": "English (en)",
+  "artworkDocumentation.examples.artwork.alternate_titles.answer":
+    "No alternate title supplied.",
+  "artworkDocumentation.examples.artwork.capture_date.answer":
+    "12 May 2025; exact day.",
+  "artworkDocumentation.examples.artwork.completion_date.answer":
+    "18 May 2025; exact day.",
+  "artworkDocumentation.examples.artwork.location.answer":
+    "Made in a studio. No more specific location is included in the public record.",
+  "artworkDocumentation.examples.artwork.medium.answer":
+    "Photographic composite. Detail: “Black-and-white composite of two digital photographs of the same handmade cardboard set.”",
+  "artworkDocumentation.examples.artwork.edition_statement.answer":
+    "“I intend this finished image for a 1/1 digital edition. This describes my proposed edition; no mint is recorded here.”",
+  "artworkDocumentation.examples.artwork.visual_description.answer":
+    "“A pale cardboard gate stands across a dark tabletop in a horizontal black-and-white image. A narrow opening just right of center reveals a bright strip of light. The gate's uneven edge and folded supports are visible. The background fades to black, with no people or lettering in the frame.”",
+  "artworkDocumentation.examples.artwork.visual_description.starter":
+    "The image shows [main subject and its position]. [Important surrounding objects, light, color and spatial relationships]. [Visible text, if relevant].",
+  "artworkDocumentation.examples.artwork.series_title.answer":
+    "Small Thresholds",
+  "artworkDocumentation.examples.artwork.canonical_asset_id.answer":
+    "The file I want to use is the-space-between-final-v1.png. It contains the full final composition at 6000 × 4000 pixels.",
+  "artworkDocumentation.examples.artwork.declared_dimensions.answer":
+    "Width 6000; height 4000 pixels. Artist-declared example, not an inspection result.",
+  "artworkDocumentation.examples.artwork.work_relationships.answer":
+    "The series title is recorded above; no related-work identifier or public reference is supplied.",
+  "artworkDocumentation.examples.files.master_availability.answer":
+    "Same file as the final artwork. My final PNG is the version I want preserved.",
+  "artworkDocumentation.examples.files.master_availability.why":
+    "Choose the status that describes your real final file. The example never supplies an asset ID or claims a completed upload.",
+  "artworkDocumentation.examples.context.caption.answer":
+    "I built this gate from cardboard on a studio table. Its narrow opening lets light through but reveals nothing beyond it. I photographed the set twice, changing the light, and combined the exposures to hold detail in both the opening and the gate. I kept the rough edges visible because I wanted the barrier to remain something made, rather than a permanent fact. For Keys and Gates, the image asks what an opening promises when we cannot see where it leads. No figure occupies the scene. I leave that position to the viewer, between the possibility of entering and hesitation.",
+  "artworkDocumentation.examples.context.caption.starter":
+    "I made this photograph when [specific circumstance]. [What is happening in the frame]. I chose [one important decision] because [why]. For me, [what the image leaves open or asks the viewer to consider].",
+  "artworkDocumentation.examples.context.artist_statement.answer":
+    "The Space Between began with a small practical problem: I wanted to photograph a gate that could be seen clearly while the space beyond it remained unreadable. I built it from plain cardboard rather than looking for an existing doorway. Working at this scale let me change the structure with my hands, but I did not want the model to disappear into the illusion of a real place. I kept the folded edges and the supports visible.\n\nI made two photographs with the camera held in the same position. In one, the light describes the front of the gate. In the other, it comes through the opening. I combined those exposures to arrive at a relationship between the surface and the light that a single exposure did not give me. This is a constructed image, and I want that construction to stay part of its record.\n\nThe work belongs to Small Thresholds, a group of photographs in which I use ordinary materials to think about boundaries. I am interested in the moment when an object seems to offer a simple instruction—enter, wait, keep out—but the image gives us too little information to obey it. In this photograph, the gate is handmade and visibly fragile, yet it still organizes the whole space.\n\nFor Keys and Gates, I think of the opening as a promise whose conditions are missing. Light suggests that there might be something on the other side, but it does not tell us who can reach it. I did not include a figure because I wanted the viewer's position to remain unsettled. I hope the image allows both hesitation and possibility. It is not a picture of one particular border or a substitute for anyone's lived account of exclusion. It is a small scene I made to keep that question open.",
+  "artworkDocumentation.examples.context.artist_statement.starter":
+    "This work began with [observation or question]. I [what you did]. The decision that mattered most was [choice], because [reason]. [How it relates to your practice]. I want viewers to have room to [encounter or interpret the work in their own way].",
+  "artworkDocumentation.examples.context.making_context.answer":
+    "“I built the gate from unprinted cardboard left over from studio packaging. I worked on a table with a fixed camera and moved the light between exposures. The model was dismantled after I photographed it. The finished work is the image, not the temporary set.”",
+  "artworkDocumentation.examples.context.making_context.starter":
+    "Before making the image, [circumstances]. During the work, [what happened]. Afterward, [relevant changes or what survives].",
+  "artworkDocumentation.examples.context.theme_connection.answer":
+    "“The gate offers an opening but no view of what comes after it. For Keys and Gates, I was interested in access as a promise: a boundary can appear simple while leaving the terms of entry uncertain.” Or select “My caption covers this” when it genuinely does.",
+  "artworkDocumentation.examples.context.misunderstandings.answer":
+    "“This is a constructed tabletop scene, not a photograph of a real checkpoint. The opening is made from two exposures of the same set. I am not documenting a particular border or a person's experience of crossing it.”",
+  "artworkDocumentation.examples.context.misunderstandings.starter":
+    "A viewer might assume [likely reading]. I want the record to make clear that [relevant fact or distinction].",
+  "artworkDocumentation.examples.context.history.answer":
+    "None known. I have not previously published, exhibited, issued a print edition of or minted this work. It has not received an award.",
+  "artworkDocumentation.examples.context.prior_mint_status.answer":
+    "I have never minted this work.",
+  "artworkDocumentation.examples.context.references.answer":
+    "No external contextual references supplied; this is the artist's own account.",
+  "artworkDocumentation.examples.process.capture_method.answer":
+    "Digital camera. Detail: “Two exposures from a fixed camera position, with different lighting on the same set.”",
+  "artworkDocumentation.examples.process.camera.answer":
+    "Unknown; explanation: “I did not retain a reliable note of the camera model.”",
+  "artworkDocumentation.examples.process.lens.answer":
+    "Unknown; explanation: “I do not have a reliable record of the lens.”",
+  "artworkDocumentation.examples.process.exposure_note.answer":
+    "“I used a tripod and made separate exposures for the gate and the opening. I have not transcribed the exposure settings from the retained camera files.”",
+  "artworkDocumentation.examples.process.techniques.answer":
+    "Staged; composite; miniature.",
+  "artworkDocumentation.examples.process.editing_tools.answer":
+    "Adobe Photoshop; version unknown.",
+  "artworkDocumentation.examples.process.process_description.answer":
+    "I cut and folded the cardboard gate, placed it on a dark tabletop and fixed the camera on a tripod. I made one exposure with light across the front surface and a second with light behind the opening. In Photoshop I aligned the two images and used a hand-painted mask to combine them. I converted the result to black and white, adjusted the tonal curve and removed two sensor-dust spots. I retained the visible cardboard edges and the full composition, then exported the final image as a PNG.",
+  "artworkDocumentation.examples.process.material_changes.answer":
+    "“The final image combines two exposures of the same set. I converted them to black and white, adjusted their tones and removed two sensor-dust spots. I did not add objects or borrow imagery from another source.”",
+  "artworkDocumentation.examples.process.ai_use.answer":
+    "None. Detail: “I used manual masking and tonal adjustments; no AI-assisted or generated material entered this version.”",
+  "artworkDocumentation.examples.process.ingredients.answer":
+    "I made both component photographs. One shows the front-lit cardboard gate and supplies its visible surface. The other shows the same set lit from behind and supplies the light in the opening. I combined these two photographs; neither contains borrowed imagery.",
+  "artworkDocumentation.examples.process.contributors.answer":
+    "I built, photographed and edited the work myself. There are no additional contributors to credit.",
+  "artworkDocumentation.examples.process.construction_note.answer":
+    "“The gate is a small, temporary cardboard model supported by folded tabs. I left those tabs visible. The scene was assembled for the photograph and dismantled afterward; no physical model is included in the proposed artwork.”",
+  "artworkDocumentation.examples.rights.rights_basis.answer":
+    "I made both component photographs, built the set and assembled the final image myself. No other person claims authorship of this work.",
+  "artworkDocumentation.examples.rights.intended_license.answer":
+    "I propose CC0 1.0 for the final artwork. The proposed license is https://creativecommons.org/publicdomain/zero/1.0/.",
+  "artworkDocumentation.examples.rights.rights_declaration.answer":
+    "I propose this final artwork for the Keys and Gates CC0 1.0 release. This records my present intention. I have not yet made that release effective.",
+  "artworkDocumentation.examples.rights.declaration_effect.answer": "Proposed.",
+  "artworkDocumentation.examples.rights.third_party_material.answer":
+    "I did not incorporate borrowed photographs, artworks, logos or other third-party source material.",
+  "artworkDocumentation.examples.rights.publication_notes.answer":
+    "I would like the final image to appear with my preferred credit and caption. My display guidance records how I hope the image is shown; it is not an extra restriction on the proposed artwork license.",
+  "artworkDocumentation.examples.preservation.significant_properties.answer":
+    "“The relationship between the bright opening and the dark space is essential. The gate must still read as handmade: its folds, rough edges and supports should remain visible. Preserve the full horizontal composition and the subtle detail in the dark tabletop. The work is a still image, with no sound or timed sequence.”",
+  "artworkDocumentation.examples.preservation.significant_properties.starter":
+    "The work depends on [specific visual or other properties]. [What a viewer needs to be able to perceive]. [Which features are secondary or flexible].",
+  "artworkDocumentation.examples.preservation.display_orientation_crop.answer":
+    "“Show the complete horizontal 3:2 frame. Keep its orientation and proportions. If the display has a different shape, fit the image within it instead of cutting off the gate or stretching the frame. I did not include an added border in the image.”",
+  "artworkDocumentation.examples.preservation.display_orientation_crop.starter":
+    "Show the work [orientation and full frame/crop]. [Treatment of any border]. On a differently shaped display, [your preferred adaptation].",
+  "artworkDocumentation.examples.preservation.color_and_tone.answer":
+    "“The intended image is neutral black and white. Keep separation in the dark tabletop and texture in the bright opening; neither should become a featureless block. Avoid a warm or cool tint. Compare a reproduction with the approved final image rather than adding contrast for impact.”",
+  "artworkDocumentation.examples.preservation.color_and_tone.starter":
+    "The intended color or tonal balance is [specific description]. Pay particular attention to [highlight, shadow or color relationships]. [Reference the actual approved version].",
+  "artworkDocumentation.examples.preservation.screen_preferences.answer":
+    "“Use a still display with the whole frame visible. Avoid automatic zooms, motion effects or filters. A neutral surround is preferred. Adjust the viewing setup so that the dark surface remains legible; I do not specify one screen model or an invented brightness target.”",
+  "artworkDocumentation.examples.preservation.screen_preferences.starter":
+    "On screen, I prefer [framing, surround or viewing conditions]. [Effects to avoid]. [What is flexible or not specified].",
+  "artworkDocumentation.examples.preservation.print_preferences.answer":
+    "“I have not approved a physical print edition or a single required print size. For an exhibition reproduction, I would prefer a matte surface and a test proof checked against the final image. Keep the full frame and assess shadow detail before choosing the final size. This is a preference for reproduction, not a record of a print being acquired.”",
+  "artworkDocumentation.examples.preservation.print_preferences.starter":
+    "For a print or exhibition reproduction, [size/material preferences, if known]. [Proofing priorities]. [Whether a print edition or physical object is actually part of this work].",
+  "artworkDocumentation.examples.preservation.acceptable_changes.answer":
+    "Make separately identified file-format or display-size derivatives when needed, while retaining the original final file. Keep the full frame, tonal relationships and visible cardboard detail. Record which file was used and what changed. A change to the composition, added content or a new color treatment would be another version of the work in my account.",
+  "artworkDocumentation.examples.preservation.acceptable_changes.starter":
+    "For preservation or display, I consider [specific conversions or adaptations] acceptable if [what remains intact]. Treat [material alterations] as another version and record [the information needed to distinguish it].",
+  "artworkDocumentation.examples.preservation.avoid_changes.answer":
+    "Avoid cropping, stretching, colorization, added animation and replacing or smoothing the rough cardboard edges. Do not invent detail when enlarging the image. Keep any restoration or experimental variation separate from the original final file.",
+  "artworkDocumentation.examples.preservation.avoid_changes.starter":
+    "Avoid [specific changes], because [what they would alter about the work]. [How to distinguish an experimental or altered version].",
+  "artworkDocumentation.examples.preservation.physical_materials.answer":
+    "“The cardboard gate was a temporary photographic set and was dismantled after capture. It is not an acquired object or a reconstruction instruction. No physical print or model is included in this proposed digital work.”",
+  "artworkDocumentation.examples.preservation.physical_materials.starter":
+    "[Related set, model, print or other material]. It [survives / no longer survives / is unknown]. It is [part of the artwork / supporting material / a separate object], as far as this record describes.",
+  "artworkDocumentation.examples.interview.mode.answer": "Written reflection.",
+  "artworkDocumentation.examples.interview.date.answer": "20 May 2025.",
+  "artworkDocumentation.examples.interview.participants.answer":
+    "Ari Example — artist, answering in writing.",
+  "artworkDocumentation.examples.interview.languages.answer": "English (en).",
+  "artworkDocumentation.examples.interview.q1.answer":
+    "“I first noticed how much a narrow strip of light could change a simple piece of cardboard. I wanted to make an opening that felt possible without showing a destination.”",
+  "artworkDocumentation.examples.interview.q1.starter":
+    "It began when [observation or experience]. What stayed with me was [specific detail].",
+  "artworkDocumentation.examples.interview.q2.answer":
+    "“The gate is standing on a studio table. Outside the frame are the camera, lighting and the rest of the work surface. There is no building or passage behind it. I made the two exposures without moving the camera or the set.”",
+  "artworkDocumentation.examples.interview.q2.starter":
+    "In the image, [what is happening]. Outside the frame, [relevant context].",
+  "artworkDocumentation.examples.interview.q3.answer":
+    "“Keeping the handmade edges visible was the most important choice. Combining two exposures let me hold detail in both the gate and the opening. I wanted construction to remain visible instead of making the model pass for a real place.”",
+  "artworkDocumentation.examples.interview.q3.starter":
+    "The choice that changed the work most was [decision]. I made it because [reason].",
+  "artworkDocumentation.examples.interview.q4.answer":
+    "“Small Thresholds uses small constructed spaces to question how objects direct us. This work is related to the others through that method, but it is the one in which the destination is most completely withheld.”",
+  "artworkDocumentation.examples.interview.q4.starter":
+    "This connects to my wider work through [specific concern or method]. It differs in [what is distinctive].",
+  "artworkDocumentation.examples.interview.q5.answer":
+    "“Here the gate separates the promise of access from the experience of passing through. The light offers a possibility, but the image does not tell us whether an opening is enough.”",
+  "artworkDocumentation.examples.interview.q5.starter":
+    "The key or gate in this work is [literal or figurative idea]. I am interested in [your particular connection].",
+  "artworkDocumentation.examples.interview.q6.answer":
+    "“I would not want this read as evidence of an actual checkpoint or an account of a particular person's exclusion. It is an invented space made from two photographs of a model.”",
+  "artworkDocumentation.examples.interview.q6.starter":
+    "Someone might read this as [possible misunderstanding]. The distinction I want to retain is [what is actually true].",
+  "artworkDocumentation.examples.interview.q7.answer":
+    "“Keep the full frame, the separation between light and dark, and the roughness of the cardboard. Those qualities hold the image between a convincing space and a visibly made object. A new display format can change; that balance should remain.”",
+  "artworkDocumentation.examples.interview.q7.starter":
+    "What needs to remain is [essential properties]. [What can adapt without changing your account of the work].",
+  "artworkDocumentation.examples.interview.q8.answer":
+    "“I made this with ordinary materials and no certainty about how the question should end. I would like someone finding it later to know that the unresolved opening is deliberate. It does not hide a lost answer.”",
+  "artworkDocumentation.examples.interview.q8.starter":
+    "Years from now, I would want someone to know [context, uncertainty or intention that might otherwise disappear].",
+  "artworkDocumentation.examples.interview.recording_asset_id.answer":
+    "I have answered in writing here and have not supplied a separate recording or transcript.",
+  "artworkDocumentation.examples.interview.transcript_asset_id.answer":
+    "I have answered in writing here and have not supplied a separate recording or transcript.",
+  "artworkDocumentation.examples.interview.recording_permission.answer":
+    "I supplied written answers only. I have not supplied a recording or separate transcript.",
+  "artworkDocumentation.examples.interview.transcript_permission.answer":
+    "I supplied written answers only. I have not supplied a recording or separate transcript.",
+  "artworkDocumentation.examples.interview.correction_note.answer":
+    "“I clarified that the final image combines two photographs of the same set, so the word ‘composite’ is not mistaken for borrowed imagery.”",
+  "artworkDocumentation.examples.interview.correction_note.starter":
+    "On [actual date, if useful], I corrected or clarified [point]. [What changed and why].",
+  "artworkDocumentation.examples.module.identity":
+    "Show how you want to be credited and introduce your practice in your own words.",
+  "artworkDocumentation.examples.module.artwork":
+    "Identify the exact work and the final image you intend for publication.",
+  "artworkDocumentation.examples.module.files":
+    "Supply the finished artwork and any supporting files you intend to publish. Keep private originals and evidence out of this form.",
+  "artworkDocumentation.examples.module.context":
+    "Give viewers a way into the image, then share the fuller account if you wish.",
+  "artworkDocumentation.examples.module.process":
+    "Describe how you made the work and the decisions that materially changed it. Say what is unknown rather than reconstructing an answer.",
+  "artworkDocumentation.examples.module.rights":
+    "Describe your intended artwork release in a public-safe summary. If anything needs clarification, use Questions for the team before finalizing.",
+  "artworkDocumentation.examples.module.preservation":
+    "Tell future people what matters when they display or preserve the work. These are your wishes, not extra copyright restrictions.",
+  "artworkDocumentation.examples.module.interview":
+    "Leave a little more of your voice with the work. Write only what you want included in the public record; a few direct sentences are enough.",
+} as const;

--- a/i18n/messages/artwork-documentation-examples.ts
+++ b/i18n/messages/artwork-documentation-examples.ts
@@ -56,7 +56,9 @@ export const ARTWORK_DOCUMENTATION_EXAMPLE_MESSAGES = {
   "artworkDocumentation.examples.context.making_context.starter":
     "Before making the image, [circumstances]. During the work, [what happened]. Afterward, [relevant changes or what survives].",
   "artworkDocumentation.examples.context.theme_connection.answer":
-    "“The gate offers an opening but no view of what comes after it. For Keys and Gates, I was interested in access as a promise: a boundary can appear simple while leaving the terms of entry uncertain.” Or select “My caption covers this” when it genuinely does.",
+    "The gate offers an opening but no view of what comes after it. For Keys and Gates, I was interested in access as a promise: a boundary can appear simple while leaving the terms of entry uncertain.",
+  "artworkDocumentation.examples.context.theme_connection.why":
+    "Choose My caption covers this when your caption already explains the connection.",
   "artworkDocumentation.examples.context.misunderstandings.answer":
     "“This is a constructed tabletop scene, not a photograph of a real checkpoint. The opening is made from two exposures of the same set. I am not documenting a particular border or a person's experience of crossing it.”",
   "artworkDocumentation.examples.context.misunderstandings.starter":

--- a/i18n/messages/artwork-documentation-guidance.ts
+++ b/i18n/messages/artwork-documentation-guidance.ts
@@ -1,4 +1,6 @@
 export const ARTWORK_DOCUMENTATION_GUIDANCE_MESSAGES = {
+  "artworkDocumentation.publicationAssetUnavailable":
+    "This file cannot be included in this publication record. Add material intended for publication, or use Questions for the team to resolve this before finalizing.",
   "artworkDocumentation.publication.reviewAll": "Return to the artwork review",
   "artworkDocumentation.publication.previewNotice":
     "This previews the artwork information intended for publication. It is still a draft; nothing is published or minted here. Drafting questions and team discussion are not part of the artwork record.",
@@ -49,7 +51,7 @@ export const ARTWORK_DOCUMENTATION_GUIDANCE_MESSAGES = {
     "Close the example and write my answers",
   "artworkDocumentation.examples.adapt": "Adapt this writing structure",
   "artworkDocumentation.examples.unsaved":
-    "Replace the bracketed prompts with your own words, or write freely. This working text is not saved. Use only information you want included with the artwork, then choose Use my answer to add it to your draft.",
+    "Replace each [[prompt]] with your own words, or write freely. This working text is not saved. Use only information you want included with the artwork, then choose Use my answer to add it to your draft.",
   "artworkDocumentation.examples.yourAnswer": "Your answer for {field}",
   "artworkDocumentation.examples.language":
     "Language of your answer (for example, en or es)",

--- a/i18n/messages/artwork-documentation-guidance.ts
+++ b/i18n/messages/artwork-documentation-guidance.ts
@@ -1,6 +1,8 @@
 export const ARTWORK_DOCUMENTATION_GUIDANCE_MESSAGES = {
   "artworkDocumentation.publicationAssetUnavailable":
     "This file cannot be included in this publication record. Add material intended for publication, or use Questions for the team to resolve this before finalizing.",
+  "artworkDocumentation.uploadBlockedRecovery":
+    "This upload is still pending. Resolve the file requirements or interview permissions before retrying, or choose Cancel upload to release it.",
   "artworkDocumentation.publication.reviewAll": "Return to the artwork review",
   "artworkDocumentation.publication.previewNotice":
     "This previews the artwork information intended for publication. It is still a draft; nothing is published or minted here. Drafting questions and team discussion are not part of the artwork record.",

--- a/i18n/messages/artwork-documentation-guidance.ts
+++ b/i18n/messages/artwork-documentation-guidance.ts
@@ -3,7 +3,7 @@ export const ARTWORK_DOCUMENTATION_GUIDANCE_MESSAGES = {
   "artworkDocumentation.publication.previewNotice":
     "This previews the artwork information intended for publication. It is still a draft; nothing is published or minted here. Drafting questions and team discussion are not part of the artwork record.",
   "artworkDocumentation.publication.interviewHelp":
-    "A short written reflection or a recorded conversation can preserve details a caption leaves out. This section is optional. Include only words and recordings you want published with the artwork, with permission from the participants.",
+    "A short written reflection or a recorded conversation can preserve details a caption leaves out. The artist interview is optional. Include only words and recordings you want published with the artwork, with permission from the participants.",
   "artworkDocumentation.publication.newContextHelp":
     "The same work can have a separate record for another program. Your existing answers, files, discussions and access grants are not copied automatically.",
   "artworkDocumentation.examples.yourRecord": "Your artwork record",

--- a/i18n/messages/artwork-documentation-guidance.ts
+++ b/i18n/messages/artwork-documentation-guidance.ts
@@ -1,0 +1,86 @@
+export const ARTWORK_DOCUMENTATION_GUIDANCE_MESSAGES = {
+  "artworkDocumentation.publication.reviewAll": "Return to the artwork review",
+  "artworkDocumentation.publication.previewNotice":
+    "This previews the artwork information intended for publication. It is still a draft; nothing is published or minted here. Drafting questions and team discussion are not part of the artwork record.",
+  "artworkDocumentation.publication.interviewHelp":
+    "A short written reflection or a recorded conversation can preserve details a caption leaves out. This section is optional. Include only words and recordings you want published with the artwork, with permission from the participants.",
+  "artworkDocumentation.publication.newContextHelp":
+    "The same work can have a separate record for another program. Your existing answers, files, discussions and access grants are not copied automatically.",
+  "artworkDocumentation.examples.yourRecord": "Your artwork record",
+  "artworkDocumentation.publication.fileAccess":
+    "Choose whether this editor can download original artwork files while you prepare the record. Editors cannot confirm a version for you.",
+  "artworkDocumentation.publication.originalAccess":
+    "Original artwork and public supporting files",
+  "artworkDocumentation.publicationUpload":
+    "Add the final artwork or public supporting material",
+  "artworkDocumentation.publicationUploadHelp":
+    "Upload the exact file you intend to publish. Keep its original dimensions; there is no need to upscale. Only include supporting files intended for publication. Check the file's embedded location and other metadata before uploading; the original file is preserved as supplied.",
+  "artworkDocumentation.publicationUploadStorage":
+    "Files are saved privately while you prepare the record. A later step will publish them; do not include private or sensitive material.",
+  "artworkDocumentation.publicationMasterRole":
+    "Preservation master for publication",
+  "artworkDocumentation.publicationProcessRole": "Public process material",
+  "artworkDocumentation.publicationInterviewPermission":
+    "Before uploading this interview material, record the participants and their permission for publication in the interview section.",
+  "artworkDocumentation.publicationNoFiles": "No artwork files added yet.",
+  "artworkDocumentation.publication.confirmCopy":
+    "I have reviewed this version. All artwork answers and selected files in this record are intended for publication with the work, including any uncertainty I have recorded. I have checked the credits and publication permissions. Questions for the team are drafting discussion and are not part of this artwork record. Confirmation does not publish or mint the work.",
+  "artworkDocumentation.publication.locationHelp":
+    "A city, region or general setting is enough. Include only the location information you want published with the artwork.",
+  "artworkDocumentation.publication.masterHelp":
+    "Your preservation file may be the same as the final artwork. Supply only files you intend to publish as part of this record.",
+  "artworkDocumentation.publication.interviewEvidenceHelp":
+    "Before selecting a recording or transcript, add its date, participants and their permission for publication. Ask the team before finalizing if anything is unclear. Only select material intended to become part of the public artwork record.",
+  "artworkDocumentation.publication.whyRights":
+    "A clear account of your rights and the sources you used helps people understand how the artwork can be shared. Resolve uncertainties with the team before finalizing, then include the relevant information in the public record.",
+  "artworkDocumentation.examples.title":
+    "See a complete example for this section",
+  "artworkDocumentation.examples.empty":
+    "A good place to start: read an example, then tell your own story.",
+  "artworkDocumentation.examples.fiction":
+    "Fictional example · The Space Between · Ari Example",
+  "artworkDocumentation.examples.notice":
+    "This invented tabletop photograph shows the level of detail that helps future viewers understand a work. These are examples to review, never facts about your artwork. Opening an example does not change your answers.",
+  "artworkDocumentation.examples.scope":
+    "The example follows the questions available in this record. Your form may show additional questions when they apply to your answers.",
+  "artworkDocumentation.examples.field": "Read a worked example",
+  "artworkDocumentation.examples.why": "Why this works",
+  "artworkDocumentation.examples.close":
+    "Close the example and write my answers",
+  "artworkDocumentation.examples.adapt": "Adapt this writing structure",
+  "artworkDocumentation.examples.unsaved":
+    "Replace the bracketed prompts with your own words, or write freely. This working text is not saved. Use only information you want included with the artwork, then choose Use my answer to add it to your draft.",
+  "artworkDocumentation.examples.yourAnswer": "Your answer for {field}",
+  "artworkDocumentation.examples.language":
+    "Language of your answer (for example, en or es)",
+  "artworkDocumentation.examples.apply": "Use my answer",
+  "artworkDocumentation.examples.discard": "Discard this working text",
+  "artworkDocumentation.examples.applied":
+    "Your answer is now in the form. Check the save status before leaving.",
+  "artworkDocumentation.examples.answerChanged":
+    "This field now has an answer. Your working text is still here; review the existing answer in the form before making changes.",
+  "artworkDocumentation.publication.intro":
+    "Build the record that will travel with your artwork.",
+  "artworkDocumentation.publication.help":
+    "Everything you enter in the artwork form, including its files, is intended for publication with the work. Write only what you want future viewers to receive. Use Questions for the team at the end for anything you want to discuss separately.",
+  "artworkDocumentation.publication.draft":
+    "Your draft is stored with 6529 while you prepare it. Saving or confirming this form does not mint or publish anything on-chain, to IPFS or to Arweave. Questions for the team stay outside the artwork record.",
+  "artworkDocumentation.publication.legacy":
+    "This earlier record includes separate publication choices and may contain restricted material. Its existing choices are preserved. Ask the team before moving that information into a new artwork record.",
+  "artworkDocumentation.publication.field": "For publication with the artwork",
+  "artworkDocumentation.publication.pinBlocked":
+    "This saved artist information includes material that cannot be copied into this publication record. Enter the public artist details you want to use, or ask the team below. Nothing has been copied.",
+  "artworkDocumentation.publication.sourceHelp":
+    "Review the proposed answers before adding them. Select only the words you want published with this artwork; a submission does not automatically become part of its record.",
+  "artworkDocumentation.questions.title": "Questions for the team",
+  "artworkDocumentation.questions.help":
+    "Use this separate conversation for uncertainties or things you want to discuss with the team. Questions and replies are not part of the artwork record, its confirmed versions or the material prepared for future publication. The artist and authorized team reviewers can read them.",
+  "artworkDocumentation.questions.label": "What would you like to ask?",
+  "artworkDocumentation.questions.hint":
+    "For example: I am unsure which final file to supply. Could you help me choose before I finish the record?",
+  "artworkDocumentation.questions.send": "Send question to the team",
+  "artworkDocumentation.questions.empty":
+    "No questions yet. You can return here whenever you need help.",
+  "artworkDocumentation.questions.notSaved":
+    "Questions are sent separately when you choose Send question to the team; they do not use the artwork form's autosave.",
+} as const;

--- a/i18n/messages/artwork-documentation.ts
+++ b/i18n/messages/artwork-documentation.ts
@@ -1,4 +1,9 @@
+import { ARTWORK_DOCUMENTATION_GUIDANCE_MESSAGES } from "./artwork-documentation-guidance";
+import { ARTWORK_DOCUMENTATION_EXAMPLE_MESSAGES } from "./artwork-documentation-examples";
+
 export const ARTWORK_DOCUMENTATION_MESSAGES = {
+  ...ARTWORK_DOCUMENTATION_GUIDANCE_MESSAGES,
+  ...ARTWORK_DOCUMENTATION_EXAMPLE_MESSAGES,
   "artworkDocumentation.interviewEvidenceHelp":
     "Before selecting a recording or transcript, add the interview date, at least one participant and permission for that material. Choose permission for a future public record only when the participants have agreed to that use; otherwise keep the material restricted for private review.",
   "artworkDocumentation.all": "All",

--- a/lib/artwork-documentation/asset-roles.ts
+++ b/lib/artwork-documentation/asset-roles.ts
@@ -1,3 +1,7 @@
+import type { ApiArtworkDocumentationContext } from "@/generated/models/ApiArtworkDocumentationContext";
+import { ApiArtworkDocumentationAnswerStatusEnum } from "@/generated/models/ApiArtworkDocumentationAnswer";
+import { isPublicationOnly } from "./intake";
+
 export const DOCUMENTATION_ASSET_ROLES = [
   "artwork_final",
   "preservation_master",
@@ -11,3 +15,33 @@ export const DOCUMENTATION_ASSET_ROLES = [
   "interview_transcript",
   "other_supporting",
 ] as const;
+
+export const PUBLICATION_DOCUMENTATION_ASSET_ROLES = [
+  "artwork_final",
+  "preservation_master",
+  "process_evidence",
+  "display_derivative",
+  "interview_recording",
+  "interview_transcript",
+  "other_supporting",
+] as const;
+const INTERVIEW_PERMISSION_FIELDS: Readonly<Record<string, string>> = {
+  interview_recording: "recording_permission",
+  interview_transcript: "transcript_permission",
+};
+
+export function canPublishDocumentationAsset(
+  context: ApiArtworkDocumentationContext,
+  role: string
+): boolean {
+  if (!isPublicationOnly(context.profile)) return true;
+  if (!PUBLICATION_DOCUMENTATION_ASSET_ROLES.some((item) => item === role))
+    return false;
+  const permissionField = INTERVIEW_PERMISSION_FIELDS[role];
+  if (!permissionField) return true;
+  const answer = context.modules["interview"]?.answers[permissionField];
+  return (
+    answer?.status === ApiArtworkDocumentationAnswerStatusEnum.Provided &&
+    answer.value === "intended_public_record"
+  );
+}

--- a/lib/artwork-documentation/confirmation.ts
+++ b/lib/artwork-documentation/confirmation.ts
@@ -3,6 +3,16 @@ import { ARTWORK_DOCUMENTATION_MESSAGES } from "@/i18n/messages/artwork-document
 export function confirmationCopyMatches(
   profile: ApiArtworkDocumentationProfile
 ): boolean {
+  if (
+    profile.confirmation_copy_version ===
+    "artwork-documentation-confirmation-v2"
+  )
+    return (
+      profile.confirmation_copy ===
+      ARTWORK_DOCUMENTATION_MESSAGES[
+        "artworkDocumentation.publication.confirmCopy"
+      ]
+    );
   return (
     profile.confirmation_copy_version ===
       "artwork-documentation-confirmation-v1" &&

--- a/lib/artwork-documentation/examples.ts
+++ b/lib/artwork-documentation/examples.ts
@@ -1,0 +1,53 @@
+import type { ApiArtworkDocumentationProfile } from "@/generated/models/ApiArtworkDocumentationProfile";
+import { ARTWORK_DOCUMENTATION_EXAMPLE_MESSAGES } from "@/i18n/messages/artwork-documentation-examples";
+import {
+  fieldSection,
+  MODULE_FIELDS,
+  MODULE_IDS,
+  type DocumentationSection,
+  type ModuleId,
+} from "./registry";
+
+export function documentationExampleKey(
+  profile: ApiArtworkDocumentationProfile,
+  moduleId: ModuleId,
+  fieldId: string,
+  part: "answer" | "why" | "starter"
+): string | undefined {
+  if (
+    moduleId === "interview" &&
+    /^q[1-8]$/.test(fieldId) &&
+    (profile.interview_instrument.id !==
+      "artwork-documentation-artist-interview-v1" ||
+      profile.interview_instrument.version !== 1)
+  )
+    return undefined;
+  const key = `examples.${moduleId}.${fieldId}.${part}`;
+  return Object.hasOwn(
+    ARTWORK_DOCUMENTATION_EXAMPLE_MESSAGES,
+    `artworkDocumentation.${key}`
+  )
+    ? key
+    : undefined;
+}
+
+export function documentationExampleFields(
+  profile: ApiArtworkDocumentationProfile,
+  section: DocumentationSection
+) {
+  return MODULE_IDS.flatMap((moduleId) => {
+    const policy = profile.modules.find(
+      (module) => String(module.id) === moduleId
+    );
+    if (policy?.version !== 1) return [];
+    return MODULE_FIELDS[moduleId]
+      .filter(
+        (field) =>
+          fieldSection(moduleId, field.id) === section &&
+          policy.fields.some((definition) => definition.id === field.id) &&
+          documentationExampleKey(profile, moduleId, field.id, "answer") !==
+            undefined
+      )
+      .map((field) => ({ moduleId, field }));
+  });
+}

--- a/lib/artwork-documentation/intake.ts
+++ b/lib/artwork-documentation/intake.ts
@@ -1,0 +1,68 @@
+import type { ApiArtworkDocumentationProfile } from "@/generated/models/ApiArtworkDocumentationProfile";
+import { ApiArtworkDocumentationProfileIntakeModeEnum } from "@/generated/models/ApiArtworkDocumentationProfile";
+import type { ApiArtworkDocumentationAnswer } from "@/generated/models/ApiArtworkDocumentationAnswer";
+import type { ApiArtworkDocumentationValueSchema } from "@/generated/models/ApiArtworkDocumentationValueSchema";
+import type { ValueEditor } from "./registry";
+import { ApiArtworkDocumentationAnswerIntendedVisibilityEnum } from "@/generated/models/ApiArtworkDocumentationAnswer";
+import { validDocumentationAnswer } from "./validation";
+
+export function isPublicationOnly(
+  profile: ApiArtworkDocumentationProfile
+): boolean {
+  return (
+    profile.intake_mode ===
+    ApiArtworkDocumentationProfileIntakeModeEnum.PublicationOnly
+  );
+}
+
+export function latestDocumentationProfiles(
+  profiles: readonly ApiArtworkDocumentationProfile[]
+): ApiArtworkDocumentationProfile[] {
+  const latest = new Map<string, ApiArtworkDocumentationProfile>();
+  for (const profile of profiles) {
+    const key = JSON.stringify([
+      profile.profile_id,
+      profile.program_id,
+      profile.wave_id,
+    ]);
+    const previous = latest.get(key);
+    if (!previous || previous.version < profile.version)
+      latest.set(key, profile);
+  }
+  return [...latest.values()];
+}
+
+export function canImportDocumentationAnswer(
+  profile: ApiArtworkDocumentationProfile,
+  path: string,
+  answer: ApiArtworkDocumentationAnswer
+): boolean {
+  if (!isPublicationOnly(profile)) return true;
+  const [moduleId, fieldId] = path.split(".");
+  return (
+    moduleId !== undefined &&
+    fieldId !== undefined &&
+    validDocumentationAnswer(profile, moduleId, fieldId, answer) &&
+    answer.intended_visibility ===
+      ApiArtworkDocumentationAnswerIntendedVisibilityEnum.PublicRecord &&
+    profile.modules.some(
+      (module) =>
+        String(module.id) === moduleId &&
+        module.fields.some(
+          (field) => field.id === fieldId && !field.locked_restricted
+        )
+    )
+  );
+}
+
+export function documentationChoiceEditor(
+  editor: ValueEditor,
+  schema: ApiArtworkDocumentationValueSchema
+): ValueEditor {
+  if (editor.kind !== "choice") return editor;
+  const options: unknown = Reflect.get(schema, "enum") ?? schema._enum;
+  return Array.isArray(options) &&
+    options.every((option: unknown) => typeof option === "string")
+    ? { ...editor, options }
+    : editor;
+}

--- a/lib/artwork-documentation/validation.ts
+++ b/lib/artwork-documentation/validation.ts
@@ -5,6 +5,8 @@ import {
   type ApiArtworkDocumentationOperation,
 } from "@/generated/models/ApiArtworkDocumentationOperation";
 import { ApiArtworkDocumentationAnswerStatusEnum } from "@/generated/models/ApiArtworkDocumentationAnswer";
+import type { ApiArtworkDocumentationAnswer } from "@/generated/models/ApiArtworkDocumentationAnswer";
+import type { ApiArtworkDocumentationProfile } from "@/generated/models/ApiArtworkDocumentationProfile";
 
 /** Client guidance uses the server's registered schema; server validation remains authoritative. */
 function matchesDocumentationSchema(
@@ -109,11 +111,32 @@ export function validDocumentationOperation(
     )
       return false;
   }
-  const definition = context.profile.modules
+  return (
+    !!operation.answer &&
+    validDocumentationAnswer(
+      context.profile,
+      moduleId,
+      operation.field,
+      operation.answer
+    )
+  );
+}
+
+export function validDocumentationAnswer(
+  profile: ApiArtworkDocumentationProfile,
+  moduleId: string,
+  fieldId: string,
+  answer: ApiArtworkDocumentationAnswer
+): boolean {
+  const definition = profile.modules
     .find((module) => String(module.id) === moduleId)
-    ?.fields.find((field) => field.id === operation.field);
-  const answer = operation.answer;
-  if (!definition || !answer) return false;
+    ?.fields.find((field) => field.id === fieldId);
+  if (
+    !definition?.allowed_statuses.some(
+      (status) => String(status) === String(answer.status)
+    )
+  )
+    return false;
   if (answer.status !== ApiArtworkDocumentationAnswerStatusEnum.Provided)
     return !answer.explanation || Array.from(answer.explanation).length <= 1000;
   return matchesDocumentationSchema(answer.value, definition.value_schema);

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15814,6 +15814,9 @@ components:
           type: boolean
         read_contact:
           type: boolean
+        read_restricted_fields:
+          type: boolean
+          description: Read restricted answers beyond individually permissioned contact and locked rights evidence. Defaults to false when absent; does not grant originals, source receipts, editing or artist confirmation.
         confirm_as_artist:
           type: boolean
         manage_assignments:
@@ -16423,6 +16426,11 @@ components:
     ApiArtworkDocumentationProfile:
       type: object
       properties:
+        intake_mode:
+          type: string
+          enum:
+            - publication_only
+          description: All artwork answers and selected files are intended for public publication. Absent on legacy private-intake profiles. Team questions are separate drafting discussion and never part of the confirmed artwork record.
         profile_id:
           type: string
         version:

--- a/ops/docs/artwork-documentation.md
+++ b/ops/docs/artwork-documentation.md
@@ -62,9 +62,9 @@ follow the questions available in your record. They are separate from your
 artwork: reading one never adds an answer, chooses a file or confirms a fact.
 
 For selected empty narrative fields, **Adapt this writing structure** opens
-working text with prompts to replace. Write in your own voice and enter the
+working text with `[[prompts]]` to replace. Write in your own voice and enter the
 language for a language-specific answer. **Use my answer** adds your reviewed
-text to the form, where ordinary autosave applies. Remaining bracketed prompts,
+text to the form, where ordinary autosave applies. Remaining double-bracket prompts,
 invalid answers and attempts to replace an existing answer are blocked. This
 working text is kept only in the current section until applied or discarded.
 Dates, identity, equipment, rights, permissions and file choices remain your
@@ -115,6 +115,7 @@ they do not use the artwork form's autosave. If sending fails, the unsent text
 stays in the current window so you can retry.
 
 The artist and authorized reviewers can discuss and resolve each question.
+Resolved questions remain available as drafting history and can be reopened.
 This conversation is a drafting tool: questions and replies stay outside the
 artwork answers, confirmed artwork versions and future publication record.
 Resolve the discussion, then put any relevant final answer into the artwork

--- a/ops/docs/artwork-documentation.md
+++ b/ops/docs/artwork-documentation.md
@@ -2,9 +2,12 @@
 
 Your work has a history. Keep it with the work.
 
-Artwork documentation brings the artist's account, credits, original files,
-rights information and display guidance together in a private workspace. It
-starts before a token exists and can grow as the artist adds information.
+Artwork documentation brings the artist's account, credits, final files,
+rights information and display guidance together in a draft workspace. The
+artwork form prepares one record intended for publication with the work.
+It starts before a token exists and can grow as the artist adds information.
+Use **Questions for the team** at the end for drafting discussion, then resolve
+uncertainties before finalizing the public account.
 
 ## Open your workspace
 
@@ -31,7 +34,8 @@ and contributors, rights and people, preservation and display, and review.
 - Choose your public artist name and preferred credit. Credit collaborators
   and describe their roles. A legal name is not required for your artist name.
 - Record the intended rights, third-party material and any depicted people.
-  Keep consent documents and sensitive details in restricted evidence.
+  Include the information you want published with the artwork. Do not upload
+  consent documents, private working files or sensitive evidence here.
 - Explain the properties that matter: crop, orientation, color, tonal balance,
   detail, scale and changes you would or would not consider acceptable.
 - Add the optional artist interview when useful. Written answers and
@@ -40,15 +44,38 @@ and contributors, rights and people, preservation and display, and review.
 Each section explains why the information matters. Required questions depend
 on the documentation profile and the answers already supplied. Recommended
 questions can add useful context without blocking review. Where a question
-allows it, record uncertainty or withhold a sensitive location instead of
-guessing.
+allows it, record uncertainty instead of guessing. A general location is
+enough; include only the location information you want published.
+
+## Start with a worked example
+
+Each section offers **See a complete example for this section**. An empty
+section opens the example so you can review a good answer before writing.
+You can close it to reach your form and reopen it after adding your answers.
+The fictional photograph *The Space Between*, by fictional artist Ari Example,
+provides a consistent account across all eight modules and the final review.
+It includes a complete caption and statement, construction and editing history,
+public credits, rights intentions and practical display guidance.
+
+**Read a worked example** beside a question shows the relevant answer. Examples
+follow the questions available in your record. They are separate from your
+artwork: reading one never adds an answer, chooses a file or confirms a fact.
+
+For selected empty narrative fields, **Adapt this writing structure** opens
+working text with prompts to replace. Write in your own voice and enter the
+language for a language-specific answer. **Use my answer** adds your reviewed
+text to the form, where ordinary autosave applies. Remaining bracketed prompts,
+invalid answers and attempts to replace an existing answer are blocked. This
+working text is kept only in the current section until applied or discarded.
+Dates, identity, equipment, rights, permissions and file choices remain your
+own deliberate answers; fictional facts are never inserted for you.
 
 The Keys and Gates profile applies the commission's photography requirements
 and asks how the work connects to its theme. Selection for the program does
 not by itself mean that a work has been minted, purchased or accessioned by
 the Museum.
 
-## Saving and private files
+## Saving and artwork files
 
 Changes save to 6529's database. Check the save status before leaving. If
 saving fails or your session expires, keep the window open while you retry
@@ -68,11 +95,31 @@ context, 100 files per context and five simultaneous upload sessions. A paused
 multipart upload can require selecting the same file again so the client can
 verify its contents before resuming.
 
-All documentation stays private during this phase. **Intended for a future
-public record** records your publication intention; it does not publish the
-answer or file. Private contact information and sensitive rights evidence
-remain restricted. Original file access can reveal embedded metadata, which
-is why it requires explicit permission.
+The draft is stored with 6529 while you prepare it. Every answer and selected
+file in a new publication form is intended to become part of the public artwork
+record; there are no per-answer privacy choices. Review files for embedded
+information before adding them. A later step handles publication and minting.
+
+Earlier records keep their original publication choices and any restricted
+material. They are clearly labelled as earlier records and are not silently
+converted. Saved artist information or submission proposals containing
+incompatible material cannot be copied into a publication record. Ask the
+team before carrying information forward.
+
+## Questions before finalizing
+
+At the end of **Review and approve**, use **Questions for the team** for things
+you need to clarify. For example, ask which final file to use or how to explain
+a source. Questions are sent when you choose **Send question to the team**;
+they do not use the artwork form's autosave. If sending fails, the unsent text
+stays in the current window so you can retry.
+
+The artist and authorized reviewers can discuss and resolve each question.
+This conversation is a drafting tool: questions and replies stay outside the
+artwork answers, confirmed artwork versions and future publication record.
+Resolve the discussion, then put any relevant final answer into the artwork
+form in the wording you want published. Do not use questions to deposit private
+files or create an appendix to the work.
 
 ## Confirm and review
 

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -7,7 +7,7 @@
     {
       "id": "artwork-documentation.overview",
       "kind": "workflow",
-      "title": "Private artwork documentation",
+      "title": "Artwork documentation and publication preparation",
       "aliases": [
         "my artwork documentation",
         "artist dossier",
@@ -27,13 +27,15 @@
       ],
       "facts": [
         "When the server enables artwork documentation for a profile, My artwork documentation appears in the account menu and opens /artwork-documentation. Eligible owned artwork menus also offer Artwork documentation on desktop and mobile.",
-        "The private workspace collects artwork identity, story and process, artist credits and contributors, files, rights and people, preservation and display guidance, and an optional artist interview. Each section explains why the information matters.",
+        "New publication forms collect one artwork record: identity, story and process, public credits, final files, rights intentions, preservation and an optional interview. All answers and selected files are intended for publication with the work.",
         "Documentation can begin independently or in a supported submission form and can continue afterward. It is optional during submission. A successful artwork post is not retried when its documentation source link needs recovery.",
         "Drafts save to the database. Unsaved text is not persisted in browser local storage. Keep the window open when saving fails or authentication expires, and resolve a version conflict before continuing.",
-        "All documentation remains private in this phase. Intended for a future public record means future publication intent, not current publication. Private contacts and sensitive rights evidence remain restricted, and original archival files require explicit access.",
+        "Drafts remain stored with 6529 during preparation. New publication forms have no per-field privacy choices or private evidence uploads. Earlier records preserve their original publication choices; restricted material is never silently converted.",
         "File transfer, checksum verification, inspection and malware screening have separate statuses. Upload limits are 4 GiB per file, 20 GiB of stored and reserved files per context, 100 files and five simultaneous upload sessions per context.",
         "Only the artist can confirm a documentation revision through a direct authenticated session. Confirmation preserves a dated immutable version in the database; it is not a wallet signature, mint instruction, or automatic effect of a proposed license. Curatorial, technical and rights reviews are separate.",
         "New edits preserve earlier confirmed versions. Shared artist information is versioned and pinned per work. Keys and Gates uses a photography documentation profile; selection does not establish minting, purchase or Museum accession.",
+        "Every section offers a complete fictional worked example for The Space Between by Ari Example. Empty sections open the example; existing records can reopen it. Examples never automatically save artist facts. Selected empty narrative fields offer an unsaved writing structure; explicit Use my answer adds only the artist-reviewed answer to ordinary autosave.",
+        "Questions for the team at the end of review are a separate drafting conversation. Questions and replies are excluded from artwork answers, confirmed versions and future publication. Resolve questions before finalizing and add relevant public answers to the artwork form.",
         "Mint preparation and on-chain, IPFS or Arweave publication are deferred. The documentation form does not perform them."
       ],
       "canonical_path": "/artwork-documentation",

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -35,7 +35,7 @@
         "Only the artist can confirm a documentation revision through a direct authenticated session. Confirmation preserves a dated immutable version in the database; it is not a wallet signature, mint instruction, or automatic effect of a proposed license. Curatorial, technical and rights reviews are separate.",
         "New edits preserve earlier confirmed versions. Shared artist information is versioned and pinned per work. Keys and Gates uses a photography documentation profile; selection does not establish minting, purchase or Museum accession.",
         "Every section offers a complete fictional worked example for The Space Between by Ari Example. Empty sections open the example; existing records can reopen it. Examples never automatically save artist facts. Selected empty narrative fields offer an unsaved writing structure; explicit Use my answer adds only the artist-reviewed answer to ordinary autosave.",
-        "Questions for the team at the end of review are a separate drafting conversation. Questions and replies are excluded from artwork answers, confirmed versions and future publication. Resolve questions before finalizing and add relevant public answers to the artwork form.",
+        "Questions for the team at the end of review are a separate drafting conversation. Questions and replies are excluded from artwork answers, confirmed versions and future publication. Resolved questions remain available as drafting history and can be reopened. Resolve questions before finalizing and add relevant public answers to the artwork form.",
         "Mint preparation and on-chain, IPFS or Arweave publication are deferred. The documentation form does not perform them."
       ],
       "canonical_path": "/artwork-documentation",

--- a/ops/workstreams/artwork-documentation-v1/05-artist-guidance-and-copy.md
+++ b/ops/workstreams/artwork-documentation-v1/05-artist-guidance-and-copy.md
@@ -17,7 +17,7 @@ sections open the example; completed sections keep it available. Examples
 follow supported profile fields and the pinned interview instrument. They
 never become artist data merely by opening or reviewing them.
 
-Selected empty narrative fields offer a bracketed writing structure in a
+Selected empty narrative fields offer a `[[prompt]]` writing structure in a
 local, unsaved editor. The artist replaces the prompts and explicitly applies
 their own schema-valid answer through ordinary draft saving. Facts, identities,
 rights, permissions, dates and asset references have no one-click insertion.

--- a/ops/workstreams/artwork-documentation-v1/05-artist-guidance-and-copy.md
+++ b/ops/workstreams/artwork-documentation-v1/05-artist-guidance-and-copy.md
@@ -2,6 +2,36 @@
 
 Parent: [index](README.md). This is ready-to-implement English source copy, version `artwork-documentation-copy-v1`. Implement with translation keys and adapt layout without changing the claims. This package does not send an invitation or publish marketing.
 
+## Publication-only intake and worked examples
+
+Version 2 of each documentation profile prepares one artwork record intended
+for publication with the work. Its artwork answers and selected files have no
+per-field privacy choice. Legacy version 1 retains its existing choices; no
+restricted material is silently republished or copied into a new record.
+Draft storage is temporary preparation, not publication or minting.
+
+Every visible section offers a coherent, clearly fictional worked example:
+*The Space Between*, by Ari Example, is a composite of two photographs of a
+handmade cardboard gate. Its complete answers cover all eight modules. Empty
+sections open the example; completed sections keep it available. Examples
+follow supported profile fields and the pinned interview instrument. They
+never become artist data merely by opening or reviewing them.
+
+Selected empty narrative fields offer a bracketed writing structure in a
+local, unsaved editor. The artist replaces the prompts and explicitly applies
+their own schema-valid answer through ordinary draft saving. Facts, identities,
+rights, permissions, dates and asset references have no one-click insertion.
+Applying a structure cannot overwrite an answer already present in the form.
+
+**Questions for the team** is a separate drafting conversation at the end of
+review. It uses context-wide comments outside artwork modules, snapshots and
+publication previews. Resolve uncertainties before finalizing and move only
+the relevant public answer into the artwork form. It is not an evidence
+deposit or a private appendix to the eventual decentralized record.
+
+The earlier private-evidence and visibility copy below applies only to legacy
+version 1. Publication-only helpers supersede those invitations for version 2.
+
 ## 1. The story we are telling
 
 Lead with the artist's work and voice. A title and an image can travel widely while the circumstances, choices and history behind them disappear. This feature helps artists keep those things together. Photography particularly benefits from distinguishing the finished image from source files, remembering how an image was constructed and recording the conditions under which it should be seen.

--- a/ops/workstreams/i18n-fallbacks/artwork-documentation.md
+++ b/ops/workstreams/i18n-fallbacks/artwork-documentation.md
@@ -4,7 +4,9 @@ The private `/artwork-documentation` workspace, list, historical versions and
 inline submission module use English source messages in
 `i18n/messages/artwork-documentation.ts`,
 `i18n/messages/artwork-documentation-fields.ts` and
-`i18n/messages/artwork-documentation-integration.ts`.
+`i18n/messages/artwork-documentation-integration.ts`,
+`i18n/messages/artwork-documentation-guidance.ts` and
+`i18n/messages/artwork-documentation-examples.ts`.
 
 Supported non-source locales currently fall back to this English copy. Date and
 number formatting uses the browser locale through the existing `i18n/format`
@@ -15,3 +17,7 @@ The feature owner should add reviewed translations for en-GB, fr-FR, es-ES and
 de-DE when their editorial review is available. Field and enum labels use the
 same English fallback dictionaries until that review. No runtime translation
 service is called and no private documentation is sent for translation.
+
+The complete fictional worked examples, publication-only intake explanations
+and separate drafting questions currently use the same explicit English
+fallback. These examples are reference copy, not translations or artist data.

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -7,7 +7,7 @@
     {
       "id": "artwork-documentation.overview",
       "kind": "workflow",
-      "title": "Private artwork documentation",
+      "title": "Artwork documentation and publication preparation",
       "aliases": [
         "my artwork documentation",
         "artist dossier",
@@ -27,13 +27,15 @@
       ],
       "facts": [
         "When the server enables artwork documentation for a profile, My artwork documentation appears in the account menu and opens /artwork-documentation. Eligible owned artwork menus also offer Artwork documentation on desktop and mobile.",
-        "The private workspace collects artwork identity, story and process, artist credits and contributors, files, rights and people, preservation and display guidance, and an optional artist interview. Each section explains why the information matters.",
+        "New publication forms collect one artwork record: identity, story and process, public credits, final files, rights intentions, preservation and an optional interview. All answers and selected files are intended for publication with the work.",
         "Documentation can begin independently or in a supported submission form and can continue afterward. It is optional during submission. A successful artwork post is not retried when its documentation source link needs recovery.",
         "Drafts save to the database. Unsaved text is not persisted in browser local storage. Keep the window open when saving fails or authentication expires, and resolve a version conflict before continuing.",
-        "All documentation remains private in this phase. Intended for a future public record means future publication intent, not current publication. Private contacts and sensitive rights evidence remain restricted, and original archival files require explicit access.",
+        "Drafts remain stored with 6529 during preparation. New publication forms have no per-field privacy choices or private evidence uploads. Earlier records preserve their original publication choices; restricted material is never silently converted.",
         "File transfer, checksum verification, inspection and malware screening have separate statuses. Upload limits are 4 GiB per file, 20 GiB of stored and reserved files per context, 100 files and five simultaneous upload sessions per context.",
         "Only the artist can confirm a documentation revision through a direct authenticated session. Confirmation preserves a dated immutable version in the database; it is not a wallet signature, mint instruction, or automatic effect of a proposed license. Curatorial, technical and rights reviews are separate.",
         "New edits preserve earlier confirmed versions. Shared artist information is versioned and pinned per work. Keys and Gates uses a photography documentation profile; selection does not establish minting, purchase or Museum accession.",
+        "Every section offers a complete fictional worked example for The Space Between by Ari Example. Empty sections open the example; existing records can reopen it. Examples never automatically save artist facts. Selected empty narrative fields offer an unsaved writing structure; explicit Use my answer adds only the artist-reviewed answer to ordinary autosave.",
+        "Questions for the team at the end of review are a separate drafting conversation. Questions and replies are excluded from artwork answers, confirmed versions and future publication. Resolve questions before finalizing and add relevant public answers to the artwork form.",
         "Mint preparation and on-chain, IPFS or Arweave publication are deferred. The documentation form does not perform them."
       ],
       "canonical_path": "/artwork-documentation",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -35,7 +35,7 @@
         "Only the artist can confirm a documentation revision through a direct authenticated session. Confirmation preserves a dated immutable version in the database; it is not a wallet signature, mint instruction, or automatic effect of a proposed license. Curatorial, technical and rights reviews are separate.",
         "New edits preserve earlier confirmed versions. Shared artist information is versioned and pinned per work. Keys and Gates uses a photography documentation profile; selection does not establish minting, purchase or Museum accession.",
         "Every section offers a complete fictional worked example for The Space Between by Ari Example. Empty sections open the example; existing records can reopen it. Examples never automatically save artist facts. Selected empty narrative fields offer an unsaved writing structure; explicit Use my answer adds only the artist-reviewed answer to ordinary autosave.",
-        "Questions for the team at the end of review are a separate drafting conversation. Questions and replies are excluded from artwork answers, confirmed versions and future publication. Resolve questions before finalizing and add relevant public answers to the artwork form.",
+        "Questions for the team at the end of review are a separate drafting conversation. Questions and replies are excluded from artwork answers, confirmed versions and future publication. Resolved questions remain available as drafting history and can be reopened. Resolve questions before finalizing and add relevant public answers to the artwork form.",
         "Mint preparation and on-chain, IPFS or Arweave publication are deferred. The documentation form does not perform them."
       ],
       "canonical_path": "/artwork-documentation",


### PR DESCRIPTION
## Issue

Artists need a useful model of a complete artwork record instead of starting from blanks. The new intake must also make clear that every final artwork answer and selected file is intended for publication, with drafting questions kept outside the record.

## Fix

Add a complete fictional photography example for each section and deliberate, editable narrative starters. Support the backend's publication-only version 2 profiles while preserving legacy version 1 records and their access rules.

## Changes

- Worked examples cover all eight modules across six sections, with field examples and 22 narrative starters. Reviewing examples never writes artwork answers; applying a starter requires artist-edited text and explicit action. Reserved [[prompt]] markers must be replaced, while ordinary citations remain valid.
- New publication-only profiles remove per-field visibility choices and private-evidence invitations. Imports and shared-artist pins reject incompatible statuses, values and restricted answers rather than converting them.
- Questions for the team use separate context-wide discussion threads, excluded from artwork answers, confirmation snapshots and future-public-record previews.
- Public upload roles and interview permission guidance follow the profile. Resumed files use their own permissions; rejected new sessions retain cancellation recovery, and incompatible saved files cannot be relabelled for publication. Autosave, conflict and confirmation protections remain in place.
- Sync the additive API models and update artist guidance and the indexed help corpus.

## Validation

- Full changed-file lint, TypeScript, Knip and 11 focused suites (66 tests) pass; the final copy corrections also pass their scoped lint and eight guidance tests.
- Full production build passes, followed by a production rebuild after the final copy corrections and current-main merge.
- The separate Jest typecheck ratchet passes after correcting four test-only typing issues; no baseline was increased. Four affected suites (20 tests) also pass.
- React Doctor: 97/100, advisory warnings only.
- Production-build visual and browser checks use a clearly labelled synthetic localhost fixture with the canonical version 2 profile: all six sections at 1440px and 390px, explicit starter save/reload, keyboard focus, separate question submission, no writes from reading examples, and no horizontal overflow. Final mobile close-ups verify caption, upload and questions readability with canonical required-field counts.
- The API specification matches the backend source byte-for-byte. Real deployed API/browser validation follows the coupled staging rollout; this PR does not claim that synthetic fixtures replace it.

## Risk

- Level: Medium
- Why: Changes artist data entry, profile-dependent publication intent and optional uploads. Legacy records retain their original profile and are never silently converted. Narrative scaffolds cannot assert facts, rights, permissions or artist approval.
- Rollback: Revert the frontend change and leave existing records on their pinned profiles; coordinate any profile upgrades with the backend rollout.

## Review Notes

Focus on legacy-versus-publication-only boundaries, source/pin filtering, deliberate starter application and the separation of team questions from the artwork record. The coupled backend capability and version 2 profile change ([backend #1992](https://github.com/6529-Collections/6529seize-backend/pull/1992)) must deploy first. Real pilot contexts will be upgraded only after the compatible frontend is deployed and verified.
