### PR TITLE
Teach help6529 about 6529 Desktop and Mobile wallets

### DIFF
--- a/__tests__/scripts/sync-help-index.test.ts
+++ b/__tests__/scripts/sync-help-index.test.ts
@@ -1,3 +1,5 @@
+jest.mock("prettier", () => ({ format: jest.fn() }));
+
 const {
   getPublicationEnvironment,
   getPublishedHelpRecords,
@@ -73,6 +75,43 @@ describe("sync-help-index publication policy", () => {
 
     for (const recordId of STREAM_SUMMARY_RECORD_IDS) {
       expect(publishedRecordIds.has(recordId)).toBe(true);
+    }
+  });
+});
+
+describe("Desktop conversational answer metadata", () => {
+  const { validateIndex } = require("../../scripts/sync-help-index.cjs");
+
+  it.each([
+    { brief_answer: "x".repeat(901) },
+    { brief_answer: "" },
+    { answer_links: [{ label: "Download", url: "https://example.com/app" }] },
+    {
+      answer_links: [
+        {
+          label: "Download",
+          url: "https://6529.io/about/6529-apps/nonexistent-desktop-route",
+        },
+      ],
+    },
+    { answer_links: [null] },
+  ])("rejects invalid short answer or public link metadata: %j", (fields) => {
+    const index = JSON.parse(JSON.stringify(helpIndex));
+    Object.assign(
+      index.records.find(
+        (record: { id: string }) => record.id === "desktop.overview"
+      ),
+      fields
+    );
+    const error = jest.spyOn(console, "error").mockImplementation(() => {});
+    const exit = jest.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("validation rejected");
+    });
+    try {
+      expect(() => validateIndex(index)).toThrow("validation rejected");
+    } finally {
+      error.mockRestore();
+      exit.mockRestore();
     }
   });
 });

--- a/ops/docs/README.md
+++ b/ops/docs/README.md
@@ -58,6 +58,8 @@ March 19, 2026.
 
 ## Area Index
 
+- [6529 Desktop (Core)](desktop/README.md): local workers, RPC, TDH recovery, wallets, and IPFS
+
 - [Home](home/README.md): `/`
 - [Waves](waves/README.md): `/discover`, `/waves`, `/waves/{waveId}`,
   `/waves/create`, `/messages`, `/messages/create`

--- a/ops/docs/desktop/README.md
+++ b/ops/docs/desktop/README.md
@@ -1,0 +1,29 @@
+# 6529 Desktop (Core)
+
+Parent: [Documentation](../README.md)
+
+## Overview
+
+Core adds local Ethereum indexing, independent TDH calculation, encrypted Core
+wallets, and a bundled IPFS node to the 6529 desktop application. These guides
+refer to the dedicated **6529 Desktop** menu, not a browser on a desktop computer
+or the 6529 Mobile app.
+
+## Features
+
+- [Workers and TDH](feature-workers-and-tdh.md)
+- [Wallets, IPFS, updates, and logs](feature-wallets-ipfs-and-about.md)
+
+## Flows
+
+- [Get started and enable RPC](flow-getting-started.md)
+
+## Troubleshooting
+
+- [TDH sync and recovery](troubleshooting-sync-and-recovery.md)
+
+## Related Areas
+
+- [Official app downloads](../navigation/feature-6529-apps-page.md)
+- [Page sharing and device connection](../navigation/feature-share-modal.md)
+- [Network and TDH](../network/README.md)

--- a/ops/docs/desktop/feature-wallets-ipfs-and-about.md
+++ b/ops/docs/desktop/feature-wallets-ipfs-and-about.md
@@ -107,4 +107,3 @@ RPC URLs. Use the installed app's confirmation text before a recovery action.
 - [Get started](flow-getting-started.md)
 - [Workers and TDH](feature-workers-and-tdh.md)
 - [Sync and recovery](troubleshooting-sync-and-recovery.md)
-- [Wallets, IPFS, and About](feature-wallets-ipfs-and-about.md)

--- a/ops/docs/desktop/feature-wallets-ipfs-and-about.md
+++ b/ops/docs/desktop/feature-wallets-ipfs-and-about.md
@@ -1,0 +1,110 @@
+# Desktop Wallets, IPFS, and About
+
+Parent: [Desktop index](README.md)
+
+## Overview
+
+Core wallets handle local signing, My IPFS opens the bundled content node, and
+About exposes updates and diagnostics. They are independent tools; no wallet
+secret is required to index transactions or calculate TDH.
+
+## Location in the Site
+
+These controls live inside the installed desktop application under the
+**6529 Desktop** sidebar menu. Core-only routes are not public website links.
+
+## Entry Points
+
+Open the monitor icon in the app sidebar. If a control described here is absent,
+check your installed version under **6529 Desktop > About**; a mobile or browser
+session does not expose Core workers.
+
+## User Journey
+
+### Create, import, and connect a Core wallet
+
+Open 6529 Desktop > Wallets for Core wallets stored on this computer. These are separate from mobile App Wallets and from connecting an external wallet or sharing a website login session.
+
+Create Wallet opens Create New Wallet: choose a name and password and select Create. Core generates a wallet and stores its private key and recovery phrase encrypted with that password in the local database.
+
+Import Wallet offers Mnemonic (the current form accepts 12 words) or Private Key. Enter it only in the trusted local app, Validate, check the resulting address, then Import Wallet with a name and password. Never send a phrase, key, or password to the help bot.
+
+Use the Core wallet connector in the wallet connection flow to select a saved wallet and unlock it when prompted. Review signature/transaction requests before approving; an unlocked wallet and an authenticated 6529 session are distinct states.
+
+Wallet details show the address and password-protected reveal/copy controls plus Download Recovery File. That download contains the decrypted private key and available mnemonic in a plaintext text file; keep it private and securely backed up, never send it to the bot. Private-key-only imports have no mnemonic.
+
+Delete removes the saved local wallet record after confirmation; disconnect first if it is the currently connected wallet. It does not erase the Ethereum address or move on-chain funds. There is no documented bot/password-recovery service; the bot cannot decrypt or recover a forgotten wallet password.
+
+A Core wallet is optional for node indexing and TDH calculation. You can run workers with an active RPC provider without importing any funded wallet, and connecting a wallet does not enable RPC workers.
+
+### Explore My IPFS
+
+6529 Desktop bundles a local IPFS daemon. Open 6529 Desktop > My IPFS to launch its WebUI when the app has resolved the local IPFS configuration; My IPFS is separate from ETH Transactions and the Ethereum RPC Providers list.
+
+The app uses a local IPFS API, gateway, and swarm port. Find the actual IPFS Port, IPFS RPC Port, and IPFS Swarm Port in 6529 Desktop > About; do not assume a fixed port or share a localhost URL as a public link.
+
+The Desktop IPFS file service pins added files and keeps a named entry under /6529-Desktop in the node file system. A CID identifies content; local storage/pinning is not a promise of permanent availability or replication elsewhere.
+
+The bundled node uses configured bootstrap peers with automatic peer discovery/routing features restricted. Do not describe it as an unrestricted network crawler, a backup of every NFT, or proof that TDH consensus has completed.
+
+If My IPFS is missing or the WebUI cannot connect, keep the app open, check About > App Logs for IPFS startup/connection errors and confirm the displayed ports. Restart the app normally if initialization failed; persistent errors need the app version, OS, and redacted log details.
+
+The IPFS API and gateway are bound to loopback. Do not expose the local administrative API publicly, upload wallet secrets, or delete the IPFS repository to fix an unrelated TDH mismatch. IPFS storage and Ethereum transaction indexing are separate concerns.
+
+## Common Scenarios
+
+### Wallet backup and unlocking
+
+Core wallets live in 6529 Desktop > Wallets on this device. The stored private key and, when present, mnemonic are encrypted with the wallet password; a connected website profile is not a backup.
+
+Open the saved wallet details and use Download Recovery File after unlocking, or use the password-protected reveal/copy controls. The recovery download is a plaintext text file containing the private key and available mnemonic, not an encrypted wallet backup. Keep it private and securely backed up; never upload it or paste any wallet password, key, or phrase into the bot. Private-key-only imports have no mnemonic.
+
+If you cannot unlock a wallet, verify that you selected the right saved wallet and are entering its wallet password. The bot cannot inspect the wallet, bypass encryption, reset its password, or recover missing secrets.
+
+If you have an independent recovery phrase or private-key backup, the local Import Wallet flow can restore the corresponding address; validate the address before using it. Do not delete the only local copy while investigating a password problem.
+
+Deleting a wallet or app database is not a TDH repair step. Transaction/NFT worker recovery only needs the relevant indexed-data controls, not your wallet secrets. Keep independently recoverable wallet backups before any app-data removal.
+
+### App version, updates, and diagnostics
+
+Open 6529 Desktop > About for the installed version, OS/architecture, app scheme, app port, IPFS ports, updater status, and App Logs. Opening About checks for updates.
+
+The update area shows checking, available, downloading progress, downloaded, no-update, or error states. Use the action offered for that state; the bot does not know the latest available build unless it has current release evidence.
+
+Use ETH Transactions > the affected worker > Logs for a worker-specific failure. Expand Advanced Options for recovery controls. Logs > Locate opens the log file location; selecting log text enables Copy Selection.
+
+For a TDH issue include both Last Block values, the mismatched field, last calculation time, and the failing worker message. For a missing transfer include a public transaction hash and the expected block; distinguish a local-node mismatch from personal website TDH.
+
+Share only relevant redacted diagnostic lines. Remove RPC API keys/credential URLs, passwords, private keys, and recovery phrases. The bot cannot inspect your filesystem, operate workers, or confirm the node is repaired without observations from you.
+
+The native titlebar identifies a Live/Test backend where applicable. That backend target is distinct from TDH TestNet Mode Phase 1. Core-only menu controls and routes are unavailable on mobile and ordinary web browsers.
+
+## Edge Cases
+
+A private-key-only wallet cannot display a mnemonic it never had. A website
+connection or Mobile connection transfer is not a backup of the locally saved
+Core wallet. My IPFS can be absent when the local configuration is unavailable.
+The IPFS RPC port is unrelated to the Ethereum RPC provider URL.
+
+## Failure and Recovery
+
+For an IPFS startup or updater error, inspect About > App Logs and report the
+version, OS, and relevant redacted error. Avoid deleting local storage as a
+generic remedy. For a forgotten wallet password, preserve the local copy and
+use only independently backed-up recovery material in the local import flow.
+The bot cannot recover the encryption password.
+
+## Limitations / Notes
+
+The help bot explains documented controls. It cannot read or change your local
+node, confirm a repair remotely, decrypt wallets, or promise a sync duration.
+Never provide it passwords, private keys, recovery phrases, or credential-bearing
+RPC URLs. Use the installed app's confirmation text before a recovery action.
+
+## Related Pages
+
+- [Desktop index](README.md)
+- [Get started](flow-getting-started.md)
+- [Workers and TDH](feature-workers-and-tdh.md)
+- [Sync and recovery](troubleshooting-sync-and-recovery.md)
+- [Wallets, IPFS, and About](feature-wallets-ipfs-and-about.md)

--- a/ops/docs/desktop/feature-workers-and-tdh.md
+++ b/ops/docs/desktop/feature-workers-and-tdh.md
@@ -1,0 +1,89 @@
+# Desktop Workers and TDH
+
+Parent: [Desktop index](README.md)
+
+## Overview
+
+Open 6529 Desktop > ETH Transactions > App Workers for Transactions, NFTDelegation, and NFTs. The TDH worker is on 6529 Desktop > TDH Calculation.
+
+Transactions indexes transfers related to the 6529 contracts every minute. NFTDelegation follows delegation and consolidation events every minute. NFTs discovers and refreshes The Memes, Gradients, Meme Lab, and NextGen every two minutes, with periodic full refreshes. These are local indexes, not an index of every Ethereum contract.
+
+With an active RPC provider, non-TDH workers start when the schedulers initialize and then follow their schedules. TDH normally runs daily at 00:15 UTC. Keep the app running and the computer awake for scheduled work; do not promise a fixed initial sync duration.
+
+Worker cards show their schedule, status, progress, and message. Expand Logs for details. Idle or Completed between runs is normal; Disabled calls for checking the active RPC provider. A waiting message can mean a prerequisite checkpoint or another worker must finish.
+
+Advanced Options > Run Now requests an immediate run without changing the schedule. Stop ends the current non-TDH execution, but the next scheduled run can start again; it is not a permanent disable switch.
+
+TDH is coordinated with NFT/delegation work and transaction repairs. Respect a busy or queued response rather than repeatedly clicking recovery actions. Transactions must reach the TDH target block, and NFTDelegation must reach it too.
+
+An interrupted transaction reconciliation resumes from its saved range on restart with an active provider. An interrupted TDH calculation reruns from scratch on restart; it does not continue a partially calculated result.
+
+## Location in the Site
+
+These controls live inside the installed desktop application under the
+**6529 Desktop** sidebar menu. Core-only routes are not public website links.
+
+## Entry Points
+
+Open the monitor icon in the app sidebar. If a control described here is absent,
+check your installed version under **6529 Desktop > About**; a mobile or browser
+session does not expose Core workers.
+
+## User Journey
+
+6529 Desktop > TDH Calculation independently computes TDH from local indexed data. Your Node is compared with the reference 6529.io result. The TDH row is all TDH across the whole system, not your personal profile TDH.
+
+TDH is scheduled daily at 00:15 UTC while the app runs with an active RPC provider. It calculates the daily snapshot using an Ethereum block before the UTC day boundary, not a continuously changing live balance.
+
+Transactions and NFTDelegation must both reach the target block before TDH can proceed. A message such as Waiting for Transactions or Waiting for NFTDelegation reports the target and current checkpoint; allow that worker to catch up and check its Logs if it stalls.
+
+For a manual calculation, open the TDH worker Advanced Options > Recalculate TDH Now and confirm Run TDH Calculation Now. It replaces local TDH calculation data; it does not repair missing transaction history. Finish any underlying history/NFT repair and prerequisite sync first.
+
+Compare Last Block first, then total TDH and Merkle Root. Different snapshot blocks can explain different values. A Merkle Root hashes the address/TDH results; a missing reference root is N/A and is not proof your node is wrong.
+
+The page describes TestNet Mode Phase 1: comparison with the 6529.io reference. Phase 2 node-only consensus is described as future behavior, not something already active. This label is separate from Live/Test backend builds and does not switch Ethereum to a testnet.
+
+Transaction repairs or resets can mark the existing result stale and show Transaction history changed — recalculation required. Recalculate after repair completes or wait for the next scheduled TDH run. Marking stale alone does not immediately start a fresh calculation.
+
+If the app closes during TDH work, an active provider allows a fresh rerun on restart after worker guards permit it. The bot cannot read your local TDH values or fix your node remotely.
+
+## Common Scenarios
+
+| Observation | Meaning and next step |
+| --- | --- |
+| Idle/Completed between runs | Normal scheduled operation; inspect the last completion. |
+| Disabled | Check that an RPC provider is Active. |
+| Waiting for Transactions/NFTDelegation | That checkpoint must reach the displayed target block. |
+| Waiting for another worker | The scheduler is avoiding incompatible concurrent work. |
+| Different Last Block | Compare equivalent snapshots before diagnosing a TDH mismatch. |
+| Reference Merkle Root N/A | Missing reference evidence, not a confirmed local mismatch. |
+| Transaction history changed | Finish the repair and recalculate TDH. |
+
+## Edge Cases
+
+The schedule runs while Core is open; a sleeping/offline computer cannot be
+assumed to perform its daily calculation. Reopening Core resumes pending
+reconciliation and reruns interrupted TDH when enabled, but a normal launch
+does not itself promise a new TDH run. **Stop** is not permanent disablement.
+
+## Failure and Recovery
+
+Resolve input and provider problems first. If a completed calculation differs
+at the same block, follow [Sync and recovery](troubleshooting-sync-and-recovery.md).
+Do not mistake global node TDH for a single profile’s score or claim that a local
+reset changes the website’s reference result.
+
+## Limitations / Notes
+
+The help bot explains documented controls. It cannot read or change your local
+node, confirm a repair remotely, decrypt wallets, or promise a sync duration.
+Never provide it passwords, private keys, recovery phrases, or credential-bearing
+RPC URLs. Use the installed app's confirmation text before a recovery action.
+
+## Related Pages
+
+- [Desktop index](README.md)
+- [Get started](flow-getting-started.md)
+- [Workers and TDH](feature-workers-and-tdh.md)
+- [Sync and recovery](troubleshooting-sync-and-recovery.md)
+- [Wallets, IPFS, and About](feature-wallets-ipfs-and-about.md)

--- a/ops/docs/desktop/feature-workers-and-tdh.md
+++ b/ops/docs/desktop/feature-workers-and-tdh.md
@@ -84,6 +84,5 @@ RPC URLs. Use the installed app's confirmation text before a recovery action.
 
 - [Desktop index](README.md)
 - [Get started](flow-getting-started.md)
-- [Workers and TDH](feature-workers-and-tdh.md)
 - [Sync and recovery](troubleshooting-sync-and-recovery.md)
 - [Wallets, IPFS, and About](feature-wallets-ipfs-and-about.md)

--- a/ops/docs/desktop/flow-getting-started.md
+++ b/ops/docs/desktop/flow-getting-started.md
@@ -82,7 +82,6 @@ RPC URLs. Use the installed app's confirmation text before a recovery action.
 ## Related Pages
 
 - [Desktop index](README.md)
-- [Get started](flow-getting-started.md)
 - [Workers and TDH](feature-workers-and-tdh.md)
 - [Sync and recovery](troubleshooting-sync-and-recovery.md)
 - [Wallets, IPFS, and About](feature-wallets-ipfs-and-about.md)

--- a/ops/docs/desktop/flow-getting-started.md
+++ b/ops/docs/desktop/flow-getting-started.md
@@ -1,0 +1,88 @@
+# Get Started with 6529 Desktop
+
+Parent: [Desktop index](README.md)
+
+## Overview
+
+6529 Desktop, also called Core, is the Windows, macOS, and Linux app with local Core wallets, Ethereum indexing workers, independent TDH calculation, and a bundled IPFS node. These Core tools are separate from the mobile app and desktop-browser website.
+
+Get the official installer from [6529 Apps](https://6529.io/about/6529-apps), choose your operating system, install, and open the app.
+
+Open the dedicated 6529 Desktop sidebar menu (monitor icon). Its entries are Wallets, ETH Transactions, TDH Calculation, My IPFS when available, and About.
+
+First open 6529 Desktop > ETH Transactions > RPC Providers > Providers List. Choose Set Active on a provider, or Add RPC Provider, enter an Ethereum mainnet RPC URL, Test it, give it a Provider Name, Add, then Set Active. Saving a provider alone does not enable it.
+
+With an active RPC provider and the app running, Transactions and NFTDelegation sync automatically, and NFTs discovers and refreshes local NFT data. Initial history sync may take time; inspect worker progress and Logs instead of repeatedly resetting.
+
+Then open 6529 Desktop > TDH Calculation. TDH runs daily at 00:15 UTC; after prerequisite workers catch up you can use the TDH worker Advanced Options > Recalculate TDH Now. Compare Your Node and 6529.io at the same Last Block.
+
+Wallets lets you create or import a Core wallet for signing, but importing a wallet or seed phrase is not required to run indexing and TDH. My IPFS opens the bundled node WebUI; About shows version, ports, updates, and App Logs.
+
+The bot can explain these controls but cannot inspect or operate your local node. Never send it wallet passwords, recovery phrases, private keys, or RPC URLs containing credentials.
+
+## Location in the Site
+
+These controls live inside the installed desktop application under the
+**6529 Desktop** sidebar menu. Core-only routes are not public website links.
+
+## Entry Points
+
+Open the monitor icon in the app sidebar. If a control described here is absent,
+check your installed version under **6529 Desktop > About**; a mobile or browser
+session does not expose Core workers.
+
+## User Journey
+
+1. Download and install Core from the official Apps page.
+2. Open **6529 Desktop > ETH Transactions**.
+3. Expand **Providers List** and choose **Set Active**, or add/test/name a provider and then activate it.
+4. Leave the app running while Transactions, NFTDelegation, and NFTs catch up.
+5. Inspect **TDH Calculation**; use **Recalculate TDH Now** after the inputs are ready, or let its daily schedule run.
+6. Explore optional Wallets and My IPFS; use About for version and diagnostics.
+
+## Common Scenarios
+
+### Configure or change RPC
+
+In 6529 Desktop open 6529 Desktop > ETH Transactions > RPC Providers and expand Providers List. Workers require an active RPC provider, not merely a saved one.
+
+To use a listed provider, click Set Active and check its Active indicator. Only one provider is active at a time; selecting another deactivates the previous one and recreates the workers with the selected endpoint.
+
+For your own provider, choose Add RPC Provider, paste its Ethereum mainnet RPC URL, click Test, enter a unique Provider Name after validation, click Add, then Set Active in Providers List. The test reads the current block and its logs; passing it does not guarantee historical requests will succeed.
+
+Invalid RPC URL means the test could not read the block/logs. Check the endpoint, network, provider credentials, and service availability. For throttling, rate-limit or history errors, inspect worker Logs and use an endpoint with adequate Ethereum historical log access and request allowance. Do not assume a paid provider is required.
+
+Deactivate leaves that provider saved but inactive. With no active provider, scheduled workers are disabled. Built-in default providers cannot be deleted; an inactive custom provider exposes Delete.
+
+RPC provider configuration is for the local Ethereum workers; it is different from the IPFS RPC port shown in About. The TDH page TestNet Mode Phase 1 label does not mean you should select an Ethereum testnet endpoint.
+
+Do not post your full authenticated RPC URL or API key in chat or logs shared for support. Share the provider name and a redacted error instead.
+
+## Edge Cases
+
+Saving a provider leaves it inactive. A valid latest-block RPC test may still
+be followed by historical-log errors or throttling during a long sync. Initial
+NFT discovery can wait for mint transactions to arrive. Wallet connection and
+RPC activation are independent; importing a wallet is not an onboarding prerequisite.
+
+## Failure and Recovery
+
+Inspect the failing worker’s Logs, check provider availability and request
+allowance, and use an appropriate working Ethereum endpoint. Let checkpoint
+progress finish before recalculating TDH. For a persistent same-block mismatch,
+follow [Sync and recovery](troubleshooting-sync-and-recovery.md).
+
+## Limitations / Notes
+
+The help bot explains documented controls. It cannot read or change your local
+node, confirm a repair remotely, decrypt wallets, or promise a sync duration.
+Never provide it passwords, private keys, recovery phrases, or credential-bearing
+RPC URLs. Use the installed app's confirmation text before a recovery action.
+
+## Related Pages
+
+- [Desktop index](README.md)
+- [Get started](flow-getting-started.md)
+- [Workers and TDH](feature-workers-and-tdh.md)
+- [Sync and recovery](troubleshooting-sync-and-recovery.md)
+- [Wallets, IPFS, and About](feature-wallets-ipfs-and-about.md)

--- a/ops/docs/desktop/troubleshooting-sync-and-recovery.md
+++ b/ops/docs/desktop/troubleshooting-sync-and-recovery.md
@@ -1,0 +1,128 @@
+# Desktop TDH Sync and Recovery
+
+Parent: [Desktop index](README.md)
+
+## Overview
+
+Choose the recovery action for the observed problem. A stale checkpoint, missing
+transfer, inconsistent ownership, and stale NFT metadata need different steps.
+
+## Location in the Site
+
+These controls live inside the installed desktop application under the
+**6529 Desktop** sidebar menu. Core-only routes are not public website links.
+
+## Entry Points
+
+Open the monitor icon in the app sidebar. If a control described here is absent,
+check your installed version under **6529 Desktop > About**; a mobile or browser
+session does not expose Core workers.
+
+## User Journey
+
+For an out-of-sync 6529 Desktop node, first open 6529 Desktop > TDH Calculation and compare Your Node and 6529.io Last Block, total TDH, and Merkle Root. Different blocks are not a same-snapshot mismatch; missing reference data is not proof of local corruption.
+
+Check 6529 Desktop > ETH Transactions > Providers List for an Active Ethereum RPC provider, then inspect Transactions, NFTDelegation, and NFTs progress and Logs. Let initial syncing and queued prerequisites finish. Fix provider errors before rebuilding data.
+
+When the inputs are caught up, use TDH Calculation > TDH worker > Advanced Options > Recalculate TDH Now and confirm. Compare again after completion at the same Last Block.
+
+If a same-block mismatch persists and transaction history is suspect, use ETH Transactions > Transactions > Advanced Options > Reconcile. Choose a specific starting block if known, or Reconcile full history. It compares Ethereum transfer logs through the captured local checkpoint, repairs only missing/inconsistent/orphaned records, and rebuilds affected ownership. Full-history reconciliation can take significant time.
+
+Use Transactions > Advanced Options > Rebuild Ownership only when the stored transaction history is believed correct but local ownership balances are inconsistent. It cannot recover missing transfers. After history/ownership repairs complete, recalculate TDH.
+
+If NFTs or metadata are missing or inconsistent, use NFTs > Advanced Options > Full Refresh first; it refreshes chain/metadata without deleting local NFT rows. If rediscovery is needed, NFTs > Advanced Options > Reset opens Reset All NFTs, which deletes local NFT records and resyncs them. There is no button named Full Recovery.
+
+More disruptive transaction recovery is Transactions > Advanced Options > Reset to Block: it deletes transactions after the chosen block and rebuilds ownership before resync. Use Min Block in that dialog for a full resync from the earliest supported block; Transactions does not expose a separate Reset button. Read the confirmation, choose the smallest justified recovery, allow inputs to catch up, then recalculate TDH. These local repairs do not change on-chain holdings and are not reasons to delete wallets or the app database.
+
+For a persistent failure, share app version and OS from 6529 Desktop > About, the two Last Block values, failing worker/status, and a redacted error or transaction hash. The bot cannot inspect the device; never share wallet secrets or credential-bearing RPC URLs.
+
+## Common Scenarios
+
+### Repair transaction history
+
+In 6529 Desktop go to 6529 Desktop > ETH Transactions > Transactions > Advanced Options > Reconcile. The dialog is Reconcile Transactions.
+
+Choose Reconcile from a specific block and enter the first suspect block, or Reconcile full history from the displayed earliest block (13360860). The run ends at the local transaction checkpoint captured at start; it is not forward sync to the live chain tip.
+
+Reconciliation compares Ethereum transfer logs to the local index and repairs missing, inconsistent, or orphaned records. It rebuilds ownership for affected tokens, and marks TDH for recalculation when repairs are made. It does not blindly delete all history.
+
+Use an active working RPC provider and let active Transactions/TDH work finish; the action can be disabled or rejected while conflicting work runs. Full history can take significant time and RPC requests.
+
+Progress is saved. If reconciliation is interrupted, restarting the app with an active RPC provider resumes it from its saved range. Do not start a competing reset while a reconciliation is active.
+
+After repairs and normal sync finish, open TDH Calculation > Advanced Options > Recalculate TDH Now. Repairing history alone can leave the displayed TDH result stale.
+
+For correct transaction records but wrong balances use Rebuild Ownership; for metadata issues use NFTs Full Refresh. Reset to Block, including its Min Block option for a full resync, is more disruptive and is not equivalent to Reconcile.
+
+### Rebuild ownership or roll back transactions
+
+In 6529 Desktop > ETH Transactions > Transactions > Advanced Options, Rebuild Ownership, Reset to Block, and Reconcile have different effects. Let the current worker and conflicting TDH work finish before using them.
+
+Rebuild Ownership rebuilds every locally indexed NFT balance from existing transaction history. It leaves transaction records and the sync checkpoint unchanged. Use it only when transaction history is believed correct; it cannot discover missing transfers.
+
+Prefer Reconcile for missing or inconsistent historical transfers: it checks chain logs and repairs affected records without a blanket history deletion.
+
+Reset to Block rolls back to the chosen block: transactions after it are deleted, ownership is rebuilt at that point, and later syncing reimports forward from there. The dialog offers Min Block for the earliest supported worker block, 13360860. Choose a block based on the observed problem rather than guessing.
+
+To fully resync Transactions from the beginning, use Reset to Block > Min Block and confirm. Transactions does not expose a standalone Reset button. Rolling back to the earliest supported block removes later local history for reimport; this is a more disruptive fallback than reconciliation and requires time and RPC access.
+
+Once repair/resync and prerequisite workers complete, use TDH Calculation > TDH worker > Advanced Options > Recalculate TDH Now. A stale-result warning is expected after history changes until a successful recalculation.
+
+Worker recovery changes local indexed data, not on-chain NFTs or balances. Do not delete the whole app database or a Core wallet as a transaction-repair step.
+
+### Recover NFT records and metadata
+
+Open 6529 Desktop > ETH Transactions > NFTs. Data shows the locally indexed NFTs; Logs shows discovery and refresh progress. These records cover The Memes, Gradients, Meme Lab, and NextGen.
+
+For outdated metadata or inconsistent indexed NFT details, open NFTs > Advanced Options > Full Refresh and confirm Full Refresh NFTs. It refreshes all indexed NFTs from chain and metadata without deleting local NFT data.
+
+For a missing local NFT history requiring rediscovery, NFTs > Advanced Options > Reset opens Reset All NFTs. Confirming deletes all local NFT rows and starts discovery from the beginning. This is more disruptive than Full Refresh and is not named Full Recovery in the UI.
+
+An NFT can wait for its mint transaction to be indexed. A Waiting for transaction sync message calls for checking Transactions progress/provider/history first; resetting NFTs repeatedly cannot repair missing transfers.
+
+Finish active NFT work and respect TDH worker conflicts before a refresh/reset. Check Logs for RPC or metadata retrieval errors; a failing upstream source needs attention rather than repeated resets.
+
+After NFT recovery and transaction/delegation sync complete, recalculate TDH if the node result needs rebuilding. NFT refresh/reset does not change your on-chain holdings, delete your Core wallet, or replace a transaction-history reconciliation.
+
+### Inspect local data
+
+Open 6529 Desktop > ETH Transactions > Transactions > Data to inspect the locally indexed transfers. Use its collection filters, sorting, pagination, and transaction-hash search to investigate a known transfer.
+
+A missing local result can mean that the worker has not reached that block, the contract is outside the indexed 6529 collections, or history needs reconciliation. Check the transaction checkpoint and Logs before resetting.
+
+Open NFTs > Data for locally indexed NFT details, collection and season filters, and search. This data view describes the node database, not a live query of your wallet holdings.
+
+Use Reconcile for suspect transfer history, Rebuild Ownership for inconsistent balances with correct history, and NFTs Full Refresh for stale NFT metadata. Finish repair and catch-up before recalculating TDH.
+
+The bot cannot query these local tables. You can provide a public transaction hash, token/collection, observed checkpoint, and redacted error for more specific guidance.
+
+## Edge Cases
+
+Reconciliation is bounded by the checkpoint captured when it starts. It cannot
+substitute for forward sync. A full-history run can be long and resumes after
+restart; avoid replacing it with a reset simply because it has not finished.
+The UI name **Full Refresh** is distinct from **Reset All NFTs**. Neither
+requires deleting Core wallets, reinstalling the app, or removing its database.
+
+## Failure and Recovery
+
+If the same-block mismatch remains after the relevant repair and a fresh TDH
+calculation, collect the version, OS, both block numbers, failing worker, and
+redacted log error for support. Do not promise that any single reset always
+fixes a mismatch. If the reference API is unavailable, restore that comparison
+before declaring local corruption.
+
+## Limitations / Notes
+
+The help bot explains documented controls. It cannot read or change your local
+node, confirm a repair remotely, decrypt wallets, or promise a sync duration.
+Never provide it passwords, private keys, recovery phrases, or credential-bearing
+RPC URLs. Use the installed app's confirmation text before a recovery action.
+
+## Related Pages
+
+- [Desktop index](README.md)
+- [Get started](flow-getting-started.md)
+- [Workers and TDH](feature-workers-and-tdh.md)
+- [Sync and recovery](troubleshooting-sync-and-recovery.md)
+- [Wallets, IPFS, and About](feature-wallets-ipfs-and-about.md)

--- a/ops/docs/desktop/troubleshooting-sync-and-recovery.md
+++ b/ops/docs/desktop/troubleshooting-sync-and-recovery.md
@@ -124,5 +124,4 @@ RPC URLs. Use the installed app's confirmation text before a recovery action.
 - [Desktop index](README.md)
 - [Get started](flow-getting-started.md)
 - [Workers and TDH](feature-workers-and-tdh.md)
-- [Sync and recovery](troubleshooting-sync-and-recovery.md)
 - [Wallets, IPFS, and About](feature-wallets-ipfs-and-about.md)

--- a/ops/docs/navigation/feature-6529-apps-page.md
+++ b/ops/docs/navigation/feature-6529-apps-page.md
@@ -68,10 +68,9 @@ hidden behind tabs.
 
 ## Related Pages
 
-- [Get started with 6529 Desktop](../desktop/flow-getting-started.md)
-
 - [Navigation Index](README.md)
 - [Web Sidebar Navigation](feature-sidebar-navigation.md)
 - [Header Search Modal](feature-header-search-modal.md)
 - [Page Sharing and Device Connection](feature-share-modal.md)
 - [Mobile App Landing Page](feature-mobile-app-landing.md)
+- [Get started with 6529 Desktop](../desktop/flow-getting-started.md)

--- a/ops/docs/navigation/feature-6529-apps-page.md
+++ b/ops/docs/navigation/feature-6529-apps-page.md
@@ -68,6 +68,8 @@ hidden behind tabs.
 
 ## Related Pages
 
+- [Get started with 6529 Desktop](../desktop/flow-getting-started.md)
+
 - [Navigation Index](README.md)
 - [Web Sidebar Navigation](feature-sidebar-navigation.md)
 - [Header Search Modal](feature-header-search-modal.md)

--- a/ops/docs/specs/2026-06-19-6529-help-bot-knowledge-index.md
+++ b/ops/docs/specs/2026-06-19-6529-help-bot-knowledge-index.md
@@ -429,15 +429,23 @@ so users can ask how to get started before installing the application.
 
 Core-only navigation is expressed as native menu labels. Canonical paths remain
 valid public Apps destinations with source-link suppression; never publish a
-website `/core` URL. Each record contains a complete bounded procedure, including
-its local-data effects and warnings, with pinned Core GitHub source references.
+website `/core` URL. Procedure facts retain full details, including
+local-data effects and warnings, with pinned Core GitHub source references.
 The [maintenance contract](../../help/desktop-core-sources.md) tracks the source
 baseline and the [Desktop guides](../desktop/README.md) explain the workflows.
 
-The companion backend change scopes retrieval to local Desktop support, preserves
-the full primary record, and permits longer procedural answers. It does not add
+The companion backend scopes retrieval to local Desktop support, keeps replies
+short by default, and permits longer procedures on explicit request. It does not add
 remote control of workers or access to local wallets, logs, or database contents.
 
 Deploy the companion backend routing/renderer change before publishing these
 records. Its older-corpus fallback is safe; the older backend does not isolate
 Core records from generic questions and has insufficient procedural reply space.
+
+Desktop conversational replies use optional `brief_answer` and `answer_links`
+metadata. Short answers preserve action-specific warnings. Links appear once at
+the end, never inline; source provenance remains separate. The corpus separates
+“What is Core?” from setup, initial node mismatch triage, and follow-ups after
+recalculation or history reconciliation. Full facts remain available for explicit
+requests for detail. A plain RPC-provider question without local-app context asks
+which application the user means.

--- a/ops/docs/specs/2026-06-19-6529-help-bot-knowledge-index.md
+++ b/ops/docs/specs/2026-06-19-6529-help-bot-knowledge-index.md
@@ -419,3 +419,25 @@ compose a short answer.
 - Which controls should receive `data-help-*` metadata in the next pass?
 - How should unanswered production questions feed back into corpus updates and
   eval coverage?
+
+## Desktop Core knowledge
+
+The `desktop.*` records, tagged `desktop-core`, cover the native 6529 Desktop
+menu, setup and RPC activation, worker schedules, TDH comparisons and recovery,
+Core wallets, IPFS, and diagnostics. They remain available in the public corpus
+so users can ask how to get started before installing the application.
+
+Core-only navigation is expressed as native menu labels. Canonical paths remain
+valid public Apps destinations with source-link suppression; never publish a
+website `/core` URL. Each record contains a complete bounded procedure, including
+its local-data effects and warnings, with pinned Core GitHub source references.
+The [maintenance contract](../../help/desktop-core-sources.md) tracks the source
+baseline and the [Desktop guides](../desktop/README.md) explain the workflows.
+
+The companion backend change scopes retrieval to local Desktop support, preserves
+the full primary record, and permits longer procedural answers. It does not add
+remote control of workers or access to local wallets, logs, or database contents.
+
+Deploy the companion backend routing/renderer change before publishing these
+records. Its older-corpus fallback is safe; the older backend does not isolate
+Core records from generic questions and has insufficient procedural reply space.

--- a/ops/help/README.md
+++ b/ops/help/README.md
@@ -50,3 +50,10 @@ Commit the regenerated `public/` artifacts with the corpus change. PR CI runs
 `__tests__/scripts/sync-agent-files.test.ts` (the "Verify agent files sync"
 step) whenever these files change and fails if the committed artifacts drift
 from the corpus.
+
+## 6529 Desktop (Core)
+
+Desktop knowledge uses `desktop.*` records tagged `desktop-core`, with native
+menu labels and pinned Core source references. See [Desktop corpus maintenance](desktop-core-sources.md)
+and the [Desktop guides](../docs/desktop/README.md). Keep recovery effects and
+local-data boundaries explicit; do not publish nonexistent website `/core` links.

--- a/ops/help/README.md
+++ b/ops/help/README.md
@@ -18,6 +18,7 @@ Each record should be short, factual, and linkable:
 - `aliases` should include natural phrases users might type.
 - `keywords` should include important retrieval terms.
 - `facts` should be concise statements the bot can safely reuse.
+- Desktop `brief_answer` contains the short default/fallback response (at most 900 characters); `answer_links` lists relevant named public destinations for the final footer. Detailed facts remain available on request.
 - `canonical_path` should be the best 6529.io destination for the answer.
 - `link_label` should be the page/action label used when the bot links to
   `canonical_path`; omit it only when the record `title` is already the best

--- a/ops/help/desktop-core-sources.md
+++ b/ops/help/desktop-core-sources.md
@@ -4,7 +4,10 @@ The frontend publishes `desktop.*` records through the existing help index.
 The backend recognizes the `desktop-core` tag for bounded detailed answers.
 Core controls are explained by their native menu labels, never linked as public
 `/core` routes. `canonical_path` remains the real Apps route; source links are
-suppressed for these procedural answers.
+suppressed for these procedural answers. The onboarding fact intentionally links
+to the public `https://6529.io/about/6529-apps` installer page in every environment.
+It is an official distribution destination, not navigation within the requesting
+site; do not replace it with a bare relative path in bot replies.
 
 ## Evidence baseline
 

--- a/ops/help/desktop-core-sources.md
+++ b/ops/help/desktop-core-sources.md
@@ -1,13 +1,24 @@
 # Desktop Core corpus maintenance
 
 The frontend publishes `desktop.*` records through the existing help index.
-The backend recognizes the `desktop-core` tag for bounded detailed answers.
-Core controls are explained by their native menu labels, never linked as public
-`/core` routes. `canonical_path` remains the real Apps route; source links are
-suppressed for these procedural answers. The onboarding fact intentionally links
-to the public `https://6529.io/about/6529-apps` installer page in every environment.
-It is an official distribution destination, not navigation within the requesting
-site; do not replace it with a bare relative path in bot replies.
+The backend recognizes the `desktop-core` tag for local support. `facts` retain
+source-backed detail, while `brief_answer` provides a concise default and fallback
+(maximum 900 characters). Keep warnings beside any destructive action even in the
+short answer. Separate definitions, onboarding, initial triage, and later recovery
+stages. Use symptom language such as “my node does not match 6529.io”.
+
+`answer_links` contains up to three named public 6529.io destinations, validated
+against static application routes. The backend appends these once in a final `More info` footer;
+keep links out of prose facts. The official installer destination is
+`https://6529.io/about/6529-apps` in every environment. Native menu paths are
+instructions, not public `/core` links. Omit answer links for a recovery step when
+no relevant public destination exists. Provenance `source_refs` are not reply links.
+
+`desktop-dialogue` records use their short answer directly for normal turns, so
+model rephrasing cannot erase acknowledged progress. Normal answers give a few
+sentences or the next diagnostic question. Detailed
+walkthroughs require an explicit request. Recalculation and reconciliation follow-ups
+acknowledge reported progress; they must not imply an unreported action succeeded.
 
 ## Evidence baseline
 

--- a/ops/help/desktop-core-sources.md
+++ b/ops/help/desktop-core-sources.md
@@ -1,0 +1,37 @@
+# Desktop Core corpus maintenance
+
+The frontend publishes `desktop.*` records through the existing help index.
+The backend recognizes the `desktop-core` tag for bounded detailed answers.
+Core controls are explained by their native menu labels, never linked as public
+`/core` routes. `canonical_path` remains the real Apps route; source links are
+suppressed for these procedural answers.
+
+## Evidence baseline
+
+Verified against `6529-Collections/6529-core` main at `5d8a06e5ea66835f09ec89db40d4db714759462b`.
+Each record includes immutable GitHub `source_refs` for the relevant controls and
+worker behavior, plus a user-facing guide in `ops/docs/desktop/`.
+These references are provenance; the bot consumes facts, not source files.
+
+## Maintenance contract
+
+When Core changes RPC setup, worker schedules/actions, TDH recovery, wallet
+handling, IPFS, or menu labels, update the relevant records and guides from
+Core source in the same release set. Recheck action effects, busy states, and
+restart behavior; distinguish local data from on-chain state and current
+behavior from future consensus phases. Refresh the pinned references after
+verification. Do not claim arbitrary installed versions expose every control.
+
+Run both `help-index:sync` and `agent-files:sync`, then the agent-file sync tests.
+Exercise representative onboarding, RPC, TDH mismatch, reconciliation, reset,
+NFT recovery, wallet, IPFS, and contextual follow-up queries against the backend
+retriever. Generic website TDH, external wallets, mobile, and ordinary desktop
+web layout questions must retain their existing destinations. The backend
+Desktop fixture is a test-only corpus snapshot, not a runtime knowledge source.
+
+## Rollout
+
+Deploy the companion backend `helpBotReplyLoop` routing/renderer change first,
+then publish this frontend corpus. The new backend fails closed for unavailable
+Core procedures. An older backend can misroute these new records into generic
+wallet answers or truncate recovery explanations; avoid frontend-first rollout.

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -7889,6 +7889,705 @@
         "components/collect/CollectPageClient.tsx",
         "components/collect/useMarketExecution.ts"
       ]
+    },
+    {
+      "id": "desktop.getting-started",
+      "kind": "workflow",
+      "title": "Get started with 6529 Desktop (Core)",
+      "aliases": [
+        "get started with 6529 desktop",
+        "get started in core",
+        "getting started with core",
+        "how to get started with 6529 desktop app",
+        "set up 6529 desktop",
+        "set up core",
+        "what is 6529 core",
+        "what is core",
+        "what is 6529 desktop",
+        "how does 6529 desktop work",
+        "explain core",
+        "about core",
+        "6529 desktop overview"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "start",
+        "started",
+        "getting",
+        "setup",
+        "install",
+        "onboarding",
+        "beginner",
+        "overview",
+        "features",
+        "benefits",
+        "capabilities"
+      ],
+      "facts": [
+        "6529 Desktop, also called Core, is the Windows, macOS, and Linux app with local Core wallets, Ethereum indexing workers, independent TDH calculation, and a bundled IPFS node. These Core tools are separate from the mobile app and desktop-browser website.",
+        "Get the official installer from [6529 Apps](https://6529.io/about/6529-apps), choose your operating system, install, and open the app.",
+        "Open the dedicated 6529 Desktop sidebar menu (monitor icon). Its entries are Wallets, ETH Transactions, TDH Calculation, My IPFS when available, and About.",
+        "First open 6529 Desktop > ETH Transactions > RPC Providers > Providers List. Choose Set Active on a provider, or Add RPC Provider, enter an Ethereum mainnet RPC URL, Test it, give it a Provider Name, Add, then Set Active. Saving a provider alone does not enable it.",
+        "With an active RPC provider and the app running, Transactions and NFTDelegation sync automatically, and NFTs discovers and refreshes local NFT data. Initial history sync may take time; inspect worker progress and Logs instead of repeatedly resetting.",
+        "Then open 6529 Desktop > TDH Calculation. TDH runs daily at 00:15 UTC; after prerequisite workers catch up you can use the TDH worker Advanced Options > Recalculate TDH Now. Compare Your Node and 6529.io at the same Last Block.",
+        "Wallets lets you create or import a Core wallet for signing, but importing a wallet or seed phrase is not required to run indexing and TDH. My IPFS opens the bundled node WebUI; About shows version, ports, updates, and App Logs.",
+        "The bot can explain these controls but cannot inspect or operate your local node. Never send it wallet passwords, recovery phrases, private keys, or RPC URLs containing credentials."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/flow-getting-started.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/hooks/useSidebarSections.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduler.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/RpcProviders.tsx"
+      ]
+    },
+    {
+      "id": "desktop.rpc-providers",
+      "kind": "workflow",
+      "title": "6529 Desktop RPC provider setup and errors",
+      "aliases": [
+        "core rpc",
+        "desktop rpc",
+        "rpc providers",
+        "add rpc provider",
+        "set active",
+        "invalid rpc url",
+        "enable rpc",
+        "providers list"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "rpc",
+        "provider",
+        "providers",
+        "active",
+        "activate",
+        "enable",
+        "disabled",
+        "url",
+        "test",
+        "throttled",
+        "429"
+      ],
+      "facts": [
+        "In 6529 Desktop open 6529 Desktop > ETH Transactions > RPC Providers and expand Providers List. Workers require an active RPC provider, not merely a saved one.",
+        "To use a listed provider, click Set Active and check its Active indicator. Only one provider is active at a time; selecting another deactivates the previous one and recreates the workers with the selected endpoint.",
+        "For your own provider, choose Add RPC Provider, paste its Ethereum mainnet RPC URL, click Test, enter a unique Provider Name after validation, click Add, then Set Active in Providers List. The test reads the current block and its logs; passing it does not guarantee historical requests will succeed.",
+        "Invalid RPC URL means the test could not read the block/logs. Check the endpoint, network, provider credentials, and service availability. For throttling, rate-limit or history errors, inspect worker Logs and use an endpoint with adequate Ethereum historical log access and request allowance. Do not assume a paid provider is required.",
+        "Deactivate leaves that provider saved but inactive. With no active provider, scheduled workers are disabled. Built-in default providers cannot be deleted; an inactive custom provider exposes Delete.",
+        "RPC provider configuration is for the local Ethereum workers; it is different from the IPFS RPC port shown in About. The TDH page TestNet Mode Phase 1 label does not mean you should select an Ethereum testnet endpoint.",
+        "Do not post your full authenticated RPC URL or API key in chat or logs shared for support. Share the provider name and a redacted error instead."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/flow-getting-started.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/RpcProviderModal.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/RpcProviders.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/db/db.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ]
+    },
+    {
+      "id": "desktop.workers",
+      "kind": "workflow",
+      "title": "6529 Desktop workers and automatic syncing",
+      "aliases": [
+        "core workers",
+        "app workers",
+        "desktop workers",
+        "transactions worker",
+        "nftdelegation worker",
+        "nfts worker",
+        "worker stopped",
+        "worker idle"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "workers",
+        "worker",
+        "schedule",
+        "automatic",
+        "sync",
+        "running",
+        "idle",
+        "stop",
+        "queued",
+        "waiting"
+      ],
+      "facts": [
+        "Open 6529 Desktop > ETH Transactions > App Workers for Transactions, NFTDelegation, and NFTs. The TDH worker is on 6529 Desktop > TDH Calculation.",
+        "Transactions indexes transfers related to the 6529 contracts every minute. NFTDelegation follows delegation and consolidation events every minute. NFTs discovers and refreshes The Memes, Gradients, Meme Lab, and NextGen every two minutes, with periodic full refreshes. These are local indexes, not an index of every Ethereum contract.",
+        "With an active RPC provider, non-TDH workers start when the schedulers initialize and then follow their schedules. TDH normally runs daily at 00:15 UTC. Keep the app running and the computer awake for scheduled work; do not promise a fixed initial sync duration.",
+        "Worker cards show their schedule, status, progress, and message. Expand Logs for details. Idle or Completed between runs is normal; Disabled calls for checking the active RPC provider. A waiting message can mean a prerequisite checkpoint or another worker must finish.",
+        "Advanced Options > Run Now requests an immediate run without changing the schedule. Stop ends the current non-TDH execution, but the next scheduled run can start again; it is not a permanent disable switch.",
+        "TDH is coordinated with NFT/delegation work and transaction repairs. Respect a busy or queued response rather than repeatedly clicking recovery actions. Transactions must reach the TDH target block, and NFTDelegation must reach it too.",
+        "An interrupted transaction reconciliation resumes from its saved range on restart with an active provider. An interrupted TDH calculation reruns from scratch on restart; it does not continue a partially calculated result."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/feature-workers-and-tdh.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduler.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx"
+      ]
+    },
+    {
+      "id": "desktop.tdh-calculation",
+      "kind": "workflow",
+      "title": "6529 Desktop automatic TDH calculation and validation",
+      "aliases": [
+        "desktop tdh",
+        "core tdh",
+        "tdh calculation",
+        "recalculate tdh now",
+        "tdh consensus",
+        "testnet mode phase 1",
+        "merkle root"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "tdh",
+        "calculation",
+        "calculate",
+        "automatic",
+        "daily",
+        "merkle",
+        "root",
+        "block",
+        "validation",
+        "testnet",
+        "phase",
+        "consensus"
+      ],
+      "facts": [
+        "6529 Desktop > TDH Calculation independently computes TDH from local indexed data. Your Node is compared with the reference 6529.io result. The TDH row is all TDH across the whole system, not your personal profile TDH.",
+        "TDH is scheduled daily at 00:15 UTC while the app runs with an active RPC provider. It calculates the daily snapshot using an Ethereum block before the UTC day boundary, not a continuously changing live balance.",
+        "Transactions and NFTDelegation must both reach the target block before TDH can proceed. A message such as Waiting for Transactions or Waiting for NFTDelegation reports the target and current checkpoint; allow that worker to catch up and check its Logs if it stalls.",
+        "For a manual calculation, open the TDH worker Advanced Options > Recalculate TDH Now and confirm Run TDH Calculation Now. It replaces local TDH calculation data; it does not repair missing transaction history. Finish any underlying history/NFT repair and prerequisite sync first.",
+        "Compare Last Block first, then total TDH and Merkle Root. Different snapshot blocks can explain different values. A Merkle Root hashes the address/TDH results; a missing reference root is N/A and is not proof your node is wrong.",
+        "The page describes TestNet Mode Phase 1: comparison with the 6529.io reference. Phase 2 node-only consensus is described as future behavior, not something already active. This label is separate from Live/Test backend builds and does not switch Ethereum to a testnet.",
+        "Transaction repairs or resets can mark the existing result stale and show Transaction history changed — recalculation required. Recalculate after repair completes or wait for the next scheduled TDH run. Marking stale alone does not immediately start a fresh calculation.",
+        "If the app closes during TDH work, an active provider allows a fresh rerun on restart after worker guards permit it. The bot cannot read your local TDH values or fix your node remotely."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/feature-workers-and-tdh.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduler.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/tdh-worker/index.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/tdh-worker/tdh-worker.helpers.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx"
+      ]
+    },
+    {
+      "id": "desktop.tdh-out-of-sync",
+      "kind": "workflow",
+      "title": "6529 Desktop TDH out of sync troubleshooting",
+      "aliases": [
+        "tdh out of sync",
+        "tdh is out of sync",
+        "desktop tdh mismatch",
+        "tdh does not match",
+        "tdh mismatch",
+        "tdh is wrong",
+        "tdh not matching",
+        "my node is behind",
+        "tdh not synced",
+        "tdh out of date"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "tdh",
+        "sync",
+        "synced",
+        "stale",
+        "mismatch",
+        "wrong",
+        "behind",
+        "different",
+        "recovery",
+        "repair",
+        "reconcile",
+        "reset",
+        "merkle",
+        "total"
+      ],
+      "facts": [
+        "For an out-of-sync 6529 Desktop node, first open 6529 Desktop > TDH Calculation and compare Your Node and 6529.io Last Block, total TDH, and Merkle Root. Different blocks are not a same-snapshot mismatch; missing reference data is not proof of local corruption.",
+        "Check 6529 Desktop > ETH Transactions > Providers List for an Active Ethereum RPC provider, then inspect Transactions, NFTDelegation, and NFTs progress and Logs. Let initial syncing and queued prerequisites finish. Fix provider errors before rebuilding data.",
+        "When the inputs are caught up, use TDH Calculation > TDH worker > Advanced Options > Recalculate TDH Now and confirm. Compare again after completion at the same Last Block.",
+        "If a same-block mismatch persists and transaction history is suspect, use ETH Transactions > Transactions > Advanced Options > Reconcile. Choose a specific starting block if known, or Reconcile full history. It compares Ethereum transfer logs through the captured local checkpoint, repairs only missing/inconsistent/orphaned records, and rebuilds affected ownership. Full-history reconciliation can take significant time.",
+        "Use Transactions > Advanced Options > Rebuild Ownership only when the stored transaction history is believed correct but local ownership balances are inconsistent. It cannot recover missing transfers. After history/ownership repairs complete, recalculate TDH.",
+        "If NFTs or metadata are missing or inconsistent, use NFTs > Advanced Options > Full Refresh first; it refreshes chain/metadata without deleting local NFT rows. If rediscovery is needed, NFTs > Advanced Options > Reset opens Reset All NFTs, which deletes local NFT records and resyncs them. There is no button named Full Recovery.",
+        "More disruptive transaction recovery is Transactions > Advanced Options > Reset to Block: it deletes transactions after the chosen block and rebuilds ownership before resync. Use Min Block in that dialog for a full resync from the earliest supported block; Transactions does not expose a separate Reset button. Read the confirmation, choose the smallest justified recovery, allow inputs to catch up, then recalculate TDH. These local repairs do not change on-chain holdings and are not reasons to delete wallets or the app database.",
+        "For a persistent failure, share app version and OS from 6529 Desktop > About, the two Last Block values, failing worker/status, and a redacted error or transaction hash. The bot cannot inspect the device; never share wallet secrets or credential-bearing RPC URLs."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/i18n/messages/en-US.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ]
+    },
+    {
+      "id": "desktop.transaction-reconciliation",
+      "kind": "workflow",
+      "title": "6529 Desktop reconcile transaction history",
+      "aliases": [
+        "reconcile transactions",
+        "transaction reconciliation",
+        "reconcile full history",
+        "reconcile from a specific block",
+        "missing transactions",
+        "missing transfers"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "reconcile",
+        "reconciliation",
+        "transactions",
+        "transaction",
+        "trx",
+        "history",
+        "missing",
+        "orphaned",
+        "repair",
+        "checkpoint"
+      ],
+      "facts": [
+        "In 6529 Desktop go to 6529 Desktop > ETH Transactions > Transactions > Advanced Options > Reconcile. The dialog is Reconcile Transactions.",
+        "Choose Reconcile from a specific block and enter the first suspect block, or Reconcile full history from the displayed earliest block (13360860). The run ends at the local transaction checkpoint captured at start; it is not forward sync to the live chain tip.",
+        "Reconciliation compares Ethereum transfer logs to the local index and repairs missing, inconsistent, or orphaned records. It rebuilds ownership for affected tokens, and marks TDH for recalculation when repairs are made. It does not blindly delete all history.",
+        "Use an active working RPC provider and let active Transactions/TDH work finish; the action can be disabled or rejected while conflicting work runs. Full history can take significant time and RPC requests.",
+        "Progress is saved. If reconciliation is interrupted, restarting the app with an active RPC provider resumes it from its saved range. Do not start a competing reset while a reconciliation is active.",
+        "After repairs and normal sync finish, open TDH Calculation > Advanced Options > Recalculate TDH Now. Repairing history alone can leave the displayed TDH result stale.",
+        "For correct transaction records but wrong balances use Rebuild Ownership; for metadata issues use NFTs Full Refresh. Reset to Block, including its Min Block option for a full resync, is more disruptive and is not equivalent to Reconcile."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduler.ts"
+      ]
+    },
+    {
+      "id": "desktop.transaction-reset",
+      "kind": "workflow",
+      "title": "6529 Desktop transaction reset and ownership rebuild",
+      "aliases": [
+        "reset transactions worker",
+        "reset trx worker",
+        "reset transaction worker",
+        "reset to block",
+        "rebuild ownership",
+        "recalculate owners",
+        "reset worker"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "reset",
+        "transactions",
+        "transaction",
+        "trx",
+        "block",
+        "ownership",
+        "rebuild",
+        "balances",
+        "rollback"
+      ],
+      "facts": [
+        "In 6529 Desktop > ETH Transactions > Transactions > Advanced Options, Rebuild Ownership, Reset to Block, and Reconcile have different effects. Let the current worker and conflicting TDH work finish before using them.",
+        "Rebuild Ownership rebuilds every locally indexed NFT balance from existing transaction history. It leaves transaction records and the sync checkpoint unchanged. Use it only when transaction history is believed correct; it cannot discover missing transfers.",
+        "Prefer Reconcile for missing or inconsistent historical transfers: it checks chain logs and repairs affected records without a blanket history deletion.",
+        "Reset to Block rolls back to the chosen block: transactions after it are deleted, ownership is rebuilt at that point, and later syncing reimports forward from there. The dialog offers Min Block for the earliest supported worker block, 13360860. Choose a block based on the observed problem rather than guessing.",
+        "To fully resync Transactions from the beginning, use Reset to Block > Min Block and confirm. Transactions does not expose a standalone Reset button. Rolling back to the earliest supported block removes later local history for reimport; this is a more disruptive fallback than reconciliation and requires time and RPC access.",
+        "Once repair/resync and prerequisite workers complete, use TDH Calculation > TDH worker > Advanced Options > Recalculate TDH Now. A stale-result warning is expected after history changes until a successful recalculation.",
+        "Worker recovery changes local indexed data, not on-chain NFTs or balances. Do not delete the whole app database or a Core wallet as a transaction-repair step."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/i18n/messages/en-US.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/index.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ]
+    },
+    {
+      "id": "desktop.nft-recovery",
+      "kind": "workflow",
+      "title": "6529 Desktop NFT full refresh and reset recovery",
+      "aliases": [
+        "nfts full recovery",
+        "nft full recovery",
+        "full refresh nfts",
+        "reset all nfts",
+        "nft recovery",
+        "missing nfts",
+        "nft metadata"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "nft",
+        "nfts",
+        "metadata",
+        "refresh",
+        "reset",
+        "recovery",
+        "missing",
+        "edition",
+        "size",
+        "mint",
+        "date"
+      ],
+      "facts": [
+        "Open 6529 Desktop > ETH Transactions > NFTs. Data shows the locally indexed NFTs; Logs shows discovery and refresh progress. These records cover The Memes, Gradients, Meme Lab, and NextGen.",
+        "For outdated metadata or inconsistent indexed NFT details, open NFTs > Advanced Options > Full Refresh and confirm Full Refresh NFTs. It refreshes all indexed NFTs from chain and metadata without deleting local NFT data.",
+        "For a missing local NFT history requiring rediscovery, NFTs > Advanced Options > Reset opens Reset All NFTs. Confirming deletes all local NFT rows and starts discovery from the beginning. This is more disruptive than Full Refresh and is not named Full Recovery in the UI.",
+        "An NFT can wait for its mint transaction to be indexed. A Waiting for transaction sync message calls for checking Transactions progress/provider/history first; resetting NFTs repeatedly cannot repair missing transfers.",
+        "Finish active NFT work and respect TDH worker conflicts before a refresh/reset. Check Logs for RPC or metadata retrieval errors; a failing upstream source needs attention rather than repeated resets.",
+        "After NFT recovery and transaction/delegation sync complete, recalculate TDH if the node result needs rebuilding. NFT refresh/reset does not change your on-chain holdings, delete your Core wallet, or replace a transaction-history reconciliation."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/nft-worker/nft-discovery.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/NftLocalData.tsx"
+      ]
+    },
+    {
+      "id": "desktop.wallets",
+      "kind": "workflow",
+      "title": "6529 Desktop Core wallets creation import and connection",
+      "aliases": [
+        "core wallets",
+        "core wallet",
+        "desktop wallets",
+        "create core wallet",
+        "import core wallet",
+        "connect core wallet",
+        "delete core wallet"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "wallet",
+        "wallets",
+        "create",
+        "import",
+        "connect",
+        "unlock",
+        "sign",
+        "delete"
+      ],
+      "facts": [
+        "Open 6529 Desktop > Wallets for Core wallets stored on this computer. These are separate from mobile App Wallets and from connecting an external wallet or sharing a website login session.",
+        "Create Wallet opens Create New Wallet: choose a name and password and select Create. Core generates a wallet and stores its private key and recovery phrase encrypted with that password in the local database.",
+        "Import Wallet offers Mnemonic (the current form accepts 12 words) or Private Key. Enter it only in the trusted local app, Validate, check the resulting address, then Import Wallet with a name and password. Never send a phrase, key, or password to the help bot.",
+        "Use the Core wallet connector in the wallet connection flow to select a saved wallet and unlock it when prompted. Review signature/transaction requests before approving; an unlocked wallet and an authenticated 6529 session are distinct states.",
+        "Wallet details show the address and password-protected reveal/copy controls plus Download Recovery File. That download contains the decrypted private key and available mnemonic in a plaintext text file; keep it private and securely backed up, never send it to the bot. Private-key-only imports have no mnemonic.",
+        "Delete removes the saved local wallet record after confirmation; disconnect first if it is the currently connected wallet. It does not erase the Ethereum address or move on-chain funds. There is no documented bot/password-recovery service; the bot cannot decrypt or recover a forgotten wallet password.",
+        "A Core wallet is optional for node indexing and TDH calculation. You can run workers with an active RPC provider without importing any funded wallet, and connecting a wallet does not enable RPC workers."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/feature-wallets-ipfs-and-about.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/core-wallet/SeedWallets.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/core-wallet/SeedWalletImport.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/core-wallet/SeedWallet.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/db/db.ts"
+      ]
+    },
+    {
+      "id": "desktop.wallet-backup",
+      "kind": "workflow",
+      "title": "6529 Desktop Core wallet backup and password problems",
+      "aliases": [
+        "core wallet backup",
+        "forgot core wallet password",
+        "core wallet password",
+        "forgot desktop wallet password",
+        "core wallet recovery",
+        "core recovery phrase",
+        "core private key",
+        "download recovery file",
+        "core recovery file"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "wallet",
+        "backup",
+        "password",
+        "forgot",
+        "recovery",
+        "phrase",
+        "mnemonic",
+        "private",
+        "key",
+        "lost",
+        "export"
+      ],
+      "facts": [
+        "Core wallets live in 6529 Desktop > Wallets on this device. The stored private key and, when present, mnemonic are encrypted with the wallet password; a connected website profile is not a backup.",
+        "Open the saved wallet details and use Download Recovery File after unlocking, or use the password-protected reveal/copy controls. The recovery download is a plaintext text file containing the private key and available mnemonic, not an encrypted wallet backup. Keep it private and securely backed up; never upload it or paste any wallet password, key, or phrase into the bot. Private-key-only imports have no mnemonic.",
+        "If you cannot unlock a wallet, verify that you selected the right saved wallet and are entering its wallet password. The bot cannot inspect the wallet, bypass encryption, reset its password, or recover missing secrets.",
+        "If you have an independent recovery phrase or private-key backup, the local Import Wallet flow can restore the corresponding address; validate the address before using it. Do not delete the only local copy while investigating a password problem.",
+        "Deleting a wallet or app database is not a TDH repair step. Transaction/NFT worker recovery only needs the relevant indexed-data controls, not your wallet secrets. Keep independently recoverable wallet backups before any app-data removal."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/feature-wallets-ipfs-and-about.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/core-wallet/SeedWallet.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/core-wallet/SeedWalletModal.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/db/db.ts"
+      ]
+    },
+    {
+      "id": "desktop.ipfs",
+      "kind": "workflow",
+      "title": "6529 Desktop My IPFS node and local files",
+      "aliases": [
+        "my ipfs",
+        "core ipfs",
+        "desktop ipfs",
+        "ipfs node",
+        "ipfs rpc",
+        "ipfs gateway",
+        "ipfs files"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "ipfs",
+        "node",
+        "files",
+        "gateway",
+        "rpc",
+        "port",
+        "pins",
+        "pinning",
+        "cid",
+        "storage",
+        "webui"
+      ],
+      "facts": [
+        "6529 Desktop bundles a local IPFS daemon. Open 6529 Desktop > My IPFS to launch its WebUI when the app has resolved the local IPFS configuration; My IPFS is separate from ETH Transactions and the Ethereum RPC Providers list.",
+        "The app uses a local IPFS API, gateway, and swarm port. Find the actual IPFS Port, IPFS RPC Port, and IPFS Swarm Port in 6529 Desktop > About; do not assume a fixed port or share a localhost URL as a public link.",
+        "The Desktop IPFS file service pins added files and keeps a named entry under /6529-Desktop in the node file system. A CID identifies content; local storage/pinning is not a promise of permanent availability or replication elsewhere.",
+        "The bundled node uses configured bootstrap peers with automatic peer discovery/routing features restricted. Do not describe it as an unrestricted network crawler, a backup of every NFT, or proof that TDH consensus has completed.",
+        "If My IPFS is missing or the WebUI cannot connect, keep the app open, check About > App Logs for IPFS startup/connection errors and confirm the displayed ports. Restart the app normally if initialization failed; persistent errors need the app version, OS, and redacted log details.",
+        "The IPFS API and gateway are bound to loopback. Do not expose the local administrative API publicly, upload wallet secrets, or delete the IPFS repository to fix an unrelated TDH mismatch. IPFS storage and Ethereum transaction indexing are separate concerns."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/feature-wallets-ipfs-and-about.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/ipfs/ipfs.server.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/ipfs/IPFSContext.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/ipfs/IPFSService.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/app-info/AppInfo.tsx"
+      ]
+    },
+    {
+      "id": "desktop.about-and-logs",
+      "kind": "workflow",
+      "title": "6529 Desktop version updates and diagnostic logs",
+      "aliases": [
+        "desktop about",
+        "core about",
+        "desktop logs",
+        "core logs",
+        "desktop update",
+        "update core",
+        "app logs"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "version",
+        "update",
+        "updates",
+        "logs",
+        "log",
+        "error",
+        "about",
+        "diagnostics",
+        "ports",
+        "os"
+      ],
+      "facts": [
+        "Open 6529 Desktop > About for the installed version, OS/architecture, app scheme, app port, IPFS ports, updater status, and App Logs. Opening About checks for updates.",
+        "The update area shows checking, available, downloading progress, downloaded, no-update, or error states. Use the action offered for that state; the bot does not know the latest available build unless it has current release evidence.",
+        "Use ETH Transactions > the affected worker > Logs for a worker-specific failure. Expand Advanced Options for recovery controls. Logs > Locate opens the log file location; selecting log text enables Copy Selection.",
+        "For a TDH issue include both Last Block values, the mismatched field, last calculation time, and the failing worker message. For a missing transfer include a public transaction hash and the expected block; distinguish a local-node mismatch from personal website TDH.",
+        "Share only relevant redacted diagnostic lines. Remove RPC API keys/credential URLs, passwords, private keys, and recovery phrases. The bot cannot inspect your filesystem, operate workers, or confirm the node is repaired without observations from you.",
+        "The native titlebar identifies a Live/Test backend where applicable. That backend target is distinct from TDH TestNet Mode Phase 1. Core-only menu controls and routes are unavailable on mobile and ordinary web browsers."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/feature-wallets-ipfs-and-about.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/app-info/AppInfo.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/logs-viewer/LogsViewer.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/README.md"
+      ]
+    },
+    {
+      "id": "desktop.local-data",
+      "kind": "workflow",
+      "title": "6529 Desktop local transaction and NFT data inspection",
+      "aliases": [
+        "local transactions",
+        "local nft data",
+        "desktop transaction search",
+        "core transaction search",
+        "transactions data"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "local",
+        "data",
+        "search",
+        "transaction",
+        "transactions",
+        "hash",
+        "nft",
+        "nfts",
+        "filter"
+      ],
+      "facts": [
+        "Open 6529 Desktop > ETH Transactions > Transactions > Data to inspect the locally indexed transfers. Use its collection filters, sorting, pagination, and transaction-hash search to investigate a known transfer.",
+        "A missing local result can mean that the worker has not reached that block, the contract is outside the indexed 6529 collections, or history needs reconciliation. Check the transaction checkpoint and Logs before resetting.",
+        "Open NFTs > Data for locally indexed NFT details, collection and season filters, and search. This data view describes the node database, not a live query of your wallet holdings.",
+        "Use Reconcile for suspect transfer history, Rebuild Ownership for inconsistent balances with correct history, and NFTs Full Refresh for stale NFT metadata. Finish repair and catch-up before recalculating TDH.",
+        "The bot cannot query these local tables. You can provide a public transaction hash, token/collection, observed checkpoint, and redacted error for more specific guidance."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/TransactionsLocalData.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/TransactionSearchModal.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/NftLocalData.tsx"
+      ]
     }
   ]
 }

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -8130,7 +8130,14 @@
         "tdh not matching",
         "my node is behind",
         "tdh not synced",
-        "tdh out of date"
+        "tdh out of date",
+        "tdh different",
+        "tdh is different",
+        "tdh differs",
+        "merkle differ",
+        "merkle differs",
+        "merkle different",
+        "merkle mismatch"
       ],
       "keywords": [
         "desktop",

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -7901,14 +7901,7 @@
         "getting started with core",
         "how to get started with 6529 desktop app",
         "set up 6529 desktop",
-        "set up core",
-        "what is 6529 core",
-        "what is core",
-        "what is 6529 desktop",
-        "how does 6529 desktop work",
-        "explain core",
-        "about core",
-        "6529 desktop overview"
+        "set up core"
       ],
       "keywords": [
         "desktop",
@@ -7927,7 +7920,7 @@
       ],
       "facts": [
         "6529 Desktop, also called Core, is the Windows, macOS, and Linux app with local Core wallets, Ethereum indexing workers, independent TDH calculation, and a bundled IPFS node. These Core tools are separate from the mobile app and desktop-browser website.",
-        "Get the official installer from [6529 Apps](https://6529.io/about/6529-apps), choose your operating system, install, and open the app.",
+        "Get the official installer from 6529 Apps, choose your operating system, install, and open the app.",
         "Open the dedicated 6529 Desktop sidebar menu (monitor icon). Its entries are Wallets, ETH Transactions, TDH Calculation, My IPFS when available, and About.",
         "First open 6529 Desktop > ETH Transactions > RPC Providers > Providers List. Choose Set Active on a provider, or Add RPC Provider, enter an Ethereum mainnet RPC URL, Test it, give it a Provider Name, Add, then Set Active. Saving a provider alone does not enable it.",
         "With an active RPC provider and the app running, Transactions and NFTDelegation sync automatically, and NFTs discovers and refreshes local NFT data. Initial history sync may take time; inspect worker progress and Logs instead of repeatedly resetting.",
@@ -7950,6 +7943,13 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduler.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/RpcProviders.tsx"
+      ],
+      "brief_answer": "Install 6529 Desktop from the Apps page, then open **6529 Desktop > ETH Transactions > RPC Providers > Providers List** and **Set Active** on a provider. Keep the app open while its workers sync; TDH calculates automatically once prerequisites are ready. You do not need to import a wallet to run your node. Have you installed the app already?",
+      "answer_links": [
+        {
+          "label": "6529 Apps",
+          "url": "https://6529.io/about/6529-apps"
+        }
       ]
     },
     {
@@ -8005,7 +8005,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/RpcProviders.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/db/db.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
-      ]
+      ],
+      "brief_answer": "Open **6529 Desktop > ETH Transactions > RPC Providers > Providers List** and click **Set Active** on your provider. If none is saved, use **Add RPC Provider**, enter an Ethereum mainnet RPC URL, **Test** it, enter a Provider Name, then **Add** and **Set Active**. Saving alone does not activate it; never share a URL containing API credentials."
     },
     {
       "id": "desktop.workers",
@@ -8058,7 +8059,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduler.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx"
-      ]
+      ],
+      "brief_answer": "With an active RPC provider and the app open, Core workers sync automatically. Check their progress and Logs under **6529 Desktop > ETH Transactions**. Transactions and NFTDelegation must catch up before TDH calculation can finish. Which worker is stalled, and what status or redacted error does it show?"
     },
     {
       "id": "desktop.tdh-calculation",
@@ -8114,7 +8116,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/tdh-worker/index.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/tdh-worker/tdh-worker.helpers.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx"
-      ]
+      ],
+      "brief_answer": "Core calculates TDH automatically at **00:15 UTC** while the app is open and its prerequisites are synced. View it under **6529 Desktop > TDH Calculation**. For a manual run, use the TDH worker’s **Advanced Options > Recalculate TDH Now**; it replaces the local TDH result and does not repair transaction history."
     },
     {
       "id": "desktop.tdh-out-of-sync",
@@ -8174,7 +8177,8 @@
         "/about/6529-apps"
       ],
       "tags": [
-        "desktop-core"
+        "desktop-core",
+        "desktop-dialogue"
       ],
       "source_refs": [
         "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
@@ -8184,7 +8188,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
-      ]
+      ],
+      "brief_answer": "In **6529 Desktop > TDH Calculation**, are the two **Last Block** values identical? Which row does not match: **TDH**, **Last Block**, or **Merkle Root**? Different blocks can explain different results; an unavailable reference root is not evidence of corruption."
     },
     {
       "id": "desktop.transaction-reconciliation",
@@ -8235,7 +8240,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduler.ts"
-      ]
+      ],
+      "brief_answer": "In **6529 Desktop > ETH Transactions > Transactions > Advanced Options > Reconcile**, choose a starting block if known, or **Reconcile full history**. This repairs missing, inconsistent, or orphaned local transfer records through the captured checkpoint and rebuilds affected ownership; a full scan can take time. Let it finish, allow prerequisites to sync, then recalculate TDH. It does not change on-chain holdings."
     },
     {
       "id": "desktop.transaction-reset",
@@ -8288,7 +8294,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/index.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
-      ]
+      ],
+      "brief_answer": "For a full transaction resync, open **6529 Desktop > ETH Transactions > Transactions > Advanced Options > Reset to Block > Min Block**. This deletes local transactions after the selected block and rebuilds ownership before resyncing; it does not change on-chain holdings. Prefer Reconcile first for suspect history. Read the confirmation, wait for syncing to finish, then recalculate TDH. Transactions has no standalone Reset button."
     },
     {
       "id": "desktop.nft-recovery",
@@ -8340,7 +8347,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/nft-worker/nft-discovery.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/NftLocalData.tsx"
-      ]
+      ],
+      "brief_answer": "Under **6529 Desktop > ETH Transactions > NFTs > Advanced Options**, try **Full Refresh** first for missing or inconsistent NFT metadata. **Reset > Reset All NFTs** deletes local NFT records and rediscovers them; use it only if rediscovery is needed. There is no button named Full Recovery. These actions do not change on-chain holdings. After repair and syncing finish, recalculate TDH."
     },
     {
       "id": "desktop.wallets",
@@ -8391,7 +8399,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/core-wallet/SeedWalletImport.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/core-wallet/SeedWallet.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/db/db.ts"
-      ]
+      ],
+      "brief_answer": "Open **6529 Desktop > Wallets** to create or import a Core wallet for signing. You do not need a wallet to run indexing or TDH calculation. What would you like to do: create, import, or connect one? Never share your recovery phrase or private key here."
     },
     {
       "id": "desktop.wallet-backup",
@@ -8444,7 +8453,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/core-wallet/SeedWallet.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/core-wallet/SeedWalletModal.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/db/db.ts"
-      ]
+      ],
+      "brief_answer": "A Core **Download Recovery File** export contains a plaintext mnemonic/private key. Keep it offline and private; never send it here. The bot cannot recover a forgotten password or missing secrets. Do you still have your recovery phrase or an existing backup? Do not delete the wallet or local data while checking."
     },
     {
       "id": "desktop.ipfs",
@@ -8497,7 +8507,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/ipfs/IPFSContext.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/ipfs/IPFSService.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/app-info/AppInfo.tsx"
-      ]
+      ],
+      "brief_answer": "**6529 Desktop > My IPFS** opens the bundled IPFS node’s WebUI when available. Its local ports are shown under **About**. Keeping content available requires pinning and a running node; this is not an automatic backup of every NFT. Are you trying to add a file, find a pin, or troubleshoot the connection?"
     },
     {
       "id": "desktop.about-and-logs",
@@ -8548,7 +8559,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/app-info/AppInfo.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/logs-viewer/LogsViewer.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/README.md"
-      ]
+      ],
+      "brief_answer": "Open **6529 Desktop > About** for the app version, local ports, updates, and **App Logs**. For a particular stalled worker, check its own **Logs** tab under ETH Transactions. Share only a redacted error and your version/OS; never include wallet secrets or credential-bearing RPC URLs."
     },
     {
       "id": "desktop.local-data",
@@ -8595,7 +8607,323 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/TransactionsLocalData.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/TransactionSearchModal.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/NftLocalData.tsx"
+      ],
+      "brief_answer": "Use the local transaction and NFT views in **6529 Desktop > ETH Transactions** to inspect indexed data. Missing results may mean your workers have not synced yet. Are you looking for a transaction hash, an NFT, or a wallet’s local history?"
+    },
+    {
+      "id": "desktop.overview",
+      "kind": "workflow",
+      "title": "What is 6529 Desktop (Core)?",
+      "aliases": [
+        "what is core",
+        "what is 6529 core",
+        "what is 6529 desktop",
+        "explain core",
+        "about core",
+        "6529 desktop overview",
+        "how does 6529 desktop work"
+      ],
+      "keywords": [
+        "core"
+      ],
+      "facts": [
+        "6529 Desktop, also called Core, is the Windows, macOS, and Linux app with local Core wallets, Ethereum indexing workers, independent TDH calculation, and a bundled IPFS node. These Core tools are separate from the mobile app and desktop-browser website."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/flow-getting-started.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/hooks/useSidebarSections.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduler.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/RpcProviders.tsx"
+      ],
+      "brief_answer": "**6529 Desktop (Core)** is the Windows, macOS, and Linux app that runs your own 6529 node: it indexes Ethereum data and calculates TDH locally. It also includes Core wallets and an IPFS node. Would you like help getting started?",
+      "answer_links": [
+        {
+          "label": "6529 Apps",
+          "url": "https://6529.io/about/6529-apps"
+        }
       ]
+    },
+    {
+      "id": "desktop.clarify-context",
+      "kind": "workflow",
+      "title": "Clarify the app for RPC or transaction support",
+      "aliases": [
+        "desktop support context clarification"
+      ],
+      "keywords": [
+        "core"
+      ],
+      "facts": [
+        "Do you mean **6529 Desktop (Core)**, or another app?"
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core",
+        "desktop-dialogue"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/i18n/messages/en-US.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ],
+      "brief_answer": "Do you mean **6529 Desktop (Core)**, or another app?"
+    },
+    {
+      "id": "desktop.tdh-after-recalculation",
+      "kind": "workflow",
+      "title": "Desktop node still mismatches after recalculation",
+      "aliases": [
+        "desktop mismatch after recalculation"
+      ],
+      "keywords": [
+        "core"
+      ],
+      "facts": [
+        "You have already recalculated and it still does not match. In **6529 Desktop > TDH Calculation**, are the two **Last Block** values identical, and is the mismatch in **TDH**, **Merkle Root**, or both?"
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core",
+        "desktop-dialogue"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/i18n/messages/en-US.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ],
+      "brief_answer": "You have already recalculated and it still does not match. In **6529 Desktop > TDH Calculation**, are the two **Last Block** values identical, and is the mismatch in **TDH**, **Merkle Root**, or both?"
+    },
+    {
+      "id": "desktop.tdh-same-block-mismatch",
+      "kind": "workflow",
+      "title": "Desktop mismatch persists at the same block after recalculation",
+      "aliases": [
+        "desktop confirmed same block mismatch"
+      ],
+      "keywords": [
+        "core"
+      ],
+      "facts": [
+        "Since recalculation did not resolve the mismatch at the same block, the next history check is **6529 Desktop > ETH Transactions > Transactions > Advanced Options > Reconcile**. Choose **Reconcile full history** if you do not know a starting block. It repairs missing/inconsistent/orphaned local transfer records and rebuilds ownership without changing on-chain holdings; it may take time. Let it finish and prerequisites sync before recalculating TDH again."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core",
+        "desktop-dialogue"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/i18n/messages/en-US.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ],
+      "brief_answer": "Since recalculation did not resolve the mismatch at the same block, the next history check is **6529 Desktop > ETH Transactions > Transactions > Advanced Options > Reconcile**. Choose **Reconcile full history** if you do not know a starting block. It repairs missing/inconsistent/orphaned local transfer records and rebuilds ownership without changing on-chain holdings; it may take time. Let it finish and prerequisites sync before recalculating TDH again."
+    },
+    {
+      "id": "desktop.tdh-after-reconciliation",
+      "kind": "workflow",
+      "title": "Desktop mismatch persists after history reconciliation",
+      "aliases": [
+        "desktop mismatch after reconciliation"
+      ],
+      "keywords": [
+        "core"
+      ],
+      "facts": [
+        "If reconciliation has finished, allow the prerequisite workers to catch up, then recalculate TDH once because the history repair can make the old result stale. If you have already done that and the same-block mismatch persists, share your **About** version/OS, both Last Block values, which row differs, and any redacted worker error. Do not reset wallets or the app database; never share wallet secrets or credential-bearing RPC URLs."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core",
+        "desktop-dialogue"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/i18n/messages/en-US.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ],
+      "brief_answer": "If reconciliation has finished, allow the prerequisite workers to catch up, then recalculate TDH once because the history repair can make the old result stale. If you have already done that and the same-block mismatch persists, share your **About** version/OS, both Last Block values, which row differs, and any redacted worker error. Do not reset wallets or the app database; never share wallet secrets or credential-bearing RPC URLs."
+    },
+    {
+      "id": "desktop.tdh-repair-diagnostics",
+      "kind": "workflow",
+      "title": "Desktop node still mismatches after reconciliation and recalculation",
+      "aliases": [
+        "desktop mismatch repair diagnostics"
+      ],
+      "keywords": [
+        "core"
+      ],
+      "facts": [
+        "You have reconciled and recalculated, but the mismatch persists. Please share your **6529 Desktop > About** version/OS, both **Last Block** values, whether **TDH**, **Merkle Root**, or both differ, and any redacted worker error. Do not reset wallets or the app database; never share wallet secrets or credential-bearing RPC URLs."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core",
+        "desktop-dialogue"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/i18n/messages/en-US.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ],
+      "brief_answer": "You have reconciled and recalculated, but the mismatch persists. Please share your **6529 Desktop > About** version/OS, both **Last Block** values, whether **TDH**, **Merkle Root**, or both differ, and any redacted worker error. Do not reset wallets or the app database; never share wallet secrets or credential-bearing RPC URLs."
+    },
+    {
+      "id": "desktop.tdh-block-mismatch",
+      "kind": "workflow",
+      "title": "Desktop Last Block values differ",
+      "aliases": [
+        "desktop last block values differ"
+      ],
+      "keywords": [
+        "core"
+      ],
+      "facts": [
+        "Different **Last Block** values mean you are comparing different snapshots. In **6529 Desktop > ETH Transactions**, check Transactions and NFTDelegation progress and Logs. Let them catch up before recalculating TDH and comparing the same block. Do either of those workers show an error or appear stalled?"
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core",
+        "desktop-dialogue"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/i18n/messages/en-US.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ],
+      "brief_answer": "Different **Last Block** values mean you are comparing different snapshots. In **6529 Desktop > ETH Transactions**, check Transactions and NFTDelegation progress and Logs. Let them catch up before recalculating TDH and comparing the same block. Do either of those workers show an error or appear stalled?"
+    },
+    {
+      "id": "desktop.tdh-check-workers",
+      "kind": "workflow",
+      "title": "Check workers before recalculating a same-block Desktop mismatch",
+      "aliases": [
+        "check workers before recalculating a same-block desktop mismatch"
+      ],
+      "keywords": [
+        "core"
+      ],
+      "facts": [
+        "Your node still does not match 6529.io at the same Last Block. In **6529 Desktop > ETH Transactions**, have **Transactions** and **NFTDelegation** both reached that block? If either is behind or stalled, share its status or a redacted error."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core",
+        "desktop-dialogue"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/i18n/messages/en-US.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ],
+      "brief_answer": "Your node still does not match 6529.io at the same Last Block. In **6529 Desktop > ETH Transactions**, have **Transactions** and **NFTDelegation** both reached that block? If either is behind or stalled, share its status or a redacted error."
+    },
+    {
+      "id": "desktop.tdh-recalculate",
+      "kind": "workflow",
+      "title": "Recalculate after confirming matching blocks and synced workers",
+      "aliases": [
+        "recalculate after confirming matching blocks and synced workers"
+      ],
+      "keywords": [
+        "core"
+      ],
+      "facts": [
+        "The Last Block values match and both workers are caught up. In **6529 Desktop > TDH Calculation**, use the TDH worker’s **Advanced Options > Recalculate TDH Now** and confirm. This replaces the local TDH result; it does not repair transaction history. Once it finishes, does **TDH**, **Merkle Root**, or both still differ?"
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": [
+        "/about/6529-apps"
+      ],
+      "tags": [
+        "desktop-core",
+        "desktop-dialogue"
+      ],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/i18n/messages/en-US.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ],
+      "brief_answer": "The Last Block values match and both workers are caught up. In **6529 Desktop > TDH Calculation**, use the TDH worker’s **Advanced Options > Recalculate TDH Now** and confirm. This replaces the local TDH result; it does not repair transaction history. Once it finishes, does **TDH**, **Merkle Root**, or both still differ?"
     }
   ]
 }

--- a/pr-reports/3947.md
+++ b/pr-reports/3947.md
@@ -1,0 +1,28 @@
+# PR Report: Desktop onboarding and recovery knowledge
+
+PR: [Frontend #3947](https://github.com/6529-Collections/6529seize-frontend/pull/3947)
+Branch: `agent-prxt/desktop-help-corpus` → `main`
+Related: [Backend #1998](https://github.com/6529-Collections/6529seize-backend/pull/1998)
+
+## Summary
+
+Add 13 focused Core knowledge records and detailed guides so help6529 can explain the dedicated 6529 Desktop menu, RPC activation, workers, automatic TDH, transaction reconciliation/reset, NFT recovery, wallets, IPFS, and diagnostics.
+
+## What Changed
+
+- Publish complete procedures in the generated help index, including local-data consequences and warnings alongside destructive controls.
+- Distinguish local total TDH from website/profile TDH, and local recovery from on-chain holdings. Wallet exports are documented as plaintext secrets that must never be shared with the bot.
+- Use exact native controls: Transactions `Reset to Block > Min Block`, NFTs `Full Refresh` versus `Reset All NFTs`, and TDH recalculation after repairs.
+- Document source provenance pinned to Core commit `5d8a06e5ea66835f09ec89db40d4db714759462b`, with a maintenance guide for future native changes.
+
+## Frontend Impact
+
+Knowledge and documentation only; no application routes, components, or generated API clients change. Native menu navigation is described without inventing public Core routes. Mobile and ordinary website answers remain distinct through the companion runtime policy.
+
+## Release Notes
+
+Deploy backend `helpBotReplyLoop` from the companion PR before publishing this corpus. The new runtime preserves longer procedures and scopes local-node retrieval; older behavior can truncate recovery instructions or mix Core facts into generic wallet answers. No Core application release or new configuration is required.
+
+## Risks / Follow-Ups
+
+Keep source-backed facts synchronized when Core controls or worker behavior change. Roll back by removing these records and regenerating the published index before reverting the companion runtime.

--- a/pr-reports/3947.md
+++ b/pr-reports/3947.md
@@ -21,7 +21,7 @@ Knowledge and documentation only; no application routes, components, or generate
 
 ## Release Notes
 
-Deploy backend `helpBotReplyLoop` from the companion PR before publishing this corpus. The new runtime preserves longer procedures and scopes local-node retrieval; older behavior can truncate recovery instructions or mix Core facts into generic wallet answers. No Core application release or new configuration is required.
+Before publishing this corpus, the release operator must verify that backend `helpBotReplyLoop` includes the companion PR in the target environment. Record that confirmation on the PR rollout checklist; merging the backend PR alone is not deployment confirmation. The new runtime preserves longer procedures and scopes local-node retrieval; older behavior can truncate recovery instructions or mix Core facts into generic wallet answers. No Core application release or new configuration is required.
 
 ## Risks / Follow-Ups
 

--- a/pr-reports/3947.md
+++ b/pr-reports/3947.md
@@ -17,7 +17,10 @@ Add 13 focused Core knowledge records and detailed guides so help6529 can explai
 
 ## Frontend Impact
 
-Knowledge and documentation only; no application routes, components, or generated API clients change. Native menu navigation is described without inventing public Core routes. Mobile and ordinary website answers remain distinct through the companion runtime policy.
+Knowledge and documentation only; no application routes, components, or generated API clients change. Native menu navigation is described without inventing public Core routes. The
+onboarding installer link intentionally uses the public production Apps page
+from every environment; it is an official download destination rather than
+environment-relative application navigation. Mobile and ordinary website answers remain distinct through the companion runtime policy.
 
 ## Release Notes
 

--- a/pr-reports/3947.md
+++ b/pr-reports/3947.md
@@ -11,6 +11,7 @@ Add 13 focused Core knowledge records and detailed guides so help6529 can explai
 ## What Changed
 
 - Publish complete procedures in the generated help index, including local-data consequences and warnings alongside destructive controls.
+- Match shorthand Desktop TDH/Merkle mismatch questions to the troubleshooting procedure.
 - Distinguish local total TDH from website/profile TDH, and local recovery from on-chain holdings. Wallet exports are documented as plaintext secrets that must never be shared with the bot.
 - Use exact native controls: Transactions `Reset to Block > Min Block`, NFTs `Full Refresh` versus `Reset All NFTs`, and TDH recalculation after repairs.
 - Document source provenance pinned to Core commit `5d8a06e5ea66835f09ec89db40d4db714759462b`, with a maintenance guide for future native changes.

--- a/pr-reports/3947.md
+++ b/pr-reports/3947.md
@@ -6,11 +6,12 @@ Related: [Backend #1998](https://github.com/6529-Collections/6529seize-backend/p
 
 ## Summary
 
-Add 13 focused Core knowledge records and detailed guides so help6529 can explain the dedicated 6529 Desktop menu, RPC activation, workers, automatic TDH, transaction reconciliation/reset, NFT recovery, wallets, IPFS, and diagnostics.
+Add 22 focused Core knowledge records and detailed guides so help6529 can explain the dedicated 6529 Desktop menu, RPC activation, workers, automatic TDH, transaction reconciliation/reset, NFT recovery, wallets, IPFS, and diagnostics.
 
 ## What Changed
 
-- Publish complete procedures in the generated help index, including local-data consequences and warnings alongside destructive controls.
+- Publish detailed facts plus concise default/fallback answers, keeping local-data consequences beside destructive controls.
+- Separate definitions, setup, initial mismatch triage, and follow-ups after completed repairs. Add validated link metadata for a final More info footer.
 - Match shorthand Desktop TDH/Merkle mismatch questions to the troubleshooting procedure.
 - Distinguish local total TDH from website/profile TDH, and local recovery from on-chain holdings. Wallet exports are documented as plaintext secrets that must never be shared with the bot.
 - Use exact native controls: Transactions `Reset to Block > Min Block`, NFTs `Full Refresh` versus `Reset All NFTs`, and TDH recalculation after repairs.

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -8103,7 +8103,14 @@
         "tdh not matching",
         "my node is behind",
         "tdh not synced",
-        "tdh out of date"
+        "tdh out of date",
+        "tdh different",
+        "tdh is different",
+        "tdh differs",
+        "merkle differ",
+        "merkle differs",
+        "merkle different",
+        "merkle mismatch"
       ],
       "keywords": [
         "desktop",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -7878,6 +7878,653 @@
         "components/collect/CollectPageClient.tsx",
         "components/collect/useMarketExecution.ts"
       ]
+    },
+    {
+      "id": "desktop.getting-started",
+      "kind": "workflow",
+      "title": "Get started with 6529 Desktop (Core)",
+      "aliases": [
+        "get started with 6529 desktop",
+        "get started in core",
+        "getting started with core",
+        "how to get started with 6529 desktop app",
+        "set up 6529 desktop",
+        "set up core",
+        "what is 6529 core",
+        "what is core",
+        "what is 6529 desktop",
+        "how does 6529 desktop work",
+        "explain core",
+        "about core",
+        "6529 desktop overview"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "start",
+        "started",
+        "getting",
+        "setup",
+        "install",
+        "onboarding",
+        "beginner",
+        "overview",
+        "features",
+        "benefits",
+        "capabilities"
+      ],
+      "facts": [
+        "6529 Desktop, also called Core, is the Windows, macOS, and Linux app with local Core wallets, Ethereum indexing workers, independent TDH calculation, and a bundled IPFS node. These Core tools are separate from the mobile app and desktop-browser website.",
+        "Get the official installer from [6529 Apps](https://6529.io/about/6529-apps), choose your operating system, install, and open the app.",
+        "Open the dedicated 6529 Desktop sidebar menu (monitor icon). Its entries are Wallets, ETH Transactions, TDH Calculation, My IPFS when available, and About.",
+        "First open 6529 Desktop > ETH Transactions > RPC Providers > Providers List. Choose Set Active on a provider, or Add RPC Provider, enter an Ethereum mainnet RPC URL, Test it, give it a Provider Name, Add, then Set Active. Saving a provider alone does not enable it.",
+        "With an active RPC provider and the app running, Transactions and NFTDelegation sync automatically, and NFTs discovers and refreshes local NFT data. Initial history sync may take time; inspect worker progress and Logs instead of repeatedly resetting.",
+        "Then open 6529 Desktop > TDH Calculation. TDH runs daily at 00:15 UTC; after prerequisite workers catch up you can use the TDH worker Advanced Options > Recalculate TDH Now. Compare Your Node and 6529.io at the same Last Block.",
+        "Wallets lets you create or import a Core wallet for signing, but importing a wallet or seed phrase is not required to run indexing and TDH. My IPFS opens the bundled node WebUI; About shows version, ports, updates, and App Logs.",
+        "The bot can explain these controls but cannot inspect or operate your local node. Never send it wallet passwords, recovery phrases, private keys, or RPC URLs containing credentials."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core"],
+      "source_refs": [
+        "ops/docs/desktop/flow-getting-started.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/hooks/useSidebarSections.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduler.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/RpcProviders.tsx"
+      ]
+    },
+    {
+      "id": "desktop.rpc-providers",
+      "kind": "workflow",
+      "title": "6529 Desktop RPC provider setup and errors",
+      "aliases": [
+        "core rpc",
+        "desktop rpc",
+        "rpc providers",
+        "add rpc provider",
+        "set active",
+        "invalid rpc url",
+        "enable rpc",
+        "providers list"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "rpc",
+        "provider",
+        "providers",
+        "active",
+        "activate",
+        "enable",
+        "disabled",
+        "url",
+        "test",
+        "throttled",
+        "429"
+      ],
+      "facts": [
+        "In 6529 Desktop open 6529 Desktop > ETH Transactions > RPC Providers and expand Providers List. Workers require an active RPC provider, not merely a saved one.",
+        "To use a listed provider, click Set Active and check its Active indicator. Only one provider is active at a time; selecting another deactivates the previous one and recreates the workers with the selected endpoint.",
+        "For your own provider, choose Add RPC Provider, paste its Ethereum mainnet RPC URL, click Test, enter a unique Provider Name after validation, click Add, then Set Active in Providers List. The test reads the current block and its logs; passing it does not guarantee historical requests will succeed.",
+        "Invalid RPC URL means the test could not read the block/logs. Check the endpoint, network, provider credentials, and service availability. For throttling, rate-limit or history errors, inspect worker Logs and use an endpoint with adequate Ethereum historical log access and request allowance. Do not assume a paid provider is required.",
+        "Deactivate leaves that provider saved but inactive. With no active provider, scheduled workers are disabled. Built-in default providers cannot be deleted; an inactive custom provider exposes Delete.",
+        "RPC provider configuration is for the local Ethereum workers; it is different from the IPFS RPC port shown in About. The TDH page TestNet Mode Phase 1 label does not mean you should select an Ethereum testnet endpoint.",
+        "Do not post your full authenticated RPC URL or API key in chat or logs shared for support. Share the provider name and a redacted error instead."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core"],
+      "source_refs": [
+        "ops/docs/desktop/flow-getting-started.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/RpcProviderModal.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/RpcProviders.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/db/db.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ]
+    },
+    {
+      "id": "desktop.workers",
+      "kind": "workflow",
+      "title": "6529 Desktop workers and automatic syncing",
+      "aliases": [
+        "core workers",
+        "app workers",
+        "desktop workers",
+        "transactions worker",
+        "nftdelegation worker",
+        "nfts worker",
+        "worker stopped",
+        "worker idle"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "workers",
+        "worker",
+        "schedule",
+        "automatic",
+        "sync",
+        "running",
+        "idle",
+        "stop",
+        "queued",
+        "waiting"
+      ],
+      "facts": [
+        "Open 6529 Desktop > ETH Transactions > App Workers for Transactions, NFTDelegation, and NFTs. The TDH worker is on 6529 Desktop > TDH Calculation.",
+        "Transactions indexes transfers related to the 6529 contracts every minute. NFTDelegation follows delegation and consolidation events every minute. NFTs discovers and refreshes The Memes, Gradients, Meme Lab, and NextGen every two minutes, with periodic full refreshes. These are local indexes, not an index of every Ethereum contract.",
+        "With an active RPC provider, non-TDH workers start when the schedulers initialize and then follow their schedules. TDH normally runs daily at 00:15 UTC. Keep the app running and the computer awake for scheduled work; do not promise a fixed initial sync duration.",
+        "Worker cards show their schedule, status, progress, and message. Expand Logs for details. Idle or Completed between runs is normal; Disabled calls for checking the active RPC provider. A waiting message can mean a prerequisite checkpoint or another worker must finish.",
+        "Advanced Options > Run Now requests an immediate run without changing the schedule. Stop ends the current non-TDH execution, but the next scheduled run can start again; it is not a permanent disable switch.",
+        "TDH is coordinated with NFT/delegation work and transaction repairs. Respect a busy or queued response rather than repeatedly clicking recovery actions. Transactions must reach the TDH target block, and NFTDelegation must reach it too.",
+        "An interrupted transaction reconciliation resumes from its saved range on restart with an active provider. An interrupted TDH calculation reruns from scratch on restart; it does not continue a partially calculated result."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core"],
+      "source_refs": [
+        "ops/docs/desktop/feature-workers-and-tdh.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduler.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx"
+      ]
+    },
+    {
+      "id": "desktop.tdh-calculation",
+      "kind": "workflow",
+      "title": "6529 Desktop automatic TDH calculation and validation",
+      "aliases": [
+        "desktop tdh",
+        "core tdh",
+        "tdh calculation",
+        "recalculate tdh now",
+        "tdh consensus",
+        "testnet mode phase 1",
+        "merkle root"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "tdh",
+        "calculation",
+        "calculate",
+        "automatic",
+        "daily",
+        "merkle",
+        "root",
+        "block",
+        "validation",
+        "testnet",
+        "phase",
+        "consensus"
+      ],
+      "facts": [
+        "6529 Desktop > TDH Calculation independently computes TDH from local indexed data. Your Node is compared with the reference 6529.io result. The TDH row is all TDH across the whole system, not your personal profile TDH.",
+        "TDH is scheduled daily at 00:15 UTC while the app runs with an active RPC provider. It calculates the daily snapshot using an Ethereum block before the UTC day boundary, not a continuously changing live balance.",
+        "Transactions and NFTDelegation must both reach the target block before TDH can proceed. A message such as Waiting for Transactions or Waiting for NFTDelegation reports the target and current checkpoint; allow that worker to catch up and check its Logs if it stalls.",
+        "For a manual calculation, open the TDH worker Advanced Options > Recalculate TDH Now and confirm Run TDH Calculation Now. It replaces local TDH calculation data; it does not repair missing transaction history. Finish any underlying history/NFT repair and prerequisite sync first.",
+        "Compare Last Block first, then total TDH and Merkle Root. Different snapshot blocks can explain different values. A Merkle Root hashes the address/TDH results; a missing reference root is N/A and is not proof your node is wrong.",
+        "The page describes TestNet Mode Phase 1: comparison with the 6529.io reference. Phase 2 node-only consensus is described as future behavior, not something already active. This label is separate from Live/Test backend builds and does not switch Ethereum to a testnet.",
+        "Transaction repairs or resets can mark the existing result stale and show Transaction history changed — recalculation required. Recalculate after repair completes or wait for the next scheduled TDH run. Marking stale alone does not immediately start a fresh calculation.",
+        "If the app closes during TDH work, an active provider allows a fresh rerun on restart after worker guards permit it. The bot cannot read your local TDH values or fix your node remotely."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core"],
+      "source_refs": [
+        "ops/docs/desktop/feature-workers-and-tdh.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduler.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/tdh-worker/index.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/tdh-worker/tdh-worker.helpers.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx"
+      ]
+    },
+    {
+      "id": "desktop.tdh-out-of-sync",
+      "kind": "workflow",
+      "title": "6529 Desktop TDH out of sync troubleshooting",
+      "aliases": [
+        "tdh out of sync",
+        "tdh is out of sync",
+        "desktop tdh mismatch",
+        "tdh does not match",
+        "tdh mismatch",
+        "tdh is wrong",
+        "tdh not matching",
+        "my node is behind",
+        "tdh not synced",
+        "tdh out of date"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "tdh",
+        "sync",
+        "synced",
+        "stale",
+        "mismatch",
+        "wrong",
+        "behind",
+        "different",
+        "recovery",
+        "repair",
+        "reconcile",
+        "reset",
+        "merkle",
+        "total"
+      ],
+      "facts": [
+        "For an out-of-sync 6529 Desktop node, first open 6529 Desktop > TDH Calculation and compare Your Node and 6529.io Last Block, total TDH, and Merkle Root. Different blocks are not a same-snapshot mismatch; missing reference data is not proof of local corruption.",
+        "Check 6529 Desktop > ETH Transactions > Providers List for an Active Ethereum RPC provider, then inspect Transactions, NFTDelegation, and NFTs progress and Logs. Let initial syncing and queued prerequisites finish. Fix provider errors before rebuilding data.",
+        "When the inputs are caught up, use TDH Calculation > TDH worker > Advanced Options > Recalculate TDH Now and confirm. Compare again after completion at the same Last Block.",
+        "If a same-block mismatch persists and transaction history is suspect, use ETH Transactions > Transactions > Advanced Options > Reconcile. Choose a specific starting block if known, or Reconcile full history. It compares Ethereum transfer logs through the captured local checkpoint, repairs only missing/inconsistent/orphaned records, and rebuilds affected ownership. Full-history reconciliation can take significant time.",
+        "Use Transactions > Advanced Options > Rebuild Ownership only when the stored transaction history is believed correct but local ownership balances are inconsistent. It cannot recover missing transfers. After history/ownership repairs complete, recalculate TDH.",
+        "If NFTs or metadata are missing or inconsistent, use NFTs > Advanced Options > Full Refresh first; it refreshes chain/metadata without deleting local NFT rows. If rediscovery is needed, NFTs > Advanced Options > Reset opens Reset All NFTs, which deletes local NFT records and resyncs them. There is no button named Full Recovery.",
+        "More disruptive transaction recovery is Transactions > Advanced Options > Reset to Block: it deletes transactions after the chosen block and rebuilds ownership before resync. Use Min Block in that dialog for a full resync from the earliest supported block; Transactions does not expose a separate Reset button. Read the confirmation, choose the smallest justified recovery, allow inputs to catch up, then recalculate TDH. These local repairs do not change on-chain holdings and are not reasons to delete wallets or the app database.",
+        "For a persistent failure, share app version and OS from 6529 Desktop > About, the two Last Block values, failing worker/status, and a redacted error or transaction hash. The bot cannot inspect the device; never share wallet secrets or credential-bearing RPC URLs."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core"],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/i18n/messages/en-US.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ]
+    },
+    {
+      "id": "desktop.transaction-reconciliation",
+      "kind": "workflow",
+      "title": "6529 Desktop reconcile transaction history",
+      "aliases": [
+        "reconcile transactions",
+        "transaction reconciliation",
+        "reconcile full history",
+        "reconcile from a specific block",
+        "missing transactions",
+        "missing transfers"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "reconcile",
+        "reconciliation",
+        "transactions",
+        "transaction",
+        "trx",
+        "history",
+        "missing",
+        "orphaned",
+        "repair",
+        "checkpoint"
+      ],
+      "facts": [
+        "In 6529 Desktop go to 6529 Desktop > ETH Transactions > Transactions > Advanced Options > Reconcile. The dialog is Reconcile Transactions.",
+        "Choose Reconcile from a specific block and enter the first suspect block, or Reconcile full history from the displayed earliest block (13360860). The run ends at the local transaction checkpoint captured at start; it is not forward sync to the live chain tip.",
+        "Reconciliation compares Ethereum transfer logs to the local index and repairs missing, inconsistent, or orphaned records. It rebuilds ownership for affected tokens, and marks TDH for recalculation when repairs are made. It does not blindly delete all history.",
+        "Use an active working RPC provider and let active Transactions/TDH work finish; the action can be disabled or rejected while conflicting work runs. Full history can take significant time and RPC requests.",
+        "Progress is saved. If reconciliation is interrupted, restarting the app with an active RPC provider resumes it from its saved range. Do not start a competing reset while a reconciliation is active.",
+        "After repairs and normal sync finish, open TDH Calculation > Advanced Options > Recalculate TDH Now. Repairing history alone can leave the displayed TDH result stale.",
+        "For correct transaction records but wrong balances use Rebuild Ownership; for metadata issues use NFTs Full Refresh. Reset to Block, including its Min Block option for a full resync, is more disruptive and is not equivalent to Reconcile."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core"],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduler.ts"
+      ]
+    },
+    {
+      "id": "desktop.transaction-reset",
+      "kind": "workflow",
+      "title": "6529 Desktop transaction reset and ownership rebuild",
+      "aliases": [
+        "reset transactions worker",
+        "reset trx worker",
+        "reset transaction worker",
+        "reset to block",
+        "rebuild ownership",
+        "recalculate owners",
+        "reset worker"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "reset",
+        "transactions",
+        "transaction",
+        "trx",
+        "block",
+        "ownership",
+        "rebuild",
+        "balances",
+        "rollback"
+      ],
+      "facts": [
+        "In 6529 Desktop > ETH Transactions > Transactions > Advanced Options, Rebuild Ownership, Reset to Block, and Reconcile have different effects. Let the current worker and conflicting TDH work finish before using them.",
+        "Rebuild Ownership rebuilds every locally indexed NFT balance from existing transaction history. It leaves transaction records and the sync checkpoint unchanged. Use it only when transaction history is believed correct; it cannot discover missing transfers.",
+        "Prefer Reconcile for missing or inconsistent historical transfers: it checks chain logs and repairs affected records without a blanket history deletion.",
+        "Reset to Block rolls back to the chosen block: transactions after it are deleted, ownership is rebuilt at that point, and later syncing reimports forward from there. The dialog offers Min Block for the earliest supported worker block, 13360860. Choose a block based on the observed problem rather than guessing.",
+        "To fully resync Transactions from the beginning, use Reset to Block > Min Block and confirm. Transactions does not expose a standalone Reset button. Rolling back to the earliest supported block removes later local history for reimport; this is a more disruptive fallback than reconciliation and requires time and RPC access.",
+        "Once repair/resync and prerequisite workers complete, use TDH Calculation > TDH worker > Advanced Options > Recalculate TDH Now. A stale-result warning is expected after history changes until a successful recalculation.",
+        "Worker recovery changes local indexed data, not on-chain NFTs or balances. Do not delete the whole app database or a Core wallet as a transaction-repair step."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core"],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/i18n/messages/en-US.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/index.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ]
+    },
+    {
+      "id": "desktop.nft-recovery",
+      "kind": "workflow",
+      "title": "6529 Desktop NFT full refresh and reset recovery",
+      "aliases": [
+        "nfts full recovery",
+        "nft full recovery",
+        "full refresh nfts",
+        "reset all nfts",
+        "nft recovery",
+        "missing nfts",
+        "nft metadata"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "nft",
+        "nfts",
+        "metadata",
+        "refresh",
+        "reset",
+        "recovery",
+        "missing",
+        "edition",
+        "size",
+        "mint",
+        "date"
+      ],
+      "facts": [
+        "Open 6529 Desktop > ETH Transactions > NFTs. Data shows the locally indexed NFTs; Logs shows discovery and refresh progress. These records cover The Memes, Gradients, Meme Lab, and NextGen.",
+        "For outdated metadata or inconsistent indexed NFT details, open NFTs > Advanced Options > Full Refresh and confirm Full Refresh NFTs. It refreshes all indexed NFTs from chain and metadata without deleting local NFT data.",
+        "For a missing local NFT history requiring rediscovery, NFTs > Advanced Options > Reset opens Reset All NFTs. Confirming deletes all local NFT rows and starts discovery from the beginning. This is more disruptive than Full Refresh and is not named Full Recovery in the UI.",
+        "An NFT can wait for its mint transaction to be indexed. A Waiting for transaction sync message calls for checking Transactions progress/provider/history first; resetting NFTs repeatedly cannot repair missing transfers.",
+        "Finish active NFT work and respect TDH worker conflicts before a refresh/reset. Check Logs for RPC or metadata retrieval errors; a failing upstream source needs attention rather than repeated resets.",
+        "After NFT recovery and transaction/delegation sync complete, recalculate TDH if the node result needs rebuilding. NFT refresh/reset does not change your on-chain holdings, delete your Core wallet, or replace a transaction-history reconciliation."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core"],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/nft-worker/nft-discovery.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/NftLocalData.tsx"
+      ]
+    },
+    {
+      "id": "desktop.wallets",
+      "kind": "workflow",
+      "title": "6529 Desktop Core wallets creation import and connection",
+      "aliases": [
+        "core wallets",
+        "core wallet",
+        "desktop wallets",
+        "create core wallet",
+        "import core wallet",
+        "connect core wallet",
+        "delete core wallet"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "wallet",
+        "wallets",
+        "create",
+        "import",
+        "connect",
+        "unlock",
+        "sign",
+        "delete"
+      ],
+      "facts": [
+        "Open 6529 Desktop > Wallets for Core wallets stored on this computer. These are separate from mobile App Wallets and from connecting an external wallet or sharing a website login session.",
+        "Create Wallet opens Create New Wallet: choose a name and password and select Create. Core generates a wallet and stores its private key and recovery phrase encrypted with that password in the local database.",
+        "Import Wallet offers Mnemonic (the current form accepts 12 words) or Private Key. Enter it only in the trusted local app, Validate, check the resulting address, then Import Wallet with a name and password. Never send a phrase, key, or password to the help bot.",
+        "Use the Core wallet connector in the wallet connection flow to select a saved wallet and unlock it when prompted. Review signature/transaction requests before approving; an unlocked wallet and an authenticated 6529 session are distinct states.",
+        "Wallet details show the address and password-protected reveal/copy controls plus Download Recovery File. That download contains the decrypted private key and available mnemonic in a plaintext text file; keep it private and securely backed up, never send it to the bot. Private-key-only imports have no mnemonic.",
+        "Delete removes the saved local wallet record after confirmation; disconnect first if it is the currently connected wallet. It does not erase the Ethereum address or move on-chain funds. There is no documented bot/password-recovery service; the bot cannot decrypt or recover a forgotten wallet password.",
+        "A Core wallet is optional for node indexing and TDH calculation. You can run workers with an active RPC provider without importing any funded wallet, and connecting a wallet does not enable RPC workers."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core"],
+      "source_refs": [
+        "ops/docs/desktop/feature-wallets-ipfs-and-about.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/core-wallet/SeedWallets.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/core-wallet/SeedWalletImport.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/core-wallet/SeedWallet.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/db/db.ts"
+      ]
+    },
+    {
+      "id": "desktop.wallet-backup",
+      "kind": "workflow",
+      "title": "6529 Desktop Core wallet backup and password problems",
+      "aliases": [
+        "core wallet backup",
+        "forgot core wallet password",
+        "core wallet password",
+        "forgot desktop wallet password",
+        "core wallet recovery",
+        "core recovery phrase",
+        "core private key",
+        "download recovery file",
+        "core recovery file"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "wallet",
+        "backup",
+        "password",
+        "forgot",
+        "recovery",
+        "phrase",
+        "mnemonic",
+        "private",
+        "key",
+        "lost",
+        "export"
+      ],
+      "facts": [
+        "Core wallets live in 6529 Desktop > Wallets on this device. The stored private key and, when present, mnemonic are encrypted with the wallet password; a connected website profile is not a backup.",
+        "Open the saved wallet details and use Download Recovery File after unlocking, or use the password-protected reveal/copy controls. The recovery download is a plaintext text file containing the private key and available mnemonic, not an encrypted wallet backup. Keep it private and securely backed up; never upload it or paste any wallet password, key, or phrase into the bot. Private-key-only imports have no mnemonic.",
+        "If you cannot unlock a wallet, verify that you selected the right saved wallet and are entering its wallet password. The bot cannot inspect the wallet, bypass encryption, reset its password, or recover missing secrets.",
+        "If you have an independent recovery phrase or private-key backup, the local Import Wallet flow can restore the corresponding address; validate the address before using it. Do not delete the only local copy while investigating a password problem.",
+        "Deleting a wallet or app database is not a TDH repair step. Transaction/NFT worker recovery only needs the relevant indexed-data controls, not your wallet secrets. Keep independently recoverable wallet backups before any app-data removal."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core"],
+      "source_refs": [
+        "ops/docs/desktop/feature-wallets-ipfs-and-about.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/core-wallet/SeedWallet.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/core-wallet/SeedWalletModal.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/db/db.ts"
+      ]
+    },
+    {
+      "id": "desktop.ipfs",
+      "kind": "workflow",
+      "title": "6529 Desktop My IPFS node and local files",
+      "aliases": [
+        "my ipfs",
+        "core ipfs",
+        "desktop ipfs",
+        "ipfs node",
+        "ipfs rpc",
+        "ipfs gateway",
+        "ipfs files"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "ipfs",
+        "node",
+        "files",
+        "gateway",
+        "rpc",
+        "port",
+        "pins",
+        "pinning",
+        "cid",
+        "storage",
+        "webui"
+      ],
+      "facts": [
+        "6529 Desktop bundles a local IPFS daemon. Open 6529 Desktop > My IPFS to launch its WebUI when the app has resolved the local IPFS configuration; My IPFS is separate from ETH Transactions and the Ethereum RPC Providers list.",
+        "The app uses a local IPFS API, gateway, and swarm port. Find the actual IPFS Port, IPFS RPC Port, and IPFS Swarm Port in 6529 Desktop > About; do not assume a fixed port or share a localhost URL as a public link.",
+        "The Desktop IPFS file service pins added files and keeps a named entry under /6529-Desktop in the node file system. A CID identifies content; local storage/pinning is not a promise of permanent availability or replication elsewhere.",
+        "The bundled node uses configured bootstrap peers with automatic peer discovery/routing features restricted. Do not describe it as an unrestricted network crawler, a backup of every NFT, or proof that TDH consensus has completed.",
+        "If My IPFS is missing or the WebUI cannot connect, keep the app open, check About > App Logs for IPFS startup/connection errors and confirm the displayed ports. Restart the app normally if initialization failed; persistent errors need the app version, OS, and redacted log details.",
+        "The IPFS API and gateway are bound to loopback. Do not expose the local administrative API publicly, upload wallet secrets, or delete the IPFS repository to fix an unrelated TDH mismatch. IPFS storage and Ethereum transaction indexing are separate concerns."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core"],
+      "source_refs": [
+        "ops/docs/desktop/feature-wallets-ipfs-and-about.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/ipfs/ipfs.server.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/ipfs/IPFSContext.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/ipfs/IPFSService.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/app-info/AppInfo.tsx"
+      ]
+    },
+    {
+      "id": "desktop.about-and-logs",
+      "kind": "workflow",
+      "title": "6529 Desktop version updates and diagnostic logs",
+      "aliases": [
+        "desktop about",
+        "core about",
+        "desktop logs",
+        "core logs",
+        "desktop update",
+        "update core",
+        "app logs"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "version",
+        "update",
+        "updates",
+        "logs",
+        "log",
+        "error",
+        "about",
+        "diagnostics",
+        "ports",
+        "os"
+      ],
+      "facts": [
+        "Open 6529 Desktop > About for the installed version, OS/architecture, app scheme, app port, IPFS ports, updater status, and App Logs. Opening About checks for updates.",
+        "The update area shows checking, available, downloading progress, downloaded, no-update, or error states. Use the action offered for that state; the bot does not know the latest available build unless it has current release evidence.",
+        "Use ETH Transactions > the affected worker > Logs for a worker-specific failure. Expand Advanced Options for recovery controls. Logs > Locate opens the log file location; selecting log text enables Copy Selection.",
+        "For a TDH issue include both Last Block values, the mismatched field, last calculation time, and the failing worker message. For a missing transfer include a public transaction hash and the expected block; distinguish a local-node mismatch from personal website TDH.",
+        "Share only relevant redacted diagnostic lines. Remove RPC API keys/credential URLs, passwords, private keys, and recovery phrases. The bot cannot inspect your filesystem, operate workers, or confirm the node is repaired without observations from you.",
+        "The native titlebar identifies a Live/Test backend where applicable. That backend target is distinct from TDH TestNet Mode Phase 1. Core-only menu controls and routes are unavailable on mobile and ordinary web browsers."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core"],
+      "source_refs": [
+        "ops/docs/desktop/feature-wallets-ipfs-and-about.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/app-info/AppInfo.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/logs-viewer/LogsViewer.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/README.md"
+      ]
+    },
+    {
+      "id": "desktop.local-data",
+      "kind": "workflow",
+      "title": "6529 Desktop local transaction and NFT data inspection",
+      "aliases": [
+        "local transactions",
+        "local nft data",
+        "desktop transaction search",
+        "core transaction search",
+        "transactions data"
+      ],
+      "keywords": [
+        "desktop",
+        "core",
+        "local",
+        "data",
+        "search",
+        "transaction",
+        "transactions",
+        "hash",
+        "nft",
+        "nfts",
+        "filter"
+      ],
+      "facts": [
+        "Open 6529 Desktop > ETH Transactions > Transactions > Data to inspect the locally indexed transfers. Use its collection filters, sorting, pagination, and transaction-hash search to investigate a known transfer.",
+        "A missing local result can mean that the worker has not reached that block, the contract is outside the indexed 6529 collections, or history needs reconciliation. Check the transaction checkpoint and Logs before resetting.",
+        "Open NFTs > Data for locally indexed NFT details, collection and season filters, and search. This data view describes the node database, not a live query of your wallet holdings.",
+        "Use Reconcile for suspect transfer history, Rebuild Ownership for inconsistent balances with correct history, and NFTs Full Refresh for stale NFT metadata. Finish repair and catch-up before recalculating TDH.",
+        "The bot cannot query these local tables. You can provide a public transaction hash, token/collection, observed checkpoint, and redacted error for more specific guidance."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core"],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/TransactionsLocalData.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/TransactionSearchModal.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/NftLocalData.tsx"
+      ]
     }
   ]
 }

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -7890,14 +7890,7 @@
         "getting started with core",
         "how to get started with 6529 desktop app",
         "set up 6529 desktop",
-        "set up core",
-        "what is 6529 core",
-        "what is core",
-        "what is 6529 desktop",
-        "how does 6529 desktop work",
-        "explain core",
-        "about core",
-        "6529 desktop overview"
+        "set up core"
       ],
       "keywords": [
         "desktop",
@@ -7916,7 +7909,7 @@
       ],
       "facts": [
         "6529 Desktop, also called Core, is the Windows, macOS, and Linux app with local Core wallets, Ethereum indexing workers, independent TDH calculation, and a bundled IPFS node. These Core tools are separate from the mobile app and desktop-browser website.",
-        "Get the official installer from [6529 Apps](https://6529.io/about/6529-apps), choose your operating system, install, and open the app.",
+        "Get the official installer from 6529 Apps, choose your operating system, install, and open the app.",
         "Open the dedicated 6529 Desktop sidebar menu (monitor icon). Its entries are Wallets, ETH Transactions, TDH Calculation, My IPFS when available, and About.",
         "First open 6529 Desktop > ETH Transactions > RPC Providers > Providers List. Choose Set Active on a provider, or Add RPC Provider, enter an Ethereum mainnet RPC URL, Test it, give it a Provider Name, Add, then Set Active. Saving a provider alone does not enable it.",
         "With an active RPC provider and the app running, Transactions and NFTDelegation sync automatically, and NFTs discovers and refreshes local NFT data. Initial history sync may take time; inspect worker progress and Logs instead of repeatedly resetting.",
@@ -7935,6 +7928,10 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduler.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/RpcProviders.tsx"
+      ],
+      "brief_answer": "Install 6529 Desktop from the Apps page, then open **6529 Desktop > ETH Transactions > RPC Providers > Providers List** and **Set Active** on a provider. Keep the app open while its workers sync; TDH calculates automatically once prerequisites are ready. You do not need to import a wallet to run your node. Have you installed the app already?",
+      "answer_links": [
+        { "label": "6529 Apps", "url": "https://6529.io/about/6529-apps" }
       ]
     },
     {
@@ -7986,7 +7983,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/RpcProviders.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/db/db.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
-      ]
+      ],
+      "brief_answer": "Open **6529 Desktop > ETH Transactions > RPC Providers > Providers List** and click **Set Active** on your provider. If none is saved, use **Add RPC Provider**, enter an Ethereum mainnet RPC URL, **Test** it, enter a Provider Name, then **Add** and **Set Active**. Saving alone does not activate it; never share a URL containing API credentials."
     },
     {
       "id": "desktop.workers",
@@ -8035,7 +8033,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduler.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx"
-      ]
+      ],
+      "brief_answer": "With an active RPC provider and the app open, Core workers sync automatically. Check their progress and Logs under **6529 Desktop > ETH Transactions**. Transactions and NFTDelegation must catch up before TDH calculation can finish. Which worker is stalled, and what status or redacted error does it show?"
     },
     {
       "id": "desktop.tdh-calculation",
@@ -8087,7 +8086,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/tdh-worker/index.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/tdh-worker/tdh-worker.helpers.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx"
-      ]
+      ],
+      "brief_answer": "Core calculates TDH automatically at **00:15 UTC** while the app is open and its prerequisites are synced. View it under **6529 Desktop > TDH Calculation**. For a manual run, use the TDH worker’s **Advanced Options > Recalculate TDH Now**; it replaces the local TDH result and does not repair transaction history."
     },
     {
       "id": "desktop.tdh-out-of-sync",
@@ -8144,7 +8144,7 @@
       "link_label": "6529 Apps",
       "suppress_source_links": true,
       "related_paths": ["/about/6529-apps"],
-      "tags": ["desktop-core"],
+      "tags": ["desktop-core", "desktop-dialogue"],
       "source_refs": [
         "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
@@ -8153,7 +8153,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
-      ]
+      ],
+      "brief_answer": "In **6529 Desktop > TDH Calculation**, are the two **Last Block** values identical? Which row does not match: **TDH**, **Last Block**, or **Merkle Root**? Different blocks can explain different results; an unavailable reference root is not evidence of corruption."
     },
     {
       "id": "desktop.transaction-reconciliation",
@@ -8200,7 +8201,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduler.ts"
-      ]
+      ],
+      "brief_answer": "In **6529 Desktop > ETH Transactions > Transactions > Advanced Options > Reconcile**, choose a starting block if known, or **Reconcile full history**. This repairs missing, inconsistent, or orphaned local transfer records through the captured checkpoint and rebuilds affected ownership; a full scan can take time. Let it finish, allow prerequisites to sync, then recalculate TDH. It does not change on-chain holdings."
     },
     {
       "id": "desktop.transaction-reset",
@@ -8249,7 +8251,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/index.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
-      ]
+      ],
+      "brief_answer": "For a full transaction resync, open **6529 Desktop > ETH Transactions > Transactions > Advanced Options > Reset to Block > Min Block**. This deletes local transactions after the selected block and rebuilds ownership before resyncing; it does not change on-chain holdings. Prefer Reconcile first for suspect history. Read the confirmation, wait for syncing to finish, then recalculate TDH. Transactions has no standalone Reset button."
     },
     {
       "id": "desktop.nft-recovery",
@@ -8297,7 +8300,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/nft-worker/nft-discovery.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/NftLocalData.tsx"
-      ]
+      ],
+      "brief_answer": "Under **6529 Desktop > ETH Transactions > NFTs > Advanced Options**, try **Full Refresh** first for missing or inconsistent NFT metadata. **Reset > Reset All NFTs** deletes local NFT records and rediscovers them; use it only if rediscovery is needed. There is no button named Full Recovery. These actions do not change on-chain holdings. After repair and syncing finish, recalculate TDH."
     },
     {
       "id": "desktop.wallets",
@@ -8344,7 +8348,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/core-wallet/SeedWalletImport.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/core-wallet/SeedWallet.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/db/db.ts"
-      ]
+      ],
+      "brief_answer": "Open **6529 Desktop > Wallets** to create or import a Core wallet for signing. You do not need a wallet to run indexing or TDH calculation. What would you like to do: create, import, or connect one? Never share your recovery phrase or private key here."
     },
     {
       "id": "desktop.wallet-backup",
@@ -8393,7 +8398,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/core-wallet/SeedWallet.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/core-wallet/SeedWalletModal.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/db/db.ts"
-      ]
+      ],
+      "brief_answer": "A Core **Download Recovery File** export contains a plaintext mnemonic/private key. Keep it offline and private; never send it here. The bot cannot recover a forgotten password or missing secrets. Do you still have your recovery phrase or an existing backup? Do not delete the wallet or local data while checking."
     },
     {
       "id": "desktop.ipfs",
@@ -8442,7 +8448,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/ipfs/IPFSContext.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/ipfs/IPFSService.ts",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/app-info/AppInfo.tsx"
-      ]
+      ],
+      "brief_answer": "**6529 Desktop > My IPFS** opens the bundled IPFS node’s WebUI when available. Its local ports are shown under **About**. Keeping content available requires pinning and a running node; this is not an automatic backup of every NFT. Are you trying to add a file, find a pin, or troubleshoot the connection?"
     },
     {
       "id": "desktop.about-and-logs",
@@ -8489,7 +8496,8 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/app-info/AppInfo.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/logs-viewer/LogsViewer.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/README.md"
-      ]
+      ],
+      "brief_answer": "Open **6529 Desktop > About** for the app version, local ports, updates, and **App Logs**. For a particular stalled worker, check its own **Logs** tab under ETH Transactions. Share only a redacted error and your version/OS; never include wallet secrets or credential-bearing RPC URLs."
     },
     {
       "id": "desktop.local-data",
@@ -8532,7 +8540,244 @@
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/TransactionsLocalData.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/TransactionSearchModal.tsx",
         "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/NftLocalData.tsx"
+      ],
+      "brief_answer": "Use the local transaction and NFT views in **6529 Desktop > ETH Transactions** to inspect indexed data. Missing results may mean your workers have not synced yet. Are you looking for a transaction hash, an NFT, or a wallet’s local history?"
+    },
+    {
+      "id": "desktop.overview",
+      "kind": "workflow",
+      "title": "What is 6529 Desktop (Core)?",
+      "aliases": [
+        "what is core",
+        "what is 6529 core",
+        "what is 6529 desktop",
+        "explain core",
+        "about core",
+        "6529 desktop overview",
+        "how does 6529 desktop work"
+      ],
+      "keywords": ["core"],
+      "facts": [
+        "6529 Desktop, also called Core, is the Windows, macOS, and Linux app with local Core wallets, Ethereum indexing workers, independent TDH calculation, and a bundled IPFS node. These Core tools are separate from the mobile app and desktop-browser website."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core"],
+      "source_refs": [
+        "ops/docs/desktop/flow-getting-started.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/hooks/useSidebarSections.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduler.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/RpcProviders.tsx"
+      ],
+      "brief_answer": "**6529 Desktop (Core)** is the Windows, macOS, and Linux app that runs your own 6529 node: it indexes Ethereum data and calculates TDH locally. It also includes Core wallets and an IPFS node. Would you like help getting started?",
+      "answer_links": [
+        { "label": "6529 Apps", "url": "https://6529.io/about/6529-apps" }
       ]
+    },
+    {
+      "id": "desktop.clarify-context",
+      "kind": "workflow",
+      "title": "Clarify the app for RPC or transaction support",
+      "aliases": ["desktop support context clarification"],
+      "keywords": ["core"],
+      "facts": ["Do you mean **6529 Desktop (Core)**, or another app?"],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core", "desktop-dialogue"],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/i18n/messages/en-US.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ],
+      "brief_answer": "Do you mean **6529 Desktop (Core)**, or another app?"
+    },
+    {
+      "id": "desktop.tdh-after-recalculation",
+      "kind": "workflow",
+      "title": "Desktop node still mismatches after recalculation",
+      "aliases": ["desktop mismatch after recalculation"],
+      "keywords": ["core"],
+      "facts": [
+        "You have already recalculated and it still does not match. In **6529 Desktop > TDH Calculation**, are the two **Last Block** values identical, and is the mismatch in **TDH**, **Merkle Root**, or both?"
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core", "desktop-dialogue"],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/i18n/messages/en-US.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ],
+      "brief_answer": "You have already recalculated and it still does not match. In **6529 Desktop > TDH Calculation**, are the two **Last Block** values identical, and is the mismatch in **TDH**, **Merkle Root**, or both?"
+    },
+    {
+      "id": "desktop.tdh-same-block-mismatch",
+      "kind": "workflow",
+      "title": "Desktop mismatch persists at the same block after recalculation",
+      "aliases": ["desktop confirmed same block mismatch"],
+      "keywords": ["core"],
+      "facts": [
+        "Since recalculation did not resolve the mismatch at the same block, the next history check is **6529 Desktop > ETH Transactions > Transactions > Advanced Options > Reconcile**. Choose **Reconcile full history** if you do not know a starting block. It repairs missing/inconsistent/orphaned local transfer records and rebuilds ownership without changing on-chain holdings; it may take time. Let it finish and prerequisites sync before recalculating TDH again."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core", "desktop-dialogue"],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/i18n/messages/en-US.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ],
+      "brief_answer": "Since recalculation did not resolve the mismatch at the same block, the next history check is **6529 Desktop > ETH Transactions > Transactions > Advanced Options > Reconcile**. Choose **Reconcile full history** if you do not know a starting block. It repairs missing/inconsistent/orphaned local transfer records and rebuilds ownership without changing on-chain holdings; it may take time. Let it finish and prerequisites sync before recalculating TDH again."
+    },
+    {
+      "id": "desktop.tdh-after-reconciliation",
+      "kind": "workflow",
+      "title": "Desktop mismatch persists after history reconciliation",
+      "aliases": ["desktop mismatch after reconciliation"],
+      "keywords": ["core"],
+      "facts": [
+        "If reconciliation has finished, allow the prerequisite workers to catch up, then recalculate TDH once because the history repair can make the old result stale. If you have already done that and the same-block mismatch persists, share your **About** version/OS, both Last Block values, which row differs, and any redacted worker error. Do not reset wallets or the app database; never share wallet secrets or credential-bearing RPC URLs."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core", "desktop-dialogue"],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/i18n/messages/en-US.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ],
+      "brief_answer": "If reconciliation has finished, allow the prerequisite workers to catch up, then recalculate TDH once because the history repair can make the old result stale. If you have already done that and the same-block mismatch persists, share your **About** version/OS, both Last Block values, which row differs, and any redacted worker error. Do not reset wallets or the app database; never share wallet secrets or credential-bearing RPC URLs."
+    },
+    {
+      "id": "desktop.tdh-repair-diagnostics",
+      "kind": "workflow",
+      "title": "Desktop node still mismatches after reconciliation and recalculation",
+      "aliases": ["desktop mismatch repair diagnostics"],
+      "keywords": ["core"],
+      "facts": [
+        "You have reconciled and recalculated, but the mismatch persists. Please share your **6529 Desktop > About** version/OS, both **Last Block** values, whether **TDH**, **Merkle Root**, or both differ, and any redacted worker error. Do not reset wallets or the app database; never share wallet secrets or credential-bearing RPC URLs."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core", "desktop-dialogue"],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/i18n/messages/en-US.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ],
+      "brief_answer": "You have reconciled and recalculated, but the mismatch persists. Please share your **6529 Desktop > About** version/OS, both **Last Block** values, whether **TDH**, **Merkle Root**, or both differ, and any redacted worker error. Do not reset wallets or the app database; never share wallet secrets or credential-bearing RPC URLs."
+    },
+    {
+      "id": "desktop.tdh-block-mismatch",
+      "kind": "workflow",
+      "title": "Desktop Last Block values differ",
+      "aliases": ["desktop last block values differ"],
+      "keywords": ["core"],
+      "facts": [
+        "Different **Last Block** values mean you are comparing different snapshots. In **6529 Desktop > ETH Transactions**, check Transactions and NFTDelegation progress and Logs. Let them catch up before recalculating TDH and comparing the same block. Do either of those workers show an error or appear stalled?"
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core", "desktop-dialogue"],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/i18n/messages/en-US.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ],
+      "brief_answer": "Different **Last Block** values mean you are comparing different snapshots. In **6529 Desktop > ETH Transactions**, check Transactions and NFTDelegation progress and Logs. Let them catch up before recalculating TDH and comparing the same block. Do either of those workers show an error or appear stalled?"
+    },
+    {
+      "id": "desktop.tdh-check-workers",
+      "kind": "workflow",
+      "title": "Check workers before recalculating a same-block Desktop mismatch",
+      "aliases": [
+        "check workers before recalculating a same-block desktop mismatch"
+      ],
+      "keywords": ["core"],
+      "facts": [
+        "Your node still does not match 6529.io at the same Last Block. In **6529 Desktop > ETH Transactions**, have **Transactions** and **NFTDelegation** both reached that block? If either is behind or stalled, share its status or a redacted error."
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core", "desktop-dialogue"],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/i18n/messages/en-US.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ],
+      "brief_answer": "Your node still does not match 6529.io at the same Last Block. In **6529 Desktop > ETH Transactions**, have **Transactions** and **NFTDelegation** both reached that block? If either is behind or stalled, share its status or a redacted error."
+    },
+    {
+      "id": "desktop.tdh-recalculate",
+      "kind": "workflow",
+      "title": "Recalculate after confirming matching blocks and synced workers",
+      "aliases": [
+        "recalculate after confirming matching blocks and synced workers"
+      ],
+      "keywords": ["core"],
+      "facts": [
+        "The Last Block values match and both workers are caught up. In **6529 Desktop > TDH Calculation**, use the TDH worker’s **Advanced Options > Recalculate TDH Now** and confirm. This replaces the local TDH result; it does not repair transaction history. Once it finishes, does **TDH**, **Merkle Root**, or both still differ?"
+      ],
+      "canonical_path": "/about/6529-apps",
+      "link_label": "6529 Apps",
+      "suppress_source_links": true,
+      "related_paths": ["/about/6529-apps"],
+      "tags": ["desktop-core", "desktop-dialogue"],
+      "source_refs": [
+        "ops/docs/desktop/troubleshooting-sync-and-recovery.md",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/eth-scanner/Workers.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/i18n/messages/en-US.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/renderer/components/core/tdh-calculation/TDHValidation.tsx",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/workers/transactions-worker/transaction-reconciliation.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/scheduled-tasks/scheduled-worker.ts",
+        "https://github.com/6529-Collections/6529-core/blob/5d8a06e5ea66835f09ec89db40d4db714759462b/electron-src/index.ts"
+      ],
+      "brief_answer": "The Last Block values match and both workers are caught up. In **6529 Desktop > TDH Calculation**, use the TDH worker’s **Advanced Options > Recalculate TDH Now** and confirm. This replaces the local TDH result; it does not repair transaction history. Once it finishes, does **TDH**, **Merkle Root**, or both still differ?"
     }
   ]
 }

--- a/scripts/sync-help-index.cjs
+++ b/scripts/sync-help-index.cjs
@@ -279,6 +279,38 @@ function validateSourceRefs(record) {
   }
 }
 
+function validateAnswerMetadata(record, routePatterns) {
+  if (record.brief_answer !== undefined) {
+    requireString(record.brief_answer, "brief_answer", record.id);
+    if (record.brief_answer.length > 900)
+      fail(`${record.id}: brief_answer exceeds 900 characters`);
+  }
+  if (record.answer_links !== undefined) {
+    if (!Array.isArray(record.answer_links) || record.answer_links.length > 3) {
+      fail(
+        `${record.id}: answer_links must be an array of at most three links`
+      );
+    }
+    for (const link of record.answer_links) {
+      if (!link || typeof link !== "object")
+        fail(`${record.id}: answer_links entries must be objects`);
+      requireString(link.label, "answer_links.label", record.id);
+      requireString(link.url, "answer_links.url", record.id);
+      if (!/^https:\/\/6529\.io\/[a-zA-Z0-9/_-]*$/.test(link.url)) {
+        fail(`${record.id}: answer_links must target a public 6529.io page`);
+      }
+      validateInternalPath(
+        new URL(link.url).pathname,
+        "answer_links",
+        record.id,
+        routePatterns.filter((route) =>
+          route.segments.every((segment) => segment.kind === "static")
+        )
+      );
+    }
+  }
+}
+
 function validateRecord(record, ids, routePatterns) {
   requireString(record.id, "id", "record");
   if (ids.has(record.id)) {
@@ -304,6 +336,7 @@ function validateRecord(record, ids, routePatterns) {
   requireStringArray(record.aliases, "aliases", record.id);
   requireStringArray(record.keywords, "keywords", record.id);
   requireStringArray(record.facts, "facts", record.id);
+  validateAnswerMetadata(record, routePatterns);
 
   for (const field of ["related_paths", "tags", "source_refs"]) {
     if (record[field] !== undefined) {


### PR DESCRIPTION
## Issue

Help6529 needs complete product knowledge for 6529 Desktop and 6529 Mobile. The former name 6529 Core should remain recognizable, but answers should use the official current names. Mobile App Wallet questions also need their own source-backed guidance.

## Fix

Publish focused 6529 Desktop onboarding and recovery knowledge plus 6529 Mobile App Wallet guidance. Add a dedicated legacy-name explanation so “Core” is understood without appearing as the normal Desktop product name.

## Changes

- Keep failed or incomplete recovery at its current range; only completed reconciliation and TDH recalculation with a persistent same-block mismatch can advance. Failed TDH calculation requests a redacted log error.
- After completed full-history reconciliation and recalculation still fail, offer Transactions > Advanced Options > Reset to Block, with Min Block as the full-resync fallback. Explain local history replacement and RPC/time cost, confirm resync before recalculation, and move persistent failures to diagnostics without repeating resets.
- Replace default full-history reconciliation with 25%, 50%, 75%, then 100% of indexed blocks, recalculating and comparing after each completed repair. Calculate starting blocks from the user-supplied Transactions checkpoint and corpus-owned minimum.
- Retain the current recovery step and block range across short replies such as “yes both in sync”, “they reached that block”, “done”, and “still different”, instead of repeating block/worker questions.
- Exclude calculated templates from ordinary retrieval and expand numeric values without model generation; keep mobile handoff links out of the corpus.
- Cover the 6529 Desktop menu, RPC activation, automatic workers, TDH comparison, transaction repair/reset, NFT recovery, Desktop wallets, IPFS, updates, and logs.
- Add 6529 Mobile App Wallet records for overview, create/import, connection, backup/recovery, deletion, missing-wallet, and unsupported-device questions.
- Answer “How do I use Core wallets on mobile?” by explaining the product boundary and directing the user to 6529 Mobile App Wallets.
- Use 6529 Desktop throughout current product guidance. Mention 6529 Core only in the legacy-name explanation or when recognizing user phrasing.
- Keep concise default answers, detailed procedures on request, and approved links in one final `More info` footer.

## Validation

Corpus generation, publication-policy tests, focused lint, and documentation-link validation pass. Tests reject invalid reconciliation minimums and template metadata.

## Rollout checklist

- [ ] Verify the target environment's `helpBotReplyLoop` includes backend PR #1998 before publishing this corpus.

Companion: [Backend PR #1998](https://github.com/6529-Collections/6529seize-backend/pull/1998).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive 6529 Desktop guides covering installation, RPC setup, workers, TDH synchronization and recovery, wallets, IPFS, diagnostics, and troubleshooting.
  - Clarified Desktop and Mobile naming, platform limitations, security boundaries, wallet recovery, and app availability.
  - Expanded help content with wallet workflows, media uploads, group eligibility, calendar and collection guidance, and progressive reconciliation recovery.
  - Improved navigation and links to relevant Desktop resources.

- **Quality**
  - Added validation for help answers, links, and reconciliation metadata.
  - Removed obsolete mobile handoff references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


