### PR TITLE
Fix wave editor strikethrough preview and inline-format deletion

### DIFF
--- a/__tests__/components/drops/create/lexical/transformers/strikethrough.test.ts
+++ b/__tests__/components/drops/create/lexical/transformers/strikethrough.test.ts
@@ -12,6 +12,8 @@ import {
   $isRangeSelection,
   createEditor,
   DELETE_CHARACTER_COMMAND,
+  COMMAND_PRIORITY_LOW,
+  FORMAT_TEXT_COMMAND,
   UNDO_COMMAND,
   REDO_COMMAND,
   type LexicalEditor,
@@ -224,6 +226,73 @@ describe("editor inline formatting", () => {
     await typeText("~test~");
     await backspace();
     expect(root.textContent).toBe("prefix ~testsuffix");
+  });
+
+  it.each([
+    {
+      name: "an explicit format command",
+      change: () => {
+        editor.dispatchCommand(FORMAT_TEXT_COMMAND, "bold");
+      },
+    },
+    {
+      name: "a node style update without a text change",
+      change: () => {
+        $getRoot().getAllTextNodes()[0]?.setStyle("color: red");
+      },
+    },
+    {
+      name: "cursor movement away and back",
+      change: () => {
+        $getRoot().getAllTextNodes()[0]?.select(0, 0);
+      },
+    },
+  ])("uses normal deletion after $name", async ({ change }) => {
+    await typeText("~hi~");
+    await update(change);
+    await update(() => {
+      $getRoot().getAllTextNodes()[0]?.selectEnd();
+    });
+    // Observe normal command fallthrough before jsdom's unsupported native
+    // Selection.modify is reached. The shortcut must not restore old content.
+    const normalDelete = jest.fn(() => true);
+    const unregister = editor.registerCommand(
+      DELETE_CHARACTER_COMMAND,
+      normalDelete,
+      COMMAND_PRIORITY_LOW
+    );
+    try {
+      await backspace();
+      expect(normalDelete).toHaveBeenCalledTimes(1);
+      expect(root.textContent).toBe("hi");
+    } finally {
+      unregister();
+    }
+  });
+
+  it("does not restore over a content update in the same command transaction", async () => {
+    await typeText("~hi~");
+    const normalDelete = jest.fn(() => true);
+    const unregister = editor.registerCommand(
+      DELETE_CHARACTER_COMMAND,
+      normalDelete,
+      COMMAND_PRIORITY_LOW
+    );
+    try {
+      await update(() => {
+        $getRoot().getAllTextNodes()[0]?.setStyle("color: red");
+        editor.dispatchCommand(DELETE_CHARACTER_COMMAND, true);
+      });
+      expect(normalDelete).toHaveBeenCalledTimes(1);
+      expect(root.textContent).toBe("hi");
+      expect(
+        editor
+          .getEditorState()
+          .read(() => $getRoot().getAllTextNodes()[0]?.getStyle())
+      ).toBe("color: red");
+    } finally {
+      unregister();
+    }
   });
 
   it("supports undo and redo of shortcut reversal", async () => {

--- a/__tests__/components/drops/create/lexical/transformers/strikethrough.test.ts
+++ b/__tests__/components/drops/create/lexical/transformers/strikethrough.test.ts
@@ -1,0 +1,134 @@
+jest.unmock("lexical");
+
+import {
+  $convertFromMarkdownString,
+  $convertToMarkdownString,
+  registerMarkdownShortcuts,
+} from "@lexical/markdown";
+import {
+  $createParagraphNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  createEditor,
+  type LexicalEditor,
+} from "lexical";
+import ExampleTheme from "@/components/drops/create/lexical/ExampleTheme";
+import {
+  SAFE_MARKDOWN_TRANSFORMERS,
+  SAFE_MARKDOWN_TRANSFORMERS_WITHOUT_CODE,
+} from "@/components/drops/create/lexical/transformers/markdownTransformers";
+
+const textTransformers = SAFE_MARKDOWN_TRANSFORMERS.filter(
+  (transformer) => transformer.type === "text-format"
+);
+
+describe("editor strikethrough", () => {
+  let editor: LexicalEditor;
+  let root: HTMLDivElement;
+  let unregister: () => void;
+
+  beforeEach(() => {
+    root = document.createElement("div");
+    root.contentEditable = "true";
+    document.body.append(root);
+    editor = createEditor({
+      theme: ExampleTheme,
+      onError: (error) => {
+        throw error;
+      },
+    });
+    editor.setRootElement(root);
+    editor.update(
+      () => {
+        $getRoot().append($createParagraphNode()).selectEnd();
+      },
+      { discrete: true }
+    );
+    unregister = registerMarkdownShortcuts(editor, textTransformers);
+  });
+
+  afterEach(() => {
+    unregister();
+    editor.setRootElement(null);
+    root.remove();
+  });
+
+  const typeText = async (text: string) => {
+    for (const character of text) {
+      editor.update(
+        () => {
+          const selection = $getSelection();
+          if (!$isRangeSelection(selection)) {
+            throw new Error("Expected a text selection");
+          }
+          selection.insertText(character);
+        },
+        { discrete: true }
+      );
+      await Promise.resolve();
+    }
+  };
+
+  it.each(["~hi~", "~~hi~~"])(
+    "previews %s as it is typed and exports strikethrough",
+    async (markdown) => {
+      await typeText(markdown.slice(0, -1));
+      expect(root.textContent).toBe(markdown.slice(0, -1));
+      expect(root.querySelector(".editor-text-strikethrough")).toBeNull();
+
+      await typeText(markdown.slice(-1));
+      const struck = root.querySelector(".editor-text-strikethrough");
+      expect(struck).toHaveTextContent("hi");
+      expect(root.textContent).toBe("hi");
+      expect(
+        editor
+          .getEditorState()
+          .read(() => $convertToMarkdownString(textTransformers))
+      ).toBe("~~hi~~");
+    }
+  );
+
+  it.each([
+    { name: "compose", transformers: SAFE_MARKDOWN_TRANSFORMERS },
+    { name: "edit", transformers: SAFE_MARKDOWN_TRANSFORMERS_WITHOUT_CODE },
+  ])("imports either syntax for $name", ({ transformers }) => {
+    const formats = transformers.filter(
+      (transformer) => transformer.type === "text-format"
+    );
+    editor.update(
+      () => {
+        $convertFromMarkdownString("~hi~ and ~~bye~~", formats);
+      },
+      { discrete: true }
+    );
+    expect(root.textContent).toBe("hi and bye");
+    expect(root.querySelectorAll(".editor-text-strikethrough")).toHaveLength(2);
+  });
+
+  it.each(["~hi", "hi~", "`~hi~`"])(
+    "does not import %s as strikethrough",
+    (markdown) => {
+      editor.update(
+        () => {
+          $convertFromMarkdownString(markdown, textTransformers);
+        },
+        { discrete: true }
+      );
+      expect(root.querySelector(".editor-text-strikethrough")).toBeNull();
+    }
+  );
+
+  it("keeps the strike visible when combined with underline", async () => {
+    await typeText("~hi~");
+    editor.update(
+      () => {
+        $getRoot().getAllTextNodes()[0]?.toggleFormat("underline");
+      },
+      { discrete: true }
+    );
+    expect(
+      root.querySelector(".editor-text-underlineStrikethrough")
+    ).toHaveTextContent("hi");
+  });
+});

--- a/__tests__/components/drops/create/lexical/transformers/strikethrough.test.ts
+++ b/__tests__/components/drops/create/lexical/transformers/strikethrough.test.ts
@@ -11,8 +11,22 @@ import {
   $getSelection,
   $isRangeSelection,
   createEditor,
+  DELETE_CHARACTER_COMMAND,
+  UNDO_COMMAND,
+  REDO_COMMAND,
   type LexicalEditor,
 } from "lexical";
+import { registerInlineFormatEditing } from "@/components/drops/create/lexical/utils/inlineFormatEditing";
+import { mergeRegister } from "@lexical/utils";
+import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
+import { render } from "@testing-library/react";
+import { createElement } from "react";
+
+const mockUseLexicalComposerContext = jest.fn();
+jest.mock("@lexical/react/LexicalComposerContext", () => ({
+  useLexicalComposerContext: () => mockUseLexicalComposerContext(),
+}));
+import { registerRichText } from "@lexical/rich-text";
 import ExampleTheme from "@/components/drops/create/lexical/ExampleTheme";
 import {
   SAFE_MARKDOWN_TRANSFORMERS,
@@ -23,7 +37,7 @@ const textTransformers = SAFE_MARKDOWN_TRANSFORMERS.filter(
   (transformer) => transformer.type === "text-format"
 );
 
-describe("editor strikethrough", () => {
+describe("editor inline formatting", () => {
   let editor: LexicalEditor;
   let root: HTMLDivElement;
   let unregister: () => void;
@@ -45,7 +59,14 @@ describe("editor strikethrough", () => {
       },
       { discrete: true }
     );
-    unregister = registerMarkdownShortcuts(editor, textTransformers);
+    mockUseLexicalComposerContext.mockReturnValue([editor]);
+    const history = render(createElement(HistoryPlugin));
+    unregister = mergeRegister(
+      registerInlineFormatEditing(editor, textTransformers),
+      registerMarkdownShortcuts(editor, textTransformers),
+      registerRichText(editor),
+      history.unmount
+    );
   });
 
   afterEach(() => {
@@ -69,6 +90,157 @@ describe("editor strikethrough", () => {
       await Promise.resolve();
     }
   };
+
+  const update = async (callback: () => void) => {
+    editor.update(callback, { discrete: true });
+    await Promise.resolve();
+  };
+
+  const backspace = () =>
+    update(() => {
+      editor.dispatchCommand(DELETE_CHARACTER_COMMAND, true);
+    });
+
+  const selectStrike = async (start = 0, end?: number) =>
+    update(() => {
+      const node = $getRoot()
+        .getAllTextNodes()
+        .find((text) => text.hasFormat("strikethrough"));
+      if (!node) throw new Error("Expected struck text");
+      const selection = node.select(start, end ?? node.getTextContentSize());
+      selection.format = node.getFormat();
+    });
+
+  it.each(["~test~", "~~test~~"])(
+    "reverses %s with immediate Backspace",
+    async (markdown) => {
+      await typeText("prefix " + markdown);
+      await backspace();
+      expect(root.textContent).toBe("prefix " + markdown.slice(0, -1));
+      expect(root.querySelector(".editor-text-strikethrough")).toBeNull();
+      await typeText("~");
+      expect(
+        root.querySelector(".editor-text-strikethrough")
+      ).toHaveTextContent("test");
+    }
+  );
+
+  it.each(["", "no strikethrough, "])(
+    "clears strike after deleting the entire word following %j",
+    async (prefix) => {
+      await typeText(prefix + "~test~");
+      await selectStrike();
+      await backspace();
+      await typeText("normal");
+      expect(root.textContent).toBe(prefix + "normal");
+      expect(root.querySelector(".editor-text-strikethrough")).toBeNull();
+    }
+  );
+
+  it("preserves strike after a partial deletion", async () => {
+    await typeText("plain ~test~");
+    await selectStrike(3, 4);
+    await backspace();
+    await typeText("ting");
+    expect(root.querySelector(".editor-text-strikethrough")).toHaveTextContent(
+      "testing"
+    );
+  });
+
+  it.each(["*test*", "**test**", "***test***", "`test`", "==test=="])(
+    "reverses the inline shortcut %s",
+    async (markdown) => {
+      await typeText("plain " + markdown);
+      expect(root.textContent).toBe("plain test");
+      await backspace();
+      expect(root.textContent).toBe("plain " + markdown.slice(0, -1));
+      await typeText(markdown.slice(-1));
+      expect(root.textContent).toBe("plain test");
+    }
+  );
+
+  it.each([
+    "bold",
+    "italic",
+    "underline",
+    "strikethrough",
+    "code",
+    "highlight",
+    "subscript",
+    "superscript",
+  ] as const)(
+    "clears deleted %s formatting while retaining surrounding text",
+    async (format) => {
+      await typeText("plain word");
+      await update(() => {
+        const node = $getRoot().getAllTextNodes()[0];
+        if (!node) throw new Error("Expected text");
+        node.select(6, 10);
+        const selection = $getSelection();
+        if ($isRangeSelection(selection)) selection.formatText(format);
+      });
+      await backspace();
+      await typeText("normal");
+      expect(root.textContent).toBe("plain normal");
+      expect(
+        editor.getEditorState().read(() =>
+          $getRoot()
+            .getAllTextNodes()
+            .some((node) => node.hasFormat(format))
+        )
+      ).toBe(false);
+    }
+  );
+
+  it("retains an enclosing format after deleting a nested formatted word", async () => {
+    await typeText("plain ~word~");
+    await update(() => {
+      for (const node of $getRoot().getAllTextNodes())
+        node.toggleFormat("bold");
+    });
+    await selectStrike();
+    await backspace();
+    await typeText("normal");
+    expect(root.textContent).toBe("plain normal");
+    expect(root.querySelector(".editor-text-strikethrough")).toBeNull();
+    expect(root.querySelector(".editor-text-bold")).toHaveTextContent(
+      "plain normal"
+    );
+  });
+
+  it("reverses a nested shortcut without removing its existing bold text", async () => {
+    await typeText("~**test**~");
+    await backspace();
+    expect(root.textContent).toBe("~test");
+    expect(root.querySelector(".editor-text-bold")).toHaveTextContent("test");
+    expect(root.querySelector(".editor-text-strikethrough")).toBeNull();
+  });
+
+  it("preserves text after the cursor when reversing a shortcut", async () => {
+    await typeText("prefix suffix");
+    await update(() => {
+      $getRoot().getAllTextNodes()[0]?.select(7, 7);
+    });
+    await typeText("~test~");
+    await backspace();
+    expect(root.textContent).toBe("prefix ~testsuffix");
+  });
+
+  it("supports undo and redo of shortcut reversal", async () => {
+    await typeText("~test~");
+    await backspace();
+    await update(() => {
+      editor.dispatchCommand(UNDO_COMMAND, undefined);
+    });
+    expect(root.querySelector(".editor-text-strikethrough")).toHaveTextContent(
+      "test"
+    );
+    await update(() => {
+      editor.dispatchCommand(REDO_COMMAND, undefined);
+    });
+    expect(root.textContent).toBe("~test");
+    expect(root.querySelector(".editor-text-strikethrough")).toBeNull();
+  });
 
   it.each(["~hi~", "~~hi~~"])(
     "previews %s as it is typed and exports strikethrough",

--- a/__tests__/components/drops/create/utils/CreateDropContent.component.test.tsx
+++ b/__tests__/components/drops/create/utils/CreateDropContent.component.test.tsx
@@ -35,7 +35,7 @@ jest.mock("@lexical/react/LexicalOnChangePlugin", () => ({
     return null;
   },
 }));
-jest.mock("@lexical/react/LexicalMarkdownShortcutPlugin", () => ({
+jest.mock("@/components/drops/create/lexical/plugins/MarkdownShortcutPlugin", () => ({
   MarkdownShortcutPlugin: () => null,
 }));
 jest.mock("@lexical/react/LexicalTabIndentationPlugin", () => ({

--- a/__tests__/components/waves/CreateDropInput.inlineFormatting.test.tsx
+++ b/__tests__/components/waves/CreateDropInput.inlineFormatting.test.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   act,
   fireEvent,

--- a/__tests__/components/waves/CreateDropInput.inlineFormatting.test.tsx
+++ b/__tests__/components/waves/CreateDropInput.inlineFormatting.test.tsx
@@ -1,0 +1,200 @@
+import React, { useState } from "react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import {
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  DELETE_CHARACTER_COMMAND,
+  type EditorState,
+  type LexicalEditor,
+} from "lexical";
+import CreateDropInput from "@/components/waves/CreateDropInput";
+
+jest.unmock("lexical");
+
+const originalRangeRect = Object.getOwnPropertyDescriptor(
+  Range.prototype,
+  "getBoundingClientRect"
+);
+beforeAll(() => {
+  // jsdom has no range layout; Lexical reads this when scrolling the caret.
+  Object.defineProperty(Range.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value: () => new DOMRect(),
+  });
+});
+afterAll(() => {
+  if (originalRangeRect) {
+    Object.defineProperty(
+      Range.prototype,
+      "getBoundingClientRect",
+      originalRangeRect
+    );
+  } else {
+    Reflect.deleteProperty(Range.prototype, "getBoundingClientRect");
+  }
+});
+
+// Keep every editor plugin real. Stub external data and the picker UI only.
+jest.mock("@/hooks/useCapacitor", () => ({
+  __esModule: true,
+  default: () => ({ isCapacitor: false }),
+}));
+jest.mock("@/hooks/useIdentitiesSearch", () => ({
+  IDENTITY_SEARCH_MIN_HANDLE_LENGTH: 3,
+  useIdentitiesSearch: () => ({ identities: [] }),
+}));
+jest.mock("@/hooks/useMentionAliases", () => ({
+  useMentionAliases: () => ({ aliases: [], enabled: false, isFetched: true }),
+}));
+jest.mock("@/hooks/useWavesSearch", () => ({
+  useWavesSearch: () => ({ waves: [] }),
+}));
+jest.mock("@/hooks/useAlchemyNftQueries", () => ({
+  useTokenMetadataQuery: () => ({ data: [] }),
+}));
+jest.mock("@/contexts/EmojiContext", () => {
+  const value = {
+    emojiMap: [],
+    findNativeEmoji: () => null,
+    loadEmojiData: async () => undefined,
+  };
+  return { useEmoji: () => value };
+});
+
+let mockEditor: LexicalEditor | null = null;
+jest.mock("@/components/waves/CreateDropEmojiPicker", () => {
+  const React = jest.requireActual<typeof import("react")>("react");
+  const { useLexicalComposerContext } = jest.requireActual<
+    typeof import("@lexical/react/LexicalComposerContext")
+  >("@lexical/react/LexicalComposerContext");
+  return function CaptureEditor() {
+    const [editor] = useLexicalComposerContext();
+    React.useEffect(() => {
+      mockEditor = editor;
+      return () => {
+        mockEditor = null;
+      };
+    }, [editor]);
+    return null;
+  };
+});
+
+function Composer() {
+  const [state, setState] = useState<EditorState | null>(null);
+  return (
+    <CreateDropInput
+      waveId="wave"
+      editorState={state}
+      type={null}
+      canSubmit={false}
+      isStormMode={false}
+      isDropMode={false}
+      submitting={false}
+      onEditorState={setState}
+      onReferencedNft={jest.fn()}
+      onMentionedUser={jest.fn()}
+      onMentionedWave={jest.fn()}
+    />
+  );
+}
+
+async function mountComposer() {
+  render(<Composer />);
+  await waitFor(() => expect(mockEditor).not.toBeNull());
+  const editor = mockEditor;
+  if (!editor) throw new Error("Expected the real composer editor");
+  await act(async () => {
+    screen.getByRole("textbox").focus();
+    editor.update(
+      () => {
+        $getRoot().selectEnd();
+      },
+      { discrete: true }
+    );
+  });
+  return editor;
+}
+
+async function typeText(editor: LexicalEditor, text: string) {
+  for (const character of text) {
+    // Flush parent rerenders and plugin effects between actual text updates.
+    await act(async () => {
+      editor.update(
+        () => {
+          const selection = $getSelection();
+          if (!$isRangeSelection(selection))
+            throw new Error("Expected text selection");
+          selection.insertText(character);
+        },
+        { discrete: true }
+      );
+    });
+  }
+}
+
+it.each(["~test~", "~~test~~", "**test**", "*test*", "`test`", "==test=="])(
+  "reverses %s with real composer plugins and parent rerenders",
+  async (markdown) => {
+    const editor = await mountComposer();
+    // This prefix also exercises the emoji plugin's text listener and its
+    // no-op editor updates while the Markdown shortcut is being completed.
+    await typeText(editor, ":unknown: " + markdown);
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveTextContent(":unknown: test");
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Backspace", keyCode: 8 });
+    });
+    expect(input.textContent).toBe(":unknown: " + markdown.slice(0, -1));
+  }
+);
+
+it("bounds format normalization and allows plain typing after deleting a word", async () => {
+  const editor = await mountComposer();
+  await typeText(editor, "plain ~word~");
+  const normalization = jest.fn();
+  const unregister = editor.registerUpdateListener(
+    ({ editorState, prevEditorState }) => {
+      const previous = prevEditorState.read($getSelection);
+      const current = editorState.read($getSelection);
+      if (
+        $isRangeSelection(previous) &&
+        $isRangeSelection(current) &&
+        previous.isCollapsed() &&
+        current.isCollapsed() &&
+        previous.hasFormat("strikethrough") &&
+        !current.hasFormat("strikethrough")
+      )
+        normalization();
+    }
+  );
+  try {
+    await act(async () => {
+      editor.update(
+        () => {
+          const node = $getRoot()
+            .getAllTextNodes()
+            .find((text) => text.hasFormat("strikethrough"));
+          if (!node) throw new Error("Expected struck text");
+          const selection = node.select(node.getTextContentSize(), 0);
+          selection.format = node.getFormat();
+          editor.dispatchCommand(DELETE_CHARACTER_COMMAND, true);
+        },
+        { discrete: true }
+      );
+    });
+    expect(normalization).toHaveBeenCalledTimes(1);
+    await typeText(editor, "normal");
+    const input = screen.getByRole("textbox");
+    expect(input.textContent).toBe("plain normal");
+    expect(input.querySelector(".editor-text-strikethrough")).toBeNull();
+  } finally {
+    unregister();
+  }
+});

--- a/__tests__/components/waves/CreateDropInput.test.tsx
+++ b/__tests__/components/waves/CreateDropInput.test.tsx
@@ -39,7 +39,7 @@ jest.mock("@lexical/react/LexicalHistoryPlugin", () => ({
 jest.mock("@lexical/react/LexicalOnChangePlugin", () => ({
   OnChangePlugin: () => <div />,
 }));
-jest.mock("@lexical/react/LexicalMarkdownShortcutPlugin", () => ({
+jest.mock("@/components/drops/create/lexical/plugins/MarkdownShortcutPlugin", () => ({
   MarkdownShortcutPlugin: () => <div />,
 }));
 jest.mock("@lexical/react/LexicalTabIndentationPlugin", () => ({

--- a/__tests__/components/waves/drops/EditDropLexical.test.tsx
+++ b/__tests__/components/waves/drops/EditDropLexical.test.tsx
@@ -99,7 +99,7 @@ jest.mock("@lexical/react/LexicalOnChangePlugin", () => ({
     return null;
   },
 }));
-jest.mock("@lexical/react/LexicalMarkdownShortcutPlugin", () => ({
+jest.mock("@/components/drops/create/lexical/plugins/MarkdownShortcutPlugin", () => ({
   MarkdownShortcutPlugin: ({ transformers }: { transformers: unknown[] }) => {
     markdownShortcutTransformers = transformers;
     return null;

--- a/components/drops/create/lexical/lexical.styles.css
+++ b/components/drops/create/lexical/lexical.styles.css
@@ -60,6 +60,14 @@
   height: 200px;
 }
 
+.editor-text-strikethrough {
+  text-decoration: line-through;
+}
+
+.editor-text-underlineStrikethrough {
+  text-decoration: underline line-through;
+}
+
 .editor-code,
 .editor-text-code {
   color: #e5e7eb;

--- a/components/drops/create/lexical/plugins/MarkdownShortcutPlugin.tsx
+++ b/components/drops/create/lexical/plugins/MarkdownShortcutPlugin.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { registerMarkdownShortcuts, type Transformer } from "@lexical/markdown";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { mergeRegister } from "@lexical/utils";
+import { useEffect } from "react";
+
+import { registerInlineFormatEditing } from "../utils/inlineFormatEditing";
+
+export function MarkdownShortcutPlugin({
+  transformers,
+}: {
+  readonly transformers: Transformer[];
+}): null {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(
+    () =>
+      mergeRegister(
+        registerInlineFormatEditing(editor, transformers),
+        registerMarkdownShortcuts(editor, transformers)
+      ),
+    [editor, transformers]
+  );
+
+  return null;
+}

--- a/components/drops/create/lexical/transformers/markdownTransformers.ts
+++ b/components/drops/create/lexical/transformers/markdownTransformers.ts
@@ -1,4 +1,8 @@
-import { TRANSFORMERS, type Transformer } from "@lexical/markdown";
+import {
+  STRIKETHROUGH,
+  TRANSFORMERS,
+  type Transformer,
+} from "@lexical/markdown";
 
 const UNDERSCORE_TAGS = new Set(["__", "___", "_"]);
 
@@ -39,10 +43,15 @@ const isCodeTransformer = (transformer: Transformer): boolean => {
   });
 };
 
-export const SAFE_MARKDOWN_TRANSFORMERS = BASE_SAFE_TRANSFORMERS;
+// Keep the double-tilde transformer first so exports retain canonical Markdown.
+// The single-tilde alias matches the posted drop renderer's GFM support.
+export const SAFE_MARKDOWN_TRANSFORMERS: Transformer[] = [
+  ...BASE_SAFE_TRANSFORMERS,
+  { ...STRIKETHROUGH, tag: "~" },
+];
 
 export const SAFE_MARKDOWN_TRANSFORMERS_WITHOUT_CODE =
-  BASE_SAFE_TRANSFORMERS.filter(
+  SAFE_MARKDOWN_TRANSFORMERS.filter(
     (transformer) =>
       !isObjectTransformer(transformer) || !isCodeTransformer(transformer)
   );

--- a/components/drops/create/lexical/utils/inlineFormatEditing.ts
+++ b/components/drops/create/lexical/utils/inlineFormatEditing.ts
@@ -1,0 +1,233 @@
+import type { Transformer, TextFormatTransformer } from "@lexical/markdown";
+import { $restoreEditorState, mergeRegister } from "@lexical/utils";
+import {
+  $addUpdateTag,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $isTextNode,
+  BLUR_COMMAND,
+  CLICK_COMMAND,
+  COMMAND_PRIORITY_HIGH,
+  DELETE_CHARACTER_COMMAND,
+  KEY_DOWN_COMMAND,
+  type EditorState,
+  type LexicalEditor,
+  type TextFormatType,
+} from "lexical";
+
+const INLINE_FORMATS: TextFormatType[] = [
+  "bold",
+  "italic",
+  "underline",
+  "strikethrough",
+  "code",
+  "highlight",
+  "subscript",
+  "superscript",
+];
+
+function readCursor(state: EditorState) {
+  return state.read(() => {
+    const selection = $getSelection();
+    if (!$isRangeSelection(selection)) {
+      return null;
+    }
+    const node = selection.anchor.getNode();
+    return {
+      selection,
+      text: $isTextNode(node) ? node.getTextContent() : null,
+      previousKey: node.getPreviousSibling()?.getKey(),
+      formats:
+        $isTextNode(node) && node.getTextContentSize() > 0
+          ? node.getFormat()
+          : 0,
+      nodeFormats: $isTextNode(node)
+        ? new Set(INLINE_FORMATS.filter((format) => node.hasFormat(format)))
+        : new Set(),
+      size: $getRoot().getTextContentSize(),
+      touchedFormats: selection
+        .getNodes()
+        .reduce(
+          (formats, selected) =>
+            $isTextNode(selected) ? formats | selected.getFormat() : formats,
+          0
+        ),
+    };
+  });
+}
+
+type Cursor = NonNullable<ReturnType<typeof readCursor>>;
+
+function isMarkerInsertion(
+  previous: Cursor,
+  current: Cursor,
+  marker: string
+): boolean {
+  const before = previous.selection.anchor;
+  const after = current.selection.anchor;
+  if (
+    !previous.selection.isCollapsed() ||
+    !current.selection.isCollapsed() ||
+    previous.text === null ||
+    current.size !== previous.size + 1
+  ) {
+    return false;
+  }
+  if (before.key === after.key) {
+    return (
+      after.offset === before.offset + 1 &&
+      current.text ===
+        previous.text.slice(0, before.offset) +
+          marker +
+          previous.text.slice(before.offset)
+    );
+  }
+  // Typing a closing marker after nested formatting can create a new text
+  // node. The cursor still advances by exactly one character.
+  return (
+    current.previousKey === before.key &&
+    before.offset === previous.text.length &&
+    after.offset === 1 &&
+    current.text?.startsWith(marker) === true
+  );
+}
+
+function resetDeletedFormats(
+  editor: LexicalEditor,
+  previous: Cursor,
+  current: Cursor
+) {
+  // Only clear formats carried by deleted text that are absent from the
+  // surviving text at the cursor. Nested and neighboring formats survive.
+  const removedFormats = previous.touchedFormats & ~current.formats;
+  if (
+    previous.size > current.size &&
+    current.selection.isCollapsed() &&
+    (current.selection.format & removedFormats) !== 0
+  ) {
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        if ($isRangeSelection(selection)) {
+          selection.format &= ~removedFormats;
+          selection.dirty = true;
+        }
+      },
+      { tag: "history-merge" }
+    );
+  }
+}
+
+export function registerInlineFormatEditing(
+  editor: LexicalEditor,
+  transformers: Transformer[]
+): () => void {
+  const textFormats = transformers.filter(
+    (transformer): transformer is TextFormatTransformer =>
+      transformer.type === "text-format"
+  );
+  let pending: {
+    before: EditorState;
+    typed: EditorState;
+    matches: TextFormatTransformer[];
+  } | null = null;
+  let shortcut: { before: EditorState; converted: EditorState } | null = null;
+  const clearShortcut = () => {
+    pending = null;
+    shortcut = null;
+    return false;
+  };
+
+  return mergeRegister(
+    editor.registerUpdateListener(({ editorState, prevEditorState, tags }) => {
+      const candidate = pending;
+      clearShortcut();
+      if (
+        tags.has("historic") ||
+        tags.has("collaboration") ||
+        editor.isComposing()
+      ) {
+        return;
+      }
+      const previous = readCursor(prevEditorState);
+      const current = readCursor(editorState);
+      if (!previous || !current) {
+        return;
+      }
+      const removed = previous.size - current.size;
+      if (
+        candidate?.typed === prevEditorState &&
+        current.selection.isCollapsed() &&
+        candidate.matches.some(
+          (transformer) =>
+            removed === transformer.tag.length * 2 &&
+            transformer.format.every((format) =>
+              current.nodeFormats.has(format)
+            )
+        )
+      ) {
+        shortcut = { before: candidate.before, converted: editorState };
+      } else {
+        const beforeCursor =
+          current.text?.slice(0, current.selection.anchor.offset) ?? "";
+        const marker = beforeCursor.slice(-1);
+        const matches = textFormats.filter(
+          ({ tag }) => beforeCursor.endsWith(tag) && tag.endsWith(marker)
+        );
+        if (
+          matches.length > 0 &&
+          isMarkerInsertion(previous, current, marker)
+        ) {
+          pending = { before: prevEditorState, typed: editorState, matches };
+        }
+      }
+
+      resetDeletedFormats(editor, previous, current);
+    }),
+    editor.registerCommand(
+      DELETE_CHARACTER_COMMAND,
+      (backward) => {
+        const saved = shortcut;
+        clearShortcut();
+        const selection = $getSelection();
+        const convertedSelection = saved?.converted.read($getSelection);
+        if (
+          !backward ||
+          !saved ||
+          editor.isComposing() ||
+          !$isRangeSelection(selection) ||
+          !selection.isCollapsed() ||
+          !selection.is(convertedSelection ?? null) ||
+          editor.getEditorState() !== saved.converted
+        ) {
+          return false;
+        }
+        // Restore the exact pre-keystroke state, including nested formats and
+        // the original Markdown spelling, as one undoable action.
+        $restoreEditorState(editor, saved.before);
+        $addUpdateTag("history-push");
+        return true;
+      },
+      COMMAND_PRIORITY_HIGH
+    ),
+    editor.registerCommand(
+      KEY_DOWN_COMMAND,
+      (event) => {
+        if (
+          event.key !== "Backspace" ||
+          event.altKey ||
+          event.ctrlKey ||
+          event.metaKey ||
+          event.shiftKey
+        ) {
+          clearShortcut();
+        }
+        return false;
+      },
+      COMMAND_PRIORITY_HIGH
+    ),
+    editor.registerCommand(CLICK_COMMAND, clearShortcut, COMMAND_PRIORITY_HIGH),
+    editor.registerCommand(BLUR_COMMAND, clearShortcut, COMMAND_PRIORITY_HIGH)
+  );
+}

--- a/components/drops/create/lexical/utils/inlineFormatEditing.ts
+++ b/components/drops/create/lexical/utils/inlineFormatEditing.ts
@@ -1,5 +1,5 @@
 import type { Transformer, TextFormatTransformer } from "@lexical/markdown";
-import { $restoreEditorState, mergeRegister } from "@lexical/utils";
+import { $dfs, $restoreEditorState, mergeRegister } from "@lexical/utils";
 import {
   $addUpdateTag,
   $getRoot,
@@ -10,6 +10,7 @@ import {
   CLICK_COMMAND,
   COMMAND_PRIORITY_HIGH,
   DELETE_CHARACTER_COMMAND,
+  FORMAT_TEXT_COMMAND,
   KEY_DOWN_COMMAND,
   type EditorState,
   type LexicalEditor,
@@ -44,7 +45,7 @@ function readCursor(state: EditorState) {
           : 0,
       nodeFormats: $isTextNode(node)
         ? new Set(INLINE_FORMATS.filter((format) => node.hasFormat(format)))
-        : new Set(),
+        : new Set<TextFormatType>(),
       size: $getRoot().getTextContentSize(),
       touchedFormats: selection
         .getNodes()
@@ -119,6 +120,23 @@ function resetDeletedFormats(
   }
 }
 
+function hasSameCursor(previous: Cursor, current: Cursor): boolean {
+  return (
+    previous.selection.isCollapsed() &&
+    current.selection.isCollapsed() &&
+    previous.selection.anchor.is(current.selection.anchor)
+  );
+}
+
+function $hasSameNodes(previous: EditorState): boolean {
+  const currentNodes = $dfs().map(({ node }) => node);
+  const previousNodes = previous.read(() => $dfs().map(({ node }) => node));
+  return (
+    previousNodes.length === currentNodes.length &&
+    previousNodes.every((node, index) => node === currentNodes[index])
+  );
+}
+
 export function registerInlineFormatEditing(
   editor: LexicalEditor,
   transformers: Transformer[]
@@ -139,22 +157,48 @@ export function registerInlineFormatEditing(
     return false;
   };
 
+  const retainShortcut = (
+    previous: Cursor,
+    current: Cursor,
+    prevEditorState: EditorState,
+    editorState: EditorState
+  ): boolean => {
+    // Selection reconciliation and no-op plugin updates may create a new
+    // EditorState without changing any document node or moving the cursor.
+    // Retain the shortcut only across those updates, never across content edits.
+    if (
+      !(pending || shortcut) ||
+      !hasSameCursor(previous, current) ||
+      !editorState.read(() => $hasSameNodes(prevEditorState))
+    )
+      return false;
+    if (pending?.typed === prevEditorState) pending.typed = editorState;
+    if (shortcut?.converted === prevEditorState)
+      shortcut.converted = editorState;
+    return true;
+  };
+
   return mergeRegister(
     editor.registerUpdateListener(({ editorState, prevEditorState, tags }) => {
-      const candidate = pending;
-      clearShortcut();
       if (
         tags.has("historic") ||
         tags.has("collaboration") ||
         editor.isComposing()
       ) {
+        clearShortcut();
         return;
       }
       const previous = readCursor(prevEditorState);
       const current = readCursor(editorState);
       if (!previous || !current) {
+        clearShortcut();
         return;
       }
+      if (retainShortcut(previous, current, prevEditorState, editorState)) {
+        return;
+      }
+      const candidate = pending;
+      clearShortcut();
       const removed = previous.size - current.size;
       if (
         candidate?.typed === prevEditorState &&
@@ -198,8 +242,10 @@ export function registerInlineFormatEditing(
           editor.isComposing() ||
           !$isRangeSelection(selection) ||
           !selection.isCollapsed() ||
-          !selection.is(convertedSelection ?? null) ||
-          editor.getEditorState() !== saved.converted
+          !$isRangeSelection(convertedSelection) ||
+          !selection.anchor.is(convertedSelection.anchor) ||
+          editor.getEditorState() !== saved.converted ||
+          !$hasSameNodes(saved.converted)
         ) {
           return false;
         }
@@ -225,6 +271,11 @@ export function registerInlineFormatEditing(
         }
         return false;
       },
+      COMMAND_PRIORITY_HIGH
+    ),
+    editor.registerCommand(
+      FORMAT_TEXT_COMMAND,
+      clearShortcut,
       COMMAND_PRIORITY_HIGH
     ),
     editor.registerCommand(CLICK_COMMAND, clearShortcut, COMMAND_PRIORITY_HIGH),

--- a/components/drops/create/utils/CreateDropContent.tsx
+++ b/components/drops/create/utils/CreateDropContent.tsx
@@ -29,7 +29,7 @@ import type {
 import { MaxLengthPlugin } from "../lexical/plugins/MaxLengthPlugin";
 import { MAX_DROP_PART_UTF16_UNITS } from "@/helpers/waves/drop-content-limits";
 import ToggleViewButtonPlugin from "../lexical/plugins/ToggleViewButtonPlugin";
-import { MarkdownShortcutPlugin } from "@lexical/react/LexicalMarkdownShortcutPlugin";
+import { MarkdownShortcutPlugin } from "@/components/drops/create/lexical/plugins/MarkdownShortcutPlugin";
 
 import { TabIndentationPlugin } from "@lexical/react/LexicalTabIndentationPlugin";
 import { ListNode, ListItemNode } from "@lexical/list";

--- a/components/waves/CreateDropInput.tsx
+++ b/components/waves/CreateDropInput.tsx
@@ -21,7 +21,7 @@ import { ContentEditable } from "@lexical/react/LexicalContentEditable";
 import LexicalErrorBoundary from "@lexical/react/LexicalErrorBoundary";
 import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
 import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
-import { MarkdownShortcutPlugin } from "@lexical/react/LexicalMarkdownShortcutPlugin";
+import { MarkdownShortcutPlugin } from "@/components/drops/create/lexical/plugins/MarkdownShortcutPlugin";
 
 import { TabIndentationPlugin } from "@lexical/react/LexicalTabIndentationPlugin";
 import { ListNode, ListItemNode } from "@lexical/list";

--- a/components/waves/drops/EditDropLexical.tsx
+++ b/components/waves/drops/EditDropLexical.tsx
@@ -10,7 +10,7 @@ import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext
 import { ContentEditable } from "@lexical/react/LexicalContentEditable";
 import LexicalErrorBoundary from "@lexical/react/LexicalErrorBoundary";
 import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
-import { MarkdownShortcutPlugin } from "@lexical/react/LexicalMarkdownShortcutPlugin";
+import { MarkdownShortcutPlugin } from "@/components/drops/create/lexical/plugins/MarkdownShortcutPlugin";
 import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import {

--- a/ops/docs/waves/composer/README.md
+++ b/ops/docs/waves/composer/README.md
@@ -38,6 +38,11 @@ Use this area when you need behavior for:
 
 ### Mentions and Markdown
 
+Type `~hi~` or `~~hi~~` for strikethrough. Completing the closing tilde or pair
+of tildes replaces the markers with visibly struck-through text in the composer,
+matching the posted message. Both forms also display as strikethrough when
+reopening a message for editing.
+
 - [Wave Mentions](feature-wave-mentions.md)
 - [Global Mentions](feature-global-mentions.md)
 - [Quick Tags](feature-personal-mention-shortcuts.md)

--- a/ops/docs/waves/composer/README.md
+++ b/ops/docs/waves/composer/README.md
@@ -43,6 +43,18 @@ of tildes replaces the markers with visibly struck-through text in the composer,
 matching the posted message. Both forms also display as strikethrough when
 reopening a message for editing.
 
+Press Backspace immediately after an inline Markdown shortcut converts to
+formatted text to restore the text minus the closing character you just typed.
+For example, `~test~` becomes literal `~test`, and `~~test~~` becomes literal
+`~~test~`. This also applies to the supported bold, italic, highlight, and inline
+code shortcuts. After typing more text or moving the cursor, Backspace deletes
+normally.
+
+Deleting a whole formatted word lets you resume typing without carrying its
+formatting into new text, even when other text remains in the message. Deleting
+part of a formatted word preserves its formatting. Formats still present at the
+cursor, such as bold surrounding a deleted struck-through word, are preserved.
+
 - [Wave Mentions](feature-wave-mentions.md)
 - [Global Mentions](feature-global-mentions.md)
 - [Quick Tags](feature-personal-mention-shortcuts.md)

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -5705,6 +5705,7 @@
       "keywords": ["waves", "composer", "markdown", "code", "blank", "format"],
       "facts": [
         "Wave composer docs cover markdown code blocks and blank-line preservation.",
+        "Type ~hi~ or ~~hi~~ for strikethrough. Both forms show struck-through text in the composer and when editing, matching the posted message.",
         "Use markdown records when users ask how to format a drop.",
         "Markdown behavior belongs to composer content, not the wave creation form."
       ],
@@ -5712,6 +5713,7 @@
       "related_paths": ["/waves"],
       "tags": ["waves", "composer", "markdown"],
       "source_refs": [
+        "ops/docs/waves/composer/README.md",
         "ops/docs/waves/composer/feature-markdown-code-blocks.md",
         "ops/docs/waves/composer/feature-markdown-blank-line-preservation.md"
       ]

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -5709,7 +5709,7 @@
       "facts": [
         "Wave composer docs cover markdown code blocks and blank-line preservation.",
         "Type ~hi~ or ~~hi~~ for strikethrough. Both forms show struck-through text in the composer and when editing, matching the posted message.",
-        "Backspace immediately after an inline Markdown shortcut converts restores the text minus the last typed closing character. This covers strikethrough, bold, italic, highlight, and inline code. Moving the cursor or typing more text returns Backspace to normal deletion.",
+        "Backspace immediately after an inline Markdown shortcut restores the text minus the last typed closing character. This covers strikethrough, bold, italic, highlight, and inline code. Moving the cursor or typing more text returns Backspace to normal deletion.",
         "Deleting a whole formatted word clears its typing format even when other message text remains. Partial deletion retains formatting, and formats still present at the cursor are preserved.",
         "Use markdown records when users ask how to format a drop.",
         "Markdown behavior belongs to composer content, not the wave creation form."

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -5707,6 +5707,8 @@
       "facts": [
         "Wave composer docs cover markdown code blocks and blank-line preservation.",
         "Type ~hi~ or ~~hi~~ for strikethrough. Both forms show struck-through text in the composer and when editing, matching the posted message.",
+        "Backspace immediately after an inline Markdown shortcut converts restores the text minus the last typed closing character. This covers strikethrough, bold, italic, highlight, and inline code. Moving the cursor or typing more text returns Backspace to normal deletion.",
+        "Deleting a whole formatted word clears its typing format even when other message text remains. Partial deletion retains formatting, and formats still present at the cursor are preserved.",
         "Use markdown records when users ask how to format a drop.",
         "Markdown behavior belongs to composer content, not the wave creation form."
       ],

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -5705,7 +5705,7 @@
       "facts": [
         "Wave composer docs cover markdown code blocks and blank-line preservation.",
         "Type ~hi~ or ~~hi~~ for strikethrough. Both forms show struck-through text in the composer and when editing, matching the posted message.",
-        "Backspace immediately after an inline Markdown shortcut converts restores the text minus the last typed closing character. This covers strikethrough, bold, italic, highlight, and inline code. Moving the cursor or typing more text returns Backspace to normal deletion.",
+        "Backspace immediately after an inline Markdown shortcut restores the text minus the last typed closing character. This covers strikethrough, bold, italic, highlight, and inline code. Moving the cursor or typing more text returns Backspace to normal deletion.",
         "Deleting a whole formatted word clears its typing format even when other message text remains. Partial deletion retains formatting, and formats still present at the cursor are preserved.",
         "Use markdown records when users ask how to format a drop.",
         "Markdown behavior belongs to composer content, not the wave creation form."

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -5703,6 +5703,8 @@
       "facts": [
         "Wave composer docs cover markdown code blocks and blank-line preservation.",
         "Type ~hi~ or ~~hi~~ for strikethrough. Both forms show struck-through text in the composer and when editing, matching the posted message.",
+        "Backspace immediately after an inline Markdown shortcut converts restores the text minus the last typed closing character. This covers strikethrough, bold, italic, highlight, and inline code. Moving the cursor or typing more text returns Backspace to normal deletion.",
+        "Deleting a whole formatted word clears its typing format even when other message text remains. Partial deletion retains formatting, and formats still present at the cursor are preserved.",
         "Use markdown records when users ask how to format a drop.",
         "Markdown behavior belongs to composer content, not the wave creation form."
       ],

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -5701,6 +5701,7 @@
       "keywords": ["waves", "composer", "markdown", "code", "blank", "format"],
       "facts": [
         "Wave composer docs cover markdown code blocks and blank-line preservation.",
+        "Type ~hi~ or ~~hi~~ for strikethrough. Both forms show struck-through text in the composer and when editing, matching the posted message.",
         "Use markdown records when users ask how to format a drop.",
         "Markdown behavior belongs to composer content, not the wave creation form."
       ],
@@ -5708,6 +5709,7 @@
       "related_paths": ["/waves"],
       "tags": ["waves", "composer", "markdown"],
       "source_refs": [
+        "ops/docs/waves/composer/README.md",
         "ops/docs/waves/composer/feature-markdown-code-blocks.md",
         "ops/docs/waves/composer/feature-markdown-blank-line-preservation.md"
       ]


### PR DESCRIPTION
## Issue

The wave editor hid the `~~hi~~` markers without visibly striking the text, while `~hi~` stayed literal even though posted messages supported it. Inline formatting could also remain active after deleting its entire word, and immediate Backspace after a Markdown conversion deleted a content character instead of the closing marker just typed.

## Fix

Preview both tilde forms and make inline-format deletion predictable across the shared compose and edit editors. Immediate Backspace restores the exact text before the closing character. Typing a suffix and deleting it back to the conversion boundary preserves that behavior; cursor movement, focus changes, explicit formatting, and plugin replacements cancel it. Removing a whole formatted span clears its carried typing format while preserving formats still present at the cursor.

## Changes

- Add single-tilde strikethrough support and the missing strike/underline-strike theme styles; retain canonical double-tilde export.
- Add shared inline-format editing behavior around the existing Markdown shortcuts. This covers strikethrough, bold, italic, combined bold/italic, highlight, and inline code; whole-span deletion also handles the editor's other inline formats.
- Preserve partial formatting, enclosing formats, surrounding content, and undo/redo.
- Update the composer guide and Help Bot corpus.

## Validation

- Full-composer integration tests keep the editor plugins active and rerender the parent between keystrokes; they cover immediate reversal for six shortcut forms and one-time format clearing after selected-word deletion.
- Focused real-Lexical and composer/edit tests cover both tilde forms, imports/exports, every supported inline shortcut, suffix round-trips, whole/partial deletion, enclosing and nested formats, text after the cursor, and undo/redo. Regression tests also cover same-serialization plugin replacements and navigation-key invalidation.
- Isolated production browser keyboard checks cover immediate reversal, reconversion, normal continuation, navigation, Backspace/Delete selections, character-by-character deletion, and delete-all/retype. Earlier visual checks verified strike lines at mobile and desktop widths.
- Changed-file lint/type checks and React Doctor were run; React Doctor's two advisory warnings concern existing edit-form state logic outside this change.
- Help corpus synchronization and documentation link validation passed. The authenticated wave route was not exercised.

## Risk

Medium: the behavior is shared by the compose and edit editors and changes inline editing semantics. No backend, API, dependency, or posted-renderer changes. Reverting this PR restores the prior behavior.

## Review Notes

Shortcut reversal tracks the converted content and caret through suffix typing/deletion. Equal-sized node replacements invalidate it even when serialized content matches. It survives Lexical's cursor-format reconciliation and no-op plugin updates; explicit formatting commands, node/style changes, navigation, and focus changes cancel it. Text after a completed strike starts without strike; existing bold/italic/code continuation is preserved. The helper does not reverse block, link, or mention transforms. Escaped or malformed Markdown imports can still differ from posted GFM rendering; this change does not replace the Markdown parser.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Markdown strikethrough formatting with single-tilde syntax (`~text~`).
  - Added support for combining strikethrough with underline formatting.
  - Improved formatting preservation and restoration during editing, deletion, Backspace actions, and undo/redo.

- **Documentation**
  - Documented strikethrough syntax, shortcut restoration, Backspace behavior, and formatting rules.

- **Tests**
  - Added comprehensive coverage for strikethrough editing, nested formatting, deletion, Markdown conversion, keyboard input, cursor behavior, and undo/redo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

