### PR TITLE
Fix reconnect guidance for expired native profile actions

### DIFF
--- a/__tests__/components/auth/Auth.test.tsx
+++ b/__tests__/components/auth/Auth.test.tsx
@@ -9,6 +9,7 @@ import userEvent from "@testing-library/user-event";
 import { getAccount } from "@wagmi/core";
 import React from "react";
 import Auth, { AuthContext, useAuth } from "@/components/auth/Auth";
+import type { RequestAuthOptions } from "@/components/auth/authTypes";
 import { ReactQueryWrapperContext } from "@/components/react-query-wrapper/ReactQueryWrapper";
 import { mockTitleContextModule } from "@/__tests__/utils/titleTestUtils";
 import { createDeferredPromise } from "@/__tests__/utils/deferredPromise";
@@ -350,7 +351,11 @@ function RequestAuthButton() {
   );
 }
 
-function RequestAuthResultButton() {
+function RequestAuthResultButton({
+  options,
+}: {
+  readonly options?: RequestAuthOptions;
+}) {
   const { requestAuth } = useAuth();
   const [result, setResult] = React.useState("pending");
 
@@ -359,7 +364,7 @@ function RequestAuthResultButton() {
       <button
         type="button"
         onClick={() =>
-          void requestAuth().then(({ success }) => {
+          void requestAuth(options).then(({ success }) => {
             setResult(String(success));
           })
         }
@@ -671,6 +676,9 @@ describe("Auth component", () => {
         const mockValidateJwt =
           require("@/services/auth/jwt-validation.utils").validateJwt;
         authUtils.getAuthJwt.mockReturnValue("valid-jwt");
+        if (!canSign) {
+          sessionV2.getSessionClientType.mockReturnValue("native");
+        }
 
         render(
           <ReactQueryWrapperContext.Provider
@@ -700,8 +708,65 @@ describe("Auth component", () => {
         expect(sessionV2.loginWithSessionV2).not.toHaveBeenCalled();
         expect(mockSeizeDisconnect).not.toHaveBeenCalled();
         expect(mockSeizeDisconnectAndLogout).not.toHaveBeenCalled();
+        expect(require("react-toastify").toast).not.toHaveBeenCalled();
       }
     );
+
+    it("accepts a refreshed native session for composer preflight without a signer or active chain", async () => {
+      const validAddress = "0x1111111111111111111111111111111111111111";
+      walletAddress = validAddress;
+      canSignActiveWallet = false;
+      mockActiveChainId = undefined;
+      mockWagmiIsConnected = false;
+      const authUtils = jest.requireMock<typeof AuthUtilsModule>(
+        "@/services/auth/auth.utils"
+      );
+      const sessionV2 = jest.requireMock<typeof SessionV2Module>(
+        "@/services/auth/session-v2.utils"
+      );
+      const { validateJwt } = jest.requireMock<
+        typeof import("@/services/auth/jwt-validation.utils")
+      >("@/services/auth/jwt-validation.utils");
+      jest.mocked(authUtils.getWalletAddress).mockReturnValue(validAddress);
+      jest
+        .mocked(authUtils.getAuthJwt)
+        .mockReturnValue(TEST_REJECTED_SESSION_VALUE);
+      jest.mocked(sessionV2.getSessionClientType).mockReturnValue("native");
+      jest.mocked(validateJwt).mockImplementationOnce(async (params) => {
+        expect(params.shouldPersistRefreshedSession?.()).toBe(true);
+        jest
+          .mocked(authUtils.getAuthJwt)
+          .mockReturnValue(TEST_REPLACEMENT_SESSION_VALUE);
+        return {
+          isValid: true,
+          wasCancelled: false,
+          refreshOutcome: "success",
+        };
+      });
+
+      render(
+        <ReactQueryWrapperContext.Provider
+          value={createReactQueryWrapperContextValue()}
+        >
+          <Auth>
+            <RequestAuthResultButton />
+          </Auth>
+        </ReactQueryWrapperContext.Provider>
+      );
+      await userEvent.click(screen.getByTestId("request-auth-result"));
+
+      await waitFor(() =>
+        expect(screen.getByTestId("request-auth-success")).toHaveTextContent(
+          "true"
+        )
+      );
+      expect(authUtils.getAuthJwt()).toBe(TEST_REPLACEMENT_SESSION_VALUE);
+      expect(authUtils.invalidateAuthSessionForAddress).not.toHaveBeenCalled();
+      expect(sessionV2.getSessionNonce).not.toHaveBeenCalled();
+      expect(mockSignMessage).not.toHaveBeenCalled();
+      expect(mockSeizeDisconnect).not.toHaveBeenCalled();
+      expect(require("react-toastify").toast).not.toHaveBeenCalled();
+    });
 
     it.each([
       { chainId: undefined, chainState: "unknown" },
@@ -811,92 +876,107 @@ describe("Auth component", () => {
       });
     });
 
-    it("cancels deferred server-rejected recovery after the token changes", async () => {
-      const validAddress = "0x1111111111111111111111111111111111111111";
-      walletAddress = validAddress;
-      const authUtils =
-        require("@/services/auth/auth.utils") as typeof AuthUtilsModule;
-      const mockGetAuthJwt = authUtils.getAuthJwt as jest.MockedFunction<
-        typeof authUtils.getAuthJwt
-      >;
-      const mockGetWalletAddress =
-        authUtils.getWalletAddress as jest.MockedFunction<
-          typeof authUtils.getWalletAddress
+    it.each([
+      { profileState: "connected", hasSigner: true },
+      { profileState: "saved native", hasSigner: false },
+    ])(
+      "cancels deferred server-rejected recovery for a $profileState profile after the token changes",
+      async ({ hasSigner }) => {
+        const validAddress = "0x1111111111111111111111111111111111111111";
+        walletAddress = validAddress;
+        canSignActiveWallet = hasSigner;
+        mockActiveChainId = hasSigner ? 1 : undefined;
+        mockWagmiIsConnected = hasSigner;
+        const authUtils =
+          require("@/services/auth/auth.utils") as typeof AuthUtilsModule;
+        const mockGetAuthJwt = authUtils.getAuthJwt as jest.MockedFunction<
+          typeof authUtils.getAuthJwt
         >;
-      const mockRemoveAuthJwt = authUtils.removeAuthJwt as jest.MockedFunction<
-        typeof authUtils.removeAuthJwt
-      >;
-      const mockValidateJwt =
-        require("@/services/auth/jwt-validation.utils").validateJwt;
-      const sessionV2 = require("@/services/auth/session-v2.utils");
-      const validation = createDeferredPromise<{
-        readonly isValid: boolean;
-        readonly wasCancelled: boolean;
-        readonly refreshOutcome: "cancelled";
-      }>();
-      let shouldPersistRefreshedSession: (() => boolean) | undefined;
-      let requestResult: Promise<{ success: boolean }> | undefined;
-
-      mockGetAuthJwt.mockReturnValue(TEST_REJECTED_SESSION_VALUE);
-      mockGetWalletAddress.mockReturnValue(validAddress);
-      const rejectedAuthStateFingerprint = getAuthStateFingerprint({
-        walletAddress: validAddress,
-        jwt: TEST_REJECTED_SESSION_VALUE,
-      });
-      mockValidateJwt.mockImplementationOnce(
-        (params: { shouldPersistRefreshedSession?: () => boolean }) => {
-          shouldPersistRefreshedSession = params.shouldPersistRefreshedSession;
-          return validation.promise;
+        const mockGetWalletAddress =
+          authUtils.getWalletAddress as jest.MockedFunction<
+            typeof authUtils.getWalletAddress
+          >;
+        const mockRemoveAuthJwt =
+          authUtils.removeAuthJwt as jest.MockedFunction<
+            typeof authUtils.removeAuthJwt
+          >;
+        const mockValidateJwt =
+          require("@/services/auth/jwt-validation.utils").validateJwt;
+        const sessionV2 = require("@/services/auth/session-v2.utils");
+        if (!hasSigner) {
+          sessionV2.getSessionClientType.mockReturnValue("native");
         }
-      );
+        const validation = createDeferredPromise<{
+          readonly isValid: boolean;
+          readonly wasCancelled: boolean;
+          readonly refreshOutcome: "empty";
+        }>();
+        let shouldPersistRefreshedSession: (() => boolean) | undefined;
+        let requestResult: Promise<{ success: boolean }> | undefined;
 
-      const Child = () => {
-        const { requestAuth } = React.useContext(AuthContext);
-        return (
-          <button
-            type="button"
-            onClick={() => {
-              requestResult = requestAuth({
-                serverRejected: true,
-                expectedAuthStateFingerprint: rejectedAuthStateFingerprint,
-              });
-            }}
-          >
-            recover auth
-          </button>
+        mockGetAuthJwt.mockReturnValue(TEST_REJECTED_SESSION_VALUE);
+        mockGetWalletAddress.mockReturnValue(validAddress);
+        const rejectedAuthStateFingerprint = getAuthStateFingerprint({
+          walletAddress: validAddress,
+          jwt: TEST_REJECTED_SESSION_VALUE,
+        });
+        mockValidateJwt.mockImplementationOnce(
+          (params: { shouldPersistRefreshedSession?: () => boolean }) => {
+            shouldPersistRefreshedSession =
+              params.shouldPersistRefreshedSession;
+            return validation.promise;
+          }
         );
-      };
 
-      render(
-        <ReactQueryWrapperContext.Provider
-          value={{ invalidateAll: jest.fn() } as any}
-        >
-          <Auth>
-            <Child />
-          </Auth>
-        </ReactQueryWrapperContext.Provider>
-      );
+        const Child = () => {
+          const { requestAuth } = React.useContext(AuthContext);
+          return (
+            <button
+              type="button"
+              onClick={() => {
+                requestResult = requestAuth({
+                  serverRejected: true,
+                  expectedAuthStateFingerprint: rejectedAuthStateFingerprint,
+                });
+              }}
+            >
+              recover auth
+            </button>
+          );
+        };
 
-      fireEvent.click(screen.getByRole("button", { name: "recover auth" }));
-      await waitFor(() => expect(mockValidateJwt).toHaveBeenCalled());
-      expect(shouldPersistRefreshedSession?.()).toBe(true);
+        render(
+          <ReactQueryWrapperContext.Provider
+            value={{ invalidateAll: jest.fn() } as any}
+          >
+            <Auth>
+              <Child />
+            </Auth>
+          </ReactQueryWrapperContext.Provider>
+        );
 
-      mockGetAuthJwt.mockReturnValue(TEST_REPLACEMENT_SESSION_VALUE);
-      expect(shouldPersistRefreshedSession?.()).toBe(false);
+        fireEvent.click(screen.getByRole("button", { name: "recover auth" }));
+        await waitFor(() => expect(mockValidateJwt).toHaveBeenCalled());
+        expect(shouldPersistRefreshedSession?.()).toBe(true);
 
-      validation.resolve({
-        isValid: false,
-        wasCancelled: true,
-        refreshOutcome: "cancelled",
-      });
-      await act(async () => {
-        await requestResult;
-      });
+        mockGetAuthJwt.mockReturnValue(TEST_REPLACEMENT_SESSION_VALUE);
+        expect(shouldPersistRefreshedSession?.()).toBe(false);
 
-      expect(mockRemoveAuthJwt).not.toHaveBeenCalled();
-      expect(sessionV2.loginWithSessionV2).not.toHaveBeenCalled();
-      expect(sessionV2.persistSessionResponse).not.toHaveBeenCalled();
-    });
+        validation.resolve({
+          isValid: false,
+          wasCancelled: false,
+          refreshOutcome: "empty",
+        });
+        await act(async () => {
+          await requestResult;
+        });
+
+        expect(mockRemoveAuthJwt).not.toHaveBeenCalled();
+        expect(sessionV2.loginWithSessionV2).not.toHaveBeenCalled();
+        expect(sessionV2.persistSessionResponse).not.toHaveBeenCalled();
+        expect(require("react-toastify").toast).not.toHaveBeenCalled();
+      }
+    );
 
     it("cancels server-rejected sign-in if auth changes during persistence", async () => {
       const validAddress = "0x1111111111111111111111111111111111111111";
@@ -1194,6 +1274,12 @@ describe("Auth component", () => {
         expect(sessionV2.getSessionNonce).not.toHaveBeenCalled();
         expect(mockSignMessage).not.toHaveBeenCalled();
         expect(mockSeizeDisconnect).not.toHaveBeenCalled();
+        if (!canSign) {
+          expect(require("react-toastify").toast).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ type: "error" })
+          );
+        }
       }
     );
 
@@ -1387,6 +1473,90 @@ describe("Auth component", () => {
       expect(mockInvalidateAuthSession).not.toHaveBeenCalled();
       expect(mockSignMessage).not.toHaveBeenCalled();
     });
+
+    it.each([
+      { action: "composer preflight", serverRejected: false },
+      { action: "reaction recovery", serverRejected: true },
+    ])(
+      "asks to reconnect a saved native profile without a signer or chain during $action",
+      async ({ serverRejected }) => {
+        const validAddress = "0x1111111111111111111111111111111111111111";
+        walletAddress = validAddress;
+        canSignActiveWallet = false;
+        mockActiveChainId = undefined;
+        mockWagmiIsConnected = false;
+        const authUtils = jest.requireMock<typeof AuthUtilsModule>(
+          "@/services/auth/auth.utils"
+        );
+        const sessionV2 = jest.requireMock<typeof SessionV2Module>(
+          "@/services/auth/session-v2.utils"
+        );
+        const { validateJwt } = jest.requireMock<
+          typeof import("@/services/auth/jwt-validation.utils")
+        >("@/services/auth/jwt-validation.utils");
+        const { toast } =
+          jest.requireMock<typeof import("react-toastify")>("react-toastify");
+        jest.mocked(authUtils.getAuthJwt).mockReturnValue("expired-native-jwt");
+        jest.mocked(authUtils.getWalletAddress).mockReturnValue(validAddress);
+        jest.mocked(sessionV2.getSessionClientType).mockReturnValue("native");
+        jest.mocked(validateJwt).mockResolvedValue({
+          isValid: false,
+          wasCancelled: false,
+          refreshOutcome: "empty",
+        });
+        const expectedAuthStateFingerprint = getAuthStateFingerprint({
+          walletAddress: validAddress,
+          jwt: "expired-native-jwt",
+        });
+
+        render(
+          <ReactQueryWrapperContext.Provider
+            value={createReactQueryWrapperContextValue()}
+          >
+            <Auth>
+              <RequestAuthResultButton
+                options={{ serverRejected, expectedAuthStateFingerprint }}
+              />
+            </Auth>
+          </ReactQueryWrapperContext.Provider>
+        );
+        await userEvent.click(screen.getByTestId("request-auth-result"));
+
+        await waitFor(() =>
+          expect(screen.getByTestId("request-auth-success")).toHaveTextContent(
+            "false"
+          )
+        );
+        expect(validateJwt).toHaveBeenCalledWith(
+          expect.objectContaining({
+            jwt: "expired-native-jwt",
+            wallet: validAddress,
+            serverRejected,
+          })
+        );
+        expect(toast).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({ type: "error" })
+        );
+        const renderedToast = jest.mocked(toast).mock.calls.at(-1)?.[0];
+        if (!React.isValidElement(renderedToast)) {
+          throw new Error("Expected a rendered reconnect toast");
+        }
+        render(renderedToast);
+        expect(
+          screen.getByText(
+            "Reconnect the wallet for this profile and try again."
+          )
+        ).toBeVisible();
+        expect(
+          authUtils.invalidateAuthSessionForAddress
+        ).not.toHaveBeenCalled();
+        expect(authUtils.removeAuthJwt).not.toHaveBeenCalled();
+        expect(sessionV2.getSessionNonce).not.toHaveBeenCalled();
+        expect(mockSignMessage).not.toHaveBeenCalled();
+        expect(mockSeizeDisconnect).not.toHaveBeenCalled();
+      }
+    );
 
     it("uses session nonce signable_message for web sign-in", async () => {
       const validAddress = "0x1111111111111111111111111111111111111111";

--- a/__tests__/components/waves/drops/WaveDropReactions.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropReactions.test.tsx
@@ -815,7 +815,7 @@ describe("WaveDropReactions", () => {
     });
   });
 
-  it("blocks reaction chips while a rejected session is recovering", async () => {
+  it("recovers after a raw 401 and sends another reaction only on an explicit retry", async () => {
     mockUseEmoji.mockReturnValue(
       createEmojiContextValue(
         [
@@ -831,6 +831,8 @@ describe("WaveDropReactions", () => {
     requestAuthMock.mockReturnValueOnce(recovery.promise);
     (commonApi.commonApiPost as jest.Mock).mockRejectedValueOnce(
       createStructuredReactionError({
+        body: "Unauthorized",
+        headers: new Headers({ "Content-Type": "application/json" }),
         message: "Unauthorized",
         status: 401,
       })
@@ -861,6 +863,10 @@ describe("WaveDropReactions", () => {
       });
       expect(button).toBeDisabled();
     });
+    expect(setToastMock).toHaveBeenCalledWith({
+      message: "Unauthorized",
+      type: "error",
+    });
     fireEvent.click(button);
     expect(commonApi.commonApiPost).toHaveBeenCalledTimes(1);
 
@@ -871,6 +877,27 @@ describe("WaveDropReactions", () => {
 
     await waitFor(() => expect(button).toBeEnabled());
     expect(commonApi.commonApiPost).toHaveBeenCalledTimes(1);
+    expect(button).toHaveTextContent("1");
+    expect(button).not.toHaveClass("tw-border-primary-500");
+
+    (commonApi.commonApiPost as jest.Mock).mockResolvedValueOnce({});
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(commonApi.commonApiPost).toHaveBeenCalledTimes(2);
+      expect(button).toBeEnabled();
+    });
+    expect(commonApi.commonApiPost).toHaveBeenLastCalledWith({
+      endpoint: "drops/test-drop/reaction",
+      body: { reaction: ":gm:" },
+      errorMode: "structured",
+      signal: expect.any(AbortSignal),
+    });
+    expect(button).toHaveTextContent("2");
+    expect(button).toHaveClass("tw-border-primary-500");
+    expect(commonApi.commonApiDelete).not.toHaveBeenCalled();
+    expect(requestAuthMock).toHaveBeenCalledTimes(1);
+    expect(setToastMock).toHaveBeenCalledTimes(1);
   });
 
   it("shows rate-limit guidance and rolls back chip state after a 429", async () => {

--- a/__tests__/components/waves/drops/reaction-utils.test.ts
+++ b/__tests__/components/waves/drops/reaction-utils.test.ts
@@ -146,6 +146,51 @@ describe("getReactionErrorMessage", () => {
     ).toBe("Unauthorized");
   });
 
+  it("maps a raw Unauthorized body even when the content type claims JSON", () => {
+    expect(
+      getReactionErrorMessage(
+        createStructuredReactionError({
+          body: "Unauthorized",
+          headers: new Headers({ "Content-Type": "application/json" }),
+          message: "Unauthorized",
+          status: 401,
+        }),
+        "Error adding reaction"
+      )
+    ).toBe("Unauthorized");
+  });
+
+  it("preserves a structured message ahead of the unauthorized status fallback", () => {
+    expect(
+      getReactionErrorMessage(
+        createStructuredReactionError({
+          body: JSON.stringify({
+            message: "Sign in with the wallet that owns this profile.",
+          }),
+          message: "Unauthorized",
+          status: 401,
+        }),
+        "Error adding reaction"
+      )
+    ).toBe("Sign in with the wallet that owns this profile.");
+  });
+
+  it.each([403, 500])(
+    "keeps the safe fallback for an opaque %s response",
+    (status) => {
+      expect(
+        getReactionErrorMessage(
+          createStructuredReactionError({
+            body: "Unauthorized",
+            message: "Unauthorized",
+            status,
+          }),
+          "Error adding reaction"
+        )
+      ).toBe("Error adding reaction");
+    }
+  );
+
   it("maps unauthorized status when response is null", () => {
     expect(
       getReactionErrorMessage(
@@ -342,16 +387,16 @@ describe("getReactionErrorMessage", () => {
     );
   });
 
-  it("does not use the raw error message when an unsafe body is present", () => {
+  it("maps the unauthorized status without exposing an unsafe body or message", () => {
     expect(
       getReactionErrorMessage(
         createStructuredReactionError({
           body: "<html><body>Bad Gateway</body></html>",
-          message: "Unauthorized",
+          message: "<html><body>Bad Gateway</body></html>",
           status: 401,
         }),
         "Error adding reaction"
       )
-    ).toBe("Error adding reaction");
+    ).toBe("Unauthorized");
   });
 });

--- a/components/auth/authActions.ts
+++ b/components/auth/authActions.ts
@@ -356,13 +356,6 @@ export function createAuthRequestActions({
     if (!validationResult.requiresSessionUpgrade) {
       setSignModalReason("auth");
       setSessionUpgradeRequired(false);
-      if (!canSignActiveWallet) {
-        setToast({
-          message: "Reconnect the wallet for this profile and try again.",
-          type: "error",
-        });
-        return false;
-      }
       if (!serverRejected) {
         const didInvalidate =
           await invalidateAuthSessionForAddress(walletAddress);
@@ -421,9 +414,7 @@ export function createAuthRequestActions({
     readonly role: string | null;
     readonly walletAddress: string;
   }): Promise<boolean> => {
-    const signingAuthRequestGuard =
-      createSigningAuthRequestGuard(authRequestGuard);
-    if (!signingAuthRequestGuard.isCurrent()) {
+    if (!authRequestGuard.isCurrent()) {
       return false;
     }
     if (!canSignActiveWallet) {
@@ -431,6 +422,11 @@ export function createAuthRequestActions({
         message: "Reconnect the wallet for this profile and try again.",
         type: "error",
       });
+      return false;
+    }
+    const signingAuthRequestGuard =
+      createSigningAuthRequestGuard(authRequestGuard);
+    if (!signingAuthRequestGuard.isCurrent()) {
       return false;
     }
 
@@ -471,6 +467,17 @@ export function createAuthRequestActions({
     readonly validationResult: AuthorizedWalletValidationResult;
     readonly walletAddress: string;
   }): Promise<boolean> => {
+    if (!authRequestGuard.isCurrent()) {
+      return false;
+    }
+    // A saved profile can need reconnection without an active signing chain.
+    if (!canSignActiveWallet && !validationResult.requiresSessionUpgrade) {
+      setToast({
+        message: "Reconnect the wallet for this profile and try again.",
+        type: "error",
+      });
+      return false;
+    }
     const signingAuthRequestGuard =
       createSigningAuthRequestGuard(authRequestGuard);
     if (!signingAuthRequestGuard.isCurrent()) {

--- a/components/waves/drops/reaction-utils.ts
+++ b/components/waves/drops/reaction-utils.ts
@@ -447,7 +447,11 @@ export const getReactionErrorMessage = (
         return safeMessage;
       }
 
-      if (!hasNoStructuredReactionBody(structuredBody)) {
+      // Gateway 401 responses can contain plain text instead of JSON.
+      if (
+        !hasNoStructuredReactionBody(structuredBody) &&
+        structuredStatus !== 401
+      ) {
         return fallback;
       }
     }

--- a/ops/docs/waves/troubleshooting-wave-navigation-and-posting.md
+++ b/ops/docs/waves/troubleshooting-wave-navigation-and-posting.md
@@ -82,6 +82,13 @@ is blocked.
   your connection, complete sign-in if prompted, then retry Post. A stalled
   session check expires so a later attempt can check the session again; the
   failed attempt does not automatically post your draft.
+- Post asks you to reconnect, or reactions show `Please reconnect your wallet`:
+  a saved profile can remain visible after its session can no longer renew.
+  Reconnect that profile using the
+  [wallet account controls](../navigation/feature-wallet-account-controls.md#failure-and-recovery),
+  then retry the action. Post keeps the draft when authentication fails; save
+  it before logging out or reloading. Reactions are not automatically retried
+  after signing in.
 - Footer shows `Connect your wallet to participate in this wave`:
   both chat and submission are blocked because the current viewer is signed out.
 - Footer shows `Create a profile to participate in this wave`:

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -1376,6 +1376,7 @@
         "Sign out all clears every connected profile in one visible transition without switching through the remaining profiles.",
         "If wallet connection is not working, retry from the header wallet controls and confirm the wallet modal is completed before using write actions.",
         "If Post cannot finish its session check, the draft stays in the composer. Wait for loading to finish, check the connection, complete sign-in if prompted, then retry Post. A stalled session check expires so a later attempt can check again; it does not automatically post the draft.",
+        "If Post asks you to reconnect or reactions show Please reconnect your wallet, the saved profile can still be visible even though its session cannot renew. Reconnect that profile from the wallet account controls, then retry the action. Save your draft before logging out or reloading; failed authentication keeps it in the composer, and reactions are not automatically retried after sign-in.",
         "Some write actions, settings, and subscriptions require a connected profile."
       ],
       "canonical_path": "/",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -1372,6 +1372,7 @@
         "Sign out all clears every connected profile in one visible transition without switching through the remaining profiles.",
         "If wallet connection is not working, retry from the header wallet controls and confirm the wallet modal is completed before using write actions.",
         "If Post cannot finish its session check, the draft stays in the composer. Wait for loading to finish, check the connection, complete sign-in if prompted, then retry Post. A stalled session check expires so a later attempt can check again; it does not automatically post the draft.",
+        "If Post asks you to reconnect or reactions show Please reconnect your wallet, the saved profile can still be visible even though its session cannot renew. Reconnect that profile from the wallet account controls, then retry the action. Save your draft before logging out or reloading; failed authentication keeps it in the composer, and reactions are not automatically retried after sign-in.",
         "Some write actions, settings, and subscriptions require a connected profile."
       ],
       "canonical_path": "/",


### PR DESCRIPTION
## Issue

A saved native profile can remain visible after its session can no longer renew. With no live wallet signer or chain, Post authentication returned false before showing reconnect guidance. A reaction rejected with a plain-text HTTP 401 showed a generic retry error. This follows the iPad report in #3937; the previous timeout repair did not resolve the reporter's native-app failure.

## Fix

Show the existing reconnect guidance before the signing-only network guard for an expired saved session. Recognize HTTP 401 even when the gateway response body is not JSON.

## Changes

- Preserve current-session checks, signing network restrictions, saved credentials, and legacy upgrade behavior.
- Keep composer drafts and require an explicit retry after reaction recovery.
- Update troubleshooting and the generated help corpus. Device classification and Surface/iPad input behavior are untouched.

## Validation

- 239 tests pass across authentication, reaction recovery, composer, session refresh, device/input hooks, and the native Connect flow.
- Changed-file lint/typecheck, React Doctor (100/100), help-index sync, documentation links, and whitespace checks pass.
- Both saved-profile regressions failed before the runtime fix and pass afterward.
- The reporter confirmed continued failure on iPadOS 26.5 and was given fresh native connection steps. Physical-device confirmation remains pending; these tests reproduce the recovery defect, not the cause of that device's missing or unusable refresh credentials.

## Risk

- Level: Low
- Why: Two narrowly scoped client recovery/error paths. No authentication bypass, automatic mutation replay, credential deletion, or device-layout changes.
- Rollback: Revert this PR and deploy through the ordinary workflow.

## Review Notes

Focus on stale auth state, unsupported signing networks, legacy upgrade behavior, and safe error-message precedence. This repairs recovery guidance; an expired connection still needs to be renewed by the user.

Auth toast fallback debt: components/auth/authActions.ts retains its existing English reconnect/session error copy, so non-English users receive English guidance. Frontend auth maintainers own progressive migration to meaning-based message keys and locale-aware auth actions; tracked here. This fix relocates existing copy and preserves the three pre-existing reconnect-message occurrences.
