### PR TITLE
Fix pinned waves after expired sessions

### DIFF
--- a/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.test.tsx
@@ -1,11 +1,10 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import BrainLeftSidebarWavePin from "@/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin";
 import {
   MAX_PINNED_WAVES,
   usePinnedWavesServer,
 } from "@/hooks/usePinnedWavesServer";
-import { useMyStream } from "@/contexts/wave/MyStreamContext";
 import { useAuth } from "@/components/auth/Auth";
 
 // Mock ResizeObserver
@@ -27,7 +26,6 @@ jest.mock("react-tooltip", () => ({
 jest.mock("@fortawesome/react-fontawesome", () => ({
   FontAwesomeIcon: () => <svg data-testid="icon" />,
 }));
-jest.mock("@/contexts/wave/MyStreamContext");
 jest.mock("@/hooks/usePinnedWavesServer");
 jest.mock("@/components/auth/Auth");
 
@@ -56,7 +54,6 @@ const proxyAuth: AuthMock = {
   connectedProfile: { handle: "testuser" },
   activeProfileProxy: { id: "proxy-1" },
 };
-const mockedUseMyStream = useMyStream as jest.Mock;
 const mockedUsePinnedWavesServer = usePinnedWavesServer as jest.Mock;
 const mockedUseAuth = useAuth as jest.Mock;
 
@@ -67,10 +64,9 @@ function setup(
   auth: AuthMock = connectedAuth,
   compact = false
 ) {
-  mockedUseMyStream.mockReturnValue({
-    waves: { addPinnedWave, removePinnedWave },
-  });
   mockedUsePinnedWavesServer.mockReturnValue({
+    pinWave: addPinnedWave,
+    unpinWave: removePinnedWave,
     pinnedIds: storedPinned,
     isOperationInProgress: jest.fn().mockReturnValue(false),
     canPinWave: jest.fn().mockImplementation(canPinWave),
@@ -84,6 +80,8 @@ function setup(
 describe("BrainLeftSidebarWavePin", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    addPinnedWave.mockReset().mockResolvedValue(undefined);
+    removePinnedWave.mockReset().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "maxTouchPoints", {
       configurable: true,
       value: 0,
@@ -122,6 +120,39 @@ describe("BrainLeftSidebarWavePin", () => {
     expect(addPinnedWave).toHaveBeenCalledWith("1");
     expect(removePinnedWave).not.toHaveBeenCalled();
   });
+
+  it.each([true, false])(
+    "shows a failure when the async pin action rejects (pinned: %s)",
+    async (isPinned) => {
+      const error = new Error("Network request failed");
+      const consoleError = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      try {
+        (isPinned ? removePinnedWave : addPinnedWave).mockRejectedValue(error);
+        setup(isPinned, isPinned ? ["1"] : []);
+        await userEvent
+          .setup()
+          .click(
+            screen.getByRole("button", {
+              name: isPinned ? "Unpin wave" : "Pin wave",
+            })
+          );
+        await waitFor(() =>
+          expect(setToast).toHaveBeenCalledWith(
+            expect.objectContaining({
+              type: "error",
+              title: isPinned
+                ? "Couldn't unpin this wave."
+                : "Couldn't pin this wave.",
+            })
+          )
+        );
+      } finally {
+        consoleError.mockRestore();
+      }
+    }
+  );
 
   it("collapses compact desktop row width until row hover or direct keyboard focus", () => {
     setup(false, [], undefined, connectedAuth, true);

--- a/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.test.tsx
@@ -6,6 +6,7 @@ import {
   usePinnedWavesServer,
 } from "@/hooks/usePinnedWavesServer";
 import { useAuth } from "@/components/auth/Auth";
+import { SUPPORTED_LOCALES } from "@/i18n/locales";
 
 // Mock ResizeObserver
 global.ResizeObserver = jest.fn().mockImplementation(() => ({
@@ -89,6 +90,30 @@ describe("BrainLeftSidebarWavePin", () => {
     localStorage.clear();
   });
 
+  it.each(SUPPORTED_LOCALES)(
+    "keeps pin labels and limit feedback available for %s",
+    async (locale) => {
+      const languages = jest
+        .spyOn(navigator, "languages", "get")
+        .mockReturnValue([locale]);
+      try {
+        setup(false, [], () => false);
+        const button = screen.getByRole("button", { name: "Pin wave" });
+        await userEvent.setup().click(button);
+        expect(button).toHaveAttribute(
+          "data-tooltip-content",
+          `Max ${MAX_PINNED_WAVES} pinned waves. Unpin another wave first.`
+        );
+        expect(setToast).toHaveBeenCalledWith({
+          type: "error",
+          message: `Maximum ${MAX_PINNED_WAVES} pinned waves allowed`,
+        });
+      } finally {
+        languages.mockRestore();
+      }
+    }
+  );
+
   it("does not render pin button for logged-out users", () => {
     const { container } = setup(false, [], undefined, loggedOutAuth);
     expect(container.firstChild).toBeNull();
@@ -131,13 +156,11 @@ describe("BrainLeftSidebarWavePin", () => {
       try {
         (isPinned ? removePinnedWave : addPinnedWave).mockRejectedValue(error);
         setup(isPinned, isPinned ? ["1"] : []);
-        await userEvent
-          .setup()
-          .click(
-            screen.getByRole("button", {
-              name: isPinned ? "Unpin wave" : "Pin wave",
-            })
-          );
+        await userEvent.setup().click(
+          screen.getByRole("button", {
+            name: isPinned ? "Unpin wave" : "Pin wave",
+          })
+        );
         await waitFor(() =>
           expect(setToast).toHaveBeenCalledWith(
             expect.objectContaining({

--- a/__tests__/hooks/usePinnedWavesServer.test.tsx
+++ b/__tests__/hooks/usePinnedWavesServer.test.tsx
@@ -74,14 +74,14 @@ const queryClientMock = {
 };
 
 const requestAuth = jest.fn();
-const createAuthJwt = (role: string | null) =>
+const createAuthJwt = (role: string | null | undefined) =>
   `e30.${btoa(JSON.stringify({ role, sub: "0xabc", exp: Date.now() / 1000 + 3600 }))}.signature`;
 
 const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <AuthContext.Provider
     value={
       {
-        connectedProfile: { handle: "me" },
+        connectedProfile: { id: "profile-me", handle: "me" },
         activeProfileProxy: null,
         requestAuth,
       } as any
@@ -136,8 +136,8 @@ beforeEach(() => {
   unpinMutateAsync = jest.fn().mockResolvedValue(undefined);
   requestAuth.mockReset().mockResolvedValue({ success: true });
   jest.mocked(getWalletAddress).mockReturnValue("0xabc");
-  jest.mocked(getAuthJwt).mockReturnValue(createAuthJwt(null));
-  jest.mocked(getWalletRole).mockReturnValue(null);
+  jest.mocked(getAuthJwt).mockReturnValue(createAuthJwt("profile-me"));
+  jest.mocked(getWalletRole).mockReturnValue("profile-me");
 
   let mutationCallCount = 0;
   useMutationMock.mockImplementation(() => {
@@ -337,6 +337,20 @@ test.each(["pinWave", "unpinWave"] as const)(
     expect(
       action === "pinWave" ? pinnedWavesApi.pinWave : pinnedWavesApi.unpinWave
     ).toHaveBeenCalledWith("wave");
+  }
+);
+
+test.each([null, undefined])(
+  "accepts a legacy token without a primary profile role (%s)",
+  async (role) => {
+    jest.mocked(getAuthJwt).mockReturnValue(createAuthJwt(role));
+    const { result } = renderHook(() => usePinnedWavesServer(), { wrapper });
+
+    await result.current.pinWave("wave");
+    await result.current.unpinWave("wave");
+
+    expect(pinMutateAsync).toHaveBeenCalledWith("wave");
+    expect(unpinMutateAsync).toHaveBeenCalledWith("wave");
   }
 );
 
@@ -545,9 +559,14 @@ test.each(["pinWave", "unpinWave"] as const)(
   }
 );
 
-test.each([0, 1])(
-  "pin mutation %s rejects a viewer switch while cancelling queries before optimistic writes",
-  async (index) => {
+test.each([
+  [0, "wallet"],
+  [1, "wallet"],
+  [0, "proxy"],
+  [1, "proxy"],
+] as const)(
+  "pin mutation %s rejects a %s switch while cancelling queries before optimistic writes",
+  async (index, switchType) => {
     let finishCancellation!: () => void;
     queryClientMock.cancelQueries.mockReturnValueOnce(
       new Promise<void>((resolve) => {
@@ -557,7 +576,11 @@ test.each([0, 1])(
     renderHook(() => usePinnedWavesServer(), { wrapper });
     const { onMutate } = useMutationMock.mock.calls[index][0];
     const operation = onMutate("wave");
-    jest.mocked(getWalletAddress).mockReturnValue("0xdef");
+    if (switchType === "wallet") {
+      jest.mocked(getWalletAddress).mockReturnValue("0xdef");
+    } else {
+      jest.mocked(getAuthJwt).mockReturnValue(createAuthJwt("other-profile"));
+    }
     finishCancellation();
     await expect(operation).rejects.toThrow("The active profile changed");
     expect(queryClientMock.setQueryData).not.toHaveBeenCalled();

--- a/__tests__/hooks/usePinnedWavesServer.test.tsx
+++ b/__tests__/hooks/usePinnedWavesServer.test.tsx
@@ -303,9 +303,12 @@ test.each(["pinWave", "unpinWave"] as const)(
       return { success: true };
     });
     const { result } = renderHook(() => usePinnedWavesServer(), { wrapper });
-    await result.current[action]("wave");
+    await expect(result.current[action]("wave")).rejects.toThrow(
+      "The active profile changed"
+    );
     expect(pinMutateAsync).not.toHaveBeenCalled();
     expect(unpinMutateAsync).not.toHaveBeenCalled();
+    expect(queryClientMock.setQueryData).not.toHaveBeenCalled();
     expect(result.current.isOperationInProgress("wave")).toBe(false);
   }
 );
@@ -340,6 +343,8 @@ test.each(["pinWave", "unpinWave"] as const)(
     await result.current[action]("wave");
     expect(pinMutateAsync).not.toHaveBeenCalled();
     expect(unpinMutateAsync).not.toHaveBeenCalled();
+    expect(queryClientMock.setQueryData).not.toHaveBeenCalled();
+    expect(result.current.isOperationInProgress("wave")).toBe(false);
   }
 );
 
@@ -351,9 +356,12 @@ test.each(["pinWave", "unpinWave"] as const)(
       return { success: true };
     });
     const { result } = renderHook(() => usePinnedWavesServer(), { wrapper });
-    await result.current[action]("wave");
+    await expect(result.current[action]("wave")).rejects.toThrow(
+      "The active profile changed"
+    );
     expect(pinMutateAsync).not.toHaveBeenCalled();
     expect(unpinMutateAsync).not.toHaveBeenCalled();
+    expect(queryClientMock.setQueryData).not.toHaveBeenCalled();
   }
 );
 
@@ -469,3 +477,39 @@ test("still enforces the cap once non-announcement pins reach the limit", async 
   );
   expect(pinMutateAsync).not.toHaveBeenCalled();
 });
+
+test.each(["pinWave", "unpinWave"] as const)(
+  "%s propagates authentication errors and releases the pending operation",
+  async (action) => {
+    requestAuth.mockRejectedValue(new Error("Authentication unavailable"));
+    const { result } = renderHook(() => usePinnedWavesServer(), { wrapper });
+    await expect(result.current[action]("wave")).rejects.toThrow(
+      "Authentication unavailable"
+    );
+    expect(pinMutateAsync).not.toHaveBeenCalled();
+    expect(unpinMutateAsync).not.toHaveBeenCalled();
+    expect(queryClientMock.setQueryData).not.toHaveBeenCalled();
+    expect(result.current.isOperationInProgress("wave")).toBe(false);
+  }
+);
+
+test.each([0, 1])(
+  "pin mutation %s rejects a viewer switch while cancelling queries before optimistic writes",
+  async (index) => {
+    let finishCancellation!: () => void;
+    queryClientMock.cancelQueries.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishCancellation = resolve;
+      })
+    );
+    renderHook(() => usePinnedWavesServer(), { wrapper });
+    const { onMutate } = useMutationMock.mock.calls[index][0];
+    const operation = onMutate("wave");
+    jest.mocked(getWalletAddress).mockReturnValue("0xdef");
+    finishCancellation();
+    await expect(operation).rejects.toThrow("The active profile changed");
+    expect(queryClientMock.setQueryData).not.toHaveBeenCalled();
+    expect(pinnedWavesApi.pinWave).not.toHaveBeenCalled();
+    expect(pinnedWavesApi.unpinWave).not.toHaveBeenCalled();
+  }
+);

--- a/__tests__/hooks/usePinnedWavesServer.test.tsx
+++ b/__tests__/hooks/usePinnedWavesServer.test.tsx
@@ -11,7 +11,11 @@ import { useSeizeSettingsOptional } from "@/contexts/SeizeSettingsContext";
 import { fetchWavesV2Page } from "@/services/api/waves-v2-api";
 import { ApiWavesOverviewType } from "@/generated/models/ApiWavesOverviewType";
 import { ApiWavesPinFilter } from "@/generated/models/ApiWavesPinFilter";
-import { getWalletAddress, getWalletRole } from "@/services/auth/auth.utils";
+import {
+  getAuthJwt,
+  getWalletAddress,
+  getWalletRole,
+} from "@/services/auth/auth.utils";
 import { pinnedWavesApi } from "@/services/api/pinned-waves-api";
 
 jest.mock("@/services/api/pinned-waves-api", () => ({
@@ -20,6 +24,7 @@ jest.mock("@/services/api/pinned-waves-api", () => ({
 
 jest.mock("@/services/auth/auth.utils", () => ({
   ...jest.requireActual("@/services/auth/auth.utils"),
+  getAuthJwt: jest.fn(),
   getWalletAddress: jest.fn(),
   getWalletRole: jest.fn(),
 }));
@@ -69,6 +74,8 @@ const queryClientMock = {
 };
 
 const requestAuth = jest.fn();
+const createAuthJwt = (role: string | null) =>
+  `e30.${btoa(JSON.stringify({ role, sub: "0xabc", exp: Date.now() / 1000 + 3600 }))}.signature`;
 
 const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <AuthContext.Provider
@@ -129,6 +136,7 @@ beforeEach(() => {
   unpinMutateAsync = jest.fn().mockResolvedValue(undefined);
   requestAuth.mockReset().mockResolvedValue({ success: true });
   jest.mocked(getWalletAddress).mockReturnValue("0xabc");
+  jest.mocked(getAuthJwt).mockReturnValue(createAuthJwt(null));
   jest.mocked(getWalletRole).mockReturnValue(null);
 
   let mutationCallCount = 0;
@@ -299,7 +307,7 @@ test.each(["pinWave", "unpinWave"] as const)(
   "%s cancels when a proxy becomes active during authentication",
   async (action) => {
     requestAuth.mockImplementation(async () => {
-      jest.mocked(getWalletRole).mockReturnValue("proxy-1");
+      jest.mocked(getAuthJwt).mockReturnValue(createAuthJwt("proxy-1"));
       return { success: true };
     });
     const { result } = renderHook(() => usePinnedWavesServer(), { wrapper });
@@ -310,6 +318,50 @@ test.each(["pinWave", "unpinWave"] as const)(
     expect(unpinMutateAsync).not.toHaveBeenCalled();
     expect(queryClientMock.setQueryData).not.toHaveBeenCalled();
     expect(result.current.isOperationInProgress("wave")).toBe(false);
+  }
+);
+
+test.each(["pinWave", "unpinWave"] as const)(
+  "%s accepts a primary JWT when saved proxy metadata is stale",
+  async (action) => {
+    jest.mocked(getWalletRole).mockReturnValue("stale-proxy");
+    const { result } = renderHook(() => usePinnedWavesServer(), { wrapper });
+
+    await result.current[action]("wave");
+
+    expect(
+      action === "pinWave" ? pinMutateAsync : unpinMutateAsync
+    ).toHaveBeenCalledWith("wave");
+    const index = action === "pinWave" ? 0 : 1;
+    await useMutationMock.mock.calls[index][0].mutationFn("wave");
+    expect(
+      action === "pinWave" ? pinnedWavesApi.pinWave : pinnedWavesApi.unpinWave
+    ).toHaveBeenCalledWith("wave");
+  }
+);
+
+test.each([null, "invalid-jwt", createAuthJwt("proxy-1")])(
+  "rejects an absent, malformed, or proxy JWT before changing pin state (%s)",
+  async (jwt) => {
+    const { result } = renderHook(() => usePinnedWavesServer(), { wrapper });
+    jest.mocked(getAuthJwt).mockReturnValue(jwt);
+
+    for (const action of ["pinWave", "unpinWave"] as const) {
+      await expect(result.current[action]("wave")).rejects.toThrow(
+        "The active profile changed"
+      );
+      expect(result.current.isOperationInProgress("wave")).toBe(false);
+    }
+    expect(pinMutateAsync).not.toHaveBeenCalled();
+    expect(unpinMutateAsync).not.toHaveBeenCalled();
+    expect(queryClientMock.setQueryData).not.toHaveBeenCalled();
+    for (const [options] of useMutationMock.mock.calls) {
+      expect(() => options.mutationFn("wave")).toThrow(
+        "The active profile changed"
+      );
+    }
+    expect(pinnedWavesApi.pinWave).not.toHaveBeenCalled();
+    expect(pinnedWavesApi.unpinWave).not.toHaveBeenCalled();
   }
 );
 

--- a/__tests__/hooks/usePinnedWavesServer.test.tsx
+++ b/__tests__/hooks/usePinnedWavesServer.test.tsx
@@ -11,6 +11,18 @@ import { useSeizeSettingsOptional } from "@/contexts/SeizeSettingsContext";
 import { fetchWavesV2Page } from "@/services/api/waves-v2-api";
 import { ApiWavesOverviewType } from "@/generated/models/ApiWavesOverviewType";
 import { ApiWavesPinFilter } from "@/generated/models/ApiWavesPinFilter";
+import { getWalletAddress, getWalletRole } from "@/services/auth/auth.utils";
+import { pinnedWavesApi } from "@/services/api/pinned-waves-api";
+
+jest.mock("@/services/api/pinned-waves-api", () => ({
+  pinnedWavesApi: { pinWave: jest.fn(), unpinWave: jest.fn() },
+}));
+
+jest.mock("@/services/auth/auth.utils", () => ({
+  ...jest.requireActual("@/services/auth/auth.utils"),
+  getWalletAddress: jest.fn(),
+  getWalletRole: jest.fn(),
+}));
 
 jest.mock("@tanstack/react-query", () => ({
   useMutation: jest.fn(),
@@ -56,10 +68,16 @@ const queryClientMock = {
   setQueryData: jest.fn(),
 };
 
+const requestAuth = jest.fn();
+
 const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <AuthContext.Provider
     value={
-      { connectedProfile: { handle: "me" }, activeProfileProxy: null } as any
+      {
+        connectedProfile: { handle: "me" },
+        activeProfileProxy: null,
+        requestAuth,
+      } as any
     }
   >
     {children}
@@ -109,6 +127,9 @@ beforeEach(() => {
   jest.clearAllMocks();
   pinMutateAsync = jest.fn().mockResolvedValue(undefined);
   unpinMutateAsync = jest.fn().mockResolvedValue(undefined);
+  requestAuth.mockReset().mockResolvedValue({ success: true });
+  jest.mocked(getWalletAddress).mockReturnValue("0xabc");
+  jest.mocked(getWalletRole).mockReturnValue(null);
 
   let mutationCallCount = 0;
   useMutationMock.mockImplementation(() => {
@@ -235,6 +256,106 @@ test("fetches pinned waves across multiple API pages", async () => {
     expect.objectContaining({ page: 2, pageSize: 20 })
   );
 });
+
+test("does not turn anonymous overview results into pins or paginate through public waves", async () => {
+  fetchWavesV2PageMock.mockResolvedValue({
+    page: 1,
+    next: true,
+    waves: [{ ...createWave("public-wave"), pinned: false }],
+  });
+  renderHook(() => usePinnedWavesServer(), { wrapper });
+
+  await expect(getPinnedWavesQueryOptions().queryFn()).resolves.toEqual([]);
+  expect(fetchWavesV2PageMock).toHaveBeenCalledTimes(1);
+});
+
+test("excludes unpinned entries already present in the pinned cache", () => {
+  useQueryMock.mockReturnValue({
+    data: [createWave("pin"), { ...createWave("public"), pinned: false }],
+  });
+  const { result } = renderHook(() => usePinnedWavesServer(), { wrapper });
+  expect(result.current.pinnedIds).toEqual(["pin"]);
+});
+
+test.each([0, 1])(
+  "pin mutation %s checks the active account immediately before the API request",
+  async (index) => {
+    renderHook(() => usePinnedWavesServer(), { wrapper });
+    const { mutationFn } = useMutationMock.mock.calls[index][0];
+    jest.mocked(getWalletAddress).mockReturnValue("0xdef");
+    expect(() => mutationFn("wave")).toThrow("The active profile changed");
+    expect(pinnedWavesApi.pinWave).not.toHaveBeenCalled();
+    expect(pinnedWavesApi.unpinWave).not.toHaveBeenCalled();
+
+    jest.mocked(getWalletAddress).mockReturnValue("0xabc");
+    await mutationFn("wave");
+    expect(
+      index === 0 ? pinnedWavesApi.pinWave : pinnedWavesApi.unpinWave
+    ).toHaveBeenCalledWith("wave");
+  }
+);
+
+test.each(["pinWave", "unpinWave"] as const)(
+  "%s cancels when a proxy becomes active during authentication",
+  async (action) => {
+    requestAuth.mockImplementation(async () => {
+      jest.mocked(getWalletRole).mockReturnValue("proxy-1");
+      return { success: true };
+    });
+    const { result } = renderHook(() => usePinnedWavesServer(), { wrapper });
+    await result.current[action]("wave");
+    expect(pinMutateAsync).not.toHaveBeenCalled();
+    expect(unpinMutateAsync).not.toHaveBeenCalled();
+    expect(result.current.isOperationInProgress("wave")).toBe(false);
+  }
+);
+
+test.each(["pinWave", "unpinWave"] as const)(
+  "%s authenticates before changing pin state",
+  async (action) => {
+    let finishAuth!: (value: { success: boolean }) => void;
+    requestAuth.mockReturnValue(
+      new Promise((resolve) => {
+        finishAuth = resolve;
+      })
+    );
+    const { result } = renderHook(() => usePinnedWavesServer(), { wrapper });
+    const operation = result.current[action]("wave");
+    expect(requestAuth).toHaveBeenCalledTimes(1);
+    expect(pinMutateAsync).not.toHaveBeenCalled();
+    expect(unpinMutateAsync).not.toHaveBeenCalled();
+    finishAuth({ success: true });
+    await operation;
+    expect(
+      action === "pinWave" ? pinMutateAsync : unpinMutateAsync
+    ).toHaveBeenCalledWith("wave");
+  }
+);
+
+test.each(["pinWave", "unpinWave"] as const)(
+  "%s leaves pin state intact when authentication fails",
+  async (action) => {
+    requestAuth.mockResolvedValue({ success: false });
+    const { result } = renderHook(() => usePinnedWavesServer(), { wrapper });
+    await result.current[action]("wave");
+    expect(pinMutateAsync).not.toHaveBeenCalled();
+    expect(unpinMutateAsync).not.toHaveBeenCalled();
+  }
+);
+
+test.each(["pinWave", "unpinWave"] as const)(
+  "%s cancels when the account changes during authentication",
+  async (action) => {
+    requestAuth.mockImplementation(async () => {
+      jest.mocked(getWalletAddress).mockReturnValue("0xdef");
+      return { success: true };
+    });
+    const { result } = renderHook(() => usePinnedWavesServer(), { wrapper });
+    await result.current[action]("wave");
+    expect(pinMutateAsync).not.toHaveBeenCalled();
+    expect(unpinMutateAsync).not.toHaveBeenCalled();
+  }
+);
 
 test("stops fetching pinned waves once the pinned limit is reached", async () => {
   fetchWavesV2PageMock.mockImplementation(({ page }) =>

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
@@ -10,6 +10,9 @@ import {
 import { getToastErrorDetails } from "@/helpers/toast.helpers";
 import { TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
 import useIsTouchDevice from "@/hooks/useIsTouchDevice";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import { formatInteger } from "@/i18n/format";
+import { t } from "@/i18n/messages";
 
 interface BrainLeftSidebarWavePinProps {
   readonly waveId: string;
@@ -56,6 +59,8 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
     usePinnedWavesServer();
   const { setToast, connectedProfile, activeProfileProxy } = useAuth();
   const isTouchDevice = useIsTouchDevice();
+  const locale = useBrowserLocale();
+  const pinLimit = formatInteger(locale, MAX_PINNED_WAVES);
   const [maxLimitTooltipRequest, setMaxLimitTooltipRequest] =
     useState<MaxLimitTooltipRequest | null>(null);
 
@@ -105,7 +110,9 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
           setMaxLimitTooltipRequest({ waveId, pinnedIdsKey });
           setToast({
             type: "error",
-            message: `Maximum ${MAX_PINNED_WAVES} pinned waves allowed`,
+            message: t(locale, "waves.sidebar.pinControl.limitMessage", {
+              count: pinLimit,
+            }),
           });
         }
       }
@@ -114,10 +121,13 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
 
       setToast({
         type: "error",
-        title: isPinned
-          ? "Couldn't unpin this wave."
-          : "Couldn't pin this wave.",
-        description: "Please try again.",
+        title: t(
+          locale,
+          isPinned
+            ? "waves.sidebar.pinControl.unpinErrorTitle"
+            : "waves.sidebar.pinControl.pinErrorTitle"
+        ),
+        description: t(locale, "waves.sidebar.pinControl.retryDescription"),
         details: getToastErrorDetails(error),
       });
     }
@@ -132,10 +142,13 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
 
   // Only show max-limit guidance for the keyed request window after a failed pin.
   const getTooltipContent = () => {
-    if (isPinned) return "Unpin";
-    if (canPinCurrentWave) return "Pin";
+    if (isPinned) return t(locale, "waves.sidebar.pinControl.unpinTooltip");
+    if (canPinCurrentWave)
+      return t(locale, "waves.sidebar.pinControl.pinTooltip");
     if (showMaxLimitTooltip) {
-      return `Max ${MAX_PINNED_WAVES} pinned waves. Unpin another wave first.`;
+      return t(locale, "waves.sidebar.pinControl.limitTooltip", {
+        count: pinLimit,
+      });
     }
     return null;
   };
@@ -149,7 +162,12 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
   };
 
   const getAriaLabel = () => {
-    return isPinned ? "Unpin wave" : "Pin wave";
+    return t(
+      locale,
+      isPinned
+        ? "waves.sidebar.pinControl.unpinAriaLabel"
+        : "waves.sidebar.pinControl.pinAriaLabel"
+    );
   };
 
   const positionClasses = compact ? "" : "-tw-mr-2 tw-mt-0.5";

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useEffect, useState, useMemo } from "react";
-import { useMyStream } from "@/contexts/wave/MyStreamContext";
 import { Tooltip } from "react-tooltip";
 import { useAuth } from "@/components/auth/Auth";
 import {
@@ -53,8 +52,7 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
   compact = false,
   className,
 }) => {
-  const { waves } = useMyStream();
-  const { pinnedIds, isOperationInProgress, canPinWave } =
+  const { pinnedIds, isOperationInProgress, canPinWave, pinWave, unpinWave } =
     usePinnedWavesServer();
   const { setToast, connectedProfile, activeProfileProxy } = useAuth();
   const isTouchDevice = useIsTouchDevice();
@@ -96,13 +94,13 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
 
     try {
       if (isPinned) {
-        waves.removePinnedWave(waveId);
+        await unpinWave(waveId);
         setMaxLimitTooltipRequest(null);
       } else {
         const canPin = canPinWave(waveId);
 
         if (canPin) {
-          waves.addPinnedWave(waveId);
+          await pinWave(waveId);
         } else {
           setMaxLimitTooltipRequest({ waveId, pinnedIdsKey });
           setToast({

--- a/hooks/usePinnedWavesServer.ts
+++ b/hooks/usePinnedWavesServer.ts
@@ -308,10 +308,11 @@ async function optimisticallyPinWave(
   queryClient: QueryClient,
   queryKey: PinnedWavesQueryKey,
   waveId: string,
-  viewerIdentityKey: string | null
+  viewerIdentityKey: string | null,
+  primaryProfileId: string | null
 ): Promise<MutationContext> {
   await queryClient.cancelQueries({ queryKey });
-  assertCurrentPinViewer(viewerIdentityKey);
+  assertCurrentPinViewer(viewerIdentityKey, primaryProfileId);
 
   const previousPinnedWaves = queryClient.getQueryData<SidebarWave[]>(queryKey);
   const waveToPin = findWaveForOptimisticPin(queryClient, waveId);
@@ -332,10 +333,11 @@ async function optimisticallyUnpinWave(
   queryClient: QueryClient,
   queryKey: PinnedWavesQueryKey,
   waveId: string,
-  viewerIdentityKey: string | null
+  viewerIdentityKey: string | null,
+  primaryProfileId: string | null
 ): Promise<MutationContext> {
   await queryClient.cancelQueries({ queryKey });
-  assertCurrentPinViewer(viewerIdentityKey);
+  assertCurrentPinViewer(viewerIdentityKey, primaryProfileId);
 
   const previousPinnedWaves = queryClient.getQueryData<SidebarWave[]>(queryKey);
 
@@ -359,7 +361,10 @@ function restorePinnedWaves(
   }
 }
 
-function isCurrentPinViewer(viewerIdentityKey: string | null): boolean {
+function isCurrentPinViewer(
+  viewerIdentityKey: string | null,
+  primaryProfileId: string | null
+): boolean {
   const address = getWalletAddress();
   const jwt = getAuthJwt();
   if (
@@ -370,15 +375,20 @@ function isCurrentPinViewer(viewerIdentityKey: string | null): boolean {
     return false;
   }
   try {
-    // Match AuthProvider's effective role; saved role metadata can be stale.
-    return !getRole(jwt);
+    // Normal logins carry the owner's profile ID as role; other IDs are proxies.
+    // Older tokens may omit role. Saved role metadata can be stale.
+    const role = getRole(jwt);
+    return !role || role === primaryProfileId;
   } catch {
     return false;
   }
 }
 
-function assertCurrentPinViewer(viewerIdentityKey: string | null): void {
-  if (!isCurrentPinViewer(viewerIdentityKey)) {
+function assertCurrentPinViewer(
+  viewerIdentityKey: string | null,
+  primaryProfileId: string | null
+): void {
+  if (!isCurrentPinViewer(viewerIdentityKey, primaryProfileId)) {
     throw new Error(
       t(DEFAULT_LOCALE, "waves.sidebar.pinControl.viewerChanged")
     );
@@ -388,7 +398,8 @@ function assertCurrentPinViewer(viewerIdentityKey: string | null): void {
 function usePinnedWaveMutations(
   queryClient: QueryClient,
   pinnedWavesQueryKey: PinnedWavesQueryKey,
-  viewerIdentityKey: string | null
+  viewerIdentityKey: string | null,
+  primaryProfileId: string | null
 ) {
   const invalidateWavesQueries = useInvalidateWavesQueries(
     queryClient,
@@ -398,7 +409,7 @@ function usePinnedWaveMutations(
 
   const pinMutation = useMutation<void, Error, string, MutationContext>({
     mutationFn: (waveId) => {
-      assertCurrentPinViewer(viewerIdentityKey);
+      assertCurrentPinViewer(viewerIdentityKey, primaryProfileId);
       return pinnedWavesApi.pinWave(waveId);
     },
     onMutate: (waveId: string) =>
@@ -406,7 +417,8 @@ function usePinnedWaveMutations(
         queryClient,
         pinnedWavesQueryKey,
         waveId,
-        viewerIdentityKey
+        viewerIdentityKey,
+        primaryProfileId
       ),
     onError: (err, _, context) => {
       restorePinnedWaves(queryClient, pinnedWavesQueryKey, context);
@@ -417,7 +429,7 @@ function usePinnedWaveMutations(
 
   const unpinMutation = useMutation<void, Error, string, MutationContext>({
     mutationFn: (waveId) => {
-      assertCurrentPinViewer(viewerIdentityKey);
+      assertCurrentPinViewer(viewerIdentityKey, primaryProfileId);
       return pinnedWavesApi.unpinWave(waveId);
     },
     onMutate: (waveId: string) =>
@@ -425,7 +437,8 @@ function usePinnedWaveMutations(
         queryClient,
         pinnedWavesQueryKey,
         waveId,
-        viewerIdentityKey
+        viewerIdentityKey,
+        primaryProfileId
       ),
     onError: (err, _, context) => {
       restorePinnedWaves(queryClient, pinnedWavesQueryKey, context);
@@ -461,6 +474,7 @@ export function usePinnedWavesServer(
   const hasAuthenticatedProfile =
     !!connectedProfile?.handle && !activeProfileProxy && hasAuthContextProfile;
   const activeProfileProxyId = activeProfileProxy?.id ?? null;
+  const primaryProfileId = connectedProfile?.id ?? null;
   const isPendingAuthSwitch = Boolean(
     address && (!hasValidWalletAuthorization || fetchingProfile)
   );
@@ -509,7 +523,8 @@ export function usePinnedWavesServer(
   const { pinMutation, unpinMutation } = usePinnedWaveMutations(
     queryClient,
     pinnedWavesQueryKey,
-    viewerIdentityKey
+    viewerIdentityKey,
+    primaryProfileId
   );
 
   const pinWave = useCallback(
@@ -529,13 +544,13 @@ export function usePinnedWavesServer(
         if (!success) {
           return;
         }
-        assertCurrentPinViewer(viewerIdentityKey);
+        assertCurrentPinViewer(viewerIdentityKey, primaryProfileId);
         await pinMutation.mutateAsync(waveId);
       } finally {
         ongoingOperations.current.delete(waveId);
       }
     },
-    [canPinWave, pinMutation, requestAuth, viewerIdentityKey]
+    [canPinWave, pinMutation, requestAuth, viewerIdentityKey, primaryProfileId]
   );
 
   const unpinWave = useCallback(
@@ -551,13 +566,13 @@ export function usePinnedWavesServer(
         if (!success) {
           return;
         }
-        assertCurrentPinViewer(viewerIdentityKey);
+        assertCurrentPinViewer(viewerIdentityKey, primaryProfileId);
         await unpinMutation.mutateAsync(waveId);
       } finally {
         ongoingOperations.current.delete(waveId);
       }
     },
-    [unpinMutation, requestAuth, viewerIdentityKey]
+    [unpinMutation, requestAuth, viewerIdentityKey, primaryProfileId]
   );
 
   return {

--- a/hooks/usePinnedWavesServer.ts
+++ b/hooks/usePinnedWavesServer.ts
@@ -23,6 +23,7 @@ import {
 } from "@/services/api/waves-v2-api";
 import type { SidebarWave, SidebarWavesPage } from "@/types/waves.types";
 import { useOfficialWaves } from "./useOfficialWaves";
+import { getWalletAddress, getWalletRole } from "@/services/auth/auth.utils";
 
 export const MAX_PINNED_WAVES = 100;
 
@@ -90,9 +91,14 @@ async function fetchPinnedWavesPages(): Promise<SidebarWave[]> {
       pinned: ApiWavesPinFilter.Pinned,
     });
 
-    pinnedWaves.push(...page.waves);
+    const confirmedPins = page.waves.filter((wave) => wave.pinned === true);
+    pinnedWaves.push(...confirmedPins);
 
-    if (!page.next || page.waves.length === 0) {
+    if (
+      !page.next ||
+      page.waves.length === 0 ||
+      confirmedPins.length !== page.waves.length
+    ) {
       break;
     }
 
@@ -344,6 +350,21 @@ function restorePinnedWaves(
   }
 }
 
+function isCurrentPinViewer(viewerIdentityKey: string | null): boolean {
+  const address = getWalletAddress();
+  return Boolean(
+    address &&
+    !getWalletRole() &&
+    viewerIdentityKey === `${address.toLowerCase()}:primary`
+  );
+}
+
+function assertCurrentPinViewer(viewerIdentityKey: string | null): void {
+  if (!isCurrentPinViewer(viewerIdentityKey)) {
+    throw new Error("The active profile changed. Please try again.");
+  }
+}
+
 function usePinnedWaveMutations(
   queryClient: QueryClient,
   pinnedWavesQueryKey: PinnedWavesQueryKey,
@@ -356,7 +377,10 @@ function usePinnedWaveMutations(
   );
 
   const pinMutation = useMutation<void, Error, string, MutationContext>({
-    mutationFn: pinnedWavesApi.pinWave,
+    mutationFn: (waveId) => {
+      assertCurrentPinViewer(viewerIdentityKey);
+      return pinnedWavesApi.pinWave(waveId);
+    },
     onMutate: (waveId: string) =>
       optimisticallyPinWave(queryClient, pinnedWavesQueryKey, waveId),
     onError: (err, _, context) => {
@@ -367,7 +391,10 @@ function usePinnedWaveMutations(
   });
 
   const unpinMutation = useMutation<void, Error, string, MutationContext>({
-    mutationFn: pinnedWavesApi.unpinWave,
+    mutationFn: (waveId) => {
+      assertCurrentPinViewer(viewerIdentityKey);
+      return pinnedWavesApi.unpinWave(waveId);
+    },
     onMutate: (waveId: string) =>
       optimisticallyUnpinWave(queryClient, pinnedWavesQueryKey, waveId),
     onError: (err, _, context) => {
@@ -392,6 +419,7 @@ export function usePinnedWavesServer(
     activeProfileProxy,
     fetchingProfile,
     isAuthenticated,
+    requestAuth,
   } = useAuth();
   const { address, hasValidWalletAuth } = useSeizeConnectContext();
   const queryClient = useQueryClient();
@@ -439,7 +467,10 @@ export function usePinnedWavesServer(
     isEnabled && hasAuthenticatedProfile && !isPendingAuthSwitch,
     !hasAuthenticatedProfile || isPendingAuthSwitch
   );
-  const pinnedWaves = data ?? [];
+  const pinnedWaves = useMemo(
+    () => data?.filter((wave) => wave.pinned === true) ?? [],
+    [data]
+  );
   const { pinnedIds, canPinWave } = usePinnedWavesBudget(
     pinnedWaves,
     ongoingOperations,
@@ -464,12 +495,16 @@ export function usePinnedWavesServer(
       ongoingOperations.current.add(waveId);
 
       try {
+        const { success } = await requestAuth();
+        if (!success || !isCurrentPinViewer(viewerIdentityKey)) {
+          return;
+        }
         await pinMutation.mutateAsync(waveId);
       } finally {
         ongoingOperations.current.delete(waveId);
       }
     },
-    [canPinWave, pinMutation]
+    [canPinWave, pinMutation, requestAuth, viewerIdentityKey]
   );
 
   const unpinWave = useCallback(
@@ -481,12 +516,16 @@ export function usePinnedWavesServer(
       ongoingOperations.current.add(waveId);
 
       try {
+        const { success } = await requestAuth();
+        if (!success || !isCurrentPinViewer(viewerIdentityKey)) {
+          return;
+        }
         await unpinMutation.mutateAsync(waveId);
       } finally {
         ongoingOperations.current.delete(waveId);
       }
     },
-    [unpinMutation]
+    [unpinMutation, requestAuth, viewerIdentityKey]
   );
 
   return {

--- a/hooks/usePinnedWavesServer.ts
+++ b/hooks/usePinnedWavesServer.ts
@@ -23,7 +23,8 @@ import {
 } from "@/services/api/waves-v2-api";
 import type { SidebarWave, SidebarWavesPage } from "@/types/waves.types";
 import { useOfficialWaves } from "./useOfficialWaves";
-import { getWalletAddress, getWalletRole } from "@/services/auth/auth.utils";
+import { getAuthJwt, getWalletAddress } from "@/services/auth/auth.utils";
+import { getRole } from "@/services/auth/jwt-validation.utils";
 import { DEFAULT_LOCALE } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
 
@@ -360,11 +361,20 @@ function restorePinnedWaves(
 
 function isCurrentPinViewer(viewerIdentityKey: string | null): boolean {
   const address = getWalletAddress();
-  return Boolean(
-    address &&
-    !getWalletRole() &&
-    viewerIdentityKey === `${address.toLowerCase()}:primary`
-  );
+  const jwt = getAuthJwt();
+  if (
+    !address ||
+    !jwt ||
+    viewerIdentityKey !== `${address.toLowerCase()}:primary`
+  ) {
+    return false;
+  }
+  try {
+    // Match AuthProvider's effective role; saved role metadata can be stale.
+    return !getRole(jwt);
+  } catch {
+    return false;
+  }
 }
 
 function assertCurrentPinViewer(viewerIdentityKey: string | null): void {

--- a/hooks/usePinnedWavesServer.ts
+++ b/hooks/usePinnedWavesServer.ts
@@ -24,6 +24,8 @@ import {
 import type { SidebarWave, SidebarWavesPage } from "@/types/waves.types";
 import { useOfficialWaves } from "./useOfficialWaves";
 import { getWalletAddress, getWalletRole } from "@/services/auth/auth.utils";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 
 export const MAX_PINNED_WAVES = 100;
 
@@ -94,6 +96,8 @@ async function fetchPinnedWavesPages(): Promise<SidebarWave[]> {
     const confirmedPins = page.waves.filter((wave) => wave.pinned === true);
     pinnedWaves.push(...confirmedPins);
 
+    // An unconfirmed pin means the server ignored the pinned-only filter.
+    // Stop rather than walking the public overview after session expiry.
     if (
       !page.next ||
       page.waves.length === 0 ||
@@ -302,9 +306,11 @@ function createOptimisticPinnedWaves(
 async function optimisticallyPinWave(
   queryClient: QueryClient,
   queryKey: PinnedWavesQueryKey,
-  waveId: string
+  waveId: string,
+  viewerIdentityKey: string | null
 ): Promise<MutationContext> {
   await queryClient.cancelQueries({ queryKey });
+  assertCurrentPinViewer(viewerIdentityKey);
 
   const previousPinnedWaves = queryClient.getQueryData<SidebarWave[]>(queryKey);
   const waveToPin = findWaveForOptimisticPin(queryClient, waveId);
@@ -324,9 +330,11 @@ async function optimisticallyPinWave(
 async function optimisticallyUnpinWave(
   queryClient: QueryClient,
   queryKey: PinnedWavesQueryKey,
-  waveId: string
+  waveId: string,
+  viewerIdentityKey: string | null
 ): Promise<MutationContext> {
   await queryClient.cancelQueries({ queryKey });
+  assertCurrentPinViewer(viewerIdentityKey);
 
   const previousPinnedWaves = queryClient.getQueryData<SidebarWave[]>(queryKey);
 
@@ -361,7 +369,9 @@ function isCurrentPinViewer(viewerIdentityKey: string | null): boolean {
 
 function assertCurrentPinViewer(viewerIdentityKey: string | null): void {
   if (!isCurrentPinViewer(viewerIdentityKey)) {
-    throw new Error("The active profile changed. Please try again.");
+    throw new Error(
+      t(DEFAULT_LOCALE, "waves.sidebar.pinControl.viewerChanged")
+    );
   }
 }
 
@@ -382,7 +392,12 @@ function usePinnedWaveMutations(
       return pinnedWavesApi.pinWave(waveId);
     },
     onMutate: (waveId: string) =>
-      optimisticallyPinWave(queryClient, pinnedWavesQueryKey, waveId),
+      optimisticallyPinWave(
+        queryClient,
+        pinnedWavesQueryKey,
+        waveId,
+        viewerIdentityKey
+      ),
     onError: (err, _, context) => {
       restorePinnedWaves(queryClient, pinnedWavesQueryKey, context);
       console.error("Error pinning wave:", err);
@@ -396,7 +411,12 @@ function usePinnedWaveMutations(
       return pinnedWavesApi.unpinWave(waveId);
     },
     onMutate: (waveId: string) =>
-      optimisticallyUnpinWave(queryClient, pinnedWavesQueryKey, waveId),
+      optimisticallyUnpinWave(
+        queryClient,
+        pinnedWavesQueryKey,
+        waveId,
+        viewerIdentityKey
+      ),
     onError: (err, _, context) => {
       restorePinnedWaves(queryClient, pinnedWavesQueryKey, context);
       console.error("Error unpinning wave:", err);
@@ -496,9 +516,10 @@ export function usePinnedWavesServer(
 
       try {
         const { success } = await requestAuth();
-        if (!success || !isCurrentPinViewer(viewerIdentityKey)) {
+        if (!success) {
           return;
         }
+        assertCurrentPinViewer(viewerIdentityKey);
         await pinMutation.mutateAsync(waveId);
       } finally {
         ongoingOperations.current.delete(waveId);
@@ -517,9 +538,10 @@ export function usePinnedWavesServer(
 
       try {
         const { success } = await requestAuth();
-        if (!success || !isCurrentPinViewer(viewerIdentityKey)) {
+        if (!success) {
           return;
         }
+        assertCurrentPinViewer(viewerIdentityKey);
         await unpinMutation.mutateAsync(waveId);
       } finally {
         ongoingOperations.current.delete(waveId);

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -1265,6 +1265,17 @@ const FOLLOWERS_MESSAGES = objectMessages("followers", {
 } as const);
 
 const WAVES_SIDEBAR_MESSAGES = objectMessages("waves.sidebar", {
+  "pinControl.pinTooltip": "Pin",
+  "pinControl.unpinTooltip": "Unpin",
+  "pinControl.pinAriaLabel": "Pin wave",
+  "pinControl.unpinAriaLabel": "Unpin wave",
+  "pinControl.pinErrorTitle": "Couldn't pin this wave.",
+  "pinControl.unpinErrorTitle": "Couldn't unpin this wave.",
+  "pinControl.retryDescription": PLEASE_TRY_AGAIN,
+  "pinControl.limitMessage": "Maximum {count} pinned waves allowed",
+  "pinControl.limitTooltip":
+    "Max {count} pinned waves. Unpin another wave first.",
+  "pinControl.viewerChanged": "The active profile changed. Please try again.",
   highlyRated: "Worth Checking Out",
   highlyRatedInfoTooltip: "Highly rated waves you don’t follow yet.",
   "highlyRatedPreviewOpenAriaLabel.none": "Open {waveName}",

--- a/ops/docs/waves/sidebars/feature-pinned-wave-controls.md
+++ b/ops/docs/waves/sidebars/feature-pinned-wave-controls.md
@@ -9,7 +9,9 @@ This page covers two separate pin-style controls:
 - App shortcuts: local recent-thread chips shown above content in the native app
   on small screens.
 
-Both lists are capped at **20** items. They are independent and do not sync.
+Server pins allow **100** ordinary waves; announcement and official waves do not
+count toward that limit. App shortcuts are capped at **20** items. The lists are
+independent and do not sync.
 
 ## Location in the Site
 
@@ -35,7 +37,7 @@ Both lists are capped at **20** items. They are independent and do not sync.
 1. Open `/waves/{waveId}` and select `Pin wave` from the header or wave row.
 2. The wave appears in the pinned block above regular waves.
 3. Unpin from either control to remove it from the pinned block.
-4. If 20 waves are already pinned, pinning is blocked until you unpin one.
+4. If 100 ordinary waves are already pinned, pinning is blocked until you unpin one.
 5. In native app small-screen mode, opened threads are added to local shortcuts
    (newest first, max 20).
 
@@ -59,10 +61,15 @@ Both lists are capped at **20** items. They are independent and do not sync.
 
 ## Failure and Recovery
 
-- If the 20-wave limit is reached, pinning is blocked and an error toast is
+- If the 100-wave limit is reached, pinning is blocked and an error toast is
   shown. Unpin another wave, then retry.
-- If a server pin/unpin request fails, optimistic UI changes are reverted. Retry
-  from the same control.
+- Pin and unpin check your session before changing the list. If you are asked to
+  reconnect, reconnect the wallet for the selected profile, then retry the action.
+  An unsuccessful session check leaves the pin state unchanged.
+- If a server pin/unpin request fails, optimistic UI changes are reverted and an
+  error is shown. Retry from the same control.
+- If your session expires, public waves remain browsable but are not added to
+  your pinned list. Reconnect to load your saved pins.
 - If an app shortcut points to a thread that no longer resolves, that chip is
   removed.
 - If you remove the currently open shortcut, the app returns to section home

--- a/ops/docs/waves/troubleshooting-wave-navigation-and-posting.md
+++ b/ops/docs/waves/troubleshooting-wave-navigation-and-posting.md
@@ -77,6 +77,10 @@ is blocked.
 
 ## Posting and Submission Checks
 
+- Pin or unpin asks you to reconnect, or your saved pins are unavailable:
+  reconnect the wallet for the selected profile, then retry. Public waves can
+  remain readable while your session is expired; this does not pin them. See
+  [Pinned Wave Controls](sidebars/feature-pinned-wave-controls.md#failure-and-recovery).
 - Post waits for a session check, then shows a connection or timeout error:
   the draft stays in the composer. Wait for the loading state to finish, check
   your connection, complete sign-in if prompted, then retry Post. A stalled

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -2435,7 +2435,8 @@
         "Every Worth Checking Out recommendation also appears in All at its recent-activity position; Joined normally includes only waves the user has joined.",
         "A Wave opened from a direct link remains visible and highlighted in the left sidebar even when it is not followed, pinned, or present in the loaded overview; this temporary route context does not join or pin it.",
         "When a direct link opens a subwave, the sidebar surfaces its visible parent, loads and expands the subwave list, reveals the selected child row, and keeps that parent tree ahead of paginated activity rows so every sibling remains reachable.",
-        "An active subwave header shows an up-left arrow and a linked parent wave name; selecting that name opens the parent wave."
+        "An active subwave header shows an up-left arrow and a linked parent wave name; selecting that name opens the parent wave.",
+        "Pin and unpin check the selected profile session before changing the list. If the session cannot renew, reconnect that wallet and retry; a failed session check leaves the pin state unchanged. Public waves can remain readable after session expiry but are not added to saved pins. Failed server pin changes roll back and show an error."
       ],
       "canonical_path": "/waves",
       "related_paths": ["/waves?create=wave", "/messages"],
@@ -2443,7 +2444,8 @@
       "source_refs": [
         "ops/docs/waves/README.md",
         "ops/docs/waves/sidebars/feature-wave-list-navigation.md",
-        "ops/docs/wave-subwave-interaction-model.md"
+        "ops/docs/wave-subwave-interaction-model.md",
+        "ops/docs/waves/sidebars/feature-pinned-wave-controls.md"
       ]
     },
     {

--- a/ops/workstreams/i18n-fallbacks/sidebar-navigation.md
+++ b/ops/workstreams/i18n-fallbacks/sidebar-navigation.md
@@ -26,3 +26,17 @@
   sidebar consumers instead of resolving with `DEFAULT_LOCALE`, and remove this
   fallback note once non-source locale dictionaries and runtime locale wiring are
   in place.
+
+## Wave pin controls
+
+- Component: `BrainLeftSidebarWavePin`; internal viewer-change errors in
+  `usePinnedWavesServer`.
+- Untranslated surface: pin/unpin accessible names, tooltips, limit feedback,
+  and error messages now use `waves.sidebar.pinControl.*` source messages.
+- Current fallback: the button follows browser locale; missing translations in
+  `en-GB`, `fr-FR`, `es-ES`, and `de-DE` resolve to `en-US`. Internal error details
+  use the canonical `en-US` message. The pin limit uses locale-aware formatting.
+- User impact: these controls and errors remain English in non-source locales.
+- Owner/follow-up: Waves UI maintainers and the frontend i18n migration workstream.
+- Remediation path: add reviewed translations for the pin-control message keys
+  and localize internal error details when the shared error surface is migrated.

--- a/public/glossary.json
+++ b/public/glossary.json
@@ -820,7 +820,8 @@
         "Every Worth Checking Out recommendation also appears in All at its recent-activity position; Joined normally includes only waves the user has joined.",
         "A Wave opened from a direct link remains visible and highlighted in the left sidebar even when it is not followed, pinned, or present in the loaded overview; this temporary route context does not join or pin it.",
         "When a direct link opens a subwave, the sidebar surfaces its visible parent, loads and expands the subwave list, reveals the selected child row, and keeps that parent tree ahead of paginated activity rows so every sibling remains reachable.",
-        "An active subwave header shows an up-left arrow and a linked parent wave name; selecting that name opens the parent wave."
+        "An active subwave header shows an up-left arrow and a linked parent wave name; selecting that name opens the parent wave.",
+        "Pin and unpin check the selected profile session before changing the list. If the session cannot renew, reconnect that wallet and retry; a failed session check leaves the pin state unchanged. Public waves can remain readable after session expiry but are not added to saved pins. Failed server pin changes roll back and show an error."
       ],
       "canonical_path": "/waves",
       "related_paths": [

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -2431,7 +2431,8 @@
         "Every Worth Checking Out recommendation also appears in All at its recent-activity position; Joined normally includes only waves the user has joined.",
         "A Wave opened from a direct link remains visible and highlighted in the left sidebar even when it is not followed, pinned, or present in the loaded overview; this temporary route context does not join or pin it.",
         "When a direct link opens a subwave, the sidebar surfaces its visible parent, loads and expands the subwave list, reveals the selected child row, and keeps that parent tree ahead of paginated activity rows so every sibling remains reachable.",
-        "An active subwave header shows an up-left arrow and a linked parent wave name; selecting that name opens the parent wave."
+        "An active subwave header shows an up-left arrow and a linked parent wave name; selecting that name opens the parent wave.",
+        "Pin and unpin check the selected profile session before changing the list. If the session cannot renew, reconnect that wallet and retry; a failed session check leaves the pin state unchanged. Public waves can remain readable after session expiry but are not added to saved pins. Failed server pin changes roll back and show an error."
       ],
       "canonical_path": "/waves",
       "related_paths": ["/waves?create=wave", "/messages"],
@@ -2439,7 +2440,8 @@
       "source_refs": [
         "ops/docs/waves/README.md",
         "ops/docs/waves/sidebars/feature-wave-list-navigation.md",
-        "ops/docs/wave-subwave-interaction-model.md"
+        "ops/docs/wave-subwave-interaction-model.md",
+        "ops/docs/waves/sidebars/feature-pinned-wave-controls.md"
       ]
     },
     {


### PR DESCRIPTION
## Issue

An expired saved session can receive the public wave overview in response to a pinned-waves request. The sidebar then labels every returned wave as pinned, and unpinning briefly removes a wave before the failed request restores it. Report: https://6529.io/waves/e933d8d6-0c78-4e8f-aa12-f67d8c11b4dc?serialNo=1419915.

## Fix

Only render server-confirmed pins and authenticate before starting a pin or unpin mutation. Await sidebar mutations so asynchronous failures reach the existing error toast.

## Changes

- Filter fetched and cached pinned-wave results by the server's `pinned` flag; stop pagination when a response includes unconfirmed pins.
- Recheck the active wallet and JWT role after authentication and before optimistic cache writes and immediately before the API request to prevent an account switch from applying the action to another profile. Accept the owner profile ID used by normal backend logins, or a legacy absent role; reject other profile roles.
- Add regression coverage for public responses, contaminated cache, rejected authentication, account/proxy changes, and asynchronous failures.
- Move pin-control labels, accessible names, validation, and errors into the existing message dictionary; document English fallback and verify all five supported locales.
- Update pinning and session-recovery help, including generated public help data.

## Validation

- 123 focused pin-control, wave-list, and message tests passed after review fixes; 150 existing posting/auth/session-recovery tests also passed.
- Latest GitHub CI passed the production build, both browser packs, and all related Jest batches. Changed-file lint/typecheck and formatting also passed locally.
- React Doctor: 100/100. Help index sync and 304 documentation link checks passed.
- Staging deployment [34596449445](https://github.com/6529-Collections/6529seize-frontend/actions/runs/34596449445) passed artifact, live-version, and health checks. All 16 API cases passed; desktop and 390×844 browser pin/unpin survived reloads, both UI test posts were confirmed through the API, and original pins were restored. Physical iPhone testing has not been performed; the native shell checkout is unavailable locally.

## Risk

- Level: Medium
- Why: changes shared pinning behavior and adds authentication before mutations; failed requests retain the existing rollback behavior.
- Rollback: revert this PR through the normal deployment workflow. No API shape or database changes.

## Review Notes

Deploy backend https://github.com/6529-Collections/6529seize-backend/pull/2002 (`api` only) before this frontend in each environment. The frontend filter also tolerates the old backend during rollout. Existing native reconnect/posting recovery from #3950 is retained and covered by the focused tests.
