### PR TITLE
Fix mint E2E title assertion for artwork names containing pipes

### DIFF
--- a/__tests__/playwright/mintTitle.test.ts
+++ b/__tests__/playwright/mintTitle.test.ts
@@ -1,0 +1,25 @@
+import { MEMES_MINT_TITLE_PATTERN } from "../../tests/support/mintTitle";
+
+describe("The Memes mint page title", () => {
+  it.each([
+    "Mint | The Memes",
+    "Mint #1 | 6529Seizing | The Memes",
+    "Mint #547 | The Great Meme Expo | Sgt. Pepe’s World — Episode 1 | The Memes",
+    "Mint #12 | One | Two | Three | The Memes",
+    "Mint #12 | Artwork | The Memes | The Memes",
+  ])("accepts the supported title %s", (title) => {
+    expect(title).toMatch(MEMES_MINT_TITLE_PATTERN);
+  });
+
+  it.each([
+    "Mint # | Name | The Memes",
+    "Mint #abc | Name | The Memes",
+    "Mint #1 |  | The Memes",
+    "Mint #1 | Name | Meme Lab",
+    "Other Mint #1 | Name | The Memes",
+    "Mint #1 | Name | The Memes trailing",
+    "Mint | The Memes | extra",
+  ])("rejects the malformed title %s", (title) => {
+    expect(title).not.toMatch(MEMES_MINT_TITLE_PATTERN);
+  });
+});

--- a/tests/media/media-mint-detail-readonly.spec.ts
+++ b/tests/media/media-mint-detail-readonly.spec.ts
@@ -7,6 +7,7 @@ import {
   waitForRouteReady,
 } from "../testHelpers";
 import { gotoDocumentWithTransientRetry } from "../support/routeReadiness";
+import { MEMES_MINT_TITLE_PATTERN } from "../support/mintTitle";
 
 async function gotoReady(page: Page, path: string) {
   await gotoDocumentWithTransientRetry(page, path);
@@ -114,12 +115,7 @@ test.describe("Media, mint, and detail read-only coverage @surface @medium @larg
   test("renders The Memes mint page read-only", async ({ page }) => {
     await gotoReady(page, "/the-memes/mint");
 
-    // The "Mint #N | <name>" prefix is client-side enrichment (TitleContext)
-    // that races the App Router's metadata commit on deployed builds; the
-    // server metadata title is "Mint | The Memes". Accept both so the pack
-    // asserts the page, not the race. Artwork names can contain pipes, so
-    // only the outer title format is fixed.
-    await expect(page).toHaveTitle(/^Mint( #\d+ \| .+)? \| The Memes$/);
+    await expect(page).toHaveTitle(MEMES_MINT_TITLE_PATTERN);
     await expect(page.getByText("Retrieving Mint information")).toBeHidden({
       timeout: 15000,
     });

--- a/tests/media/media-mint-detail-readonly.spec.ts
+++ b/tests/media/media-mint-detail-readonly.spec.ts
@@ -117,8 +117,9 @@ test.describe("Media, mint, and detail read-only coverage @surface @medium @larg
     // The "Mint #N | <name>" prefix is client-side enrichment (TitleContext)
     // that races the App Router's metadata commit on deployed builds; the
     // server metadata title is "Mint | The Memes". Accept both so the pack
-    // asserts the page, not the race.
-    await expect(page).toHaveTitle(/^Mint( #\d+ \| [^|]+)? \| The Memes$/);
+    // asserts the page, not the race. Artwork names can contain pipes, so
+    // only the outer title format is fixed.
+    await expect(page).toHaveTitle(/^Mint( #\d+ \| .+)? \| The Memes$/);
     await expect(page.getByText("Retrieving Mint information")).toBeHidden({
       timeout: 15000,
     });

--- a/tests/support/mintTitle.ts
+++ b/tests/support/mintTitle.ts
@@ -1,0 +1,4 @@
+// Client-side TitleContext enrichment races the App Router metadata commit.
+// Accept both the plain server title and the enriched title. Artwork names
+// can contain pipes, so only the outer title format is fixed.
+export const MEMES_MINT_TITLE_PATTERN = /^Mint( #\d+ \| .+)? \| The Memes$/;


### PR DESCRIPTION
## Issue

The media read-only E2E pack rejects valid mint-page titles when an artwork name contains a pipe. Card #547, “The Great Meme Expo | Sgt. Pepe’s World — Episode 1”, caused the staging and production canaries to fail despite the page rendering correctly.

## Fix

Allow pipes within the artwork-name portion while preserving the anchored mint number and collection suffix, plus the existing plain server-title fallback.

## Changes

- Share the mint-title pattern between the browser assertion and fast Jest coverage.
- Add 12 permanent title-format cases so pipe-containing names remain covered when the live latest artwork changes.
- Frontend test only; no runtime, backend, database, or deployment-order changes.

## Validation

- Reproduced the original assertion failure against production card #547 before editing.
- `6529 run test:e2e:production:media-readonly --reporter=list`: all 5 tests passed after the fix.
- `6529 run test:e2e:staging:media-readonly --reporter=list`: 8 passed across desktop/mobile Chromium; 2 expected skips for the production-only ReMemes fixture.
- `6529 run test:no-coverage __tests__/playwright/mintTitle.test.ts --runInBand`: 12 passed. Restoring the old matcher first reproduced 3 failures for pipe-containing artwork names.
- After sharing the pattern, the targeted production mint browser test passed again; the other media assertions are unchanged.
- `6529 run lint:changed`, `6529 run typecheck:changed`, `6529 run typecheck:playwright`, focused Prettier check, and `git diff --check` passed.

## Risk

- Low: test support, one browser assertion, and focused Jest coverage; application behavior is unchanged.
- Rollback: revert this test-only change if necessary.

## Review Notes

The remaining mint-page content, media, navigation, and metadata assertions are retained. No backend services need deployment. The requested rollout is staging followed by production through the existing frontend workflows.
