### PR TITLE
Fix borders and spacing across artwork documentation

### DIFF
--- a/components/artwork-documentation/ArtworkDocumentationWorkspace.tsx
+++ b/components/artwork-documentation/ArtworkDocumentationWorkspace.tsx
@@ -350,7 +350,7 @@ function WorkspaceEditor({
               assets={assets}
             />
           )}
-          <div className="tw-flex tw-flex-wrap tw-justify-between tw-gap-3 tw-border-t tw-border-solid tw-border-iron-800 tw-pt-5">
+          <div className="tw-flex tw-flex-wrap tw-justify-between tw-gap-3 tw-border-0 tw-border-t tw-border-solid tw-border-iron-800 tw-pt-5">
             <DocumentationButton
               secondary
               onClick={() => {

--- a/components/artwork-documentation/DocumentationAccess.tsx
+++ b/components/artwork-documentation/DocumentationAccess.tsx
@@ -125,7 +125,7 @@ export default function DocumentationAccess({
         disabled={busy}
       />
       {artist ? (
-        <fieldset className="tw-space-y-3">
+        <fieldset className="tw-m-0 tw-min-w-0 tw-space-y-3 tw-border-0 tw-p-0">
           <legend className="tw-mb-3 tw-text-sm tw-font-medium">
             {msg("editorPermissions")}
           </legend>

--- a/components/artwork-documentation/DocumentationNarrativeStarter.tsx
+++ b/components/artwork-documentation/DocumentationNarrativeStarter.tsx
@@ -69,7 +69,7 @@ export default function DocumentationNarrativeStarter(props: Props) {
           {msg("examples.adapt")}
         </DocumentationButton>
       ) : (
-        <div className="tw-space-y-3 tw-border-l-2 tw-border-solid tw-border-primary-400 tw-pl-4">
+        <div className="tw-space-y-3 tw-border-0 tw-border-l-2 tw-border-solid tw-border-primary-400 tw-pl-4">
           <p
             id={`${props.id}-starter-help`}
             className="tw-m-0 tw-text-sm tw-leading-relaxed tw-text-iron-300"

--- a/components/artwork-documentation/DocumentationReview.tsx
+++ b/components/artwork-documentation/DocumentationReview.tsx
@@ -271,7 +271,7 @@ function DocumentationLaneReviews({
         return (
           <div
             key={lane}
-            className="tw-border-b tw-border-solid tw-border-iron-800 tw-pb-4"
+            className="tw-border-0 tw-border-b tw-border-solid tw-border-iron-800 tw-pb-4"
           >
             <h3 className="tw-text-base tw-font-semibold">
               {msg(`lane.${lane}`)}

--- a/components/artwork-documentation/DocumentationSources.tsx
+++ b/components/artwork-documentation/DocumentationSources.tsx
@@ -140,7 +140,7 @@ function SourceReceipt({
       {fields.map((field) => (
         <div
           key={field.target_field}
-          className="tw-space-y-2 tw-border-t tw-border-solid tw-border-iron-800 tw-pt-3"
+          className="tw-space-y-2 tw-border-0 tw-border-t tw-border-solid tw-border-iron-800 tw-pt-3"
         >
           <label className="tw-flex tw-items-center tw-gap-3 tw-text-sm">
             <input

--- a/components/artwork-documentation/DocumentationUpload.tsx
+++ b/components/artwork-documentation/DocumentationUpload.tsx
@@ -492,33 +492,35 @@ export default function DocumentationUpload({ context, controller }: Props) {
             </p>
             {asset.state === "ready" && (
               <>
-                <DocumentationButton
-                  secondary
-                  onClick={() => {
-                    void download(asset.id);
-                  }}
-                >
-                  {msg("download")}
-                </DocumentationButton>
-                {!context.asset_links.some(
-                  (link) => link.asset_id === asset.id
-                ) &&
-                  canUpload &&
-                  canPublishDocumentationAsset(context, asset.role) && (
-                    <DocumentationButton
-                      secondary
-                      onClick={() => {
-                        void attach(
-                          asset.id,
-                          asset.role,
-                          asset.intended_visibility,
-                          asset.filename
-                        );
-                      }}
-                    >
-                      {msg("add")}
-                    </DocumentationButton>
-                  )}
+                <div className="tw-flex tw-flex-wrap tw-gap-3">
+                  <DocumentationButton
+                    secondary
+                    onClick={() => {
+                      void download(asset.id);
+                    }}
+                  >
+                    {msg("download")}
+                  </DocumentationButton>
+                  {!context.asset_links.some(
+                    (link) => link.asset_id === asset.id
+                  ) &&
+                    canUpload &&
+                    canPublishDocumentationAsset(context, asset.role) && (
+                      <DocumentationButton
+                        secondary
+                        onClick={() => {
+                          void attach(
+                            asset.id,
+                            asset.role,
+                            asset.intended_visibility,
+                            asset.filename
+                          );
+                        }}
+                      >
+                        {msg("add")}
+                      </DocumentationButton>
+                    )}
+                </div>
                 <details className="tw-mt-3 tw-text-xs tw-text-iron-400">
                   <summary className="tw-cursor-pointer tw-py-2">
                     {msg("fileDetails")}

--- a/components/artwork-documentation/DocumentationWorkedExample.tsx
+++ b/components/artwork-documentation/DocumentationWorkedExample.tsx
@@ -112,7 +112,7 @@ export default function DocumentationWorkedExample({
                           )?.text
                         : undefined) ?? documentationFieldLabel(field.id);
                     return (
-                      <div key={field.id} className="tw-py-4">
+                      <div key={field.id} className="tw-border-0 tw-py-4">
                         <dt className="tw-text-sm tw-font-semibold tw-text-iron-100">
                           {label}
                         </dt>


### PR DESCRIPTION
## Issue

Artwork documentation separators appeared as square boxes around the Save and exit / Next section row and other parts of the form. Tailwind preflight is disabled, so directional border utilities left the browser's default widths on the other edges.

## Fix

Reset border widths before applying the intended separator. Keep existing rounded panels and button styling.

## Changes

- Correct the footer, writing starters, worked-example dividers, review lanes, and source comparisons.
- Remove the browser-default inner fieldset frame in editor permissions.
- Space Download and Add buttons for ready files, allowing them to wrap.

## Validation

- Changed-file lint and TypeScript checks passed.
- React Doctor passed (97/100); existing component-size/state warnings remain outside this styling change.
- Full production build passed. Browser inspection passed for all six steps at 1440px and 390px, expanded examples, source comparisons, permission fields, review lanes, ready-file actions, and personal/program lists. Computed borders are limited to the intended sides; no page overflow or application errors. Synthetic local data only; no artwork writes.

## Risk

Low: local presentation changes in seven artwork documentation components. No API, data, permission, dependency, global style, or workflow changes. Revert this commit to roll back.

## Review Notes

Check directional-border resets with preflight disabled and file action spacing. Product wording and workflows are unchanged, so the help corpus requires no update. These are authenticated artwork documentation routes, outside the public Museum route gate.

