### PR TITLE
Fix mint artwork alignment on desktop

### DIFF
--- a/components/manifold-minting/ManifoldMinting.tsx
+++ b/components/manifold-minting/ManifoldMinting.tsx
@@ -535,7 +535,7 @@ export default function ManifoldMinting(props: Readonly<Props>) {
     }
 
     return (
-      <div className="tw-order-1 tw-flex tw-items-center tw-justify-center tw-pt-4 md:tw-order-2 md:tw-col-span-7 md:tw-h-screen md:tw-pt-0">
+      <div className="tw-order-1 tw-flex tw-items-center tw-justify-center tw-pt-4 md:tw-order-2 md:tw-col-span-7 md:tw-self-start md:tw-pt-8">
         <NFTImage
           nft={nftImage}
           animation={true}

--- a/ops/docs/media/memes/feature-mint-flow.md
+++ b/ops/docs/media/memes/feature-mint-flow.md
@@ -5,6 +5,8 @@
 - `/the-memes/mint` is the mint route for the current latest The Memes drop.
 - The page combines artwork, drop details, countdown status, recipient
   selection, phase-aware mint controls, and transaction status.
+- On desktop, artwork aligns with the top of the drop details. On mobile,
+  artwork appears above the details and mint controls.
 - The same mint data and widget are also reused by the standalone latest-mint
   shell documented in
   [Standalone The Memes Mint Page](feature-standalone-mint-page.md).


### PR DESCRIPTION
## Issue

The live mint video sits far below the drop details on tall desktop windows because the artwork is vertically centered in a viewport-height column.

## Fix

Top-align the desktop artwork with the details using the existing spacing scale. Keep the mobile artwork-first layout.

## Changes

- Replace the artwork column's desktop viewport height with start alignment and matching top padding.
- Document desktop alignment and mobile ordering.

## Validation

- Exact class replacement checked in the browser at 1280×720, 1655×1220, and 390×844. Desktop artwork begins at 32px, mobile retains 16px padding and artwork-first ordering, and no horizontal overflow was observed. The temporary override was removed.
- Actual compiled app verified at the same three viewport sizes with matching alignment, preserved artwork-first mobile order, and no horizontal overflow. Next.js reports no configuration or session errors.
- Lint changed and typecheck changed passed.
- Existing mint component, mint route, and standalone mint tests passed: 3 suites, 11 tests.
- React Doctor checked the committed diff against origin/main: 97/100, no errors, four existing component warnings outside the changed line.
- Whitespace and documentation-link validation passed (304 Markdown files).
- App PR CI passed, including production build, quality/contracts, Playwright smoke, and critical-shell tests. CodeQL, Sonar, DCO, Snyk, and debt checks passed.
- Automated general, security, WCAG, and i18n reviews found no blocking defects. CodeRabbit was rate-limited. The separate responsiveness reviewer failed during dependency setup before testing; manual layout QA covers this change.
- Original HEVC playback could not be visually verified in the inspection browser; the reported issue and this fix concern positioning. No transaction was submitted.

## Risk

Low: one layout-class change shared by the main and standalone mint pages. No mint transaction, wallet, API, or media-source behavior changes. Rollback is a focused revert.

## Review Notes

The player retains its own aspect-ratio and maximum-height constraints. The image renderer retains its 90vh maximum height. Both main and standalone mint shells use the same grid, and self-start prevents a taller controls column from recentering artwork. Help Bot controls and workflows are unchanged.

