### PR TITLE
fix: load mint videos from their API-provided CDN source

### DIFF
--- a/__tests__/components/manifold-minting/ManifoldMinting.test.tsx
+++ b/__tests__/components/manifold-minting/ManifoldMinting.test.tsx
@@ -1,4 +1,6 @@
 import ManifoldMinting from "@/components/manifold-minting/ManifoldMinting";
+import NFTImage from "@/components/nft-image/NFTImage";
+import { getResolvedAnimationSrc } from "@/components/nft-image/utils/animation-source";
 import { render, screen, waitFor } from "@testing-library/react";
 
 jest.mock("next/link", () => ({
@@ -8,7 +10,7 @@ jest.mock("next/link", () => ({
 
 jest.mock("@/components/nft-image/NFTImage", () => ({
   __esModule: true,
-  default: () => <div data-testid="image" />,
+  default: jest.fn(() => <div data-testid="image" />),
 }));
 jest.mock("@/components/nft-attributes/NFTAttributes", () => ({
   __esModule: true,
@@ -293,5 +295,85 @@ describe("Component Structure", () => {
       },
       { timeout: 3000 }
     );
+  });
+});
+
+describe("Mint artwork source", () => {
+  const metadataAnimation = "https://arweave.net/original-film";
+  const videoMetadata = {
+    ...defaultProps.mintMetadata,
+    metadata: {
+      ...defaultProps.mintMetadata.metadata,
+      animation_url: metadataAnimation,
+      animation_details: { format: "MP4" },
+    },
+  };
+
+  const renderedArtwork = () => {
+    const props = jest.mocked(NFTImage).mock.calls.at(-1)?.[0];
+    expect(props).toBeDefined();
+    return props?.nft;
+  };
+
+  beforeEach(() => {
+    useManifoldClaim.mockReturnValue(createMockClaimState());
+  });
+
+  it("uses the API animation and updates it when the mint changes", () => {
+    const firstAnimation = "https://cdn.example/videos/123.MP4";
+    const nextAnimation = "https://cdn.example/videos/124.MP4";
+    const { rerender } = render(
+      <ManifoldMinting
+        {...defaultProps}
+        mintMetadata={videoMetadata}
+        animationSrc={firstAnimation}
+      />
+    );
+
+    expect(getResolvedAnimationSrc(renderedArtwork())).toBe(firstAnimation);
+
+    rerender(
+      <ManifoldMinting
+        {...defaultProps}
+        mintMetadata={{ ...videoMetadata, tokenId: 124 }}
+        animationSrc={nextAnimation}
+      />
+    );
+
+    expect(getResolvedAnimationSrc(renderedArtwork())).toBe(nextAnimation);
+    expect(renderedArtwork()?.id).toBe(124);
+  });
+
+  it.each([undefined, null, "", "   "])(
+    "uses token metadata when the API animation is %p",
+    (animationSrc) => {
+      render(
+        <ManifoldMinting
+          {...defaultProps}
+          mintMetadata={videoMetadata}
+          animationSrc={animationSrc}
+        />
+      );
+
+      expect(getResolvedAnimationSrc(renderedArtwork())).toBe(metadataAnimation);
+    }
+  );
+
+  it("keeps interactive HTML artwork on its metadata source", () => {
+    render(
+      <ManifoldMinting
+        {...defaultProps}
+        mintMetadata={{
+          ...videoMetadata,
+          metadata: {
+            ...videoMetadata.metadata,
+            animation_details: { format: "HTML" },
+          },
+        }}
+        animationSrc="https://cdn.example/videos/123.MP4"
+      />
+    );
+
+    expect(getResolvedAnimationSrc(renderedArtwork())).toBe(metadataAnimation);
   });
 });

--- a/__tests__/components/manifold-minting/ManifoldMinting.test.tsx
+++ b/__tests__/components/manifold-minting/ManifoldMinting.test.tsx
@@ -2,6 +2,7 @@ import ManifoldMinting from "@/components/manifold-minting/ManifoldMinting";
 import NFTImage from "@/components/nft-image/NFTImage";
 import { getResolvedAnimationSrc } from "@/components/nft-image/utils/animation-source";
 import { render, screen, waitFor } from "@testing-library/react";
+import type { ComponentProps } from "react";
 
 jest.mock("next/link", () => ({
   __esModule: true,
@@ -308,6 +309,11 @@ describe("Mint artwork source", () => {
       animation_details: { format: "MP4" },
     },
   };
+  const artworkProps = {
+    ...defaultProps,
+    abi: [],
+    mintMetadata: videoMetadata,
+  } satisfies ComponentProps<typeof ManifoldMinting>;
 
   const renderedArtwork = () => {
     const props = jest.mocked(NFTImage).mock.calls.at(-1)?.[0];
@@ -324,8 +330,7 @@ describe("Mint artwork source", () => {
     const nextAnimation = "https://cdn.example/videos/124.MP4";
     const { rerender } = render(
       <ManifoldMinting
-        {...defaultProps}
-        mintMetadata={videoMetadata}
+        {...artworkProps}
         animationSrc={firstAnimation}
       />
     );
@@ -334,7 +339,7 @@ describe("Mint artwork source", () => {
 
     rerender(
       <ManifoldMinting
-        {...defaultProps}
+        {...artworkProps}
         mintMetadata={{ ...videoMetadata, tokenId: 124 }}
         animationSrc={nextAnimation}
       />
@@ -349,8 +354,7 @@ describe("Mint artwork source", () => {
     (animationSrc) => {
       render(
         <ManifoldMinting
-          {...defaultProps}
-          mintMetadata={videoMetadata}
+          {...artworkProps}
           animationSrc={animationSrc}
         />
       );
@@ -362,7 +366,7 @@ describe("Mint artwork source", () => {
   it("keeps interactive HTML artwork on its metadata source", () => {
     render(
       <ManifoldMinting
-        {...defaultProps}
+        {...artworkProps}
         mintMetadata={{
           ...videoMetadata,
           metadata: {

--- a/__tests__/components/the-memes/TheMemesMint.test.tsx
+++ b/__tests__/components/the-memes/TheMemesMint.test.tsx
@@ -1,0 +1,53 @@
+import TheMemesMint from "@/components/the-memes/TheMemesMint";
+import type { ApiMemesExtendedData } from "@/generated/models/ApiMemesExtendedData";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("next/dynamic", () => () => {
+  return function MockManifoldMinting({
+    animationSrc,
+  }: {
+    readonly animationSrc?: string | null;
+  }) {
+    return <div data-testid="mint-artwork" data-animation-src={animationSrc} />;
+  };
+});
+
+jest.mock("@/components/drop-forge/drop-forge-config", () => ({
+  useDropForgeMintingConfig: () => ({ contract: "0x123", chain: { id: 1 } }),
+}));
+
+jest.mock("@/contexts/TitleContext", () => ({
+  useTitle: () => ({ setTitle: jest.fn() }),
+}));
+
+describe("TheMemesMint artwork", () => {
+  it("passes each mint's API animation instead of its metadata or derivative", () => {
+    const nft = {
+      id: 123,
+      name: "First film",
+      animation: "https://cdn.example/videos/123.MP4",
+      compressed_animation: "https://cdn.example/scaledx750/123.MP4",
+      metadata: { animation_url: "https://arweave.net/first-film" },
+      mint_date: null,
+    } as ApiMemesExtendedData;
+    const { rerender } = render(<TheMemesMint nft={nft} />);
+
+    expect(screen.getByTestId("mint-artwork")).toHaveAttribute(
+      "data-animation-src",
+      nft.animation
+    );
+
+    const nextNft = {
+      ...nft,
+      id: 124,
+      name: "Next film",
+      animation: "https://cdn.example/videos/124.MP4",
+    };
+    rerender(<TheMemesMint nft={nextNft} />);
+
+    expect(screen.getByTestId("mint-artwork")).toHaveAttribute(
+      "data-animation-src",
+      nextNft.animation
+    );
+  });
+});

--- a/components/manifold-minting/ManifoldMinting.tsx
+++ b/components/manifold-minting/ManifoldMinting.tsx
@@ -63,6 +63,7 @@ interface Props {
   abi: Abi;
   mint_date: Time;
   mintMetadata: ManifoldMintMetadata;
+  animationSrc?: string | null | undefined;
   standalone?: boolean;
 }
 
@@ -295,18 +296,22 @@ export default function ManifoldMinting(props: Readonly<Props>) {
     if (!instance) {
       return undefined;
     }
+    const animationSrc = props.animationSrc?.trim();
     return {
       id: instance.id,
       contract: props.contract,
       name: instance.asset.name ?? props.title,
       image: instance.asset.image_url ?? instance.asset.image ?? "",
-      animation: instance.asset.animation_url ?? instance.asset.animation ?? "",
+      animation:
+        animationSrc !== undefined && animationSrc.length > 0
+          ? animationSrc
+          : (instance.asset.animation_url ?? instance.asset.animation ?? ""),
       icon: "",
       thumbnail: "",
       scaled: "",
       metadata: instance.asset,
     };
-  }, [instance, props.contract, props.title]);
+  }, [instance, props.animationSrc, props.contract, props.title]);
 
   const artist = useMemo(() => {
     const name =

--- a/components/the-memes/TheMemesMint.tsx
+++ b/components/the-memes/TheMemesMint.tsx
@@ -57,6 +57,7 @@ export default function TheMemesMint({
       abi={MEMES_MANIFOLD_PROXY_ABI}
       mint_date={Time.fromString(nft.mint_date?.toString() ?? "")}
       mintMetadata={mintMetadata}
+      animationSrc={nft.animation}
       standalone={standalone}
     />
   );

--- a/ops/docs/media/memes/feature-mint-flow.md
+++ b/ops/docs/media/memes/feature-mint-flow.md
@@ -7,6 +7,9 @@
   selection, phase-aware mint controls, and transaction status.
 - On desktop, artwork aligns with the top of the drop details. On mobile,
   artwork appears above the details and mint controls.
+- Video playback uses the drop's API-provided media URL when available, so
+  mirrored videos load through the CDN. If that URL is missing, the page uses
+  the animation URL from the artwork metadata.
 - The same mint data and widget are also reused by the standalone latest-mint
   shell documented in
   [Standalone The Memes Mint Page](feature-standalone-mint-page.md).


### PR DESCRIPTION
## Issue

The mint page discards the API-provided animation URL and plays the metadata URL directly. For the current film that means Arweave, which ignored the tested byte-range request; playback metadata is near the end of the 195 MB file, delaying startup.

## Fix

Pass each mint's API animation URL into the mint artwork. This uses the existing CloudFront original dynamically for every mint, while missing or blank API URLs retain the metadata source.

## Changes

- Preserve the API animation URL through TheMemesMint and ManifoldMinting.
- Update the source when the mint changes and preserve interactive HTML metadata-source precedence.
- Document media delivery and add regression coverage for source selection and fallback.

## Validation

- Six focused suites passed: 73 tests covering mint wiring, source selection, fallback, interactive HTML, the video renderer, the mint route, and the standalone consumer.
- Compiled mint page selects the CloudFront original, reports the full film duration, preserves top alignment, and has no Next.js configuration or session errors.
- CloudFront returns partial-content byte ranges for the complete film. The tested Arweave range request returned the whole-object response instead.
- Changed-file lint and TypeScript checks passed. The dedicated Jest typecheck ratchet also passed, with no new diagnostics.
- React Doctor: 97/100, no errors, four existing component warnings. Whitespace and all 304 documentation link checks passed.
- Latest App PR CI passed: production build, quality/contracts, both Playwright packs, security, trust, DCO, and Sonar checks.
- Staging artifact, deployed version, and health checks passed. Fresh staging browser QA verified the CloudFront original at desktop, tall-screen, and mobile sizes with preserved alignment and no overflow.
- Latest Claude reviews found no blocking issues. CodeRabbit was rate-limited; responsiveness and GLM advisory reviews had infrastructure limitations.
- Original HEVC visual playback remains unverified in the inspection browser; URL selection, full-duration metadata, and layout were verified.

## Risk

Low: two components pass through an existing API field; no new fetches, hosts, transaction logic, or API contracts. A focused revert restores the prior source selection.

## Review Notes

The current compressed derivative is only 1,265 bytes and contains no media samples. This change deliberately uses the valid API animation original, not compressed_animation. No mint ID or CloudFront hostname is hardcoded. Interactive HTML remains on its metadata source through the existing resolver. The alignment fix is already merged in #3954 and continues to production separately.




