### PR TITLE
Clarify 6529 mission and agent site discovery

### DIFF
--- a/ops/docs/specs/2026-06-19-6529-help-bot-knowledge-index.md
+++ b/ops/docs/specs/2026-06-19-6529-help-bot-knowledge-index.md
@@ -341,8 +341,11 @@ The same corpus also feeds two public artifacts for external AI agents, so
 term definitions never fork from the help bot's source of truth:
 
 - `public/llms.txt`: the agent entry point, rendered from
-  `ops/help/llms.txt.template` with record and term counts injected at sync
-  time. The template must keep referencing `/llms.txt`, `/glossary.json`,
+  `ops/help/llms.txt.template` with the published corpus's base URL. It explains
+  6529's mission and links the main site areas, detailed help index, API guides,
+  and website-agent integration. It does not advertise the corpus's manually
+  maintained timestamp as a current revision. The template must keep
+  referencing `/llms.txt`, `/glossary.json`,
   `/help-index.json`, and `/sitemap.xml`; the sync step fails otherwise.
 - `public/glossary.json`: a projection of glossary records. A record is
   included when its `kind` is `glossary` or its `tags` include `glossary`.

--- a/ops/help/README.md
+++ b/ops/help/README.md
@@ -46,6 +46,11 @@ endpoints fail closed to the production corpus. `agent-files:sync` regenerates
 `public/glossary.json` and `public/llms.txt` from that published,
 environment-matching corpus and `ops/help/llms.txt.template`.
 
+Keep the template's mission summary, main site links, and agent integration
+links aligned with the public site. Use the help index for detailed route
+coverage. Do not present the corpus's manually maintained `generated_at` field
+as the entry point's current revision or the freshness of live API data.
+
 Commit the regenerated `public/` artifacts with the corpus change. PR CI runs
 `__tests__/scripts/sync-agent-files.test.ts` (the "Verify agent files sync"
 step) whenever these files change and fails if the committed artifacts drift

--- a/ops/help/llms.txt.template
+++ b/ops/help/llms.txt.template
@@ -1,8 +1,23 @@
 # 6529.io
 
-> 6529.io is the home of The Memes by 6529 — an open-edition NFT art collection whose community tier is released under CC0 — and of the 6529 network: on-chain identity and reputation metrics (TDH, REP, NIC, Levels) plus Waves, the site's social threads. This file is the entry point for AI agents and lists the machine-readable files the site publishes.
+> 6529 is building a decentralized network state: a global community where people coordinate, fund, and build public goods across art, science, culture, and technology. Its goal is to make human coordination permissionless.
 
-Site data such as TDH, REP, and Wave activity changes continuously. Fetch the files below for current definitions and routes instead of relying on cached copies. These files are generated from the site's curated help corpus at build time (corpus revision {{GENERATED_AT}}).
+6529.io provides the network's tools for participation: wallet-based identities, reputation, community conversations and voting in Waves, digital art collections including The Memes, Meme Lab, and 6529 Gradient, and the NextGen generative art platform. This file is the entry point for AI agents exploring the site, its public data, and its APIs.
+
+Start with Explore 6529 below for the main site areas. Use help-index.json for the detailed map of documented features, workflows, and canonical page paths; use sitemap.xml to discover crawlable public pages. These are guides to the site, not an inventory of every profile, Wave, or drop. Use the API for live records and activity.
+
+The help index, glossary, and this entry point are regenerated at build time. Fetch the published resources for current definitions and routes. Values such as TDH, REP, and Wave activity change independently of these documentation files.
+
+## Explore 6529
+
+- [What is 6529?]({{BASE_URL}}/about/faq): the network's mission, how to get started, and how participation works.
+- [The Memes]({{BASE_URL}}/the-memes): large-edition art NFTs released by their artists under CC0; see the [license]({{BASE_URL}}/about/license) for scope and third-party rights.
+- [Meme Lab]({{BASE_URL}}/meme-lab): experimental art from artists who have minted a Meme Card.
+- [6529 Gradient]({{BASE_URL}}/6529-gradient): the collection of 101 NFTs interpreting the 6529 symbol.
+- [NextGen]({{BASE_URL}}/nextgen): the on-chain generative art platform, including collection and artwork browsing.
+- [Waves]({{BASE_URL}}/waves): community spaces for conversations, sharing drops, and voting.
+- [Network]({{BASE_URL}}/network): member discovery, reputation, and network metrics such as TDH, xTDH, and Levels.
+- [Tools]({{BASE_URL}}/tools): developer and utility tools, including the API guides linked below.
 
 ## Machine-readable files
 
@@ -20,6 +35,11 @@ Site data such as TDH, REP, and Wave activity changes continuously. Fetch the fi
 - [Authentication guide]({{BASE_URL}}/tools/api/authentication): session-v2 wallet authentication for external clients, with Node.js examples.
 - Respect documented rate limits, cache responses where possible, and do not hammer endpoints.
 
+## Website agent integration
+
+- [Website-agent setup guide]({{BASE_URL}}/profile-cms/agent/v1/README.md): connect a local MCP adapter to a profile website draft and submit revisions for owner review. Saving and publishing remain owner actions.
+- [Adapter download]({{BASE_URL}}/profile-cms/agent/v1/6529-cms-agent.zip): the local MCP adapter; its [manifest]({{BASE_URL}}/profile-cms/agent/v1/manifest.json) lists version, runtime requirements, and file hashes.
+
 ## Source code
 
 - [GitHub organization](https://github.com/6529-Collections): open-source repositories, including this site (6529seize-frontend, Apache-2.0) and the API server (6529seize-backend).
@@ -27,5 +47,5 @@ Site data such as TDH, REP, and Wave activity changes continuously. Fetch the fi
 ## Usage policy
 
 - Link to the 6529.io page URL when citing site content; canonical paths are listed in help-index.json.
-- Do not present guesses as 6529 facts. If a term, metric, or feature is not described in glossary.json, help-index.json, or the API, say it is not documented instead of inventing it.
+- Do not present guesses as 6529 facts. Check the linked first-party pages and guides, glossary.json, help-index.json, and API documentation. If they do not document a term, metric, or feature, say so instead of inventing it.
 - Do not expose wallet addresses, identity statements, or profile data beyond what the cited public page already shows.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,8 +1,23 @@
 # 6529.io
 
-> 6529.io is the home of The Memes by 6529 — an open-edition NFT art collection whose community tier is released under CC0 — and of the 6529 network: on-chain identity and reputation metrics (TDH, REP, NIC, Levels) plus Waves, the site's social threads. This file is the entry point for AI agents and lists the machine-readable files the site publishes.
+> 6529 is building a decentralized network state: a global community where people coordinate, fund, and build public goods across art, science, culture, and technology. Its goal is to make human coordination permissionless.
 
-Site data such as TDH, REP, and Wave activity changes continuously. Fetch the files below for current definitions and routes instead of relying on cached copies. These files are generated from the site's curated help corpus at build time (corpus revision 2026-08-11T15:43:52Z).
+6529.io provides the network's tools for participation: wallet-based identities, reputation, community conversations and voting in Waves, digital art collections including The Memes, Meme Lab, and 6529 Gradient, and the NextGen generative art platform. This file is the entry point for AI agents exploring the site, its public data, and its APIs.
+
+Start with Explore 6529 below for the main site areas. Use help-index.json for the detailed map of documented features, workflows, and canonical page paths; use sitemap.xml to discover crawlable public pages. These are guides to the site, not an inventory of every profile, Wave, or drop. Use the API for live records and activity.
+
+The help index, glossary, and this entry point are regenerated at build time. Fetch the published resources for current definitions and routes. Values such as TDH, REP, and Wave activity change independently of these documentation files.
+
+## Explore 6529
+
+- [What is 6529?](https://6529.io/about/faq): the network's mission, how to get started, and how participation works.
+- [The Memes](https://6529.io/the-memes): large-edition art NFTs released by their artists under CC0; see the [license](https://6529.io/about/license) for scope and third-party rights.
+- [Meme Lab](https://6529.io/meme-lab): experimental art from artists who have minted a Meme Card.
+- [6529 Gradient](https://6529.io/6529-gradient): the collection of 101 NFTs interpreting the 6529 symbol.
+- [NextGen](https://6529.io/nextgen): the on-chain generative art platform, including collection and artwork browsing.
+- [Waves](https://6529.io/waves): community spaces for conversations, sharing drops, and voting.
+- [Network](https://6529.io/network): member discovery, reputation, and network metrics such as TDH, xTDH, and Levels.
+- [Tools](https://6529.io/tools): developer and utility tools, including the API guides linked below.
 
 ## Machine-readable files
 
@@ -20,6 +35,11 @@ Site data such as TDH, REP, and Wave activity changes continuously. Fetch the fi
 - [Authentication guide](https://6529.io/tools/api/authentication): session-v2 wallet authentication for external clients, with Node.js examples.
 - Respect documented rate limits, cache responses where possible, and do not hammer endpoints.
 
+## Website agent integration
+
+- [Website-agent setup guide](https://6529.io/profile-cms/agent/v1/README.md): connect a local MCP adapter to a profile website draft and submit revisions for owner review. Saving and publishing remain owner actions.
+- [Adapter download](https://6529.io/profile-cms/agent/v1/6529-cms-agent.zip): the local MCP adapter; its [manifest](https://6529.io/profile-cms/agent/v1/manifest.json) lists version, runtime requirements, and file hashes.
+
 ## Source code
 
 - [GitHub organization](https://github.com/6529-Collections): open-source repositories, including this site (6529seize-frontend, Apache-2.0) and the API server (6529seize-backend).
@@ -27,5 +47,5 @@ Site data such as TDH, REP, and Wave activity changes continuously. Fetch the fi
 ## Usage policy
 
 - Link to the 6529.io page URL when citing site content; canonical paths are listed in help-index.json.
-- Do not present guesses as 6529 facts. If a term, metric, or feature is not described in glossary.json, help-index.json, or the API, say it is not documented instead of inventing it.
+- Do not present guesses as 6529 facts. Check the linked first-party pages and guides, glossary.json, help-index.json, and API documentation. If they do not document a term, metric, or feature, say so instead of inventing it.
 - Do not expose wallet addresses, identity statements, or profile data beyond what the cited public page already shows.


### PR DESCRIPTION
## Issue

The agent entry point leads with an inaccurate description of The Memes and does not explain 6529's broader mission, orient readers to the main site areas, or link the published website-agent adapter. Its corpus revision date is manually maintained and does not reflect current content.

## Fix

Introduce 6529 as a network building permissionless coordination, then provide a concise site map and clear paths to detailed documentation and live data.

## Changes

- Name The Memes, Meme Lab, 6529 Gradient, and the NextGen generative art platform; correct The Memes edition and CC0 description.
- Link the FAQ, collections, Waves, Network, and Tools, alongside the existing help corpus and API references.
- Link the website-agent MCP setup guide, adapter download, and manifest, with owner review and publishing boundaries.
- Remove the unreliable revision stamp and align the discovery documentation and citation guidance.

## Validation

- `6529 run agent-files:sync` regenerated the published artifact.
- `6529 run test:no-coverage __tests__/scripts/sync-agent-files.test.ts --runInBand`: 12 tests passed.
- Docs link validator passed for 305 Markdown files; whitespace check passed.
- All 23 linked URLs returned HTTP 200; an independent review verified the site routes and adapter capabilities.
- Static documentation only; no browser behavior changed. Deployment workflows will validate the production build and artifact.

## Risk

- Level: Low. Four documentation/artifact files; no runtime, API, dependency, or database changes.
- Rollback: revert this change and regenerate/deploy the agent entry point.