### PR TITLE
feat: 6529.io authorize page for community app identity assertion

### DIFF
--- a/app/auth/authorize/page.client.tsx
+++ b/app/auth/authorize/page.client.tsx
@@ -36,10 +36,20 @@ export default function AuthAuthorizePageClient() {
   const [message, setMessage] = useState("");
   const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
   const [redirectUrl, setRedirectUrl] = useState("");
+  // Track which params the displayed appInfo was validated for,
+  // so stale fetch responses can't spoof a different app's consent.
+  const [validatedParams, setValidatedParams] = useState<{
+    app: string;
+    redirect_uri: string;
+  } | null>(null);
 
-  // Fetch app info on mount
+  // Fetch app info when appId or redirectUri changes.
+  // Reset state first so a stale response from a prior request
+  // can't update the consent view for a different app.
   useEffect(() => {
     if (!appId || !redirectUri) {
+      setAppInfo(null);
+      setValidatedParams(null);
       setStatus("error");
       setMessage(
         "Missing required parameters (app, redirect_uri). Please return to the community app and try again."
@@ -47,15 +57,28 @@ export default function AuthAuthorizePageClient() {
       return;
     }
 
+    // Reset for the new params before fetching
+    setAppInfo(null);
+    setValidatedParams(null);
+    setStatus("loading");
+
+    const currentApp = appId;
+    const currentRedirectUri = redirectUri;
+
+    let cancelled = false;
+
     async function fetchAppInfo() {
       try {
         const info = await commonApiFetch<AppInfo>({
           endpoint: "auth/authorize/app-info",
-          params: { app: appId!, redirect_uri: redirectUri! },
+          params: { app: currentApp, redirect_uri: currentRedirectUri },
         });
+        if (cancelled) return;
         setAppInfo(info);
+        setValidatedParams({ app: currentApp, redirect_uri: currentRedirectUri });
         setStatus("confirm");
       } catch (err) {
+        if (cancelled) return;
         setStatus("error");
         setMessage(
           err instanceof Error
@@ -66,6 +89,10 @@ export default function AuthAuthorizePageClient() {
     }
 
     fetchAppInfo();
+
+    return () => {
+      cancelled = true;
+    };
   }, [appId, redirectUri]);
 
   // If user is not logged in, show login prompt
@@ -85,6 +112,14 @@ export default function AuthAuthorizePageClient() {
 
   async function handleApprove() {
     if (!appId || !redirectUri) return;
+    // Only allow approval if appInfo was validated for the current params
+    if (
+      !validatedParams ||
+      validatedParams.app !== appId ||
+      validatedParams.redirect_uri !== redirectUri
+    ) {
+      return;
+    }
     setStatus("approving");
     try {
       const result = await commonApiPost<

--- a/app/auth/authorize/page.client.tsx
+++ b/app/auth/authorize/page.client.tsx
@@ -1,0 +1,337 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { useAuth } from "@/components/auth/Auth";
+import { ProfileConnectedStatus } from "@/entities/IProfile";
+import { commonApiFetch, commonApiPost } from "@/services/api/common-api";
+
+type AuthorizeStatus =
+  | "loading"
+  | "not-logged-in"
+  | "confirm"
+  | "approving"
+  | "redirecting"
+  | "error";
+
+interface AppInfo {
+  readonly app_id: string;
+  readonly name: string;
+  readonly description: string;
+}
+
+export default function AuthAuthorizePageClient() {
+  const searchParams = useSearchParams();
+  const {
+    connectedProfile,
+    connectionStatus,
+    requestAuth,
+  } = useAuth();
+
+  const appId = searchParams.get("app");
+  const redirectUri = searchParams.get("redirect_uri");
+  const stateParam = searchParams.get("state");
+
+  const [status, setStatus] = useState<AuthorizeStatus>("loading");
+  const [message, setMessage] = useState("");
+  const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
+  const [redirectUrl, setRedirectUrl] = useState("");
+
+  // Fetch app info on mount
+  useEffect(() => {
+    if (!appId || !redirectUri) {
+      setStatus("error");
+      setMessage(
+        "Missing required parameters (app, redirect_uri). Please return to the community app and try again."
+      );
+      return;
+    }
+
+    async function fetchAppInfo() {
+      try {
+        const info = await commonApiFetch<AppInfo>({
+          endpoint: "auth/authorize/app-info",
+          params: { app: appId!, redirect_uri: redirectUri! },
+        });
+        setAppInfo(info);
+        setStatus("confirm");
+      } catch (err) {
+        setStatus("error");
+        setMessage(
+          err instanceof Error
+            ? err.message
+            : "Failed to validate community app. Please try again."
+        );
+      }
+    }
+
+    fetchAppInfo();
+  }, [appId, redirectUri]);
+
+  // If user is not logged in, show login prompt
+  useEffect(() => {
+    if (
+      status === "confirm" &&
+      connectionStatus === ProfileConnectedStatus.NOT_CONNECTED
+    ) {
+      setStatus("not-logged-in");
+    } else if (
+      status === "not-logged-in" &&
+      connectionStatus !== ProfileConnectedStatus.NOT_CONNECTED
+    ) {
+      setStatus("confirm");
+    }
+  }, [status, connectionStatus]);
+
+  async function handleApprove() {
+    if (!appId || !redirectUri) return;
+    setStatus("approving");
+    try {
+      const result = await commonApiPost<
+        {
+          readonly app: string;
+          readonly redirect_uri: string;
+          readonly state?: string;
+        },
+        { readonly redirect_url: string }
+      >({
+        endpoint: "auth/authorize/approve",
+        body: {
+          app: appId,
+          redirect_uri: redirectUri,
+          ...(stateParam ? { state: stateParam } : {}),
+        },
+      });
+      setRedirectUrl(result.redirect_url);
+      setStatus("redirecting");
+      // Brief delay so user sees the redirecting state
+      setTimeout(() => {
+        window.location.href = result.redirect_url;
+      }, 800);
+    } catch (err) {
+      setStatus("error");
+      setMessage(
+        err instanceof Error
+          ? err.message
+          : "Authorization failed. Please try again."
+      );
+    }
+  }
+
+  async function handleLogin() {
+    const result = await requestAuth();
+    if (!result.success) {
+      setStatus("error");
+      setMessage("Failed to connect wallet. Please try again.");
+    }
+    // The connectionStatus effect will move us back to "confirm"
+  }
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: "100vh",
+        padding: "2rem",
+        backgroundColor: "#000000",
+        color: "#ffffff",
+        fontFamily: "sans-serif",
+      }}
+    >
+      {/* 6529 branding */}
+      <div
+        style={{
+          fontSize: "1.4rem",
+          fontWeight: "bold",
+          marginBottom: "2rem",
+          letterSpacing: "0.05em",
+        }}
+      >
+        6529.io
+      </div>
+
+      {status === "loading" && (
+        <p style={{ color: "#888" }}>Loading…</p>
+      )}
+
+      {status === "error" && (
+        <div style={{ textAlign: "center", maxWidth: "450px" }}>
+          <p style={{ color: "#e74c3c", marginBottom: "1rem" }}>
+            {message}
+          </p>
+          <button
+            onClick={() => window.location.reload()}
+            style={{
+              background: "#fff",
+              color: "#000",
+              border: "none",
+              padding: "0.75rem 2rem",
+              borderRadius: "8px",
+              fontSize: "1rem",
+              cursor: "pointer",
+            }}
+          >
+            Try Again
+          </button>
+        </div>
+      )}
+
+      {status === "not-logged-in" && (
+        <div style={{ textAlign: "center", maxWidth: "450px" }}>
+          {appInfo && (
+            <p
+              style={{
+                fontSize: "1.1rem",
+                marginBottom: "1rem",
+                color: "#ccc",
+              }}
+            >
+              <strong style={{ color: "#fff" }}>{appInfo.name}</strong> wants
+              to verify your 6529 identity.
+            </p>
+          )}
+          <p
+            style={{
+              marginBottom: "1.5rem",
+              color: "#888",
+              fontSize: "0.95rem",
+            }}
+          >
+            You need to be logged in to 6529.io to authorize this app.
+          </p>
+          <button
+            onClick={handleLogin}
+            style={{
+              background: "#22c55e",
+              color: "#000",
+              border: "none",
+              padding: "0.75rem 2.5rem",
+              borderRadius: "8px",
+              fontSize: "1.1rem",
+              fontWeight: "bold",
+              cursor: "pointer",
+            }}
+          >
+            Connect Wallet
+          </button>
+        </div>
+      )}
+
+      {(status === "confirm" || status === "approving") && (
+        <div style={{ textAlign: "center", maxWidth: "450px" }}>
+          {appInfo && (
+            <>
+              <p
+                style={{
+                  fontSize: "1.2rem",
+                  marginBottom: "0.5rem",
+                }}
+              >
+                <strong>{appInfo.name}</strong>
+              </p>
+              <p
+                style={{
+                  color: "#888",
+                  fontSize: "0.9rem",
+                  marginBottom: "1.5rem",
+                }}
+              >
+                {appInfo.description}
+              </p>
+            </>
+          )}
+
+          {/* User profile card */}
+          {connectedProfile && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "1rem",
+                marginBottom: "1.5rem",
+                padding: "1rem",
+                borderRadius: "12px",
+                background: "#111",
+                border: "1px solid #333",
+              }}
+            >
+              {connectedProfile.pfp?.url && (
+                <img
+                  src={connectedProfile.pfp.url}
+                  alt="PFP"
+                  style={{
+                    width: 48,
+                    height: 48,
+                    borderRadius: "50%",
+                    objectFit: "cover",
+                  }}
+                />
+              )}
+              <div style={{ textAlign: "left" }}>
+                <p style={{ fontWeight: "bold", margin: 0 }}>
+                  {connectedProfile.handle ??
+                    connectedProfile.display ??
+                    "User"}
+                </p>
+                {connectedProfile.level && (
+                  <p
+                    style={{
+                      color: "#888",
+                      fontSize: "0.85rem",
+                      margin: 0,
+                    }}
+                  >
+                    Level {connectedProfile.level}
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
+
+          <p
+            style={{
+              marginBottom: "1.5rem",
+              color: "#ccc",
+              fontSize: "0.95rem",
+            }}
+          >
+            This app will receive your wallet address and can access your public
+            6529 profile. No transaction will be made. No gas will be spent.
+          </p>
+
+          <button
+            onClick={handleApprove}
+            disabled={status === "approving"}
+            style={{
+              background: status === "approving" ? "#333" : "#22c55e",
+              color: status === "approving" ? "#888" : "#000",
+              border: "none",
+              padding: "0.75rem 2.5rem",
+              borderRadius: "8px",
+              fontSize: "1.1rem",
+              fontWeight: "bold",
+              cursor: status === "approving" ? "default" : "pointer",
+            }}
+          >
+            {status === "approving" ? "Authorizing…" : "Authorize"}
+          </button>
+        </div>
+      )}
+
+      {status === "redirecting" && (
+        <div style={{ textAlign: "center" }}>
+          <p style={{ fontSize: "1.3rem", marginBottom: "0.5rem" }}>✓</p>
+          <p style={{ fontSize: "1.1rem", marginBottom: "0.5rem" }}>
+            Authorized!
+          </p>
+          <p style={{ color: "#888", fontSize: "0.9rem" }}>
+            Redirecting you back…
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/auth/authorize/page.tsx
+++ b/app/auth/authorize/page.tsx
@@ -1,0 +1,18 @@
+import { getAppMetadata } from "@/components/providers/metadata";
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import AuthAuthorizePageClient from "./page.client";
+
+export default function AuthAuthorizePage() {
+  return (
+    <Suspense fallback={null}>
+      <AuthAuthorizePageClient />
+    </Suspense>
+  );
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  return getAppMetadata({
+    title: "Authorize Community App",
+  });
+}


### PR DESCRIPTION
Adds /auth/authorize page — the trust page community apps redirect users to. Shows 6529.io branding, community app name + description, user profile card, and Authorize button. If not logged in, shows Connect Wallet button that triggers standard 6529 SIWE login. On Approve: calls POST /auth/authorize/approve, redirects to community app with one-time code. Replaces closed PR #3938 (device auth). Works with backend PR #2018. Simple, no new services or utils needed — uses existing commonApiFetch/commonApiPost and useAuth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authorization page for connecting community apps.
  * Added page metadata with the title “Authorize Community App.”

* **Bug Fixes**
  * Authorization details now refresh when the requested app or redirect address changes.
  * Prevented outdated validation results from being used after navigation.
  * Approval is blocked when validated details do not match the current authorization request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->