### PR TITLE
fix(e2e): suppress recognized Sentry envelope telemetry

### DIFF
--- a/__tests__/playwright/readonlyMutationGuard.test.ts
+++ b/__tests__/playwright/readonlyMutationGuard.test.ts
@@ -1,6 +1,9 @@
+import type { BrowserContext, Route } from "@playwright/test";
+
 import {
   decideReadonlyRequest,
   inferPlaywrightEnvironment,
+  installReadonlyMutationGuard,
   sanitizeReadonlyRequestUrl,
   shouldUseReadonlyGuard,
 } from "../../tests/support/readonlyMutationGuard";
@@ -437,6 +440,125 @@ describe("Playwright read-only mutation guard", () => {
         reason: "ignored-external-sdk-endpoint",
       });
     }
+  });
+
+  it.each([
+    "https://o123.ingest.sentry.io/api/456/envelope/",
+    "https://o123.ingest.us.sentry.io/api/456/envelope/?sentry_key=test",
+    "https://o123.ingest.de.sentry.io/api/456/envelope/",
+    "https://o123.ingest.us.sentry.io:443/api/456/envelope/",
+  ])("aborts a recognized Sentry envelope POST: %s", (url) => {
+    expect(
+      decideReadonlyRequest({
+        baseURL: "https://6529.io",
+        method: "POST",
+        readonly: true,
+        url,
+      })
+    ).toEqual({
+      action: "abort",
+      reason: "ignored-external-sdk-endpoint",
+    });
+  });
+
+  it.each([
+    "http://o123.ingest.us.sentry.io/api/456/envelope/",
+    "https://o123.ingest.us.sentry.io:8443/api/456/envelope/",
+    "https://user@o123.ingest.us.sentry.io/api/456/envelope/",
+    "https://:password@o123.ingest.us.sentry.io/api/456/envelope/",
+    "https://o123.ingest.us.sentry.io.example.com/api/456/envelope/",
+    "https://extra.o123.ingest.us.sentry.io/api/456/envelope/",
+    "https://o123.ingest.eu.sentry.io/api/456/envelope/",
+    "https://org.ingest.us.sentry.io/api/456/envelope/",
+    "https://ingest.sentry.io/api/456/envelope/",
+    "https://o123.ingest.sentry.io/api/456/store/",
+    "https://o123.ingest.us.sentry.io/api/456/envelope",
+    "https://o123.ingest.us.sentry.io/api/456/envelope/extra",
+    "https://o123.ingest.us.sentry.io/api/project/envelope/",
+    "https://o123.ingest.us.sentry.io/api/456/envelope-mutation/",
+    "https://o123.ingest.us.sentry.io/api/0/projects/",
+  ])("records Sentry endpoint near-matches as blocked mutations: %s", (url) => {
+    expect(
+      decideReadonlyRequest({
+        baseURL: "https://6529.io",
+        method: "POST",
+        readonly: true,
+        url,
+      })
+    ).toEqual({ action: "block", reason: "non-allowlisted-mutation" });
+  });
+
+  it.each(["PUT", "PATCH", "DELETE"])(
+    "does not suppress %s requests to the Sentry envelope endpoint",
+    (method) => {
+      expect(
+        decideReadonlyRequest({
+          baseURL: "https://6529.io",
+          method,
+          readonly: true,
+          url: "https://o123.ingest.us.sentry.io/api/456/envelope/",
+        })
+      ).toEqual({ action: "block", reason: "non-allowlisted-mutation" });
+    }
+  );
+
+  it("keeps registered mutations ahead of Sentry telemetry suppression", () => {
+    expect(
+      decideReadonlyRequest({
+        baseURL: "https://o123.ingest.us.sentry.io",
+        method: "POST",
+        readonly: true,
+        url: "https://o123.ingest.us.sentry.io/api/456/envelope/",
+      })
+    ).toMatchObject({
+      action: "block",
+      reason: "registered-mutation-endpoint",
+      ruleId: "first-party-api-mutations",
+    });
+  });
+
+  it("drops Sentry telemetry without hiding or sending business mutations", async () => {
+    const routeHandler = jest.fn();
+    const context = { route: routeHandler } as unknown as BrowserContext;
+    const guard = await installReadonlyMutationGuard(
+      context,
+      "https://6529.io"
+    );
+    const handleRoute = routeHandler.mock.calls[0][1] as (
+      route: Route
+    ) => Promise<void>;
+    const abort = jest.fn().mockResolvedValue(undefined);
+    const continueRequest = jest.fn().mockResolvedValue(undefined);
+    const makeRoute = (url: string) =>
+      ({
+        request: () => ({
+          method: () => "POST",
+          postData: () => null,
+          url: () => url,
+        }),
+        abort,
+        continue: continueRequest,
+      }) as unknown as Route;
+
+    await handleRoute(
+      makeRoute("https://o123.ingest.us.sentry.io/api/456/envelope/")
+    );
+    expect(abort).toHaveBeenCalledWith("blockedbyclient");
+    expect(guard.blockedRequests).toEqual([]);
+    expect(() => guard.assertNoBlockedRequests()).not.toThrow();
+
+    await handleRoute(makeRoute("https://api.6529.io/drops"));
+    expect(guard.blockedRequests).toEqual([
+      expect.objectContaining({
+        method: "POST",
+        url: "https://api.6529.io/drops",
+      }),
+    ]);
+    expect(() => guard.assertNoBlockedRequests()).toThrow(
+      "Read-only Playwright run blocked 1 mutation request(s)"
+    );
+    expect(abort).toHaveBeenCalledTimes(2);
+    expect(continueRequest).not.toHaveBeenCalled();
   });
 
   it("aborts exact Google CSP script-inclusion reports", () => {

--- a/tests/support/readonlyMutationGuard.ts
+++ b/tests/support/readonlyMutationGuard.ts
@@ -64,7 +64,6 @@ const FIRST_PARTY_READONLY_API_POST_PATHS = new Set([
 
 const IGNORED_EXTERNAL_MUTATION_HOSTS = [
   /(^|\.)mixpanel\.com$/i,
-  /(^|\.)ingest\.sentry\.io$/i,
   /^dataplane\.rum\.[a-z0-9-]+\.amazonaws\.com$/i,
 ];
 const GOOGLE_COLLECT_HOSTS = new Set([
@@ -167,6 +166,18 @@ export function shouldUseReadonlyGuard(baseURL?: string) {
 
   const environment = inferPlaywrightEnvironment(baseURL);
   return environment === "staging" || environment === "production";
+}
+
+function isSentryEnvelopePost(method: string, url: URL) {
+  return (
+    method === "POST" &&
+    url.protocol === "https:" &&
+    url.port === "" &&
+    url.username === "" &&
+    url.password === "" &&
+    /^o[0-9]+\.ingest(?:\.(?:us|de))?\.sentry\.io$/.test(url.hostname) &&
+    /^\/api\/[0-9]+\/envelope\/$/.test(url.pathname)
+  );
 }
 
 function isIgnoredExternalMutation(url: URL) {
@@ -428,7 +439,10 @@ export function decideReadonlyRequest({
     return { action: "block", reason: "unsafe-ethereum-rpc" };
   }
 
-  if (isIgnoredExternalMutation(parsed)) {
+  if (
+    isSentryEnvelopePost(upperMethod, parsed) ||
+    isIgnoredExternalMutation(parsed)
+  ) {
     return { action: "abort", reason: "ignored-external-sdk-endpoint" };
   }
 


### PR DESCRIPTION
## Issue

Production read-only E2E run 34731645213 classified direct Sentry envelope POSTs as application mutations after #3978 removed the first-party tunnel. The existing telemetry matcher recognized legacy ingest hosts but missed regional hosts, so all 16 packs failed the mutation guard during teardown.

## Fix

Abort recognized Sentry envelope POSTs without recording an application mutation, preserving the existing mutation registry's priority and keeping network delivery blocked.

## Changes

- Replace the broad legacy Sentry host exemption with exact numeric-organization ingest hosts (legacy, US, DE), HTTPS/default port, no URL credentials, POST, and the numeric-project envelope path.
- Add endpoint, near-match, method, registry-priority and route-level tests; ordinary business mutations still abort and fail the run.
- Keep production application telemetry and deployment/test source binding unchanged.

## Validation

- Focused read-only mutation guard suite: 40 tests passed.
- Standard changed-file lint and typecheck passed (ESLint excludes these test directories). Jest typecheck ratchet passed with no new diagnostics; Playwright typecheck passed. Formatting passed.
- Independent review found no actionable issues.
- Staging deployment [34733778395](https://github.com/6529-Collections/6529seize-frontend/actions/runs/34733778395) passed artifact and live-version checks. Staging E2E [34734209304](https://github.com/6529-Collections/6529seize-frontend/actions/runs/34734209304): 12 packs passed, 194 tests passed and 34 skipped, with no failures or flakes; NextGen rarity passed on desktop and mobile.
- Production deployment [34734275555](https://github.com/6529-Collections/6529seize-frontend/actions/runs/34734275555) passed artifact, exact-version readiness and public-version checks. Production E2E [34734970127](https://github.com/6529-Collections/6529seize-frontend/actions/runs/34734970127) passed from exact deployed source `80ba2f10f33db7d8ca3dea064ed68229722b01ec`: all 11 selected packs passed first attempt, 77 tests passed with none skipped, failed, or flaky. NextGen rarity passed; no Sentry guard failures recurred. Unrelated Museum packs were excluded by the normal classifier.

## Risk

- Level: Low. Only the test harness and its tests change. Requests remain aborted; the change affects whether recognized telemetry fails teardown.
- Rollback: revert this commit; regional telemetry will again cause read-only teardown failures.

## Review Notes

Review the anchored endpoint matcher, mutation registry precedence, and abort-without-recording behavior. Supported regional ingestion domains are documented by [Sentry](https://sentry.io/changelog/ingestion-ip-addresses-are-changing/). This is a continuation of the existing error/moderation release recorded in Coordinator inbox #90.
